### PR TITLE
fmt: Timestamped log messages

### DIFF
--- a/tracing-env-logger/examples/hyper-echo.rs
+++ b/tracing-env-logger/examples/hyper-echo.rs
@@ -119,7 +119,7 @@ fn echo(req: Request<Body>) -> Instrumented<BoxFut> {
 }
 
 fn main() {
-    let subscriber = tracing_fmt::FmtSubscriber::builder().full().finish();
+    let subscriber = tracing_fmt::FmtSubscriber::builder().finish();
     tracing_env_logger::try_init().expect("init log adapter");
 
     tracing::subscriber::with_default(subscriber, || {

--- a/tracing-fmt/Cargo.toml
+++ b/tracing-fmt/Cargo.toml
@@ -14,6 +14,7 @@ lazy_static = "1"
 owning_ref = "0.4.0"
 parking_lot = { version = "0.7"}
 lock_api = "0.1"
+chrono = "0.4"
 
 [dependencies.tracing-core]
 # TODO: replace this with a path dependency on the local `tracing-core`.

--- a/tracing-fmt/Cargo.toml
+++ b/tracing-fmt/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [features]
-default = ["ansi"]
+default = ["ansi", "chrono"]
 ansi = ["ansi_term"]
 
 [dependencies]
@@ -14,7 +14,7 @@ lazy_static = "1"
 owning_ref = "0.4.0"
 parking_lot = { version = "0.7"}
 lock_api = "0.1"
-chrono = "0.4"
+chrono = { version = "0.4", optional = true }
 
 [dependencies.tracing-core]
 # TODO: replace this with a path dependency on the local `tracing-core`.

--- a/tracing-fmt/examples/yak_shave.rs
+++ b/tracing-fmt/examples/yak_shave.rs
@@ -21,7 +21,7 @@ fn shave(yak: usize) -> bool {
 }
 
 fn main() {
-    let subscriber = tracing_fmt::FmtSubscriber::builder().full().finish();
+    let subscriber = tracing_fmt::FmtSubscriber::builder().finish();
 
     tracing::subscriber::with_default(subscriber, || {
         let number_of_yaks = 3;

--- a/tracing-fmt/src/default.rs
+++ b/tracing-fmt/src/default.rs
@@ -6,6 +6,7 @@ use chrono;
 
 use std::fmt::{self, Write};
 use std::marker::PhantomData;
+use std::time::Instant;
 use tracing_core::{
     field::{self, Field},
     Event, Level,
@@ -58,6 +59,28 @@ impl FormatTime for fn(&mut fmt::Write) -> fmt::Result {
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub struct SystemTime;
 
+/// Retrieve and print the relative elapsed wall-clock time since an epoch.
+///
+/// The `Default` implementation for `Uptime` makes the epoch the current time.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct Uptime {
+    epoch: Instant,
+}
+
+impl Default for Uptime {
+    fn default() -> Self {
+        Uptime {
+            epoch: Instant::now(),
+        }
+    }
+}
+
+impl From<Instant> for Uptime {
+    fn from(epoch: Instant) -> Self {
+        Uptime { epoch }
+    }
+}
+
 #[cfg(feature = "chrono")]
 impl FormatTime for SystemTime {
     fn format_time(&self, w: &mut fmt::Write) -> fmt::Result {
@@ -68,6 +91,13 @@ impl FormatTime for SystemTime {
 impl FormatTime for SystemTime {
     fn format_time(&self, w: &mut fmt::Write) -> fmt::Result {
         write!(w, "{:?} ", std::time::SystemTime::now())
+    }
+}
+
+impl FormatTime for Uptime {
+    fn format_time(&self, w: &mut fmt::Write) -> fmt::Result {
+        let e = self.epoch.elapsed();
+        write!(w, "{}.{:09} ", e.as_secs(), e.subsec_nanos())
     }
 }
 

--- a/tracing-fmt/src/default.rs
+++ b/tracing-fmt/src/default.rs
@@ -16,7 +16,7 @@ use ansi_term::{Colour, Style};
 
 /// A type that can measure and format the current time.
 ///
-/// This trait is used by `Standard` to include a timestamp with each `Event` when it is logged.
+/// This trait is used by `Format` to include a timestamp with each `Event` when it is logged.
 ///
 /// Notable default implementations of this trait are `SystemTime` and `()`. The former prints the
 /// current time as reported by `std::time::SystemTime`, and the latter does not print the current
@@ -63,7 +63,7 @@ impl FormatTime for SystemTime {
     }
 }
 
-/// Builder for a `Standard` formatter.
+/// Builder for a `Format` formatter.
 #[derive(Default, Debug, Clone)]
 pub struct Builder<T = SystemTime> {
     full: bool,
@@ -96,9 +96,9 @@ impl<T> Builder<T> {
         }
     }
 
-    /// Produce a `Standard` event formatter from this `Builder`'s configuration.
-    pub fn build(self) -> Standard<T> {
-        Standard {
+    /// Produce a `Format` event formatter from this `Builder`'s configuration.
+    pub fn build(self) -> Format<T> {
+        Format {
             full: self.full,
             timer: self.timer,
         }
@@ -109,12 +109,12 @@ impl<T> Builder<T> {
 ///
 /// You will usually want to use this as the `FormatEvent` for a `FmtSubscriber`.
 #[derive(Debug, Clone)]
-pub struct Standard<T = SystemTime> {
+pub struct Format<T = SystemTime> {
     full: bool,
     timer: T,
 }
 
-impl<T> Default for Standard<T>
+impl<T> Default for Format<T>
 where
     T: Default,
 {
@@ -123,7 +123,7 @@ where
     }
 }
 
-impl<N, T> FormatEvent<N> for Standard<T>
+impl<N, T> FormatEvent<N> for Format<T>
 where
     N: for<'a> ::NewVisitor<'a>,
     T: FormatTime,

--- a/tracing-fmt/src/default.rs
+++ b/tracing-fmt/src/default.rs
@@ -20,7 +20,8 @@ use ansi_term::{Colour, Style};
 ///
 /// Notable default implementations of this trait are `SystemTime` and `()`. The former prints the
 /// current time as reported by `std::time::SystemTime`, and the latter does not print the current
-/// time at all.
+/// time at all. `FormatTime` is also automatically implemented for any free-standing function with
+/// the appropriate signature.
 pub trait FormatTime {
     /// Measure and write out the current time.
     ///
@@ -33,6 +34,12 @@ pub trait FormatTime {
 impl FormatTime for () {
     fn format_time(&self, _: &mut fmt::Write) -> fmt::Result {
         Ok(())
+    }
+}
+
+impl FormatTime for fn(&mut fmt::Write) -> fmt::Result {
+    fn format_time(&self, w: &mut fmt::Write) -> fmt::Result {
+        (*self)(w)
     }
 }
 

--- a/tracing-fmt/src/default.rs
+++ b/tracing-fmt/src/default.rs
@@ -13,16 +13,24 @@ use tracing_core::{
 use ansi_term::{Colour, Style};
 
 /// Marker for `Format` that indicates that the compact log format should be used.
+///
+/// The compact format only includes the fields from the most recently entered span.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Compact;
 
 /// Marker for `Format` that indicates that the verbose log format should be used.
+///
+/// The full format includes fields from all entered spans.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Full;
 
 /// A pre-configured event formatter.
 ///
 /// You will usually want to use this as the `FormatEvent` for a `FmtSubscriber`.
+///
+/// The default logging format, [`Full`] includes all fields in each event and its containing
+/// spans. The [`Compact`] logging format includes only the fields from the most-recently-entered
+/// span.
 #[derive(Debug, Clone)]
 pub struct Format<F = Full, T = SystemTime> {
     format: PhantomData<F>,
@@ -40,6 +48,8 @@ impl<T: Default> Default for Format<Full, T> {
 
 impl<F, T> Format<F, T> {
     /// Use a less verbose output format.
+    ///
+    /// See [`Compact`].
     pub fn compact(self) -> Format<Compact, T> {
         Format {
             format: PhantomData,

--- a/tracing-fmt/src/default.rs
+++ b/tracing-fmt/src/default.rs
@@ -1,6 +1,9 @@
 use span;
 use Formatter;
 
+#[cfg(feature = "chrono")]
+use chrono;
+
 use tracing_core::{
     field::{self, Field},
     Event, Level,

--- a/tracing-fmt/src/default.rs
+++ b/tracing-fmt/src/default.rs
@@ -1,5 +1,5 @@
 use span;
-use Formatter;
+use FormatEvent;
 
 #[cfg(feature = "chrono")]
 use chrono;
@@ -107,7 +107,7 @@ impl<T> Builder<T> {
 
 /// A pre-configured event formatter.
 ///
-/// You will usually want to use this as the `Formatter` for a `FmtSubscriber`.
+/// You will usually want to use this as the `FormatEvent` for a `FmtSubscriber`.
 #[derive(Debug, Clone)]
 pub struct Standard<T = SystemTime> {
     full: bool,
@@ -123,12 +123,12 @@ where
     }
 }
 
-impl<N, T> Formatter<N> for Standard<T>
+impl<N, T> FormatEvent<N> for Standard<T>
 where
     N: for<'a> ::NewVisitor<'a>,
     T: FormatTime,
 {
-    fn format(
+    fn format_event(
         &self,
         ctx: &span::Context<N>,
         writer: &mut dyn fmt::Write,

--- a/tracing-fmt/src/default.rs
+++ b/tracing-fmt/src/default.rs
@@ -20,8 +20,8 @@ use ansi_term::{Colour, Style};
 ///
 /// Notable default implementations of this trait are `SystemTime` and `()`. The former prints the
 /// current time as reported by `std::time::SystemTime`, and the latter does not print the current
-/// time at all. `FormatTime` is also automatically implemented for any free-standing function with
-/// the appropriate signature.
+/// time at all. `FormatTime` is also automatically implemented for any function pointer with the
+/// appropriate signature.
 pub trait FormatTime {
     /// Measure and write out the current time.
     ///

--- a/tracing-fmt/src/default.rs
+++ b/tracing-fmt/src/default.rs
@@ -21,21 +21,24 @@ impl FormatTime for () {
     }
 }
 
-#[cfg(feature = "chrono")]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub struct SystemTime;
-
-#[cfg(feature = "chrono")]
-const TIMESTAMP_FORMAT: &'static str = "%b %d %H:%M:%S%.3f";
 
 #[cfg(feature = "chrono")]
 impl FormatTime for SystemTime {
     fn format_time(&self, w: &mut fmt::Write) -> fmt::Result {
-        write!(w, "{} ", chrono::Local::now().format(TIMESTAMP_FORMAT))
+        write!(w, "{} ", chrono::Local::now().format("%b %d %H:%M:%S%.3f"))
+    }
+}
+#[cfg(not(feature = "chrono"))]
+impl FormatTime for SystemTime {
+    fn format_time(&self, w: &mut fmt::Write) -> fmt::Result {
+        write!(w, "{:?} ", std::time::SystemTime::now())
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct Builder<T = ()> {
+pub struct Builder<T = SystemTime> {
     full: bool,
     timer: T,
 }
@@ -76,7 +79,7 @@ impl<T> Builder<T> {
     }
 }
 
-pub struct Standard<T = ()> {
+pub struct Standard<T = SystemTime> {
     full: bool,
     timer: T,
 }

--- a/tracing-fmt/src/default.rs
+++ b/tracing-fmt/src/default.rs
@@ -73,12 +73,12 @@ impl FormatTime for SystemTime {
 
 /// Builder for a `Format` formatter.
 #[derive(Debug, Clone)]
-pub struct Builder<F = Compact, T = SystemTime> {
+pub struct Builder<F = Full, T = SystemTime> {
     format: PhantomData<F>,
     timer: T,
 }
 
-impl<T: Default> Default for Builder<Compact, T> {
+impl<T: Default> Default for Builder<Full, T> {
     fn default() -> Self {
         Builder {
             format: PhantomData,
@@ -88,8 +88,8 @@ impl<T: Default> Default for Builder<Compact, T> {
 }
 
 impl<F, T> Builder<F, T> {
-    /// Use a more verbose output format.
-    pub fn full(self) -> Builder<Full, T> {
+    /// Use a less verbose output format.
+    pub fn compact(self) -> Builder<Compact, T> {
         Builder {
             format: PhantomData,
             timer: self.timer,
@@ -128,12 +128,12 @@ impl<F, T> Builder<F, T> {
 ///
 /// You will usually want to use this as the `FormatEvent` for a `FmtSubscriber`.
 #[derive(Debug, Clone)]
-pub struct Format<F = Compact, T = SystemTime> {
+pub struct Format<F = Full, T = SystemTime> {
     format: PhantomData<F>,
     timer: T,
 }
 
-impl<T: Default> Default for Format<Compact, T> {
+impl<T: Default> Default for Format<Full, T> {
     fn default() -> Self {
         Builder::default().build()
     }

--- a/tracing-fmt/src/default.rs
+++ b/tracing-fmt/src/default.rs
@@ -12,66 +12,13 @@ use tracing_core::{
 #[cfg(feature = "ansi")]
 use ansi_term::{Colour, Style};
 
-/// Marker for `Format` and `Builder` that indicates that the compact log format should be used.
+/// Marker for `Format` that indicates that the compact log format should be used.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Compact;
 
-/// Marker for `Format` and `Builder` that indicates that the verbose log format should be used.
+/// Marker for `Format` that indicates that the verbose log format should be used.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Full;
-
-/// Builder for a `Format` formatter.
-#[derive(Debug, Clone)]
-pub struct Builder<F = Full, T = SystemTime> {
-    format: PhantomData<F>,
-    timer: T,
-}
-
-impl<T: Default> Default for Builder<Full, T> {
-    fn default() -> Self {
-        Builder {
-            format: PhantomData,
-            timer: T::default(),
-        }
-    }
-}
-
-impl<F, T> Builder<F, T> {
-    /// Use a less verbose output format.
-    pub fn compact(self) -> Builder<Compact, T> {
-        Builder {
-            format: PhantomData,
-            timer: self.timer,
-        }
-    }
-
-    /// Use the given `timer` for log message timestamps.
-    pub fn with_timer<T2>(self, timer: T2) -> Builder<F, T2>
-    where
-        T2: FormatTime,
-    {
-        Builder {
-            format: self.format,
-            timer,
-        }
-    }
-
-    /// Do not emit timestamps with log messages.
-    pub fn without_time(self) -> Builder<F, ()> {
-        Builder {
-            format: self.format,
-            timer: (),
-        }
-    }
-
-    /// Produce a `Format` event formatter from this `Builder`'s configuration.
-    pub fn build(self) -> Format<F, T> {
-        Format {
-            format: self.format,
-            timer: self.timer,
-        }
-    }
-}
 
 /// A pre-configured event formatter.
 ///
@@ -84,7 +31,36 @@ pub struct Format<F = Full, T = SystemTime> {
 
 impl<T: Default> Default for Format<Full, T> {
     fn default() -> Self {
-        Builder::default().build()
+        Format {
+            format: PhantomData,
+            timer: T::default(),
+        }
+    }
+}
+
+impl<F, T> Format<F, T> {
+    /// Use a less verbose output format.
+    pub fn compact(self) -> Format<Compact, T> {
+        Format {
+            format: PhantomData,
+            timer: self.timer,
+        }
+    }
+
+    /// Use the given `timer` for log message timestamps.
+    pub fn with_timer<T2>(self, timer: T2) -> Format<F, T2> {
+        Format {
+            format: self.format,
+            timer,
+        }
+    }
+
+    /// Do not emit timestamps with log messages.
+    pub fn without_time(self) -> Format<F, ()> {
+        Format {
+            format: self.format,
+            timer: (),
+        }
     }
 }
 

--- a/tracing-fmt/src/default.rs
+++ b/tracing-fmt/src/default.rs
@@ -71,6 +71,13 @@ impl<T> Builder<T> {
         }
     }
 
+    pub fn without_time(self) -> Builder<()> {
+        Builder {
+            full: self.full,
+            timer: (),
+        }
+    }
+
     pub fn build(self) -> Standard<T> {
         Standard {
             full: self.full,

--- a/tracing-fmt/src/filter/reload.rs
+++ b/tracing-fmt/src/filter/reload.rs
@@ -164,6 +164,7 @@ mod test {
         }
 
         let subscriber = FmtSubscriber::builder()
+            .compact()
             .with_filter(filter1 as fn(&Metadata, &span::Context<_>) -> bool)
             .with_filter_reloading();
         let handle = subscriber.reload_handle();
@@ -192,10 +193,7 @@ mod test {
     #[test]
     fn reload_from_env() {
         use filter::EnvFilter;
-        let subscriber = FmtSubscriber::builder()
-            .with_filter_reloading()
-            .full()
-            .finish();
+        let subscriber = FmtSubscriber::builder().with_filter_reloading().finish();
         let reload_handle = subscriber.reload_handle();
         reload_handle.reload(EnvFilter::from_default_env());
     }

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -55,7 +55,11 @@ impl<N> FormatEvent<N> for fn(&span::Context<N>, &mut fmt::Write, &Event) -> fmt
 }
 
 #[derive(Debug)]
-pub struct FmtSubscriber<N = default::NewRecorder, E = default::Format, F = filter::EnvFilter> {
+pub struct FmtSubscriber<
+    N = default::NewRecorder,
+    E = default::Format<default::Compact>,
+    F = filter::EnvFilter,
+> {
     new_visitor: N,
     fmt_event: E,
     filter: F,
@@ -64,7 +68,11 @@ pub struct FmtSubscriber<N = default::NewRecorder, E = default::Format, F = filt
 }
 
 #[derive(Debug, Default)]
-pub struct Builder<N = default::NewRecorder, E = default::Format, F = filter::EnvFilter> {
+pub struct Builder<
+    N = default::NewRecorder,
+    E = default::Format<default::Compact>,
+    F = filter::EnvFilter,
+> {
     new_visitor: N,
     fmt_event: E,
     filter: F,
@@ -310,7 +318,7 @@ impl<N, E, F> Builder<N, E, F> {
 
     /// Sets the subscriber being built to use the default full span formatter.
     // TODO: this should probably just become the default.
-    pub fn full(self) -> Builder<N, default::Format, F>
+    pub fn full(self) -> Builder<N, default::Format<default::Full>, F>
     where
         N: for<'a> NewVisitor<'a> + 'static,
     {

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -57,7 +57,7 @@ impl<N> FormatEvent<N> for fn(&span::Context<N>, &mut fmt::Write, &Event) -> fmt
 #[derive(Debug)]
 pub struct FmtSubscriber<
     N = default::NewRecorder,
-    E = default::Format<default::Compact>,
+    E = default::Format<default::Full>,
     F = filter::EnvFilter,
 > {
     new_visitor: N,
@@ -70,7 +70,7 @@ pub struct FmtSubscriber<
 #[derive(Debug, Default)]
 pub struct Builder<
     N = default::NewRecorder,
-    E = default::Format<default::Compact>,
+    E = default::Format<default::Full>,
     F = filter::EnvFilter,
 > {
     new_visitor: N,
@@ -316,14 +316,13 @@ impl<N, E, F> Builder<N, E, F> {
         }
     }
 
-    /// Sets the subscriber being built to use the default full span formatter.
-    // TODO: this should probably just become the default.
-    pub fn full(self) -> Builder<N, default::Format<default::Full>, F>
+    /// Sets the subscriber being built to use a less verbose formatter.
+    pub fn compact(self) -> Builder<N, default::Format<default::Compact>, F>
     where
         N: for<'a> NewVisitor<'a> + 'static,
     {
         Builder {
-            fmt_event: default::Builder::default().full().build(),
+            fmt_event: default::Builder::default().compact().build(),
             filter: self.filter,
             new_visitor: self.new_visitor,
             settings: self.settings,

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -5,6 +5,7 @@ extern crate tracing;
 
 #[cfg(feature = "ansi")]
 extern crate ansi_term;
+extern crate chrono;
 extern crate lock_api;
 extern crate owning_ref;
 extern crate parking_lot;

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -344,6 +344,8 @@ impl<N, E, F> Builder<N, E, F> {
     }
 
     /// Sets the subscriber being built to use a less verbose formatter.
+    ///
+    /// See [`default::Compact`].
     pub fn compact(self) -> Builder<N, default::Format<default::Compact>, F>
     where
         N: for<'a> NewVisitor<'a> + 'static,

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -55,7 +55,7 @@ impl<N> FormatEvent<N> for fn(&span::Context<N>, &mut fmt::Write, &Event) -> fmt
 }
 
 #[derive(Debug)]
-pub struct FmtSubscriber<N = default::NewRecorder, E = default::Standard, F = filter::EnvFilter> {
+pub struct FmtSubscriber<N = default::NewRecorder, E = default::Format, F = filter::EnvFilter> {
     new_visitor: N,
     fmt_event: E,
     filter: F,
@@ -64,7 +64,7 @@ pub struct FmtSubscriber<N = default::NewRecorder, E = default::Standard, F = fi
 }
 
 #[derive(Debug, Default)]
-pub struct Builder<N = default::NewRecorder, E = default::Standard, F = filter::EnvFilter> {
+pub struct Builder<N = default::NewRecorder, E = default::Format, F = filter::EnvFilter> {
     new_visitor: N,
     fmt_event: E,
     filter: F,
@@ -229,7 +229,7 @@ impl Default for Builder {
         Builder {
             filter: filter::EnvFilter::from_default_env(),
             new_visitor: default::NewRecorder,
-            fmt_event: default::Standard::default(),
+            fmt_event: default::Format::default(),
             settings: Settings::default(),
         }
     }
@@ -310,7 +310,7 @@ impl<N, E, F> Builder<N, E, F> {
 
     /// Sets the subscriber being built to use the default full span formatter.
     // TODO: this should probably just become the default.
-    pub fn full(self) -> Builder<N, default::Standard, F>
+    pub fn full(self) -> Builder<N, default::Format, F>
     where
         N: for<'a> NewVisitor<'a> + 'static,
     {
@@ -364,6 +364,6 @@ mod test {
         let dispatch = Dispatch::new(subscriber);
         assert!(dispatch.downcast_ref::<default::NewRecorder>().is_some());
         assert!(dispatch.downcast_ref::<filter::EnvFilter>().is_some());
-        assert!(dispatch.downcast_ref::<default::Standard>().is_some())
+        assert!(dispatch.downcast_ref::<default::Format>().is_some())
     }
 }

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -28,8 +28,8 @@ pub use span::Context;
 
 /// A type that can format a tracing `Event` for a `fmt::Write`.
 ///
-/// `FormatEvent` is primarily used in the context of [`FmtSubscribe`]. Each time an event is
-/// dispatched to [`FmtSubscribe`], the subscriber forwards it to its associated `FormatEvent` to
+/// `FormatEvent` is primarily used in the context of [`FmtSubscriber`]. Each time an event is
+/// dispatched to [`FmtSubscriber`], the subscriber forwards it to its associated `FormatEvent` to
 /// emit a log message.
 ///
 /// This trait is already implemented for function pointers with the same signature as `format`.

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -5,6 +5,7 @@ extern crate tracing;
 
 #[cfg(feature = "ansi")]
 extern crate ansi_term;
+#[cfg(feature = "chrono")]
 extern crate chrono;
 extern crate lock_api;
 extern crate owning_ref;

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -22,6 +22,7 @@ use std::{any::TypeId, cell::RefCell, fmt, io};
 pub mod default;
 pub mod filter;
 mod span;
+pub mod time;
 
 pub use filter::Filter;
 pub use span::Context;

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -26,7 +26,16 @@ mod span;
 pub use filter::Filter;
 pub use span::Context;
 
+/// A type that can format a tracing `Event` for a `fmt::Write`.
+///
+/// `Formatter` is primarily used in the context of [`FmtSubscribe`]. Each time an event is
+/// dispatched to [`FmtSubscribe`], the subscriber forwards it to its associated `Formatter` to
+/// emit a log message.
+///
+/// This trait is already implemented for any free-standing function with the same signature as
+/// `format`.
 pub trait Formatter<N> {
+    /// Write a log message for `Event` in `Context` to the given `Write`.
     fn format(&self, ctx: &span::Context<N>, writer: &mut fmt::Write, event: &Event)
         -> fmt::Result;
 }

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -323,7 +323,7 @@ impl<N, E, F> Builder<N, E, F> {
         N: for<'a> NewVisitor<'a> + 'static,
     {
         Builder {
-            fmt_event: default::Builder::default().compact().build(),
+            fmt_event: default::Format::default().compact(),
             filter: self.filter,
             new_visitor: self.new_visitor,
             settings: self.settings,

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -261,6 +261,32 @@ where
     }
 }
 
+impl<N, L, T, F> Builder<N, default::Format<L, T>, F>
+where
+    N: for<'a> NewVisitor<'a> + 'static,
+    F: Filter<N> + 'static,
+{
+    /// Use the given `timer` for log message timestamps.
+    pub fn with_timer<T2>(self, timer: T2) -> Builder<N, default::Format<L, T2>, F> {
+        Builder {
+            new_visitor: self.new_visitor,
+            fmt_event: self.fmt_event.with_timer(timer),
+            filter: self.filter,
+            settings: self.settings,
+        }
+    }
+
+    /// Use the given `timer` for log message timestamps.
+    pub fn without_time(self) -> Builder<N, default::Format<L, ()>, F> {
+        Builder {
+            new_visitor: self.new_visitor,
+            fmt_event: self.fmt_event.without_time(),
+            filter: self.filter,
+            settings: self.settings,
+        }
+    }
+}
+
 impl<N, E, F> Builder<N, E, F>
 where
     F: Filter<N> + 'static,

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -32,8 +32,7 @@ pub use span::Context;
 /// dispatched to [`FmtSubscribe`], the subscriber forwards it to its associated `Formatter` to
 /// emit a log message.
 ///
-/// This trait is already implemented for any free-standing function with the same signature as
-/// `format`.
+/// This trait is already implemented for function pointers with the same signature as `format`.
 pub trait Formatter<N> {
     /// Write a log message for `Event` in `Context` to the given `Write`.
     fn format(&self, ctx: &span::Context<N>, writer: &mut fmt::Write, event: &Event)

--- a/tracing-fmt/src/time.rs
+++ b/tracing-fmt/src/time.rs
@@ -95,16 +95,23 @@ impl FormatTime for Uptime {
 }
 
 #[inline(always)]
+#[cfg(feature = "ansi")]
 pub(crate) fn write<T>(timer: T, writer: &mut fmt::Write) -> fmt::Result
 where
     T: FormatTime,
 {
-    #[cfg(feature = "ansi")]
     let style = Style::new().dimmed();
-    #[cfg(feature = "ansi")]
     write!(writer, "{}", style.prefix())?;
     timer.format_time(writer)?;
-    #[cfg(feature = "ansi")]
     write!(writer, "{}", style.suffix())?;
     Ok(())
+}
+
+#[inline(always)]
+#[cfg(not(feature = "ansi"))]
+pub(crate) fn write<T>(timer: T, writer: &mut fmt::Write) -> fmt::Result
+where
+    T: FormatTime,
+{
+    timer.format_time(writer)
 }

--- a/tracing-fmt/src/time.rs
+++ b/tracing-fmt/src/time.rs
@@ -90,7 +90,7 @@ impl FormatTime for SystemTime {
 impl FormatTime for Uptime {
     fn format_time(&self, w: &mut fmt::Write) -> fmt::Result {
         let e = self.epoch.elapsed();
-        write!(w, "{}.{:09} ", e.as_secs(), e.subsec_nanos())
+        write!(w, "{:4}.{:09}s ", e.as_secs(), e.subsec_nanos())
     }
 }
 

--- a/tracing-fmt/src/time.rs
+++ b/tracing-fmt/src/time.rs
@@ -1,0 +1,110 @@
+#[cfg(feature = "chrono")]
+use chrono;
+
+#[cfg(feature = "ansi")]
+use ansi_term::Style;
+
+use std::fmt;
+use std::time::Instant;
+
+/// A type that can measure and format the current time.
+///
+/// This trait is used by `Format` to include a timestamp with each `Event` when it is logged.
+///
+/// Notable default implementations of this trait are `SystemTime` and `()`. The former prints the
+/// current time as reported by `std::time::SystemTime`, and the latter does not print the current
+/// time at all. `FormatTime` is also automatically implemented for any function pointer with the
+/// appropriate signature.
+pub trait FormatTime {
+    /// Measure and write out the current time.
+    ///
+    /// When `format_time` is called, implementors should get the current time using their desired
+    /// mechanism, and write it out to the given `fmt::Write`. Implementors must insert a trailing
+    /// space themselves if they wish to separate the time from subsequent log message text.
+    fn format_time(&self, w: &mut fmt::Write) -> fmt::Result;
+}
+
+impl<'a, F> FormatTime for &'a F
+where
+    F: FormatTime,
+{
+    fn format_time(&self, w: &mut fmt::Write) -> fmt::Result {
+        (*self).format_time(w)
+    }
+}
+
+impl FormatTime for () {
+    fn format_time(&self, _: &mut fmt::Write) -> fmt::Result {
+        Ok(())
+    }
+}
+
+impl FormatTime for fn(&mut fmt::Write) -> fmt::Result {
+    fn format_time(&self, w: &mut fmt::Write) -> fmt::Result {
+        (*self)(w)
+    }
+}
+
+/// Retrieve and print the current wall-clock time.
+///
+/// If the `chrono` feature is enabled, the current time is printed in a human-readable format like
+/// "Jun 25 14:27:12.955". Otherwise the `Debug` implementation of `std::time::SystemTime` is used.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+pub struct SystemTime;
+
+/// Retrieve and print the relative elapsed wall-clock time since an epoch.
+///
+/// The `Default` implementation for `Uptime` makes the epoch the current time.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct Uptime {
+    epoch: Instant,
+}
+
+impl Default for Uptime {
+    fn default() -> Self {
+        Uptime {
+            epoch: Instant::now(),
+        }
+    }
+}
+
+impl From<Instant> for Uptime {
+    fn from(epoch: Instant) -> Self {
+        Uptime { epoch }
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl FormatTime for SystemTime {
+    fn format_time(&self, w: &mut fmt::Write) -> fmt::Result {
+        write!(w, "{} ", chrono::Local::now().format("%b %d %H:%M:%S%.3f"))
+    }
+}
+#[cfg(not(feature = "chrono"))]
+impl FormatTime for SystemTime {
+    fn format_time(&self, w: &mut fmt::Write) -> fmt::Result {
+        write!(w, "{:?} ", std::time::SystemTime::now())
+    }
+}
+
+impl FormatTime for Uptime {
+    fn format_time(&self, w: &mut fmt::Write) -> fmt::Result {
+        let e = self.epoch.elapsed();
+        write!(w, "{}.{:09} ", e.as_secs(), e.subsec_nanos())
+    }
+}
+
+#[inline(always)]
+pub(crate) fn write<T>(timer: T, writer: &mut fmt::Write) -> fmt::Result
+where
+    T: FormatTime,
+{
+    #[cfg(feature = "ansi")]
+    let style = Style::new().dimmed();
+    #[cfg(feature = "ansi")]
+    write!(writer, "{}", style.prefix())?;
+    timer.format_time(writer)?;
+    #[cfg(feature = "ansi")]
+    write!(writer, "{}", style.suffix())?;
+    Ok(())
+}

--- a/tracing-futures/examples/proxy_server.rs
+++ b/tracing-futures/examples/proxy_server.rs
@@ -113,7 +113,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Ok(())
         });
 
-    let subscriber = tracing_fmt::FmtSubscriber::builder().full().finish();
+    let subscriber = tracing_fmt::FmtSubscriber::builder().finish();
     tracing::subscriber::with_default(subscriber, || {
         let done = done.instrument(span!(
             Level::TRACE,

--- a/tracing-futures/examples/spawny-thing.rs
+++ b/tracing-futures/examples/spawny-thing.rs
@@ -37,7 +37,7 @@ fn subtask(number: usize) -> impl Future<Item = usize, Error = ()> {
 }
 
 fn main() {
-    let subscriber = tracing_fmt::FmtSubscriber::builder().full().finish();
+    let subscriber = tracing_fmt::FmtSubscriber::builder().finish();
     tracing::subscriber::with_default(subscriber, || {
         tokio::run(parent_task(10));
     });

--- a/tracing-proc-macros/examples/args.rs
+++ b/tracing-proc-macros/examples/args.rs
@@ -30,7 +30,7 @@ fn fibonacci_seq(to: u64) -> Vec<u64> {
 
 fn main() {
     env_logger::Builder::new().parse("trace").init();
-    let subscriber = tracing_fmt::FmtSubscriber::builder().full().finish();
+    let subscriber = tracing_fmt::FmtSubscriber::builder().finish();
 
     tracing::subscriber::with_default(subscriber, || {
         let n: u64 = 5;

--- a/tracing-proc-macros/examples/basic.rs
+++ b/tracing-proc-macros/examples/basic.rs
@@ -9,7 +9,7 @@ use tracing::{field, Level};
 
 fn main() {
     env_logger::Builder::new().parse("trace").init();
-    let subscriber = tracing_fmt::FmtSubscriber::builder().full().finish();
+    let subscriber = tracing_fmt::FmtSubscriber::builder().finish();
     tracing::subscriber::with_default(subscriber, || {
         let num: u64 = 1;
 

--- a/tracing-tower-http/examples/tower-h2-server.rs
+++ b/tracing-tower-http/examples/tower-h2-server.rs
@@ -112,7 +112,6 @@ fn main() {
         .with_filter(tracing_fmt::filter::EnvFilter::from(
             "tower_h2_server=trace",
         ))
-        .full()
         .finish();
 
     tracing::subscriber::with_default(subscriber, || {


### PR DESCRIPTION
This provides an initial implementation of the feature outlined in https://github.com/tokio-rs/tracing/issues/94: timestamps in log messages from the `fmt` subscriber.

## Motivation

See https://github.com/tokio-rs/tracing/issues/94.

## Solution

This PR introduces a trait for event formatters (`Formatter`) so that it is easier to write more complex formatters (previously they were just `Fn(...) -> fmt::Result` which would require boxing a closure to produce). It then implements this new trait for `default::Standard`, which is the new default formatter. It implements "normal"/full formatting exactly like before, except that it also has a builder (`default::Builder`), and is generic over a timer. The timer must implement `default::FormatTime`, which has a single method that writes the current time out to a `fmt::Write`. This method is implemented for a new unit struct `SystemTime`. It is pretty-printed using `chrono` with the new default feature `chrono`, and `Debug` of `std::net::SystemTime` is used if the feature is turned off. Users can provide `()` as the time formatter to not produce timestamps in logged entries (accessible through `default::Builder::without_time`).