### PR TITLE
Update nursery crates to use trace 0.2

### DIFF
--- a/tokio-trace-env-logger/Cargo.toml
+++ b/tokio-trace-env-logger/Cargo.toml
@@ -9,7 +9,7 @@ env_logger = "0.5"
 log = "0.4"
 
 [dev-dependencies]
-tokio-trace = "0.1.0"
+tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
 tokio-trace-fmt = { path = "../tokio-trace-fmt" }
 tokio-trace-futures = { path = "../tokio-trace-futures" }
 tokio-trace-subscriber = { path = "../tokio-trace-subscriber" }

--- a/tokio-trace-env-logger/examples/hyper-echo.rs
+++ b/tokio-trace-env-logger/examples/hyper-echo.rs
@@ -21,101 +21,99 @@ use tokio_trace_futures::{Instrument, Instrumented};
 type BoxFut = Box<Future<Item = Response<Body>, Error = hyper::Error> + Send>;
 
 fn echo(req: Request<Body>) -> Instrumented<BoxFut> {
-    span!(
+    let span = span!(
         Level::TRACE,
         "request",
         method = &field::debug(req.method()),
         uri = &field::debug(req.uri()),
         headers = &field::debug(req.headers())
-    )
-    .enter(|| {
-        info!("received request");
-        let mut response = Response::new(Body::empty());
+    );
+    let _enter = span.enter();
+    info!("received request");
+    let mut response = Response::new(Body::empty());
 
-        let (rsp_span, fut): (_, BoxFut) = match (req.method(), req.uri().path()) {
-            // Serve some instructions at /
-            (&Method::GET, "/") => {
-                const BODY: &'static str = "Try POSTing data to /echo";
-                *response.body_mut() = Body::from(BODY);
-                (
-                    span!(Level::TRACE, "response", body = &field::display(&BODY)),
-                    Box::new(future::ok(response)),
-                )
-            }
+    let (rsp_span, fut): (_, BoxFut) = match (req.method(), req.uri().path()) {
+        // Serve some instructions at /
+        (&Method::GET, "/") => {
+            const BODY: &'static str = "Try POSTing data to /echo";
+            *response.body_mut() = Body::from(BODY);
+            (
+                span!(Level::TRACE, "response", body = &field::display(&BODY)),
+                Box::new(future::ok(response)),
+            )
+        }
 
-            // Simply echo the body back to the client.
-            (&Method::POST, "/echo") => {
-                let body = req.into_body();
-                let span = span!(Level::TRACE, "response", response_kind = &"echo");
-                *response.body_mut() = body;
-                (span, Box::new(future::ok(response)))
-            }
+        // Simply echo the body back to the client.
+        (&Method::POST, "/echo") => {
+            let body = req.into_body();
+            let span = span!(Level::TRACE, "response", response_kind = &"echo");
+            *response.body_mut() = body;
+            (span, Box::new(future::ok(response)))
+        }
 
-            // Convert to uppercase before sending back to client.
-            (&Method::POST, "/echo/uppercase") => {
-                let mapping = req.into_body().map(|chunk| {
-                    let upper = chunk
-                        .iter()
-                        .map(|byte| byte.to_ascii_uppercase())
-                        .collect::<Vec<u8>>();
-                    debug!(
-                        {
-                            chunk = field::debug(str::from_utf8(&chunk[..])),
-                            uppercased = field::debug(str::from_utf8(&upper[..]))
-                        },
-                        "uppercased request body"
-                    );
-                    upper
-                });
+        // Convert to uppercase before sending back to client.
+        (&Method::POST, "/echo/uppercase") => {
+            let mapping = req.into_body().map(|chunk| {
+                let upper = chunk
+                    .iter()
+                    .map(|byte| byte.to_ascii_uppercase())
+                    .collect::<Vec<u8>>();
+                debug!(
+                    {
+                        chunk = field::debug(str::from_utf8(&chunk[..])),
+                        uppercased = field::debug(str::from_utf8(&upper[..]))
+                    },
+                    "uppercased request body"
+                );
+                upper
+            });
 
-                *response.body_mut() = Body::wrap_stream(mapping);
-                (
-                    span!(Level::TRACE, "response", response_kind = "uppercase"),
-                    Box::new(future::ok(response)),
-                )
-            }
+            *response.body_mut() = Body::wrap_stream(mapping);
+            (
+                span!(Level::TRACE, "response", response_kind = "uppercase"),
+                Box::new(future::ok(response)),
+            )
+        }
 
-            // Reverse the entire body before sending back to the client.
-            //
-            // Since we don't know the end yet, we can't simply stream
-            // the chunks as they arrive. So, this returns a different
-            // future, waiting on concatenating the full body, so that
-            // it can be reversed. Only then can we return a `Response`.
-            (&Method::POST, "/echo/reversed") => {
-                let mut span = span!(Level::TRACE, "response", response_kind = "reversed");
-                let reversed = span.enter(|| {
-                    req.into_body().concat2().map(move |chunk| {
-                        let body = chunk.iter().rev().cloned().collect::<Vec<u8>>();
-                        debug!(
-                            {
-                                chunk = field::debug(str::from_utf8(&chunk[..])),
-                                body = field::debug(str::from_utf8(&body[..]))
-                            },
-                            "reversed request body");
-                        *response.body_mut() = Body::from(body);
-                        response
-                    })
-                });
-                (span, Box::new(reversed))
-            }
+        // Reverse the entire body before sending back to the client.
+        //
+        // Since we don't know the end yet, we can't simply stream
+        // the chunks as they arrive. So, this returns a different
+        // future, waiting on concatenating the full body, so that
+        // it can be reversed. Only then can we return a `Response`.
+        (&Method::POST, "/echo/reversed") => {
+            let mut span = span!(Level::TRACE, "response", response_kind = "reversed");
+            let _enter = span.enter();
+            let reversed = req.into_body().concat2().map(move |chunk| {
+                let body = chunk.iter().rev().cloned().collect::<Vec<u8>>();
+                debug!(
+                    {
+                        chunk = ?str::from_utf8(&chunk[..]),
+                        body = ?str::from_utf8(&body[..])
+                    },
+                    "reversed request body");
+                *response.body_mut() = Body::from(body);
+                response
+            });
+            (span.clone(), Box::new(reversed))
+        }
 
-            // The 404 Not Found route...
-            _ => {
-                *response.status_mut() = StatusCode::NOT_FOUND;
-                (
-                    span!(
-                        Level::TRACE,
-                        "response",
-                        body = &field::debug(()),
-                        status = &field::debug(&StatusCode::NOT_FOUND)
-                    ),
-                    Box::new(future::ok(response)),
-                )
-            }
-        };
+        // The 404 Not Found route...
+        _ => {
+            *response.status_mut() = StatusCode::NOT_FOUND;
+            (
+                span!(
+                    Level::TRACE,
+                    "response",
+                    body = &field::debug(()),
+                    status = &field::debug(&StatusCode::NOT_FOUND)
+                ),
+                Box::new(future::ok(response)),
+            )
+        }
+    };
 
-        fut.instrument(rsp_span)
-    })
+    fut.instrument(rsp_span)
 }
 
 fn main() {
@@ -124,7 +122,8 @@ fn main() {
 
     tokio_trace::subscriber::with_default(subscriber, || {
         let addr: ::std::net::SocketAddr = ([127, 0, 0, 1], 3000).into();
-        let server_span = span!(Level::TRACE, "server", local = &field::debug(addr));
+        let server_span = span!(Level::TRACE, "server", local = %addr);
+        let _enter = server_span.enter();
         let server = tokio::net::TcpListener::bind(&addr)
             .expect("bind")
             .incoming()
@@ -132,7 +131,7 @@ fn main() {
                 let span = span!(
                     Level::TRACE,
                     "connection",
-                    remote = &field::debug(&sock.peer_addr().unwrap())
+                    remote = %sock.peer_addr().unwrap()
                 );
                 hyper::rt::spawn(
                     http.serve_connection(sock, service_fn(echo))
@@ -148,9 +147,7 @@ fn main() {
                 error!({ error = field::display(e) }, "server error");
             })
             .instrument(server_span.clone());
-        server_span.enter(|| {
-            info!("listening...");
-            hyper::rt::run(server);
-        });
+        info!("listening...");
+        hyper::rt::run(server);
     })
 }

--- a/tokio-trace-fmt/Cargo.toml
+++ b/tokio-trace-fmt/Cargo.toml
@@ -17,4 +17,4 @@ parking_lot = { version = "0.7"}
 lock_api = "0.1"
 
 [dev-dependencies]
-tokio-trace = "0.1.0"
+tokio-trace = { git = "https://github.com/tokio-rs/tokio" }

--- a/tokio-trace-fmt/examples/yak_shave.rs
+++ b/tokio-trace-fmt/examples/yak_shave.rs
@@ -5,19 +5,19 @@ extern crate tokio_trace_fmt;
 use tokio_trace::Level;
 
 fn shave(yak: usize) -> bool {
-    span!(Level::TRACE, "shave", yak = yak).enter(|| {
-        debug!(
-            message = "hello! I'm gonna shave a yak.",
-            excitement = "yay!"
-        );
-        if yak == 3 {
-            warn!(target: "yak_events", "could not locate yak!");
-            false
-        } else {
-            trace!(target: "yak_events", "yak shaved successfully");
-            true
-        }
-    })
+    let span = span!(Level::TRACE, "shave", yak = yak);
+    let _e = span.enter();
+    debug!(
+        message = "hello! I'm gonna shave a yak.",
+        excitement = "yay!"
+    );
+    if yak == 3 {
+        warn!(target: "yak_events", "could not locate yak!");
+        false
+    } else {
+        trace!(target: "yak_events", "yak shaved successfully");
+        true
+    }
 }
 
 fn main() {
@@ -28,7 +28,7 @@ fn main() {
         let mut number_shaved = 0;
         debug!("preparing to shave {} yaks", number_of_yaks);
 
-        span!(Level::TRACE, "shaving_yaks", yaks_to_shave = number_of_yaks).enter(|| {
+        span!(Level::TRACE, "shaving_yaks", yaks_to_shave = number_of_yaks).in_scope(|| {
             info!("shaving yaks");
 
             for yak in 1..=number_of_yaks {

--- a/tokio-trace-fmt/src/filter/reload.rs
+++ b/tokio-trace-fmt/src/filter/reload.rs
@@ -16,7 +16,7 @@ where
     _f: PhantomData<fn(N)>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Handle<F, N>
 where
     F: Filter<N>,
@@ -113,6 +113,18 @@ where
         })?;
         let inner = inner.read();
         Ok(f(&*inner))
+    }
+}
+
+impl<F, N> Clone for Handle<F, N>
+where
+    F: Filter<N>,
+{
+    fn clone(&self) -> Self {
+        Handle {
+            inner: self.inner.clone(),
+            _f: PhantomData,
+        }
     }
 }
 

--- a/tokio-trace-fmt/src/filter/reload.rs
+++ b/tokio-trace-fmt/src/filter/reload.rs
@@ -94,8 +94,7 @@ where
         })?;
         let mut inner = inner.write();
         f(&mut *inner);
-        // TODO(eliza): When tokio-rs/tokio#1039 lands, this is where we would
-        // invalidate the callsite cache.
+        tokio_trace::callsite::rebuild_interest_cache();
         Ok(())
     }
 

--- a/tokio-trace-futures/Cargo.toml
+++ b/tokio-trace-futures/Cargo.toml
@@ -8,7 +8,7 @@ default = ["tokio"]
 
 [dependencies]
 futures = "0.1"
-tokio-trace = "0.1.0"
+tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
 tokio = { version = "0.1", optional = true }
 tokio-executor = { version = "0.1", optional = true }
 

--- a/tokio-trace-futures/src/executor.rs
+++ b/tokio-trace-futures/src/executor.rs
@@ -4,12 +4,11 @@ use futures::{
 };
 use {Instrument, Instrumented, WithDispatch};
 
-#[cfg(all(feature = "tokio", not(feature = "tokio-executor")))]
-use tokio::executor::{Executor as TokioExecutor, SpawnError};
 #[cfg(feature = "tokio")]
-use tokio::runtime::{current_thread, Runtime, TaskExecutor};
-#[cfg(feature = "tokio-executor")]
-use tokio_executor::{Executor as TokioExecutor, SpawnError};
+use tokio::{
+    executor::{Executor as TokioExecutor, SpawnError},
+    runtime::{current_thread, Runtime, TaskExecutor},
+};
 
 macro_rules! deinstrument_err {
     ($e:expr) => {
@@ -32,7 +31,7 @@ where
     }
 }
 
-#[cfg(any(feature = "tokio", feature = "tokio-executor"))]
+#[cfg(feature = "tokio")]
 impl<T> TokioExecutor for Instrumented<T>
 where
     T: TokioExecutor,
@@ -177,7 +176,7 @@ where
     }
 }
 
