### PR TITLE
futures: add support for std::futures::Future

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,6 @@ jobs:
   - script: cargo test --features=doctest-readme --all
     name: "doctest readme"
     rust: nightly
-  - script: (cd tracing-futures/test_std_futures && cargo test)
+  - script: (cd tracing-futures/test_std_future && cargo test)
     name: "futures nightly"
     rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,6 @@ jobs:
   - script: cargo test --features=doctest-readme --all
     name: "doctest readme"
     rust: nightly
+  - script: (cd tracing-futures && cargo test --all-features)
+    name: "futures all features"
+    rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,6 @@ jobs:
   - script: cargo test --features=doctest-readme --all
     name: "doctest readme"
     rust: nightly
-  - script: (cd tracing-futures && cargo test --all-features)
-    name: "futures all features"
+  - script: (cd tracing-futures/test_std_futures && cargo test)
+    name: "futures nightly"
     rust: nightly

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -18,5 +18,6 @@ tokio-executor = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tokio = "0.1.22"
+tokio-test = { git = "https://github.com/tokio-rs/tokio.git" }
 tracing-fmt = { path = "../tracing-fmt" }
 tracing-core = "0.1.2"

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -18,6 +18,5 @@ tokio-executor = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tokio = "0.1.22"
-tokio-test = { git = "https://github.com/tokio-rs/tokio.git" }
 tracing-fmt = { path = "../tracing-fmt" }
 tracing-core = "0.1.2"

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -5,10 +5,13 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 edition = "2018"
 
 [features]
-default = ["tokio"]
+default = ["futures-01", "tokio"]
+futures-01 = ["futures"]
+std-future = ["pin-utils"]
 
 [dependencies]
-futures = "0.1"
+futures = { version = "0.1", optional = true }
+pin-utils = { version = "0.1.0-alpha.4", optional = true }
 tracing = "0.1"
 tokio = { version = "0.1", optional = true }
 tokio-executor = { version = "0.1", optional = true }

--- a/tracing-futures/src/executor.rs
+++ b/tracing-futures/src/executor.rs
@@ -1,15 +1,14 @@
 use crate::{Instrument, Instrumented, WithDispatch};
+#[cfg(feature = "futures-01")]
 use futures::{
-    future::{ExecuteError, Executor},
-    Future,
+  future::{ExecuteError, Executor},
+  Future,
 };
+#[cfg(feature = "futures-01")]
+use tokio::executor::{Executor as TokioExecutor, SpawnError};
+use tokio::runtime::{current_thread, Runtime, TaskExecutor};
 
