### PR TITLE
futures: add instrumented spawn! macro

### DIFF
--- a/tracing-futures/examples/spawn_macro.rs
+++ b/tracing-futures/examples/spawn_macro.rs
@@ -1,0 +1,38 @@
+extern crate futures;
+extern crate tokio;
+#[macro_use]
+extern crate tokio_trace;
+extern crate tokio_trace_fmt;
+#[macro_use]
+extern crate tokio_trace_futures;
+
+use futures::future::{self, Future};
+
+fn parent_task(how_many: usize) -> impl Future<Item = (), Error = ()> {
+    future::lazy(move || {
+        info!("spawning subtasks...");
+        for i in (1..=how_many) {
+            debug!(message = "spawning subtask;", number = i);
+            spawn!(subtask(i), number = i);
+        }
+        Ok(())
+    })
+    .map(|_| {
+        info!("all subtasks spawned");
+    })
+}
+
+fn subtask(number: usize) -> impl Future<Item = (), Error = ()> {
+    future::lazy(move || {
+        debug!("polling subtask...");
+        Ok(number)
+    })
+    .map(|i| trace!(i = i))
+}
+
+fn main() {
+    let subscriber = tokio_trace_fmt::FmtSubscriber::builder().full().finish();
+    tokio_trace::subscriber::with_default(subscriber, || {
+        tokio::run(parent_task(10));
+    });
+}

