### PR TITLE
tracing: fix event macros not overriding parents

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -871,7 +871,7 @@ macro_rules! event {
                 };
                 if is_enabled!(callsite) {
                     let meta = callsite.metadata();
-                    Event::dispatch(meta, &valueset!(meta.fields(), $($fields)*) );
+                    Event::child_of($parent, meta, &valueset!(meta.fields(), $($fields)*) );
                 }
             }
         }

--- a/tracing/tests/event.rs
+++ b/tracing/tests/event.rs
@@ -246,3 +246,43 @@ fn both_shorthands() {
 
     handle.assert_finished();
 }
+
+#[test]
+fn explicit_child() {
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(span::mock().named("foo"))
+        .event(event::mock().with_explicit_parent(Some("foo")))
+        .done()
+        .run_with_handle();
+
+    with_default(subscriber, || {
+        let foo = span!(Level::TRACE, "foo");
+        event!(Level::TRACE, parent: foo.id(), "bar");
+    });
+
+    handle.assert_finished();
+}
+
+#[test]
+fn explicit_child_at_levels() {
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(span::mock().named("foo"))
+        .event(event::mock().with_explicit_parent(Some("foo")))
+        .event(event::mock().with_explicit_parent(Some("foo")))
+        .event(event::mock().with_explicit_parent(Some("foo")))
+        .event(event::mock().with_explicit_parent(Some("foo")))
+        .event(event::mock().with_explicit_parent(Some("foo")))
+        .done()
+        .run_with_handle();
+
+    with_default(subscriber, || {
+        let foo = span!(Level::TRACE, "foo");
+        trace!(parent: foo.id(), "a");
+        debug!(parent: foo.id(), "b");
+        info!(parent: foo.id(), "c");
+        warn!(parent: foo.id(), "d");
+        error!(parent: foo.id(), "e");
+    });
+
+    handle.assert_finished();
+}

--- a/tracing/tests/macros.rs
+++ b/tracing/tests/macros.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use tracing::Level;
 
 #[macro_use]

--- a/tracing/tests/support/event.rs
+++ b/tracing/tests/support/event.rs
@@ -78,7 +78,6 @@ impl MockEvent {
         }
     }
 
-
     pub(in support) fn check(&mut self, event: &tracing::Event) {
         let meta = event.metadata();
         let name = meta.name();

--- a/tracing/tests/support/mod.rs
+++ b/tracing/tests/support/mod.rs
@@ -6,3 +6,11 @@ pub mod span;
 pub mod subscriber;
 
 extern crate tracing_core;
+
+#[derive(Debug, Eq, PartialEq)]
+pub(in support) enum Parent {
+    ContextualRoot,
+    Contextual(String),
+    ExplicitRoot,
+    Explicit(String),
+}

--- a/tracing/tests/support/span.rs
+++ b/tracing/tests/support/span.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-use super::{field, metadata};
+use super::{field, metadata, Parent};
 use std::fmt;
 
 /// A mock span.
@@ -9,14 +9,6 @@ use std::fmt;
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct MockSpan {
     pub(in support) metadata: metadata::Expect,
-}
-
-#[derive(Debug, Eq, PartialEq)]
-pub(in support) enum Parent {
-    ContextualRoot,
-    Contextual(String),
-    ExplicitRoot,
-    Explicit(String),
 }
 
 #[derive(Debug, Default, Eq, PartialEq)]

--- a/tracing/tests/support/subscriber.rs
+++ b/tracing/tests/support/subscriber.rs
@@ -227,7 +227,7 @@ where
                     }
                     None => {}
                 }
-            },
+            }
             Some(ex) => ex.bad(format_args!("observed event {:?}", event)),
         }
     }


### PR DESCRIPTION
## Motivation

The event macros added support for overriding the event's parent in
tokio-rs/tracing#1109, but the overridden parent was not actually set,
as the macro always called `Event::dispatch`.

## Solution

This branch fixes this, and adds tests that assert that the correct
parent is set. I've also changed the macro tests to deny all warnings,
as an unused variable warning was an indicator that the parent field was
being ignored.

Fixes #100

Signed-off-by: Eliza Weisman <eliza@buoyant.io>