-#[cfg(feature = "tokio")]
-use tokio::{
-    executor::{Executor as TokioExecutor, SpawnError},
-    runtime::{current_thread, Runtime, TaskExecutor},
-};
-
+#[cfg(feature = "futures-01")]
 macro_rules! deinstrument_err {
     ($e:expr) => {
         $e.map_err(|e| {
@@ -20,6 +19,7 @@ macro_rules! deinstrument_err {
     };
 }
 
+#[cfg(feature = "futures-01")]
 impl<T, F> Executor<F> for Instrumented<T>
 where
     T: Executor<Instrumented<F>>,
@@ -31,7 +31,7 @@ where
     }
 }
 
-#[cfg(feature = "tokio")]
+#[cfg(all(feature = "futures-01", feature = "tokio"))]
 impl<T> TokioExecutor for Instrumented<T>
 where
     T: TokioExecutor,
@@ -56,6 +56,7 @@ impl Instrumented<Runtime> {
     ///
     /// This method simply wraps a call to `tokio::runtime::Runtime::spawn`,
     /// instrumenting the spawned future beforehand.
+    #[cfg(feature = "futures-01")]
     pub fn spawn<F>(&mut self, future: F) -> &mut Self
     where
         F: Future<Item = (), Error = ()> + Send + 'static,
@@ -80,6 +81,7 @@ impl Instrumented<Runtime> {
     ///
     /// This function panics if the executor is at capacity, if the provided
     /// future panics, or if called within an asynchronous execution context.
+    #[cfg(feature = "futures-01")]
     pub fn block_on<F, R, E>(&mut self, future: F) -> Result<R, E>
     where
         F: Send + 'static + Future<Item = R, Error = E>,
@@ -108,6 +110,7 @@ impl Instrumented<current_thread::Runtime> {
     ///
     /// This method simply wraps a call to `current_thread::Runtime::spawn`,
     /// instrumenting the spawned future beforehand.
+    #[cfg(feature = "futures-01")]
     pub fn spawn<F>(&mut self, future: F) -> &mut Self
     where
         F: Future<Item = (), Error = ()> + 'static,
@@ -141,6 +144,7 @@ impl Instrumented<current_thread::Runtime> {
     ///
     /// This function panics if the executor is at capacity, if the provided
     /// future panics, or if called within an asynchronous execution context.
+    #[cfg(feature = "futures-01")]
     pub fn block_on<F, R, E>(&mut self, future: F) -> Result<R, E>
     where
         F: 'static + Future<Item = R, Error = E>,
@@ -165,6 +169,7 @@ impl Instrumented<current_thread::Runtime> {
     }
 }
 
+#[cfg(feature = "futures-01")]
 impl<T, F> Executor<F> for WithDispatch<T>
 where
     T: Executor<WithDispatch<F>>,
@@ -176,7 +181,7 @@ where
     }
 }
 
-#[cfg(feature = "tokio")]
+#[cfg(all(feature = "futures-01", feature = "tokio"))]
 impl<T> TokioExecutor for WithDispatch<T>
 where
     T: TokioExecutor,
@@ -202,6 +207,7 @@ impl WithDispatch<Runtime> {
     ///
     /// This method simply wraps a call to `tokio::runtime::Runtime::spawn`,
     /// instrumenting the spawned future beforehand.
+    #[cfg(feature = "futures-01")]
     pub fn spawn<F>(&mut self, future: F) -> &mut Self
     where
         F: Future<Item = (), Error = ()> + Send + 'static,
@@ -227,6 +233,7 @@ impl WithDispatch<Runtime> {
     ///
     /// This function panics if the executor is at capacity, if the provided
     /// future panics, or if called within an asynchronous execution context.
+    #[cfg(feature = "futures-01")]
     pub fn block_on<F, R, E>(&mut self, future: F) -> Result<R, E>
     where
         F: Send + 'static + Future<Item = R, Error = E>,
@@ -257,6 +264,7 @@ impl WithDispatch<current_thread::Runtime> {
     ///
     /// This method simply wraps a call to `current_thread::Runtime::spawn`,
     /// instrumenting the spawned future beforehand.
+    #[cfg(feature = "futures-01")]
     pub fn spawn<F>(&mut self, future: F) -> &mut Self
     where
         F: Future<Item = (), Error = ()> + 'static,
@@ -290,6 +298,7 @@ impl WithDispatch<current_thread::Runtime> {
     ///
     /// This function panics if the executor is at capacity, if the provided
     /// future panics, or if called within an asynchronous execution context.
+    #[cfg(feature = "futures-01")]
     pub fn block_on<F, R, E>(&mut self, future: F) -> Result<R, E>
     where
         F: 'static + Future<Item = R, Error = E>,

--- a/tracing-futures/src/executor.rs
+++ b/tracing-futures/src/executor.rs
@@ -1,8 +1,8 @@
 use crate::{Instrument, Instrumented, WithDispatch};
 #[cfg(feature = "futures-01")]
 use futures::{
-  future::{ExecuteError, Executor},
-  Future,
+    future::{ExecuteError, Executor},
+    Future,
 };
 #[cfg(feature = "futures-01")]
 use tokio::executor::{Executor as TokioExecutor, SpawnError};

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -27,8 +27,8 @@ extern crate tracing;
 
 #[cfg(feature = "std-future")]
 use std::{
-  pin::Pin,
-  task::Context,
+    pin::Pin,
+    task::Context,
 };
 
 #[cfg(feature = "futures-01")]

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(all(feature = "std-future", test), feature(futures_api))]
+
 //! Futures compatibility for `tracing`
 //!
 //! # Feature flags
@@ -194,12 +196,38 @@ mod tests {
 
     #[cfg(feature = "futures-01")]
     use futures::{future, stream, task, Async, Future};
+    #[cfg(feature = "std-future")]
+    use tokio_test::task::MockTask;
     use tracing::{subscriber::with_default, Level};
 
     struct PollN<T, E> {
         and_return: Option<Result<T, E>>,
         finish_at: usize,
         polls: usize,
+    }
+
+    #[cfg(feature = "std-future")]
+    impl<T, E> std::future::Future for PollN<T, E>
+    where
+        T: Unpin,
+        E: Unpin,
+    {
+        type Output = Result<T, E>;
+        fn poll(self: Pin<&mut Self>, lw: &mut Context) -> std::task::Poll<Self::Output> {
+            let this = self.get_mut();
+
+            this.polls += 1;
+            if this.polls == this.finish_at {
+                let value = this.and_return
+                    .take()
+                    .expect("polled after ready");
+
+                std::task::Poll::Ready(value)
+            } else {
+                lw.waker().wake_by_ref();
+                std::task::Poll::Pending
+            }
+        }
     }
 
     #[cfg(feature = "futures-01")]
@@ -234,6 +262,21 @@ mod tests {
                 and_return: Some(Err(())),
                 finish_at,
                 polls: 0,
+            }
+        }
+    }
+
+    #[cfg(feature = "std-future")]
+    fn block_on_future<F>(task: &mut MockTask, future: F) -> F::Output
+    where
+        F: std::future::Future,
+    {
+        let mut future = Box::pin(future);
+
+        loop {
+            match task.poll(&mut future) {
+                std::task::Poll::Ready(v) => break v,
+                _ => {},
             }
         }
     }
@@ -330,6 +373,46 @@ mod tests {
                     });
                 runtime.block_on(Box::new(future)).unwrap();
             })
+        });
+        handle.assert_finished();
+    }
+
+    #[cfg(feature = "std-future")]
+    #[test]
+    fn std_future_enter_exit_is_reasonable() {
+        let (subscriber, handle) = subscriber::mock()
+            .enter(span::mock().named("foo"))
+            .exit(span::mock().named("foo"))
+            .enter(span::mock().named("foo"))
+            .exit(span::mock().named("foo"))
+            .drop_span(span::mock().named("foo"))
+            .done()
+            .run_with_handle();
+        let mut task = MockTask::new();
+        with_default(subscriber, || {
+            let future = PollN::new_ok(2)
+                .instrument(span!(Level::TRACE, "foo"));
+            block_on_future(&mut task, future).unwrap();
+        });
+        handle.assert_finished();
+    }
+
+    #[cfg(feature = "std-future")]
+    #[test]
+    fn std_future_error_ends_span() {
+        let (subscriber, handle) = subscriber::mock()
+            .enter(span::mock().named("foo"))
+            .exit(span::mock().named("foo"))
+            .enter(span::mock().named("foo"))
+            .exit(span::mock().named("foo"))
+            .drop_span(span::mock().named("foo"))
+            .done()
+            .run_with_handle();
+        let mut task = MockTask::new();
+        with_default(subscriber, || {
+            let future = PollN::new_err(2)
+                .instrument(span!(Level::TRACE, "foo"));
+            block_on_future(&mut task, future).unwrap_err();
         });
         handle.assert_finished();
     }

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(all(feature = "std-future", test), feature(futures_api))]
-
 //! Futures compatibility for `tracing`
 //!
 //! # Feature flags

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -218,9 +218,7 @@ mod tests {
 
             this.polls += 1;
             if this.polls == this.finish_at {
-                let value = this.and_return
-                    .take()
-                    .expect("polled after ready");
+                let value = this.and_return.take().expect("polled after ready");
 
                 std::task::Poll::Ready(value)
             } else {
@@ -276,7 +274,7 @@ mod tests {
         loop {
             match task.poll(&mut future) {
                 std::task::Poll::Ready(v) => break v,
-                _ => {},
+                _ => {}
             }
         }
     }
@@ -390,8 +388,7 @@ mod tests {
             .run_with_handle();
         let mut task = MockTask::new();
         with_default(subscriber, || {
-            let future = PollN::new_ok(2)
-                .instrument(span!(Level::TRACE, "foo"));
+            let future = PollN::new_ok(2).instrument(span!(Level::TRACE, "foo"));
             block_on_future(&mut task, future).unwrap();
         });
         handle.assert_finished();
@@ -410,8 +407,7 @@ mod tests {
             .run_with_handle();
         let mut task = MockTask::new();
         with_default(subscriber, || {
-            let future = PollN::new_err(2)
-                .instrument(span!(Level::TRACE, "foo"));
+            let future = PollN::new_err(2).instrument(span!(Level::TRACE, "foo"));
             block_on_future(&mut task, future).unwrap_err();
         });
         handle.assert_finished();

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -26,10 +26,7 @@ extern crate tokio_executor;
 extern crate tracing;
 
 #[cfg(feature = "std-future")]
-use std::{
-    pin::Pin,
-    task::Context,
-};
+use std::{pin::Pin, task::Context};
 
 #[cfg(feature = "futures-01")]
 use futures::{Sink, StartSend, Stream};

--- a/tracing-futures/test_std_future/Cargo.toml
+++ b/tracing-futures/test_std_future/Cargo.toml
@@ -1,0 +1,18 @@
+# Note: these tests depend on crates that use nightly features which do not
+# run under stable and beta toolchains.
+#
+# Do not add these tests to the other tracing-futures tests unless the
+# minimum Rust version is at least 1.36.
+[workspace]
+
+[package]
+name = "test_std_future"
+version = "0.1.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+tokio-test = { git = "https://github.com/tokio-rs/tokio.git" }
+tracing = "0.1"
+tracing-core = "0.1.2"
+tracing-futures = { path = "..", features = ["std-future"] }

--- a/tracing-futures/test_std_future/tests/test.rs
+++ b/tracing-futures/test_std_future/tests/test.rs
@@ -75,7 +75,7 @@ where
 }
 
 #[test]
-fn std_future_enter_exit_is_reasonable() {
+fn enter_exit_is_reasonable() {
     let (subscriber, handle) = subscriber::mock()
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
@@ -93,7 +93,7 @@ fn std_future_enter_exit_is_reasonable() {
 }
 
 #[test]
-fn std_future_error_ends_span() {
+fn error_ends_span() {
     let (subscriber, handle) = subscriber::mock()
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))

--- a/tracing-futures/test_std_future/tests/test.rs
+++ b/tracing-futures/test_std_future/tests/test.rs
@@ -1,0 +1,111 @@
+#[macro_use]
+extern crate tracing;
+extern crate tracing_core;
+
+pub use self::support as test_support;
+// This has to have the same name as the module in `tracing`.
+#[path = "../../../tracing/tests/support/mod.rs"]
+pub mod support;
+
+use std::pin::Pin;
+use std::task::Context;
+
+use support::*;
+use tokio_test::task::MockTask;
+use tracing::{subscriber::with_default, Level};
+use tracing_futures::Instrument;
+
+struct PollN<T, E> {
+    and_return: Option<Result<T, E>>,
+    finish_at: usize,
+    polls: usize,
+}
+
+impl<T, E> std::future::Future for PollN<T, E>
+where
+    T: Unpin,
+    E: Unpin,
+{
+    type Output = Result<T, E>;
+    fn poll(self: Pin<&mut Self>, lw: &mut Context) -> std::task::Poll<Self::Output> {
+        let this = self.get_mut();
+
+        this.polls += 1;
+        if this.polls == this.finish_at {
+            let value = this.and_return.take().expect("polled after ready");
+
+            std::task::Poll::Ready(value)
+        } else {
+            lw.waker().wake_by_ref();
+            std::task::Poll::Pending
+        }
+    }
+}
+
+impl PollN<(), ()> {
+    fn new_ok(finish_at: usize) -> Self {
+        Self {
+            and_return: Some(Ok(())),
+            finish_at,
+            polls: 0,
+        }
+    }
+
+    fn new_err(finish_at: usize) -> Self {
+        Self {
+            and_return: Some(Err(())),
+            finish_at,
+            polls: 0,
+        }
+    }
+}
+
+fn block_on_future<F>(task: &mut MockTask, future: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    let mut future = Box::pin(future);
+
+    loop {
+        match task.poll(&mut future) {
+            std::task::Poll::Ready(v) => break v,
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn std_future_enter_exit_is_reasonable() {
+    let (subscriber, handle) = subscriber::mock()
+        .enter(span::mock().named("foo"))
+        .exit(span::mock().named("foo"))
+        .enter(span::mock().named("foo"))
+        .exit(span::mock().named("foo"))
+        .drop_span(span::mock().named("foo"))
+        .done()
+        .run_with_handle();
+    let mut task = MockTask::new();
+    with_default(subscriber, || {
+        let future = PollN::new_ok(2).instrument(span!(Level::TRACE, "foo"));
+        block_on_future(&mut task, future).unwrap();
+    });
+    handle.assert_finished();
+}
+
+#[test]
+fn std_future_error_ends_span() {
+    let (subscriber, handle) = subscriber::mock()
+        .enter(span::mock().named("foo"))
+        .exit(span::mock().named("foo"))
+        .enter(span::mock().named("foo"))
+        .exit(span::mock().named("foo"))
+        .drop_span(span::mock().named("foo"))
+        .done()
+        .run_with_handle();
+    let mut task = MockTask::new();
+    with_default(subscriber, || {
+        let future = PollN::new_err(2).instrument(span!(Level::TRACE, "foo"));
+        block_on_future(&mut task, future).unwrap_err();
+    });
+    handle.assert_finished();
+}


### PR DESCRIPTION
This PR adds a `std::future::Future` implementation to `Instrumented<T>`~~, but with some caveats:~~
~~- To support `async` functions, the inner future must be boxed.~~
~~- If someone can figure out how to support `!Unpin` futures without boxing, please do so.~~ Thanks hawkw!