### PR TITLE
chore: update nursery crates to use path deps on `tracing`

### DIFF
--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -455,7 +455,7 @@ impl FieldSet {
     /// [`Identifier`]: ../callsite/struct.Identifier.html
     /// [`Callsite`]: ../callsite/trait.Callsite.html
     pub(crate) fn callsite(&self) -> callsite::Identifier {
-        callsite::Identifier(self.callsite.0)
+        self.callsite.clone()
     }
 
     /// Returns the [`Field`] named `name`, or `None` if no such field exists.

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -455,7 +455,7 @@ impl FieldSet {
     /// [`Identifier`]: ../callsite/struct.Identifier.html
     /// [`Callsite`]: ../callsite/trait.Callsite.html
     pub(crate) fn callsite(&self) -> callsite::Identifier {
-        self.callsite.clone()
+        callsite::Identifier(self.callsite.0)
     }
 
     /// Returns the [`Field`] named `name`, or `None` if no such field exists.

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -170,7 +170,7 @@ pub struct Level(LevelInner);
 impl<'a> Metadata<'a> {
     /// Construct new metadata for a span, with a name, target, level, field
     /// names, and optional source code location.
-    pub const fn new(
+    pub fn new(
         name: &'static str,
         target: &'a str,
         level: Level,
@@ -178,7 +178,7 @@ impl<'a> Metadata<'a> {
         file: Option<&'a str>,
         line: Option<u32>,
         field_names: &'static [&'static str],
-        callsite: callsite::Identifier,
+        callsite: &'static dyn Callsite,
         kind: Kind,
     ) -> Self {
         Metadata {
@@ -190,7 +190,7 @@ impl<'a> Metadata<'a> {
             line,
             fields: field::FieldSet {
                 names: field_names,
-                callsite,
+                callsite: callsite::Identifier(callsite),
             },
             kind,
         }

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -170,7 +170,7 @@ pub struct Level(LevelInner);
 impl<'a> Metadata<'a> {
     /// Construct new metadata for a span, with a name, target, level, field
     /// names, and optional source code location.
-    pub fn new(
+    pub const fn new(
         name: &'static str,
         target: &'a str,
         level: Level,
@@ -178,7 +178,7 @@ impl<'a> Metadata<'a> {
         file: Option<&'a str>,
         line: Option<u32>,
         field_names: &'static [&'static str],
-        callsite: &'static dyn Callsite,
+        callsite: callsite::Identifier,
         kind: Kind,
     ) -> Self {
         Metadata {
@@ -190,7 +190,7 @@ impl<'a> Metadata<'a> {
             line,
             fields: field::FieldSet {
                 names: field_names,
-                callsite: callsite::Identifier(callsite),
+                callsite,
             },
             kind,
         }

--- a/tracing-env-logger/Cargo.toml
+++ b/tracing-env-logger/Cargo.toml
@@ -9,14 +9,10 @@ env_logger = "0.5"
 log = "0.4"
 
 [dev-dependencies]
+tracing = { version = "0.1", path = "../tracing" }
 tracing-fmt = { path = "../tracing-fmt" }
 tracing-futures = { path = "../tracing-futures" }
 tracing-subscriber = { path = "../tracing-subscriber" }
 hyper = "=0.12.25"
 futures = "0.1"
 tokio = "0.1.21"
-
-[dev-dependencies.tracing]
-# TODO: replace this with a path dependency on the local `tracing`.
-package = "tokio-trace"
-version = "0.1"

--- a/tracing-env-logger/examples/hyper-echo.rs
+++ b/tracing-env-logger/examples/hyper-echo.rs
@@ -21,101 +21,99 @@ use tracing_futures::{Instrument, Instrumented};
 type BoxFut = Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send>;
 
 fn echo(req: Request<Body>) -> Instrumented<BoxFut> {
-    span!(
+    let span = span!(
         Level::TRACE,
         "request",
         method = &field::debug(req.method()),
         uri = &field::debug(req.uri()),
         headers = &field::debug(req.headers())
-    )
-    .enter(|| {
-        info!("received request");
-        let mut response = Response::new(Body::empty());
+    );
+    let _enter = span.enter();
+    info!("received request");
+    let mut response = Response::new(Body::empty());
 
-        let (rsp_span, fut): (_, BoxFut) = match (req.method(), req.uri().path()) {
-            // Serve some instructions at /
-            (&Method::GET, "/") => {
-                const BODY: &'static str = "Try POSTing data to /echo";
-                *response.body_mut() = Body::from(BODY);
-                (
-                    span!(Level::TRACE, "response", body = &field::display(&BODY)),
-                    Box::new(future::ok(response)),
-                )
-            }
+    let (rsp_span, fut): (_, BoxFut) = match (req.method(), req.uri().path()) {
+        // Serve some instructions at /
+        (&Method::GET, "/") => {
+            const BODY: &'static str = "Try POSTing data to /echo";
+            *response.body_mut() = Body::from(BODY);
+            (
+                span!(Level::TRACE, "response", body = &field::display(&BODY)),
+                Box::new(future::ok(response)),
+            )
+        }
 
-            // Simply echo the body back to the client.
-            (&Method::POST, "/echo") => {
-                let body = req.into_body();
-                let span = span!(Level::TRACE, "response", response_kind = &"echo");
-                *response.body_mut() = body;
-                (span, Box::new(future::ok(response)))
-            }
+        // Simply echo the body back to the client.
+        (&Method::POST, "/echo") => {
+            let body = req.into_body();
+            let span = span!(Level::TRACE, "response", response_kind = &"echo");
+            *response.body_mut() = body;
+            (span, Box::new(future::ok(response)))
+        }
 
-            // Convert to uppercase before sending back to client.
-            (&Method::POST, "/echo/uppercase") => {
-                let mapping = req.into_body().map(|chunk| {
-                    let upper = chunk
-                        .iter()
-                        .map(|byte| byte.to_ascii_uppercase())
-                        .collect::<Vec<u8>>();
-                    debug!(
-                        {
-                            chunk = field::debug(str::from_utf8(&chunk[..])),
-                            uppercased = field::debug(str::from_utf8(&upper[..]))
-                        },
-                        "uppercased request body"
-                    );
-                    upper
-                });
+        // Convert to uppercase before sending back to client.
+        (&Method::POST, "/echo/uppercase") => {
+            let mapping = req.into_body().map(|chunk| {
+                let upper = chunk
+                    .iter()
+                    .map(|byte| byte.to_ascii_uppercase())
+                    .collect::<Vec<u8>>();
+                debug!(
+                    {
+                        chunk = field::debug(str::from_utf8(&chunk[..])),
+                        uppercased = field::debug(str::from_utf8(&upper[..]))
+                    },
+                    "uppercased request body"
+                );
+                upper
+            });
 
-                *response.body_mut() = Body::wrap_stream(mapping);
-                (
-                    span!(Level::TRACE, "response", response_kind = "uppercase"),
-                    Box::new(future::ok(response)),
-                )
-            }
+            *response.body_mut() = Body::wrap_stream(mapping);
+            (
+                span!(Level::TRACE, "response", response_kind = "uppercase"),
+                Box::new(future::ok(response)),
+            )
+        }
 
-            // Reverse the entire body before sending back to the client.
-            //
-            // Since we don't know the end yet, we can't simply stream
-            // the chunks as they arrive. So, this returns a different
-            // future, waiting on concatenating the full body, so that
-            // it can be reversed. Only then can we return a `Response`.
-            (&Method::POST, "/echo/reversed") => {
-                let span = span!(Level::TRACE, "response", response_kind = "reversed");
-                let reversed = span.enter(|| {
-                    req.into_body().concat2().map(move |chunk| {
-                        let body = chunk.iter().rev().cloned().collect::<Vec<u8>>();
-                        debug!(
-                            {
-                                chunk = field::debug(str::from_utf8(&chunk[..])),
-                                body = field::debug(str::from_utf8(&body[..]))
-                            },
-                            "reversed request body");
-                        *response.body_mut() = Body::from(body);
-                        response
-                    })
-                });
-                (span, Box::new(reversed))
-            }
+        // Reverse the entire body before sending back to the client.
+        //
+        // Since we don't know the end yet, we can't simply stream
+        // the chunks as they arrive. So, this returns a different
+        // future, waiting on concatenating the full body, so that
+        // it can be reversed. Only then can we return a `Response`.
+        (&Method::POST, "/echo/reversed") => {
+            let mut span = span!(Level::TRACE, "response", response_kind = "reversed");
+            let _enter = span.enter();
+            let reversed = req.into_body().concat2().map(move |chunk| {
+                let body = chunk.iter().rev().cloned().collect::<Vec<u8>>();
+                debug!(
+                    {
+                        chunk = ?str::from_utf8(&chunk[..]),
+                        body = ?str::from_utf8(&body[..])
+                    },
+                    "reversed request body");
+                *response.body_mut() = Body::from(body);
+                response
+            });
+            (span.clone(), Box::new(reversed))
+        }
 
-            // The 404 Not Found route...
-            _ => {
-                *response.status_mut() = StatusCode::NOT_FOUND;
-                (
-                    span!(
-                        Level::TRACE,
-                        "response",
-                        body = &field::debug(()),
-                        status = &field::debug(&StatusCode::NOT_FOUND)
-                    ),
-                    Box::new(future::ok(response)),
-                )
-            }
-        };
+        // The 404 Not Found route...
+        _ => {
+            *response.status_mut() = StatusCode::NOT_FOUND;
+            (
+                span!(
+                    Level::TRACE,
+                    "response",
+                    body = &field::debug(()),
+                    status = &field::debug(&StatusCode::NOT_FOUND)
+                ),
+                Box::new(future::ok(response)),
+            )
+        }
+    };
 
-        fut.instrument(rsp_span)
-    })
+    fut.instrument(rsp_span)
 }
 
 fn main() {
@@ -124,7 +122,8 @@ fn main() {
 
     tracing::subscriber::with_default(subscriber, || {
         let addr: ::std::net::SocketAddr = ([127, 0, 0, 1], 3000).into();
-        let server_span = span!(Level::TRACE, "server", local = &field::debug(addr));
+        let server_span = span!(Level::TRACE, "server", local = %addr);
+        let _enter = server_span.enter();
         let server = tokio::net::TcpListener::bind(&addr)
             .expect("bind")
             .incoming()
@@ -132,7 +131,7 @@ fn main() {
                 let span = span!(
                     Level::TRACE,
                     "connection",
-                    remote = &field::debug(&sock.peer_addr().unwrap())
+                    remote = %sock.peer_addr().unwrap()
                 );
                 hyper::rt::spawn(
                     http.serve_connection(sock, service_fn(echo))
@@ -148,9 +147,7 @@ fn main() {
                 error!({ error = field::display(e) }, "server error");
             })
             .instrument(server_span.clone());
-        server_span.enter(|| {
-            info!("listening...");
-            hyper::rt::run(server);
-        });
+        info!("listening...");
+        hyper::rt::run(server);
     })
 }

--- a/tracing-env-logger/examples/hyper-echo.rs
+++ b/tracing-env-logger/examples/hyper-echo.rs
@@ -131,7 +131,7 @@ fn main() {
                 let span = span!(
                     Level::TRACE,
                     "connection",
-                    remote = %sock.peer_addr().unwrap()
+                    remote = ?sock.peer_addr().unwrap()
                 );
                 hyper::rt::spawn(
                     http.serve_connection(sock, service_fn(echo))

--- a/tracing-fmt/Cargo.toml
+++ b/tracing-fmt/Cargo.toml
@@ -8,6 +8,7 @@ default = ["ansi"]
 ansi = ["ansi_term"]
 
 [dependencies]
+tracing-core = { version = "0.1", path = "../tracing-core" }
 ansi_term = { version = "0.11", optional = true }
 regex = "1"
 lazy_static = "1"
@@ -15,12 +16,5 @@ owning_ref = "0.4.0"
 parking_lot = { version = "0.7"}
 lock_api = "0.1"
 
-[dependencies.tracing-core]
-# TODO: replace this with a path dependency on the local `tracing-core`.
-package = "tokio-trace-core"
-version = "0.2.0"
-
-[dev-dependencies.tracing]
-# TODO: replace this with a path dependency on the local `tracing`.
-package = "tokio-trace"
-version = "0.1"
+[dev-dependencies]
+tracing = { version = "0.1", path = "../tracing" }

--- a/tracing-fmt/examples/yak_shave.rs
+++ b/tracing-fmt/examples/yak_shave.rs
@@ -5,19 +5,19 @@ extern crate tracing_fmt;
 use tracing::Level;
 
 fn shave(yak: usize) -> bool {
-    span!(Level::TRACE, "shave", yak = yak).enter(|| {
-        debug!(
-            message = "hello! I'm gonna shave a yak.",
-            excitement = "yay!"
-        );
-        if yak == 3 {
-            warn!(target: "yak_events", "could not locate yak!");
-            false
-        } else {
-            trace!(target: "yak_events", "yak shaved successfully");
-            true
-        }
-    })
+    let span = span!(Level::TRACE, "shave", yak = yak);
+    let _e = span.enter();
+    debug!(
+        message = "hello! I'm gonna shave a yak.",
+        excitement = "yay!"
+    );
+    if yak == 3 {
+        warn!(target: "yak_events", "could not locate yak!");
+        false
+    } else {
+        trace!(target: "yak_events", "yak shaved successfully");
+        true
+    }
 }
 
 fn main() {
@@ -28,7 +28,7 @@ fn main() {
         let mut number_shaved = 0;
         debug!("preparing to shave {} yaks", number_of_yaks);
 
-        span!(Level::TRACE, "shaving_yaks", yaks_to_shave = number_of_yaks).enter(|| {
+        span!(Level::TRACE, "shaving_yaks", yaks_to_shave = number_of_yaks).in_scope(|| {
             info!("shaving yaks");
 
             for yak in 1..=number_of_yaks {

--- a/tracing-fmt/src/filter/env.rs
+++ b/tracing-fmt/src/filter/env.rs
@@ -521,7 +521,6 @@ impl fmt::Display for LevelFilter {
             LevelFilter::Level(Level::INFO) => f.pad("info"),
             LevelFilter::Level(Level::DEBUG) => f.pad("debug"),
             LevelFilter::Level(Level::TRACE) => f.pad("trace"),
-            LevelFilter::Level(_) => f.pad("???"),
         }
     }
 }

--- a/tracing-fmt/src/filter/reload.rs
+++ b/tracing-fmt/src/filter/reload.rs
@@ -211,7 +211,9 @@ mod test {
             .full()
             .finish();
         let reload_handle = subscriber.reload_handle();
-        reload_handle.reload(EnvFilter::from_default_env());
+        reload_handle
+            .reload(EnvFilter::from_default_env())
+            .expect("should reload");
     }
 
 }

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -8,13 +8,9 @@ default = ["tokio"]
 
 [dependencies]
 futures = "0.1"
+tracing = { version = "0.1", path = "../tracing" }
 tokio = { version = "0.1", optional = true }
 tokio-executor = { version = "0.1", optional = true }
-
-[dependencies.tracing]
-# TODO: replace this with a path dependency on the local `tracing`.
-package = "tokio-trace"
-version = "0.1"
 
 [dev-dependencies]
 tokio = "0.1.21"

--- a/tracing-futures/src/executor.rs
+++ b/tracing-futures/src/executor.rs
@@ -4,12 +4,11 @@ use futures::{
 };
 use {Instrument, Instrumented, WithDispatch};
 
-#[cfg(all(feature = "tokio", not(feature = "tokio-executor")))]
-use tokio::executor::{Executor as TokioExecutor, SpawnError};
 #[cfg(feature = "tokio")]
-use tokio::runtime::{current_thread, Runtime, TaskExecutor};
-#[cfg(feature = "tokio-executor")]
-use tokio_executor::{Executor as TokioExecutor, SpawnError};
+use tokio::{
+    executor::{Executor as TokioExecutor, SpawnError},
+    runtime::{current_thread, Runtime, TaskExecutor},
+};
 
 macro_rules! deinstrument_err {
     ($e:expr) => {
@@ -32,7 +31,7 @@ where
     }
 }
 
-#[cfg(any(feature = "tokio", feature = "tokio-executor"))]
+#[cfg(feature = "tokio")]
 impl<T> TokioExecutor for Instrumented<T>
 where
     T: TokioExecutor,
@@ -177,7 +176,7 @@ where
     }
 }
 
-#[cfg(any(feature = "tokio", feature = "tokio-executor"))]
+#[cfg(feature = "tokio")]
 impl<T> TokioExecutor for WithDispatch<T>
 where
     T: TokioExecutor,

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -4,10 +4,6 @@ version = "0.0.1"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
+tracing = { version = "0.1", path = "../tracing" }
 tracing-subscriber = { path = "../tracing-subscriber" }
 log = "0.4"
-
-[dependencies.tracing]
-# TODO: replace this with a path dependency on the local `tracing`.
-package = "tokio-trace"
-version = "0.1"

--- a/tracing-macros/Cargo.toml
+++ b/tracing-macros/Cargo.toml
@@ -3,10 +3,8 @@ name = "tracing-macros"
 version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
-[dependencies.tracing]
-# TODO: replace this with a path dependency on the local `tracing`.
-package = "tokio-trace"
-version = "0.1"
+[dependencies]
+tracing = { version = "0.1", path = "../tracing" }
 
 [dev-dependencies]
 tracing-log = { path = "../tracing-log" }

--- a/tracing-macros/src/lib.rs
+++ b/tracing-macros/src/lib.rs
@@ -32,7 +32,7 @@ macro_rules! dbg {
             Event, Id, Subscriber,
         };
         let callsite = callsite! {
-            name: stringify!($ex),
+            name: concat!("event:trace_dbg(", stringify!($ex), ")"),
             kind: tracing::metadata::Kind::EVENT,
             target: $target,
             level: $level,

--- a/tracing-macros/src/lib.rs
+++ b/tracing-macros/src/lib.rs
@@ -32,11 +32,11 @@ macro_rules! dbg {
             Event, Id, Subscriber,
         };
         let callsite = callsite! {
-            name: concat!("event:trace_dbg(", stringify!($ex), ")"),
+            name: stringify!($ex),
             kind: tracing::metadata::Kind::EVENT,
             target: $target,
             level: $level,
-            fields: $ex
+            fields: value,
         };
         let val = $ex;
         if is_enabled!(callsite) {

--- a/tracing-proc-macros/Cargo.toml
+++ b/tracing-proc-macros/Cargo.toml
@@ -7,14 +7,10 @@ authors = ["Eliza Weisman <eliza@buoyant.io>", "David Barsky <dbarsky@amazon.com
 proc-macro = true
 
 [dependencies]
+tracing = { version = "0.1", path = "../tracing" }
 syn = { version = "0.15", features = ["full", "extra-traits"] }
 quote = "0.6"
 proc-macro2 = { version = "0.4", features = ["nightly"] }
-
-[dependencies.tracing]
-# TODO: replace this with a path dependency on the local `tracing`.
-package = "tokio-trace"
-version = "0.1"
 
 [dev-dependencies]
 tracing-fmt = { path = "../tracing-fmt" }

--- a/tracing-proc-macros/examples/basic.rs
+++ b/tracing-proc-macros/examples/basic.rs
@@ -18,13 +18,12 @@ fn main() {
             "Getting rec from another function.",
             number_of_recs = &num
         );
-        span.enter(|| {
-            let band = suggest_band();
-            info!(
-                { band_recommendation = field::display(&band) },
-                "Got a rec."
-            );
-        });
+        let _enter = span.enter();
+        let band = suggest_band();
+        info!(
+            { band_recommendation = field::display(&band) },
+            "Got a rec."
+        );
     });
 }
 

--- a/tracing-proc-macros/src/lib.rs
+++ b/tracing-proc-macros/src/lib.rs
@@ -52,15 +52,14 @@ pub fn trace(_args: TokenStream, item: TokenStream) -> TokenStream {
     quote_spanned!(call_site=>
         #(#attrs) *
         #vis #constness #unsafety #asyncness #abi fn #ident(#params) #return_type {
-            span!(
+            let __tracing_attr_span = span!(
                 tracing::Level::TRACE,
                 #ident_str,
                 traced_function = &#ident_str
                 #(, #param_names = tracing::field::debug(&#param_names_clone)),*
-            )
-            .enter(move || {
-                #block
-            })
+            );
+            let __tracing_attr_guard = __tracing_attr_span.enter();
+            #block
         }
     )
     .into()

--- a/tracing-slog/Cargo.toml
+++ b/tracing-slog/Cargo.toml
@@ -3,7 +3,5 @@ name = "tracing-slog"
 version = "0.1.0"
 authors = ["David Barsky <dbarsky@amazon.com>"]
 
-[dependencies.tracing]
-# TODO: replace this with a path dependency on the local `tracing`.
-package = "tokio-trace"
-version = "0.1"
+[dependencies]
+tracing = { version = "0.1", path = "../tracing" }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -3,10 +3,8 @@ name = "tracing-subscriber"
 version = "0.0.1"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
-[dependencies.tracing]
-# TODO: replace this with a path dependency on the local `tracing`.
-package = "tokio-trace"
-version = "0.1"
+[dependencies]
+tracing = { version = "0.1", path = "../tracing" }
 
 [dev-dependencies]
 tracing-log = { path = "../tracing-log" }

--- a/tracing-tower-http/Cargo.toml
+++ b/tracing-tower-http/Cargo.toml
@@ -4,16 +4,13 @@ version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
+
+tracing = { version = "0.1", path = "../tracing" }
 tracing-futures = { path = "../tracing-futures" }
 futures = "0.1"
 tower-service = "0.2"
 tower = { git = "https://github.com/tower-rs/tower.git" }
 http = "0.1"
-
-[dependencies.tracing]
-# TODO: replace this with a path dependency on the local `tracing`.
-package = "tokio-trace"
-version = "0.1"
 
 [dev-dependencies]
 bytes = "0.4"

--- a/tracing-tower-http/examples/tower-h2-server.rs
+++ b/tracing-tower-http/examples/tower-h2-server.rs
@@ -37,14 +37,10 @@ impl RspBody {
 }
 
 impl Body for RspBody {
-    type Item = <Bytes as IntoBuf>::Buf;
+    type Data = <Bytes as IntoBuf>::Buf;
     type Error = h2::Error;
 
-    fn is_end_stream(&self) -> bool {
-        self.0.as_ref().map(|b| b.is_empty()).unwrap_or(false)
-    }
-
-    fn poll_buf(&mut self) -> Poll<Option<Self::Item>, h2::Error> {
+    fn poll_data(&mut self) -> Poll<Option<Self::Data>, Self::Error> {
         let data = self.0.take().and_then(|b| {
             if b.is_empty() {
                 None

--- a/tracing-tower-http/examples/tower-h2-server.rs
+++ b/tracing-tower-http/examples/tower-h2-server.rs
@@ -37,14 +37,14 @@ impl RspBody {
 }
 
 impl Body for RspBody {
-    type Data = <Bytes as IntoBuf>::Buf;
+    type Item = <Bytes as IntoBuf>::Buf;
     type Error = h2::Error;
 
     fn is_end_stream(&self) -> bool {
         self.0.as_ref().map(|b| b.is_empty()).unwrap_or(false)
     }
 
-    fn poll_data(&mut self) -> Poll<Option<Self::Data>, h2::Error> {
+    fn poll_buf(&mut self) -> Poll<Option<Self::Item>, h2::Error> {
         let data = self.0.take().and_then(|b| {
             if b.is_empty() {
                 None
@@ -125,54 +125,49 @@ fn main() {
         let serve_span = span!(
             Level::TRACE,
             "serve",
-            local_ip = field::debug(addr.ip()),
-            local_port = addr.port() as u64
+            local.ip = field::debug(addr.ip()),
+            local.port = addr.port() as u64
         );
         let new_svc =
-            tracing_tower_http::InstrumentedMakeService::with_span(NewSvc, serve_span.clone());
-        let serve_span2 = serve_span.clone();
-        serve_span.enter(move || {
-            let h2 = Server::new(new_svc, Default::default(), reactor.clone());
+            tokio_trace_tower_http::InstrumentedMakeService::with_span(NewSvc, serve_span.clone());
+        let h2 = Server::new(new_svc, Default::default(), reactor.clone());
 
-            let serve = bind
-                .incoming()
-                .fold((h2, reactor), |(mut h2, reactor), sock| {
-                    let addr = sock.peer_addr().expect("can't get addr");
-                    let conn_span = span!(
-                        Level::TRACE,
-                        "conn",
-                        remote_ip = field::debug(addr.ip()),
-                        remote_port = addr.port() as u64
-                    );
-                    let conn_span2 = conn_span.clone();
-                    conn_span.enter(|| {
-                        if let Err(e) = sock.set_nodelay(true) {
-                            return Err(e);
-                        }
+        let serve = bind
+            .incoming()
+            .fold((h2, reactor), |(mut h2, reactor), sock| {
+                let addr = sock.peer_addr().expect("can't get addr");
+                let conn_span = span!(
+                    Level::TRACE,
+                    "conn",
+                    remote.ip = field::debug(addr.ip()),
+                    remote.port = addr.port() as u64
+                );
+                let _enter = conn_span.enter();
+                if let Err(e) = sock.set_nodelay(true) {
+                    return Err(e);
+                }
 
-                        info!("accepted connection");
+                info!("accepted connection");
 
-                        let serve = h2
-                            .serve(sock)
-                            .map_err(|e| error!("error {:?}", e))
-                            .and_then(|_| {
-                                debug!("response finished");
-                                future::ok(())
-                            })
-                            .instrument(conn_span2);
-                        reactor.spawn(Box::new(serve));
-
-                        Ok((h2, reactor))
+                let serve = h2
+                    .serve(sock)
+                    .map_err(|e| error!("error {:?}", e))
+                    .and_then(|_| {
+                        debug!("response finished");
+                        future::ok(())
                     })
-                })
-                .map_err(|e| {
-                    error!("serve error {:?}", e);
-                })
-                .map(|_| {})
-                .instrument(serve_span2);
+                    .instrument(conn_span.clone());
+                reactor.spawn(Box::new(serve));
 
-            rt.spawn(serve);
-            rt.shutdown_on_idle().wait().unwrap();
-        });
+                Ok((h2, reactor))
+            })
+            .map_err(|e| {
+                error!("serve error {:?}", e);
+            })
+            .map(|_| {})
+            .instrument(serve_span);
+
+        rt.spawn(serve);
+        rt.shutdown_on_idle().wait().unwrap();
     });
 }

--- a/tracing-tower-http/examples/tower-h2-server.rs
+++ b/tracing-tower-http/examples/tower-h2-server.rs
@@ -124,6 +124,8 @@ fn main() {
             local.ip = field::debug(addr.ip()),
             local.port = addr.port() as u64
         );
+        let _enter = serve_span.enter();
+
         let new_svc =
             tracing_tower_http::InstrumentedMakeService::with_span(NewSvc, serve_span.clone());
         let h2 = Server::new(new_svc, Default::default(), reactor.clone());
@@ -161,7 +163,7 @@ fn main() {
                 error!("serve error {:?}", e);
             })
             .map(|_| {})
-            .instrument(serve_span);
+            .instrument(serve_span.clone());
 
         rt.spawn(serve);
         rt.shutdown_on_idle().wait().unwrap();

--- a/tracing-tower-http/examples/tower-h2-server.rs
+++ b/tracing-tower-http/examples/tower-h2-server.rs
@@ -129,7 +129,7 @@ fn main() {
             local.port = addr.port() as u64
         );
         let new_svc =
-            tokio_trace_tower_http::InstrumentedMakeService::with_span(NewSvc, serve_span.clone());
+            tracing_tower_http::InstrumentedMakeService::with_span(NewSvc, serve_span.clone());
         let h2 = Server::new(new_svc, Default::default(), reactor.clone());
 
         let serve = bind

--- a/tracing-tower-http/src/lib.rs
+++ b/tracing-tower-http/src/lib.rs
@@ -134,7 +134,7 @@ where
 
     fn call(&mut self, request: http::Request<B>) -> Self::Future {
         let span = trace_span!(
-            parent: self.span.as_ref(),
+            parent: self.span.as_ref().and_then(Into::into),
             "request",
             // TODO: custom `Value` impls for `http` types would be nicer
             // than just sticking these in `debug`s...

--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -4,11 +4,7 @@ version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
+tracing = { version = "0.1", path = "../tracing" }
 tracing-futures = { path = "../tracing-futures" }
 futures = "0.1"
 tower-service = "0.2"
-
-[dependencies.tracing]
-# TODO: replace this with a path dependency on the local `tracing`.
-package = "tokio-trace"
-version = "0.1"

--- a/tracing-tower/src/lib.rs
+++ b/tracing-tower/src/lib.rs
@@ -37,7 +37,8 @@ where
 
     fn call(&mut self, req: Request) -> Self::Future {
         // TODO: custom `Value` impls for `http` types would be nice...
-        let span = span!(Level::TRACE, parent: &self.span, "request", request = &field::debug(&req));
+        let span =
+            span!(Level::TRACE, parent: &self.span, "request", request = &field::debug(&req));
         let _enter = span.enter();
         self.inner.call(req).instrument(span.clone())
     }

--- a/tracing-tower/src/lib.rs
+++ b/tracing-tower/src/lib.rs
@@ -6,7 +6,7 @@ extern crate tracing_futures;
 
 use std::fmt;
 use tower_service::Service;
-use tracing::{field, Level};
+use tracing::Level;
 use tracing_futures::{Instrument, Instrumented};
 
 #[derive(Clone, Debug)]
@@ -37,8 +37,7 @@ where
 
     fn call(&mut self, req: Request) -> Self::Future {
         // TODO: custom `Value` impls for `http` types would be nice...
-        let span =
-            span!(Level::TRACE, parent: &self.span, "request", request = ?req);
+        let span = span!(Level::TRACE, parent: &self.span, "request", request = ?req);
         let _enter = span.enter();
         self.inner.call(req).instrument(span.clone())
     }

--- a/tracing-tower/src/lib.rs
+++ b/tracing-tower/src/lib.rs
@@ -37,7 +37,8 @@ where
 
     fn call(&mut self, req: Request) -> Self::Future {
         // TODO: custom `Value` impls for `http` types would be nice...
-        let span = span!(Level::TRACE, parent: &self.span, "request", request = ?req);
+        let span =
+            span!(Level::TRACE, parent: &self.span, "request", request = ?req);
         let _enter = span.enter();
         self.inner.call(req).instrument(span.clone())
     }

--- a/tracing-tower/src/lib.rs
+++ b/tracing-tower/src/lib.rs
@@ -37,8 +37,7 @@ where
 
     fn call(&mut self, req: Request) -> Self::Future {
         // TODO: custom `Value` impls for `http` types would be nice...
-        let span =
-            span!(Level::TRACE, parent: &self.span, "request", request = ?req);
+        let span = span!(Level::TRACE, parent: &self.span, "request", request = ?req);
         let _enter = span.enter();
         self.inner.call(req).instrument(span.clone())
     }

--- a/tracing-tower/src/lib.rs
+++ b/tracing-tower/src/lib.rs
@@ -38,7 +38,7 @@ where
     fn call(&mut self, req: Request) -> Self::Future {
         // TODO: custom `Value` impls for `http` types would be nice...
         let span = span!(Level::TRACE, parent: &self.span, "request", request = &field::debug(&req));
-        let enter = span.enter();
+        let _enter = span.enter();
         self.inner.call(req).instrument(span.clone())
     }
 }

--- a/tracing-tower/src/lib.rs
+++ b/tracing-tower/src/lib.rs
@@ -38,7 +38,7 @@ where
     fn call(&mut self, req: Request) -> Self::Future {
         // TODO: custom `Value` impls for `http` types would be nice...
         let span =
-            span!(Level::TRACE, parent: &self.span, "request", request = &field::debug(&req));
+            span!(Level::TRACE, parent: &self.span, "request", request = ?req);
         let _enter = span.enter();
         self.inner.call(req).instrument(span.clone())
     }


### PR DESCRIPTION
This branch updates the "nursery" crates to depend on `tracing` and
`tracing-core` as path dependencies, rather than depending on the
crates.io releases of `tokio-trace` and `tokio-trace-core`. When
`tracing` and `tracing-core` are released, we will change these from
path dependencies to crates.io dependencies.

This branch also updates those crates to track API changes in `tracing`
and `tracing-core`.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>