--- a/tracing-futures/examples/spawn_macro.rs
+++ b/tracing-futures/examples/spawn_macro.rs
@@ -1,38 +1,30 @@
-extern crate futures;
-extern crate tokio;
-#[macro_use]
-extern crate tokio_trace;
-extern crate tokio_trace_fmt;
-#[macro_use]
-extern crate tokio_trace_futures;
-
 use futures::future::{self, Future};
 
 fn parent_task(how_many: usize) -> impl Future<Item = (), Error = ()> {
     future::lazy(move || {
-        info!("spawning subtasks...");
-        for i in 1..=how_many {
-            debug!(message = "spawning subtask;", number = i);
-            spawn!(subtask(i), number = i);
+        tracing::info!("spawning subtasks...");
+        for number in 1..=how_many {
+            tracing::debug!(message = "spawning subtask;", number);
+            tracing_futures::spawn!(subtask(number), number);
         }
         Ok(())
     })
     .map(|_| {
-        info!("all subtasks spawned");
+        tracing::info!("all subtasks spawned");
     })
 }
 
 fn subtask(number: usize) -> impl Future<Item = (), Error = ()> {
     future::lazy(move || {
-        debug!("polling subtask...");
+        tracing::debug!("polling subtask...");
         Ok(number)
     })
-    .map(|i| trace!(i = i))
+    .map(|i| tracing::trace!(i))
 }
 
 fn main() {
-    let subscriber = tokio_trace_fmt::FmtSubscriber::builder().full().finish();
-    tokio_trace::subscriber::with_default(subscriber, || {
+    let subscriber = tracing_fmt::FmtSubscriber::builder().finish();
+    tracing::subscriber::with_default(subscriber, || {
         tokio::run(parent_task(10));
     });
 }

--- a/tracing-futures/examples/spawn_macro.rs
+++ b/tracing-futures/examples/spawn_macro.rs
@@ -11,7 +11,7 @@ use futures::future::{self, Future};
 fn parent_task(how_many: usize) -> impl Future<Item = (), Error = ()> {
     future::lazy(move || {
         info!("spawning subtasks...");
-        for i in (1..=how_many) {
+        for i in 1..=how_many {
             debug!(message = "spawning subtask;", number = i);
             spawn!(subtask(i), number = i);
         }

--- a/tracing-futures/examples/task_counter.rs
+++ b/tracing-futures/examples/task_counter.rs
@@ -1,0 +1,262 @@
+//! A demonstration of how a subscriber might use the spans created by the
+//! `tokio_trace_futures::spawn!` macro to track the number of
+//! currently-executing tasks.
+//!
+//! Note that this subscriber implementation is not optimized for production
+//! use. It is intended only for demonstration purposes.
+
+extern crate futures;
+extern crate tokio;
+#[macro_use]
+extern crate tokio_trace;
+#[macro_use]
+extern crate tokio_trace_futures;
+
+use futures::future::{self, Future};
+
+use tokio_trace::{
+    field::{Field, Visit},
+    span,
+    subscriber::{self, Subscriber},
+    Event, Metadata,
+};
+
+use std::{
+    collections::HashMap,
+    cell::Cell,
+    fmt,
+    sync::{
+        atomic::{self, AtomicUsize, Ordering}, RwLock,
+    },
+};
+
+struct TaskCounter {
+    ids: AtomicUsize,
+    tasks: RwLock<HashMap<u64, ActiveTask>>,
+    task_list: RwLock<HashMap<&'static str, AtomicUsize>>,
+}
+
+struct ActiveTask {
+    name: &'static str,
+    ref_count: AtomicUsize,
+}
+
+thread_local! {
+    static CURRENT_TASK: Cell<Option<u64>> = Cell::new(None);
+}
+
+impl Subscriber for TaskCounter {
+    fn register_callsite(&self, meta: &Metadata) -> subscriber::Interest {
+        if meta.is_event() {
+            return subscriber::Interest::always();
+        }
+        let is_task = meta.fields().iter().any(|key| key.name().starts_with("tokio.task"));
+        if is_task {
+            let mut task_list = self.task_list.write().unwrap();
+            task_list.insert(meta.name(), AtomicUsize::new(0));
+            subscriber::Interest::always()
+        } else {
+            subscriber::Interest::never()
+        }
+    }
+
+    fn new_span(&self, new_span: &span::Attributes) -> span::Id {
+        let meta = new_span.metadata();
+        let task = ActiveTask {
+            name: meta.name(),
+            ref_count: AtomicUsize::from(1),
+        };
+        let id = self.ids.fetch_add(1, Ordering::SeqCst) as u64;
+
+        let task_list = self.task_list.read().unwrap();
+        task_list.get(meta.name()).map(|count| count.fetch_add(1, Ordering::Relaxed));
+
+        self.print_ctx(format_args!("task `{}` (id={}) spawned", meta.name(), id));
+        let mut tasks = self.tasks.write().unwrap();
+        tasks.insert(id, task);
+        span::Id::from_u64(id)
+    }
+
+    fn record_follows_from(&self, _: &span::Id, _: &span::Id) {
+        // unimplemented
+    }
+
+    fn record(&self, _: &span::Id, _: &span::Record) {
+        // unimplemented
+    }
+
+    fn event(&self, event: &Event) {
+        struct FmtEvent<'a>(&'a Event<'a>);
+        struct Recorder<'a, 'b> {
+            f: &'a mut fmt::Formatter<'b>,
+            pad: bool,
+        }
+        impl<'a> fmt::Display for FmtEvent<'a> {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                let mut rec = Recorder {
+                    f,
+                    pad: false,
+                };
+                self.0.record(&mut rec);
+                Ok(())
+            }
+        }
+
+        impl<'a, 'b> Visit for Recorder<'a, 'b> {
+            fn record_str(&mut self, field: &Field, value: &str) {
+                if field.name() == "message" {
+                    self.record_debug(field, &format_args!("{}", value))
+                } else {
+                    self.record_debug(field, &value)
+                }
+            }
+
+            fn record_debug(&mut self, field: &Field, value: &fmt::Debug) {
+                if self.pad {
+                    write!(self.f, "; ").unwrap();
+                }
+                if field.name() == "message" {
+                    write!(self.f, "{:?}", value).unwrap();
+                } else {
+                    write!(self.f, "{}={:?}", field, value).unwrap();
+                }
+                self.pad = true;
+            }
+        }
+
+        self.print_ctx(FmtEvent(event));
+    }
+
+    fn enabled(&self, meta: &Metadata) -> bool {
+        meta.is_event() || meta.fields().iter().any(|f| f.name().starts_with("tokio.task"))
+    }
+
+    fn enter(&self, span: &span::Id) {
+        CURRENT_TASK.with(|current| current.set(Some(span.into_u64())));
+    }
+
+    fn exit(&self, _span: &span::Id) {
+        CURRENT_TASK.with(|current| current.set(None));
+    }
+
+    fn clone_span(&self, span: &span::Id) -> span::Id {
+        let num = span.into_u64();
+        let tasks = self.tasks.read().unwrap();
+        if let Some(task) = tasks.get(&num) {
+            task.ref_count.fetch_add(1, Ordering::Relaxed);
+        }
+        span::Id::from_u64(num)
+    }
+
+    fn drop_span(&self, span: span::Id) {
+        let num = span.into_u64();
+        let is_closing = {
+            let tasks = match self.tasks.read() {
+                Ok(t) => t,
+                Err(_) => return, // don't panic in drop!
+            };
+            if let Some(task) = tasks.get(&num) {
+                task.ref_count.fetch_sub(1, Ordering::Relaxed) == 1
+            } else {
+                false
+            }
+        };
+        if is_closing {
+            atomic::fence(Ordering::Release);
+            if let Some(task) = self.tasks.write().ok().and_then(|mut tasks| tasks.remove(&num)) {
+                if let Ok(task_list) = self.task_list.read() {
+                    task_list.get(task.name).map(|count| count.fetch_sub(1, Ordering::Release));
+                }
+                self.print_ctx(format_args!("task `{}` (id={}) completed", task.name, num));
+            }
+        }
+    }
+}
+
+impl TaskCounter {
+    pub fn new() -> Self {
+        Self {
+            ids: AtomicUsize::from(1),
+            tasks: RwLock::new(HashMap::new()),
+            task_list: RwLock::new(HashMap::new()),
+        }
+    }
+
+    fn print_ctx(&self, msg: impl fmt::Display) {
+
+        static LONGEST: AtomicUsize = AtomicUsize::new(20);
+        let curr  = self.tasks.read().ok().and_then(|tasks| {
+            let id = CURRENT_TASK.try_with(|id| id.get()).ok()?;
+            id
+                .and_then(|id| Some((tasks.get(&id)?, id)))
+                .map(|(task, id)| format!("{} (id={})", task.name, id))
+                .or_else(|| Some(String::new()))
+        }).unwrap_or_else(|| String::from("panicking"));
+
+        let lock = self.task_list.read().ok();
+        let mut task_list = lock.iter().flat_map(|ts| ts.iter());
+        let mut counts = String::new();
+        if let Some((name, count)) = task_list.next() {
+            use fmt::Write;
+
+            write!(&mut counts, "{{ {}: {}", name, count.load(Ordering::Acquire)).unwrap();
+            for (name, count) in task_list {
+                write!(&mut counts, ", {}: {}", name, count.load(Ordering::Acquire)).unwrap();
+            }
+            write!(&mut counts, "}} ").unwrap();
+        }
+
+        let len = curr.len();
+        let longest = LONGEST.load(Ordering::Relaxed);
+        let padding = if len > longest {
+            LONGEST.store(len, Ordering::Relaxed);
+            len
+        } else {
+            longest
+        };
+
+        println!(
+            "{}{:<padding$} | {msg}",
+            counts,
+            curr,
+            padding = padding,
+            msg = msg,
+        );
+    }
+}
+
+fn main() {
+    fn parent_task(how_many: usize) -> impl Future<Item = (), Error = ()> {
+        future::lazy(move || {
+            // Since this span does not directly correspond to a spawned task,
+            // it will be ignored.
+            debug_span!("spawning subtasks", tasks = how_many).enter(|| {
+                for i in 1..=how_many {
+                    debug!(message = "spawning subtask", number = i);
+                    spawn!(subtask(i), number = i);
+                }
+            });
+
+            Ok(())
+        })
+        .map(|_| {
+            info!("all subtasks spawned");
+        })
+    }
+
+    fn subtask(number: usize) -> impl Future<Item = (), Error = ()> {
+        future::lazy(move || {
+            debug!("polling subtask...");
+            Ok(number)
+        })
+        .map(|i| trace!(i = i))
+    }
+
+    tokio_trace::subscriber::with_default(TaskCounter::new(), || {
+        tokio::run(future::lazy(|| {
+            spawn!(parent_task(10))
+        }))
+    });
+
+    // counters.print_counters();
+}

--- a/tracing-futures/examples/task_counter.rs
+++ b/tracing-futures/examples/task_counter.rs
@@ -254,7 +254,8 @@ fn main() {
 
     tokio_trace::subscriber::with_default(TaskCounter::new(), || {
         tokio::run(future::lazy(|| {
-            spawn!(parent_task(10))
+            spawn!(parent_task(10));
+            Ok(())
         }))
     });
 

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -37,6 +37,9 @@ use tracing::{Dispatch, Span};
 #[cfg(feature = "tokio")]
 pub mod executor;
 
+#[macro_use]
+pub mod macros;
+
 // TODO: seal?
 pub trait Instrument: Sized {
     fn instrument(self, span: Span) -> Instrumented<Self> {

--- a/tracing-futures/src/macros.rs
+++ b/tracing-futures/src/macros.rs
@@ -19,7 +19,7 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 /// in projects using `tokio-trace`.
 ///
 /// In order for a future to do work, it must be spawned on an executor. The
-/// `spawn!` macro spawns a future on the provided executor, or using the
+/// `$crate::spawn!` macro spawns a future on the provided executor, or using the
 /// [default executor] for the current execution context if none is provided.
 ///
 /// The default executor is **usually** a thread pool.
@@ -50,7 +50,7 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 ///     // ...
 /// #    Ok(())
 /// });
-/// spawn!(name: "my_future", fut);
+/// $crate::spawn!(name: "my_future", fut);
 /// # }
 ///  # fn main() {}
 /// ```
@@ -64,7 +64,7 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 /// # use futures::future;
 /// # fn doc() {
 /// # let fut = future::lazy(|| { Ok(()) });
-/// spawn!(target: "spawned_futures", fut);
+/// $crate::spawn!(target: "spawned_futures", fut);
 /// # }
 ///  # fn main() {}
 /// ```
@@ -80,7 +80,7 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 ///
 /// # fn doc() {
 /// # let fut = future::lazy(|| { Ok(()) });
-/// spawn!(level: Level::INFO, fut);
+/// $crate::spawn!(level: Level::INFO, fut);
 /// # }
 ///  # fn main() {}
 /// ```
@@ -96,7 +96,7 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 /// # use tracing::Level;
 /// # fn doc() {
 /// # let fut = future::lazy(|| { Ok(()) });
-/// spawn!(level: Level::WARN, target: "spawned_futures", name: "a_bad_future", fut);
+/// $crate::spawn!(level: Level::WARN, target: "spawned_futures", name: "a_bad_future", fut);
 /// # }
 /// # fn main() {}
 /// ```
@@ -111,7 +111,7 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 /// # use futures::future;
 /// # fn doc() {
 /// # let fut = future::lazy(|| { Ok(()) });
-/// spawn!(fut, foo = "bar", baz = 42);
+/// $crate::spawn!(fut, foo = "bar", baz = 42);
 /// # }
 ///  # fn main() {}
 /// ```
@@ -128,7 +128,7 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 ///         // ...
 ///         # Ok(())
 ///     });
-///     spawn!(fut, number = 1);
+///     $crate::spawn!(fut, number = 1);
 /// }
 /// # }
 /// # fn main() {}
@@ -136,7 +136,7 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 /// # Examples
 ///
 /// In this example, based on the example in the documentation for
-/// [`tokio::spawn`], a server is started and `spawn!` is used to start
+/// [`tokio::spawn`], a server is started and `$crate::spawn!` is used to start
 /// a new task that processes each received connection.
 ///
 /// ```rust
@@ -157,7 +157,7 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 /// let server = listener.incoming()
 ///     .map_err(|e| println!("error = {:?}", e))
 ///     .for_each(|socket| {
-///         spawn!(process(socket))
+///         $crate::spawn!(process(socket))
 ///     });
 ///
 /// tokio::run(server);
@@ -167,7 +167,7 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 ///
 /// # Providing an Executor
 ///
-/// By default, `spawn!` uses the [`DefaultExecutor`]. However, an alternative
+/// By default, `$crate::spawn!` uses the [`DefaultExecutor`]. However, an alternative
 /// executor can be provided using the `on:` macro field. For example,
 ///
 /// ```rust
@@ -185,7 +185,7 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 /// #    tokio::executor::DefaultExecutor::current()
 /// #}
 /// let my_executor = get_custom_executor();
-/// spawn!(name: "my_future", on: my_executor, fut);
+/// $crate::spawn!(name: "my_future", on: my_executor, fut);
 /// # }
 ///  # fn main() {}
 /// ```
@@ -204,6 +204,7 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 /// [`tokio::spawn`]: https://docs.rs/tokio/latest/tokio/executor/fn.spawn.html
 /// [`TRACE` verbosity level]: https://docs.rs/tokio-trace/latest/tracing/struct.Level.html#associatedconstant.TRACE
 #[cfg(any(feature = "tokio", feature = "tokio-executor"))]
+#[macro_export]
 macro_rules! spawn {
     (level: $lvl:expr, target: $tgt:expr, name: $name:expr, on:  $ex:expr, $fut:expr, $($field:tt)*) => {{
         use $crate::{Instrument, macros::__Executor};
@@ -218,7 +219,7 @@ macro_rules! spawn {
         $ex.spawn(Box::new($fut.instrument(span))).unwrap();
     }};
     (level: $lvl:expr, name: $name:expr, on:  $ex:expr, $fut:expr, $($field:tt)*) => {
-        spawn!(
+        $crate::spawn!(
             level: $lvl,
             target: module_path!(),
             name: $name,
@@ -228,10 +229,10 @@ macro_rules! spawn {
         )
     };
     (level: $lvl:expr, target: $tgt:expr, name: $name:expr, on:  $ex:expr, $fut:expr) => {
-        spawn!(level: $lvl, target: $tgt, name: $name, on:  $ex, $fut,)
+        $crate::spawn!(level: $lvl, target: $tgt, name: $name, on:  $ex, $fut,)
     };
     (level: $lvl:expr, target: $tgt:expr, on:  $ex:expr, $fut:expr, $($field:tt)*) => {
-        spawn!(
+        $crate::spawn!(
             level: $lvl,
             target: $tgt,
             name: stringify!($fut),
@@ -240,10 +241,10 @@ macro_rules! spawn {
         )
     };
     (level: $lvl:expr, name: $name:expr, on:  $ex:expr, $fut:expr) => {
-        spawn!(level: $lvl, name: $name, on:  $ex, $fut,)
+        $crate::spawn!(level: $lvl, name: $name, on:  $ex, $fut,)
     };
     (target: $tgt:expr, name: $name:expr, on:  $ex:expr, $fut:expr, $($field:tt)*) => {
-        spawn!(
+        $crate::spawn!(
             level: $crate::macros::Level::TRACE,
             target: $tgt,
             name: $name,
@@ -253,7 +254,7 @@ macro_rules! spawn {
         )
     };
     (target: $tgt:expr, on:  $ex:expr, $fut:expr, $($field:tt)*) => {
-        spawn!(
+        $crate::spawn!(
             level: $crate::macros::Level::TRACE,
             target: $tgt,
             on:  $ex,
@@ -262,7 +263,7 @@ macro_rules! spawn {
         )
     };
     (name: $name:expr, on:  $ex:expr, $fut:expr, $($field:tt)*) => {
-        spawn!(
+        $crate::spawn!(
             target: module_path!(),
             name: $name,
             on:  $ex,
@@ -271,10 +272,10 @@ macro_rules! spawn {
         )
     };
     (level: $lvl:expr, target: $tgt:expr, on:  $ex:expr, $fut:expr) => {
-        spawn!(level: $lvl, target: $tgt, on:  $ex, $fut,)
+        $crate::spawn!(level: $lvl, target: $tgt, on:  $ex, $fut,)
     };
     (target: $tgt:expr, name: $name:expr, on:  $ex:expr, $fut:expr) => {
-        spawn!(
+        $crate::spawn!(
             target: $tgt,
             name: $name,
             on:  $ex,
@@ -282,7 +283,7 @@ macro_rules! spawn {
         )
     };
     (level: $lvl:expr, on:  $ex:expr, $fut:expr) => {
-        spawn!(
+        $crate::spawn!(
             level: $lvl,
             name: stringify!($fut),
             on:  $ex,
@@ -290,13 +291,13 @@ macro_rules! spawn {
         )
     };
     (target: $tgt:expr, on:  $ex:expr, $fut:expr) => {
-        spawn!(target: $tgt, on:  $ex, $fut,)
+        $crate::spawn!(target: $tgt, on:  $ex, $fut,)
     };
     (name: $name:expr, on:  $ex:expr, $fut:expr) => {
-        spawn!(name: $name, on:  $ex, $fut,)
+        $crate::spawn!(name: $name, on:  $ex, $fut,)
     };
     (level: $lvl:expr, on:  $ex:expr, $fut:expr, $($field:tt)*) => {
-        spawn!(
+        $crate::spawn!(
             level: $lvl,
             target: module_path!(),
             name: stringify!($fut),
@@ -306,7 +307,7 @@ macro_rules! spawn {
         )
     };
     (on:  $ex:expr, $fut:expr, $($field:tt)*) => {
-        spawn!(
+        $crate::spawn!(
             name: stringify!($fut),
             on:  $ex,
             $fut,
@@ -314,13 +315,13 @@ macro_rules! spawn {
         )
     };
     (on:  $ex:expr, $fut:expr) => {
-        spawn!(on:  $ex, $fut,)
+        $crate::spawn!(on:  $ex, $fut,)
     };
 
     // === default executor ===
 
     (level: $lvl:expr, target: $tgt:expr, name: $name:expr, $fut:expr, $($field:tt)*) => {{
-        spawn!(
+        $crate::spawn!(
             level: $lvl,
             target: $tgt,
             name: $name,
@@ -330,7 +331,7 @@ macro_rules! spawn {
         )
     }};
     (level: $lvl:expr, name: $name:expr, $fut:expr, $($field:tt)*) => {
-        spawn!(
+        $crate::spawn!(
             level: $lvl,
             target: module_path!(),
             name: $name,
@@ -339,10 +340,10 @@ macro_rules! spawn {
         )
     };
     (level: $lvl:expr, target: $tgt:expr, name: $name:expr, $fut:expr) => {
-        spawn!(level: $lvl, target: $tgt, name: $name, $fut,)
+        $crate::spawn!(level: $lvl, target: $tgt, name: $name, $fut,)
     };
     (level: $lvl:expr, target: $tgt:expr, $fut:expr, $($field:tt)*) => {
-        spawn!(
+        $crate::spawn!(
             level: $lvl,
             target: $tgt,
             name: stringify!($fut),
@@ -351,10 +352,10 @@ macro_rules! spawn {
         )
     };
     (level: $lvl:expr, name: $name:expr, $fut:expr) => {
-        spawn!(level: $lvl, name: $name, $fut,)
+        $crate::spawn!(level: $lvl, name: $name, $fut,)
     };
     (target: $tgt:expr, name: $name:expr, $fut:expr, $($field:tt)*) => {
-        spawn!(
+        $crate::spawn!(
             level: $crate::macros::Level::TRACE,
             target: $tgt,
             name: $name,
@@ -363,7 +364,7 @@ macro_rules! spawn {
         )
     };
     (target: $tgt:expr, $fut:expr, $($field:tt)*) => {
-        spawn!(
+        $crate::spawn!(
             level: $crate::macros::Level::TRACE,
             target: $tgt,
             $fut,
@@ -371,7 +372,7 @@ macro_rules! spawn {
         )
     };
     (name: $name:expr, $fut:expr, $($field:tt)*) => {
-        spawn!(
+        $crate::spawn!(
             target: module_path!(),
             name: $name,
             $fut,
@@ -379,22 +380,22 @@ macro_rules! spawn {
         )
     };
     (level: $lvl:expr, target: $tgt:expr, $fut:expr) => {
-        spawn!(level: $lvl, target: $tgt, $fut,)
+        $crate::spawn!(level: $lvl, target: $tgt, $fut,)
     };
     (target: $tgt:expr, name: $name:expr, $fut:expr) => {
-        spawn!(target: $tgt, name: $name, $fut,)
+        $crate::spawn!(target: $tgt, name: $name, $fut,)
     };
     (level: $lvl:expr, $fut:expr) => {
-        spawn!(level: $lvl, name: stringify!($fut), $fut,)
+        $crate::spawn!(level: $lvl, name: stringify!($fut), $fut,)
     };
     (target: $tgt:expr, $fut:expr) => {
-        spawn!(target: $tgt, $fut,)
+        $crate::spawn!(target: $tgt, $fut,)
     };
     (name: $name:expr, $fut:expr) => {
-        spawn!(name: $name, $fut,)
+        $crate::spawn!(name: $name, $fut,)
     };
     (level: $lvl:expr, $fut:expr, $($field:tt)*) => {
-        spawn!(
+        $crate::spawn!(
             level: $lvl,
             target: module_path!(),
             name: stringify!($fut),
@@ -403,27 +404,11 @@ macro_rules! spawn {
         )
     };
     ($fut:expr, $($field:tt)*) => {
-        spawn!(name: stringify!($fut), $fut, $($field)*)
+        $crate::spawn!(name: stringify!($fut), $fut, $($field)*)
     };
 
     ($fut:expr) => {
-        spawn!($fut,)
+        $crate::spawn!($fut,)
     };
 
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! module_path {
-    () => {
-        module_path!()
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __tracing_futures_stringify {
-    ($ex:expr) => {
-        stringify!($ex)
-    };
 }

--- a/tracing-futures/src/macros.rs
+++ b/tracing-futures/src/macros.rs
@@ -16,10 +16,10 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 /// This macro behaves similarly to the [`tokio::spawn`] function, but the
 /// spawned future is instrumented with a new `tokio-trace` span prior to
 /// spawning. This macro may be used as a drop-in replacement for `tokio::spawn`
-/// in projects using `tokio-trace`.
+/// in projects using `tracing`.
 ///
 /// In order for a future to do work, it must be spawned on an executor. The
-/// `$crate::spawn!` macro spawns a future on the provided executor, or using the
+/// `spawn!` macro spawns a future on the provided executor, or using the
 /// [default executor] for the current execution context if none is provided.
 ///
 /// The default executor is **usually** a thread pool.
@@ -41,16 +41,13 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 /// Overriding the name of the span:
 ///
 /// ```rust
-/// # extern crate futures;
-/// #[macro_use]
-/// extern crate tracing_futures;
 /// # use futures::future;
 /// # fn doc() {
 /// let fut = future::lazy(|| {
 ///     // ...
 /// #    Ok(())
 /// });
-/// $crate::spawn!(name: "my_future", fut);
+/// tracing_futures::spawn!(name: "my_future", fut);
 /// # }
 ///  # fn main() {}
 /// ```
@@ -58,29 +55,22 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 /// Overriding the target:
 ///
 ///```rust
-/// # #[macro_use]
-/// # extern crate tracing_futures;
-/// # extern crate futures;
 /// # use futures::future;
 /// # fn doc() {
 /// # let fut = future::lazy(|| { Ok(()) });
-/// $crate::spawn!(target: "spawned_futures", fut);
+/// tracing_futures::spawn!(target: "spawned_futures", fut);
 /// # }
 ///  # fn main() {}
 /// ```
 /// Overriding the level:
 ///
 ///```rust
-/// # extern crate futures;
-/// # #[macro_use]
-/// # extern crate tracing_futures;
-/// # extern crate tracing;
 /// # use futures::future;
 /// use tracing::Level;
 ///
 /// # fn doc() {
 /// # let fut = future::lazy(|| { Ok(()) });
-/// $crate::spawn!(level: Level::INFO, fut);
+/// tracing_futures::spawn!(level: Level::INFO, fut);
 /// # }
 ///  # fn main() {}
 /// ```
@@ -88,15 +78,11 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 /// Any number of metadata items may be overridden:
 ///
 ///```rust
-/// # extern crate futures;
-/// # #[macro_use]
-/// # extern crate tracing_futures;
-/// # extern crate tracing;
 /// # use futures::future;
 /// # use tracing::Level;
 /// # fn doc() {
 /// # let fut = future::lazy(|| { Ok(()) });
-/// $crate::spawn!(level: Level::WARN, target: "spawned_futures", name: "a_bad_future", fut);
+/// tracing_futures::spawn!(level: Level::WARN, target: "spawned_futures", name: "a_bad_future", fut);
 /// # }
 /// # fn main() {}
 /// ```
@@ -104,14 +90,10 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 /// Adding fields to the span:
 ///
 ///```rust
-/// # extern crate futures;
-/// # #[macro_use]
-/// # extern crate tracing_futures;
-/// # extern crate tracing;
 /// # use futures::future;
 /// # fn doc() {
 /// # let fut = future::lazy(|| { Ok(()) });
-/// $crate::spawn!(fut, foo = "bar", baz = 42);
+/// tracing_futures::spawn!(fut, foo = "bar", baz = 42);
 /// # }
 ///  # fn main() {}
 /// ```
@@ -128,7 +110,7 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 ///         // ...
 ///         # Ok(())
 ///     });
-///     $crate::spawn!(fut, number = 1);
+///     tracing_futures::spawn!(fut, number = 1);
 /// }
 /// # }
 /// # fn main() {}
@@ -136,14 +118,10 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 /// # Examples
 ///
 /// In this example, based on the example in the documentation for
-/// [`tokio::spawn`], a server is started and `$crate::spawn!` is used to start
+/// [`tokio::spawn`], a server is started and `spawn!` is used to start
 /// a new task that processes each received connection.
 ///
 /// ```rust
-/// # extern crate tokio;
-/// # extern crate futures;
-/// #[macro_use]
-/// extern crate tracing_futures;
 /// # use futures::{Future, Stream};
 /// use tokio::net::TcpListener;
 ///
@@ -157,7 +135,8 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 /// let server = listener.incoming()
 ///     .map_err(|e| println!("error = {:?}", e))
 ///     .for_each(|socket| {
-///         $crate::spawn!(process(socket))
+///         tracing_futures::spawn!(process(socket));
+///         Ok(())
 ///     });
 ///
 /// tokio::run(server);
@@ -167,14 +146,10 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 ///
 /// # Providing an Executor
 ///
-/// By default, `$crate::spawn!` uses the [`DefaultExecutor`]. However, an alternative
+/// By default, `spawn!` uses the [`DefaultExecutor`]. However, an alternative
 /// executor can be provided using the `on:` macro field. For example,
 ///
 /// ```rust
-/// # extern crate futures;
-/// # extern crate tokio
-/// #[macro_use]
-/// extern crate tracing_futures;
 /// # use futures::future;
 /// # fn doc() {
 /// let fut = future::lazy(|| {
@@ -183,11 +158,11 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 /// });
 /// # fn get_custom_executor() -> tokio::executor::DefaultExecutor {
 /// #    tokio::executor::DefaultExecutor::current()
-/// #}
-/// let my_executor = get_custom_executor();
-/// $crate::spawn!(name: "my_future", on: my_executor, fut);
 /// # }
-///  # fn main() {}
+/// let mut my_executor = get_custom_executor();
+/// tracing_futures::spawn!(name: "my_future", on: my_executor, fut);
+/// # }
+/// # fn main() {}
 /// ```
 ///
 /// The executor that spawned the future is recorded in the
@@ -202,7 +177,7 @@ pub use tracing::{field::debug, span as __tracing_futures_span, Level};
 /// [default executor]: https://docs.rs/tokio/latest/tokio/executor/struct.DefaultExecutor.html
 /// [`DefaultExecutor`]: https://docs.rs/tokio/latest/tokio/executor/struct.DefaultExecutor.html
 /// [`tokio::spawn`]: https://docs.rs/tokio/latest/tokio/executor/fn.spawn.html
-/// [`TRACE` verbosity level]: https://docs.rs/tokio-trace/latest/tracing/struct.Level.html#associatedconstant.TRACE
+/// [`TRACE` verbosity level]: https://docs.rs/tracing/latest/tracing/struct.Level.html#associatedconstant.TRACE
 #[cfg(any(feature = "tokio", feature = "tokio-executor"))]
 #[macro_export]
 macro_rules! spawn {
@@ -314,7 +289,7 @@ macro_rules! spawn {
             $($field)*,
         )
     };
-    (on:  $ex:expr, $fut:expr) => {
+    (on: $ex:expr, $fut:expr) => {
         $crate::spawn!(on:  $ex, $fut,)
     };
 

--- a/tracing-futures/src/macros.rs
+++ b/tracing-futures/src/macros.rs
@@ -44,7 +44,7 @@ pub use tracing::{span as __span, Level as __Level};
 /// ```rust
 /// # extern crate futures;
 /// #[macro_use]
-/// extern crate tokio_trace_futures;
+/// extern crate tracing_futures;
 /// # use futures::future;
 /// # fn main() {
 /// let fut = future::lazy(|| {
@@ -60,7 +60,7 @@ pub use tracing::{span as __span, Level as __Level};
 ///```rust
 /// # extern crate futures;
 /// # #[macro_use]
-/// # extern crate tokio_trace_futures;
+/// # extern crate tracing_futures;
 /// # use futures::future;
 /// # fn main() {
 /// # let fut = future::lazy(|| { Ok(()) });
@@ -72,10 +72,10 @@ pub use tracing::{span as __span, Level as __Level};
 ///```rust
 /// # extern crate futures;
 /// # #[macro_use]
-/// # extern crate tokio_trace_futures;
-/// # extern crate tokio_trace;
+/// # extern crate tracing_futures;
+/// # extern crate tracing;
 /// # use futures::future;
-/// use tokio_trace::Level;
+/// use tracing::Level;
 ///
 /// # fn main() {
 /// # let fut = future::lazy(|| { Ok(()) });
@@ -88,10 +88,10 @@ pub use tracing::{span as __span, Level as __Level};
 ///```rust
 /// # extern crate futures;
 /// # #[macro_use]
-/// # extern crate tokio_trace_futures;
-/// # extern crate tokio_trace;
+/// # extern crate tracing_futures;
+/// # extern crate tracing;
 /// # use futures::future;
-/// # use tokio_trace::Level;
+/// # use tracing::Level;
 /// # fn main() {
 /// # let fut = future::lazy(|| { Ok(()) });
 /// spawn!(level: Level::WARN, target: "spawned_futures", name: "a_bad_future", fut);
@@ -103,8 +103,8 @@ pub use tracing::{span as __span, Level as __Level};
 ///```rust
 /// # extern crate futures;
 /// # #[macro_use]
-/// # extern crate tokio_trace_futures;
-/// # extern crate tokio_trace;
+/// # extern crate tracing_futures;
+/// # extern crate tracing;
 /// # use futures::future;
 /// # fn main() {
 /// # let fut = future::lazy(|| { Ok(()) });
@@ -115,8 +115,8 @@ pub use tracing::{span as __span, Level as __Level};
 ///```rust
 /// # extern crate futures;
 /// # #[macro_use]
-/// # extern crate tokio_trace_futures;
-/// # extern crate tokio_trace;
+/// # extern crate tracing_futures;
+/// # extern crate tracing;
 /// # use futures::future;
 /// # fn main() {
 /// for i in 0..10 {
@@ -139,7 +139,7 @@ pub use tracing::{span as __span, Level as __Level};
 /// # extern crate tokio;
 /// # extern crate futures;
 /// #[macro_use]
-/// extern crate tokio_trace_futures;
+/// extern crate tracing_futures;
 /// # use futures::{Future, Stream};
 /// use tokio::net::TcpListener;
 ///
@@ -170,14 +170,14 @@ pub use tracing::{span as __span, Level as __Level};
 /// [default executor]: https://docs.rs/tokio/latest/tokio/executor/struct.DefaultExecutor.html
 /// [`DefaultExecutor`]: https://docs.rs/tokio/latest/tokio/executor/struct.DefaultExecutor.html
 /// [`tokio::spawn`]: https://docs.rs/tokio/latest/tokio/executor/fn.spawn.html
-/// [`TRACE` verbosity level]: https://docs.rs/tokio-trace/latest/tokio_trace/struct.Level.html#associatedconstant.TRACE
+/// [`TRACE` verbosity level]: https://docs.rs/tokio-trace/latest/tracing/struct.Level.html#associatedconstant.TRACE
 #[cfg(any(feature = "tokio", feature = "tokio-executor"))]
 #[macro_export(inner_local_macros)]
 macro_rules! spawn {
     (level: $lvl:expr, target: $tgt:expr, name: $name:expr, $fut:expr, $($field:tt)*) => {{
         use $crate::macros::__spawn;
         use $crate::Instrument;
-        let span = $crate::macros::__span!(
+        let span = __tracing_futures_span!(
             $lvl,
             target: $tgt,
             $name,
@@ -190,7 +190,7 @@ macro_rules! spawn {
     (level: $lvl:expr, name: $name:expr, $fut:expr, $($field:tt)*) => {
         spawn!(
             level: $lvl,
-            target: __tokio_trace_futures_module_path!(),
+            target: __tracing_futures_module_path!(),
             name: $name,
             $fut,
             $($field)*
@@ -200,7 +200,7 @@ macro_rules! spawn {
         spawn!(
             level: $lvl,
             target: $tgt,
-            name: __tokio_trace_futures_stringify!($fut),
+            name: __tracing_futures_stringify!($fut),
             $fut,
             $($field)*
         )
@@ -256,6 +256,7 @@ macro_rules! spawn {
     };
 }
 
+#[cfg(any(feature = "tokio", feature = "tokio-executor"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __tracing_futures_module_path {
@@ -264,10 +265,20 @@ macro_rules! __tracing_futures_module_path {
     };
 }
 
+#[cfg(any(feature = "tokio", feature = "tokio-executor"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __tracing_futures_stringify {
     ($ex:expr) => {
         stringify!($ex)
+    };
+}
+
+#[cfg(any(feature = "tokio", feature = "tokio-executor"))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __tracing_futures_span {
+    ($lvl:expr, target: $tgt:expr, $name:expr, $($field:tt)*) => {
+        span!($lvl, target: $tgt, $name, $($field)*)
     };
 }

--- a/tracing-futures/src/macros.rs
+++ b/tracing-futures/src/macros.rs
@@ -209,8 +209,8 @@ macro_rules! spawn {
     (level: $lvl:expr, target: $tgt:expr, name: $name:expr, on:  $ex:expr, $fut:expr, $($field:tt)*) => {{
         use $crate::{Instrument, macros::__Executor};
         let span = $crate::macros::__tracing_futures_span!(
-            $lvl,
             target: $tgt,
+            $lvl,
             $name,
             tokio.task.is_spawned = true,
             tokio.task.executor = ?$ex,

--- a/tracing-futures/src/macros.rs
+++ b/tracing-futures/src/macros.rs
@@ -12,20 +12,43 @@ pub use tracing::{span as __span, Level as __Level};
 #[cfg(any(feature = "tokio", feature = "tokio-executor"))]
 #[macro_export(inner_local_macros)]
 macro_rules! spawn {
-    (level: $lvl:expr, target: $tgt:expr, name: $name:expr, $fut:expr) => {
-        spawn!(level: $lvl, target: $tgt, name: $name, $fut,)
-    };
     (level: $lvl:expr, target: $tgt:expr, name: $name:expr, $fut:expr, $($field:tt)*) => {{
         use $crate::macros::__spawn;
         use $crate::Instrument;
         let fut = Box::new($fut.instrument($crate::macros::__span!($lvl, target: $tgt, $name, $($field)*)));
         __spawn(fut)
     }};
+    (level: $lvl:expr, name: $name:expr, $fut:expr, $($field:tt)*) => {
+        spawn!(
+            level: $lvl,
+            target: __tokio_trace_futures_module_path!(),
+            name: $name,
+            $fut,
+            $($field)*
+        )
+    };
+    (level: $lvl:expr, target: $tgt:expr, $fut:expr, $($field:tt)*) => {
+        spawn!(
+            level: $lvl,
+            target: $tgt,
+            name: __tokio_trace_futures_stringify!($fut),
+            $fut,
+            $($field)*
+        )
+    };
     (target: $tgt:expr, name: $name:expr, $fut:expr, $($field:tt)*) => {
         spawn!(
             level: $crate::macros::__Level::TRACE,
             target: $tgt,
             name: $name,
+            $fut,
+            $($field)*
+        )
+    };
+    (target: $tgt:expr, $fut:expr, $($field:tt)*) => {
+        spawn!(
+            level: $crate::macros::__Level::TRACE,
+            target: $tgt,
             $fut,
             $($field)*
         )
@@ -41,12 +64,23 @@ macro_rules! spawn {
     ($fut:expr, $($field:tt)*) => {
         spawn!(name: __tracing_futures_stringify!($fut), $fut, $($field)*)
     };
+    (level: $lvl:expr, target: $tgt:expr, name: $name:expr, $fut:expr) => {
+        spawn!(level: $lvl, target: $tgt, name: $name, $fut,)
+    };
+    (level: $lvl:expr, name: $name:expr, $fut:expr) => {
+        spawn!(level: $lvl, name: $name, $fut,)
+    };
+    (level: $lvl:expr, target: $tgt:expr, $fut:expr) => {
+        spawn!(level: $lvl, target: $tgt, $fut,)
+    };
     (target: $tgt:expr, name: $name:expr, $fut:expr) => {
         spawn!(target: $tgt, name: $name, $fut,)
     };
+    (target: $tgt:expr, $fut:expr) => {
+        spawn!(target: $tgt, $fut,)
+    };
     (name: $name:expr, $fut:expr) => {
-        spawn!(name: $name, $fut
-        )
+        spawn!(name: $name, $fut,)
     };
     ($fut:expr) => {
         spawn!($fut,)

--- a/tracing-futures/src/macros.rs
+++ b/tracing-futures/src/macros.rs
@@ -7,7 +7,7 @@ pub use tokio_executor::spawn as __spawn;
 
 #[cfg(any(feature = "tokio", feature = "tokio-executor"))]
 #[doc(hidden)]
-pub use tracing::{span as __span, Level as __Level};
+pub use tracing::{span as __tracing_futures_span, Level as __Level};
 
 /// Spawns a future on the default executor, instrumented with its own span.
 ///
@@ -177,7 +177,7 @@ macro_rules! spawn {
     (level: $lvl:expr, target: $tgt:expr, name: $name:expr, $fut:expr, $($field:tt)*) => {{
         use $crate::macros::__spawn;
         use $crate::Instrument;
-        let span = __tracing_futures_span!(
+        let span = $crate::macros::__tokio_trace_futures_span!(
             $lvl,
             target: $tgt,
             $name,
@@ -256,7 +256,6 @@ macro_rules! spawn {
     };
 }
 
-#[cfg(any(feature = "tokio", feature = "tokio-executor"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __tracing_futures_module_path {
@@ -265,20 +264,10 @@ macro_rules! __tracing_futures_module_path {
     };
 }
 
-#[cfg(any(feature = "tokio", feature = "tokio-executor"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __tracing_futures_stringify {
     ($ex:expr) => {
         stringify!($ex)
-    };
-}
-
-#[cfg(any(feature = "tokio", feature = "tokio-executor"))]
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __tracing_futures_span {
-    ($lvl:expr, target: $tgt:expr, $name:expr, $($field:tt)*) => {
-        span!($lvl, target: $tgt, $name, $($field)*)
     };
 }

--- a/tracing-futures/src/macros.rs
+++ b/tracing-futures/src/macros.rs
@@ -1,0 +1,70 @@
+#[cfg(feature = "tokio")]
+#[doc(hidden)]
+pub use tokio::spawn as __spawn;
+#[cfg(all(feature = "tokio-executor", not(feature = "tokio")))]
+#[doc(hidden)]
+pub use tokio_executor::spawn as __spawn;
+
+#[cfg(any(feature = "tokio", feature = "tokio-executor"))]
+#[doc(hidden)]
+pub use tracing::{span as __span, Level as __Level};
+
+#[cfg(any(feature = "tokio", feature = "tokio-executor"))]
+#[macro_export(inner_local_macros)]
+macro_rules! spawn {
+    (level: $lvl:expr, target: $tgt:expr, name: $name:expr, $fut:expr) => {
+        spawn!(level: $lvl, target: $tgt, name: $name, $fut,)
+    };
+    (level: $lvl:expr, target: $tgt:expr, name: $name:expr, $fut:expr, $($field:tt)*) => {{
+        use $crate::macros::__spawn;
+        use $crate::Instrument;
+        let fut = Box::new($fut.instrument($crate::macros::__span!($lvl, target: $tgt, $name, $($field)*)));
+        __spawn(fut)
+    }};
+    (target: $tgt:expr, name: $name:expr, $fut:expr, $($field:tt)*) => {
+        spawn!(
+            level: $crate::macros::__Level::TRACE,
+            target: $tgt,
+            name: $name,
+            $fut,
+            $($field)*
+        )
+    };
+    (name: $name:expr, $fut:expr, $($field:tt)*) => {
+        spawn!(
+            target: __tracing_futures_module_path!(),
+            name: $name,
+            $fut,
+            $($field)*
+        )
+    };
+    ($fut:expr, $($field:tt)*) => {
+        spawn!(name: __tracing_futures_stringify!($fut), $fut, $($field)*)
+    };
+    (target: $tgt:expr, name: $name:expr, $fut:expr) => {
+        spawn!(target: $tgt, name: $name, $fut,)
+    };
+    (name: $name:expr, $fut:expr) => {
+        spawn!(name: $name, $fut
+        )
+    };
+    ($fut:expr) => {
+        spawn!($fut,)
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __tracing_futures_module_path {
+    () => {
+        module_path!()
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __tracing_futures_stringify {
+    ($ex:expr) => {
+        stringify!($ex)
+    };
+}


### PR DESCRIPTION
Depends on #57.

This branch adds a macro, `spawn!`, to the `tokio-trace-futures` crate.
This macro behaves analogously to `tokio::spawn`, but instruments the
spawned future in its own span prior to spawning it. 

Default values for the span constructed by `spawn!` are provided in
order to allow `tokio_trace_futures::spawn!` to be dropped in in place
of `tokio::spawn` as easily as possible. However, the span's metadata
may also be customized and fields may be added to it. 

The span constructed by `spawn!` will have a special 
`tokio.task.is_spawned = true` field added, to indicate to the 
subscriber that it  corresponds to a spawned task. In the future, I 
suspect we will likely be able to add additional per-task information
in fields namespaced under `tokio.task.`. In addition, I've added an 
example showing a subscriber that tracks active tasks, which I hope 
will inspire future work in this area.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>