### PR TITLE
fmt: add `reload::Handle::with_current`

### DIFF
--- a/tokio-trace-fmt/src/filter/reload.rs
+++ b/tokio-trace-fmt/src/filter/reload.rs
@@ -111,12 +111,9 @@ where
     /// Invokes a closure with a borrowed reference to the current filter,
     /// returning the result (or an error if the filter no longer exists).
     pub fn with_current<T>(&self, f: impl FnOnce(&F) -> T) -> Result<T, Error> {
-        let inner = self
-            .inner
-            .upgrade()
-            .ok_or(Error {
-                kind: ErrorKind::SubscriberGone,
-            })?;
+        let inner = self.inner.upgrade().ok_or(Error {
+            kind: ErrorKind::SubscriberGone,
+        })?;
         let inner = inner.read();
         Ok(f(&*inner))
     }


### PR DESCRIPTION

## Motivation

In some cases, when filter reloading is in use, it can be valuable to
inspect the current value of a filter without reloading it. For example,
this could be used to format the current state, or call filter-specific
methods on it.

## Solution

This branch adds a new `Handle::with_current` method. This method
invokes a closure with a borrowed reference to the filter's current
state and returns the result. This does not require acquiring a write
lock.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>