### PR TITLE
fix: allow update to span fields

### DIFF
--- a/tokio-trace-fmt/examples/yak_shave.rs
+++ b/tokio-trace-fmt/examples/yak_shave.rs
@@ -53,7 +53,6 @@ fn main() {
             info!("shaving yaks");
         });
 
-
         debug!(
             message = "yak shaving completed.",
             all_yaks_shaved = number_shaved == number_of_yaks,

--- a/tokio-trace-fmt/examples/yak_shave.rs
+++ b/tokio-trace-fmt/examples/yak_shave.rs
@@ -28,7 +28,9 @@ fn main() {
         let mut number_shaved = 0;
         debug!("preparing to shave {} yaks", number_of_yaks);
 
-        span!(Level::TRACE, "shaving_yaks", yaks_to_shave = number_of_yaks).enter(|| {
+        let s = span!(Level::TRACE, "shaving_yaks", yaks_to_shave = number_of_yaks);
+
+        s.enter(|| {
             info!("shaving yaks");
 
             for yak in 1..=number_of_yaks {
@@ -44,6 +46,13 @@ fn main() {
                 trace!(target: "yak_events", yaks_shaved = number_shaved);
             }
         });
+
+        s.record("yaks_to_shave", &10);
+
+        s.enter(|| {
+            info!("shaving yaks");
+        });
+
 
         debug!(
             message = "yak shaving completed.",

--- a/tokio-trace-fmt/src/default.rs
+++ b/tokio-trace-fmt/src/default.rs
@@ -149,7 +149,7 @@ where
 
             span.fields().try_for_each(|(_, value)| {
                 write!(f, " {}{}{}", style.paint("{"), value, style.paint("}"))
-            });
+            })?;
             ":".fmt(f)
         })?;
         if seen {

--- a/tokio-trace-fmt/src/default.rs
+++ b/tokio-trace-fmt/src/default.rs
@@ -27,8 +27,10 @@ where
         event.record(&mut recorder);
     }
     ctx.with_current(|(_, span)| {
-        span.fields()
-            .try_for_each(|(_, value)| write!(f, " {}", value))
+        for (_, value) in span.fields() {
+            write!(f, " {}", value)?;
+        }
+        Ok(())
     })
     .unwrap_or(Ok(()))?;
     writeln!(f)
@@ -157,9 +159,10 @@ where
             write!(f, "{}", style.paint(span.name()))?;
             seen = true;
 
-            span.fields().try_for_each(|(_, value)| {
-                write!(f, "{}{}{}", style.paint("{"), value, style.paint("}"))
-            })?;
+            for (_, value) in span.fields() {
+                write!(f, "{}{}{}", style.paint("{"), value, style.paint("}"))?;
+            }
+
             ":".fmt(f)
         })?;
         if seen {

--- a/tokio-trace-fmt/src/filter/env.rs
+++ b/tokio-trace-fmt/src/filter/env.rs
@@ -147,7 +147,7 @@ impl<N> Filter<N> for EnvFilter {
                                     || directive
                                         .fields
                                         .iter()
-                                        .any(|field| span.fields().contains(field))
+                                        .any(|field| span.has_field(field.as_ref()))
                                 {
                                     // Return `Err` to short-circuit the span visitation.
                                     Err(())

--- a/tokio-trace-fmt/src/lib.rs
+++ b/tokio-trace-fmt/src/lib.rs
@@ -277,6 +277,7 @@ impl<N, E, F> Builder<N, E, F> {
 
     /// Sets the subscriber being built to use the default full span formatter.
     // TODO: this should probably just become the default.
+    #[allow(clippy::type_complexity)]
     pub fn full(
         self,
     ) -> Builder<N, fn(&span::Context<N>, &mut fmt::Write, &Event) -> fmt::Result, F>

--- a/tokio-trace-fmt/src/lib.rs
+++ b/tokio-trace-fmt/src/lib.rs
@@ -277,7 +277,6 @@ impl<N, E, F> Builder<N, E, F> {
 
     /// Sets the subscriber being built to use the default full span formatter.
     // TODO: this should probably just become the default.
-    #[allow(clippy::type_complexity)]
     pub fn full(
         self,
     ) -> Builder<N, fn(&span::Context<N>, &mut fmt::Write, &Event) -> fmt::Result, F>

--- a/tokio-trace-fmt/src/lib.rs
+++ b/tokio-trace-fmt/src/lib.rs
@@ -173,19 +173,19 @@ where
 pub trait NewVisitor<'a> {
     type Visitor: field::Visit + 'a;
 
-    fn make(&self, writer: &'a mut fmt::Write, is_empty: bool) -> Self::Visitor;
+    fn make(&self, writer: &'a mut fmt::Write) -> Self::Visitor;
 }
 
 impl<'a, F, R> NewVisitor<'a> for F
 where
-    F: Fn(&'a mut fmt::Write, bool) -> R,
+    F: Fn(&'a mut fmt::Write) -> R,
     R: field::Visit + 'a,
 {
     type Visitor = R;
 
     #[inline]
-    fn make(&self, writer: &'a mut fmt::Write, is_empty: bool) -> Self::Visitor {
-        (self)(writer, is_empty)
+    fn make(&self, writer: &'a mut fmt::Write) -> Self::Visitor {
+        (self)(writer)
     }
 }
 

--- a/tokio-trace-fmt/src/lib.rs
+++ b/tokio-trace-fmt/src/lib.rs
@@ -173,19 +173,19 @@ where
 pub trait NewVisitor<'a> {
     type Visitor: field::Visit + 'a;
 
-    fn make(&self, writer: &'a mut fmt::Write) -> Self::Visitor;
+    fn make(&self, writer: &'a mut fmt::Write, is_empty: bool) -> Self::Visitor;
 }
 
 impl<'a, F, R> NewVisitor<'a> for F
 where
-    F: Fn(&'a mut fmt::Write) -> R,
+    F: Fn(&'a mut fmt::Write, bool) -> R,
     R: field::Visit + 'a,
 {
     type Visitor = R;
 
     #[inline]
-    fn make(&self, writer: &'a mut fmt::Write) -> Self::Visitor {
-        (self)(writer)
+    fn make(&self, writer: &'a mut fmt::Write, is_empty: bool) -> Self::Visitor {
+        (self)(writer, is_empty)
     }
 }
 

--- a/tokio-trace-fmt/src/span.rs
+++ b/tokio-trace-fmt/src/span.rs
@@ -403,39 +403,51 @@ impl Drop for Data {
     }
 }
 
-impl<'map, 'visitor, N> MapVisitor<'map, 'visitor, N>
-where
-    N: for<'a> ::NewVisitor<'a>,
-{
-    fn visitor<'a>(&'a mut self, field: &Field) -> <N as ::NewVisitor<'a>>::Visitor {
-        let entry: &'map mut String = self.map.entry(field.clone()).or_insert_with(String::new);
-        entry.clear();
-        self.new_visitor.make(&mut entry)
-    }
-}
+// impl<'map, 'visitor, N> MapVisitor<'map, 'visitor, N>
+// where
+//     N: for<'a> ::NewVisitor<'a>,
+// {
+//     fn visitor<'a>(&'a mut self, field: &Field) -> <N as ::NewVisitor<'a>>::Visitor {
+//         let mut entry = self.map.entry(field.clone()).or_insert_with(String::new);
+//         entry.clear();
+//         self.new_visitor.make(&mut entry)
+//     }
+// }
 
 impl<'map, 'visitor, N> field::Visit for MapVisitor<'map, 'visitor, N>
 where
     N: for<'a> ::NewVisitor<'a>,
 {
     fn record_i64(&mut self, field: &Field, value: i64) {
-        self.visitor(field).record_i64(field, value)
+        let entry = self.map.entry(field.clone()).or_insert_with(String::new);
+        entry.clear();
+        self.new_visitor.make(entry).record_i64(field, value)
+        // self.visitor(field).record_i64(field, value)
     }
 
     fn record_u64(&mut self, field: &Field, value: u64) {
-        self.visitor(field).record_u64(field, value)
+        let entry = self.map.entry(field.clone()).or_insert_with(String::new);
+        entry.clear();
+        self.new_visitor.make(entry).record_u64(field, value)
+        // self.visitor(field).record_u64(field, value)
     }
 
     fn record_bool(&mut self, field: &Field, value: bool) {
-        self.visitor(field).record_bool(field, value)
+        let entry = self.map.entry(field.clone()).or_insert_with(String::new);
+        entry.clear();
+        self.new_visitor.make(entry).record_bool(field, value)
     }
 
     fn record_str(&mut self, field: &Field, value: &str) {
-        self.visitor(field).record_str(field, value)
+        let entry = self.map.entry(field.clone()).or_insert_with(String::new);
+        entry.clear();
+        self.new_visitor.make(entry).record_str(field, value)
     }
 
     fn record_debug(&mut self, field: &Field, value: &fmt::Debug) {
-        self.visitor(field).record_debug(field, value)
+        let entry = self.map.entry(field.clone()).or_insert_with(String::new);
+        entry.clear();
+        self.new_visitor.make(entry).record_debug(field, value)
     }
 }
 
@@ -472,15 +484,14 @@ impl Slot {
     where
         N: for<'a> ::NewVisitor<'a>,
     {
-        let fields = &mut self.fields;
         {
             let mut recorder = MapVisitor {
                 new_visitor,
-                map: &mut fields,
+                map: &mut self.fields,
             };
             attrs.record(&mut recorder);
         }
-        if fields.is_empty() {
+        if self.fields.is_empty() {
             data.is_empty = false;
         }
         match mem::replace(&mut self.span, State::Full(data)) {

--- a/tokio-trace-fmt/src/span.rs
+++ b/tokio-trace-fmt/src/span.rs
@@ -60,7 +60,7 @@ enum State {
     Empty(usize),
 }
 
-struct MapVisitor<'map, 'visitor, N> {
+struct MapVisitor<'map, 'visitor, N: 'visitor> {
     map: &'map mut HashMap<Field, String>,
     new_visitor: &'visitor N,
 }

--- a/tokio-trace-fmt/src/span.rs
+++ b/tokio-trace-fmt/src/span.rs
@@ -407,69 +407,31 @@ impl Drop for Data {
     }
 }
 
+macro_rules! whytho {
+    ($fn_name:ident, $input:ty) => {
+        fn $fn_name(&mut self, field: &Field, value: $input) {
+            self.new_visitor
+                .make(
+                    self.map
+                        .entry(field.clone())
+                        .and_modify(String::clear)
+                        .or_insert_with(String::new),
+                    true,
+                )
+                .$fn_name(field, value)
+        }
+    };
+}
+
 impl<'map, 'visitor, N> field::Visit for MapVisitor<'map, 'visitor, N>
 where
     N: for<'a> ::NewVisitor<'a>,
 {
-    fn record_i64(&mut self, field: &Field, value: i64) {
-        self.new_visitor
-            .make(
-                self.map
-                    .entry(field.clone())
-                    .and_modify(String::clear)
-                    .or_insert_with(String::new),
-                true,
-            )
-            .record_i64(field, value)
-    }
-
-    fn record_u64(&mut self, field: &Field, value: u64) {
-        self.new_visitor
-            .make(
-                self.map
-                    .entry(field.clone())
-                    .and_modify(String::clear)
-                    .or_insert_with(String::new),
-                true,
-            )
-            .record_u64(field, value)
-    }
-
-    fn record_bool(&mut self, field: &Field, value: bool) {
-        self.new_visitor
-            .make(
-                self.map
-                    .entry(field.clone())
-                    .and_modify(String::clear)
-                    .or_insert_with(String::new),
-                true,
-            )
-            .record_bool(field, value)
-    }
-
-    fn record_str(&mut self, field: &Field, value: &str) {
-        self.new_visitor
-            .make(
-                self.map
-                    .entry(field.clone())
-                    .and_modify(String::clear)
-                    .or_insert_with(String::new),
-                true,
-            )
-            .record_str(field, value)
-    }
-
-    fn record_debug(&mut self, field: &Field, value: &fmt::Debug) {
-        self.new_visitor
-            .make(
-                self.map
-                    .entry(field.clone())
-                    .and_modify(String::clear)
-                    .or_insert_with(String::new),
-                true,
-            )
-            .record_debug(field, value)
-    }
+    whytho!(record_i64, i64);
+    whytho!(record_u64, u64);
+    whytho!(record_bool, bool);
+    whytho!(record_str, &str);
+    whytho!(record_debug, &fmt::Debug);
 }
 
 impl Slot {

--- a/tokio-trace-fmt/src/span.rs
+++ b/tokio-trace-fmt/src/span.rs
@@ -221,11 +221,15 @@ impl<'a, N> Context<'a, N> {
         Self { store, new_visitor }
     }
 
-    pub fn new_visitor<'writer>(&self, writer: &'writer mut fmt::Write) -> N::Visitor
+    pub fn new_visitor<'writer>(
+        &self,
+        writer: &'writer mut fmt::Write,
+        is_empty: bool,
+    ) -> N::Visitor
     where
         N: ::NewVisitor<'writer>,
     {
-        self.new_visitor.make(writer)
+        self.new_visitor.make(writer, is_empty)
     }
 }
 
@@ -403,51 +407,68 @@ impl Drop for Data {
     }
 }
 
-// impl<'map, 'visitor, N> MapVisitor<'map, 'visitor, N>
-// where
-//     N: for<'a> ::NewVisitor<'a>,
-// {
-//     fn visitor<'a>(&'a mut self, field: &Field) -> <N as ::NewVisitor<'a>>::Visitor {
-//         let mut entry = self.map.entry(field.clone()).or_insert_with(String::new);
-//         entry.clear();
-//         self.new_visitor.make(&mut entry)
-//     }
-// }
-
 impl<'map, 'visitor, N> field::Visit for MapVisitor<'map, 'visitor, N>
 where
     N: for<'a> ::NewVisitor<'a>,
 {
     fn record_i64(&mut self, field: &Field, value: i64) {
-        let entry = self.map.entry(field.clone()).or_insert_with(String::new);
-        entry.clear();
-        self.new_visitor.make(entry).record_i64(field, value)
-        // self.visitor(field).record_i64(field, value)
+        self.new_visitor
+            .make(
+                self.map
+                    .entry(field.clone())
+                    .and_modify(String::clear)
+                    .or_insert_with(String::new),
+                true,
+            )
+            .record_i64(field, value)
     }
 
     fn record_u64(&mut self, field: &Field, value: u64) {
-        let entry = self.map.entry(field.clone()).or_insert_with(String::new);
-        entry.clear();
-        self.new_visitor.make(entry).record_u64(field, value)
-        // self.visitor(field).record_u64(field, value)
+        self.new_visitor
+            .make(
+                self.map
+                    .entry(field.clone())
+                    .and_modify(String::clear)
+                    .or_insert_with(String::new),
+                true,
+            )
+            .record_u64(field, value)
     }
 
     fn record_bool(&mut self, field: &Field, value: bool) {
-        let entry = self.map.entry(field.clone()).or_insert_with(String::new);
-        entry.clear();
-        self.new_visitor.make(entry).record_bool(field, value)
+        self.new_visitor
+            .make(
+                self.map
+                    .entry(field.clone())
+                    .and_modify(String::clear)
+                    .or_insert_with(String::new),
+                true,
+            )
+            .record_bool(field, value)
     }
 
     fn record_str(&mut self, field: &Field, value: &str) {
-        let entry = self.map.entry(field.clone()).or_insert_with(String::new);
-        entry.clear();
-        self.new_visitor.make(entry).record_str(field, value)
+        self.new_visitor
+            .make(
+                self.map
+                    .entry(field.clone())
+                    .and_modify(String::clear)
+                    .or_insert_with(String::new),
+                true,
+            )
+            .record_str(field, value)
     }
 
     fn record_debug(&mut self, field: &Field, value: &fmt::Debug) {
-        let entry = self.map.entry(field.clone()).or_insert_with(String::new);
-        entry.clear();
-        self.new_visitor.make(entry).record_debug(field, value)
+        self.new_visitor
+            .make(
+                self.map
+                    .entry(field.clone())
+                    .and_modify(String::clear)
+                    .or_insert_with(String::new),
+                true,
+            )
+            .record_debug(field, value)
     }
 }
 


### PR DESCRIPTION
Prior to this change re running `record` on field in a span would append a second copy of that field with the new value to the String representation of the fields.

This commit reworks span fields to be stored in a HashMap instead of a String so that updates can replace the old value rather than living along side it.

Benchmarks are still needed eventually to compare performance and possibly optimize things a bit.