-#[cfg(any(feature = "tokio", feature = "tokio-executor"))]
+#[cfg(feature = "tokio")]
 impl<T> TokioExecutor for WithDispatch<T>
 where
     T: TokioExecutor,

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -65,9 +65,8 @@ impl<T: Future> Future for Instrumented<T> {
     type Error = T::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let span = &mut self.span;
-        let inner = &mut self.inner;
-        span.enter(|| inner.poll())
+        let _enter = self.span.enter();
+        self.inner.poll()
     }
 }
 
@@ -76,9 +75,8 @@ impl<T: Stream> Stream for Instrumented<T> {
     type Error = T::Error;
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        let span = &mut self.span;
-        let inner = &mut self.inner;
-        span.enter(|| inner.poll())
+        let _enter = self.span.enter();
+        self.inner.poll()
     }
 }
 
@@ -87,15 +85,13 @@ impl<T: Sink> Sink for Instrumented<T> {
     type SinkError = T::SinkError;
 
     fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Self::SinkError> {
-        let span = &mut self.span;
-        let inner = &mut self.inner;
-        span.enter(|| inner.start_send(item))
+        let _enter = self.span.enter();
+        self.inner.start_send(item)
     }
 
     fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
-        let span = &mut self.span;
-        let inner = &mut self.inner;
-        span.enter(|| inner.poll_complete())
+        let _enter = self.span.enter();
+        self.inner.poll_complete()
     }
 }
 

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -274,11 +274,11 @@ mod tests {
             .run_with_handle();
         let mut runtime = tokio::runtime::Runtime::new().unwrap();
         with_default(subscriber, || {
-            span!(Level::TRACE, "a").enter(|| {
+            span!(Level::TRACE, "a").in_scope(|| {
                 let future = PollN::new_ok(2)
                     .instrument(span!(Level::TRACE, "b"))
                     .map(|_| {
-                        span!(Level::TRACE, "c").enter(|| {
+                        span!(Level::TRACE, "c").in_scope(|| {
                             // "c" happens _outside_ of the instrumented future's
                             // spab, so we don't expect it.
                         })

--- a/tokio-trace-log/Cargo.toml
+++ b/tokio-trace-log/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.0.1"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
-tokio-trace = "0.1.0"
+tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
 tokio-trace-subscriber = { path = "../tokio-trace-subscriber" }
 log = "0.4"

--- a/tokio-trace-macros/Cargo.toml
+++ b/tokio-trace-macros/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
-tokio-trace = "0.1.0"
+tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
 
 [dev-dependencies]
 tokio-trace-log = { path = "../tokio-trace-log" }

--- a/tokio-trace-macros/src/lib.rs
+++ b/tokio-trace-macros/src/lib.rs
@@ -32,11 +32,11 @@ macro_rules! dbg {
             Event, Id, Subscriber,
         };
         let callsite = callsite! {
-            name: concat!("event:trace_dbg(", stringify!($ex), ")"),
+            name: stringify!($ex),
             kind: tokio_trace::metadata::Kind::EVENT,
             target: $target,
             level: $level,
-            fields: $ex
+            fields: value,
         };
         let val = $ex;
         if is_enabled!(callsite) {

--- a/tokio-trace-proc-macros/Cargo.toml
+++ b/tokio-trace-proc-macros/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Eliza Weisman <eliza@buoyant.io>", "David Barsky <dbarsky@amazon.com
 proc-macro = true
 
 [dependencies]
-tokio-trace = "0.1.0"
+tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
 syn = { version = "0.15", features = ["full", "extra-traits"] }
 quote = "0.6"
 proc-macro2 = { version = "0.4", features = ["nightly"] }

--- a/tokio-trace-proc-macros/examples/basic.rs
+++ b/tokio-trace-proc-macros/examples/basic.rs
@@ -18,13 +18,12 @@ fn main() {
             "Getting rec from another function.",
             number_of_recs = &num
         );
-        span.enter(|| {
-            let band = suggest_band();
-            info!(
-                { band_recommendation = field::display(&band) },
-                "Got a rec."
-            );
-        });
+        let _enter = span.enter();
+        let band = suggest_band();
+        info!(
+            { band_recommendation = field::display(&band) },
+            "Got a rec."
+        );
     });
 }
 

--- a/tokio-trace-proc-macros/src/lib.rs
+++ b/tokio-trace-proc-macros/src/lib.rs
@@ -52,15 +52,14 @@ pub fn trace(_args: TokenStream, item: TokenStream) -> TokenStream {
     quote_spanned!(call_site=>
         #(#attrs) *
         #vis #constness #unsafety #asyncness #abi fn #ident(#params) #return_type {
-            span!(
+            let __tokio_trace_attr_span = span!(
                 tokio_trace::Level::TRACE,
                 #ident_str,
                 traced_function = &#ident_str
                 #(, #param_names = tokio_trace::field::debug(&#param_names_clone)),*
-            )
-            .enter(move || {
-                #block
-            })
+            );
+            let __tokio_trace_attr_guard = __tokio_trace_attr_span.enter();
+            #block
         }
     )
     .into()

--- a/tokio-trace-slog/Cargo.toml
+++ b/tokio-trace-slog/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["David Barsky <dbarsky@amazon.com>"]
 
 [dependencies]
-tokio-trace = "0.1.0"
+tokio-trace = { git = "https://github.com/tokio-rs/tokio" }

--- a/tokio-trace-subscriber/Cargo.toml
+++ b/tokio-trace-subscriber/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
-tokio-trace = "0.1.0"
+tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
 
 [dev-dependencies]
 tokio-trace-log = { path = "../tokio-trace-log" }

--- a/tokio-trace-tower-http/Cargo.toml
+++ b/tokio-trace-tower-http/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
-tokio-trace = "0.1.0"
+tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
 tokio-trace-futures = { path = "../tokio-trace-futures" }
 futures = "0.1"
 tower-service = "0.2"

--- a/tokio-trace-tower/Cargo.toml
+++ b/tokio-trace-tower/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
-tokio-trace = "0.1.0"
+tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
 tokio-trace-futures = { path = "../tokio-trace-futures" }
 futures = "0.1"
 tower-service = "0.2"

--- a/tokio-trace-tower/src/lib.rs
+++ b/tokio-trace-tower/src/lib.rs
@@ -39,6 +39,6 @@ where
         // TODO: custom `Value` impls for `http` types would be nice...
         let span = span!(Level::TRACE, parent: &self.span, "request", request = &field::debug(&req));
         let enter = span.enter();
-        self.inner.call(req).instrument(span2)
+        self.inner.call(req).instrument(span.clone())
     }
 }

--- a/tokio-trace-tower/src/lib.rs
+++ b/tokio-trace-tower/src/lib.rs
@@ -31,19 +31,14 @@ where
     type Future = Instrumented<T::Future>;
 
     fn poll_ready(&mut self) -> futures::Poll<(), Self::Error> {
-        let span = &mut self.span;
-        let inner = &mut self.inner;
-        span.enter(|| inner.poll_ready())
+        let _enter = self.span.enter();
+        self.inner.poll_ready()
     }
 
     fn call(&mut self, req: Request) -> Self::Future {
-        let span = &mut self.span;
-        let inner = &mut self.inner;
-        span.enter(|| {
-            // TODO: custom `Value` impls for `http` types would be nice...
-            let span = span!(Level::TRACE, "request", request = &field::debug(&req));
-            let span2 = span.clone();
-            span.enter(move || inner.call(req).instrument(span2))
-        })
+        // TODO: custom `Value` impls for `http` types would be nice...
+        let span = span!(Level::TRACE, parent: &self.span, "request", request = &field::debug(&req));
+        let enter = span.enter();
+        self.inner.call(req).instrument(span2)
     }
 }


### PR DESCRIPTION
Currently these are all git dependencies. When `tokio-trace` 0.2 
is released, I'll change these back to crates.io dependencies 
and release this. 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>