### PR TITLE
fmt, log: fix API breakage

### DIFF
--- a/tracing-fmt/src/filter/env.rs
+++ b/tracing-fmt/src/filter/env.rs
@@ -531,6 +531,7 @@ mod tests {
     use default::NewRecorder;
     use span::*;
     use tracing_core::*;
+    use tracing_core::field::FieldSet;
 
     struct Cs;
 
@@ -553,8 +554,7 @@ mod tests {
             None,
             None,
             None,
-            &[],
-            &Cs,
+            FieldSet::new(&[], identify_callsite!(&Cs)),
             Kind::SPAN,
         );
 
@@ -574,8 +574,7 @@ mod tests {
             None,
             None,
             None,
-            &[],
-            &Cs,
+            FieldSet::new(&[], identify_callsite!(&Cs)),
             Kind::SPAN,
         );
 
@@ -595,8 +594,7 @@ mod tests {
             None,
             None,
             None,
-            &[],
-            &Cs,
+            FieldSet::new(&[], identify_callsite!(&Cs)s),
             Kind::SPAN,
         );
 
@@ -616,8 +614,7 @@ mod tests {
             None,
             None,
             None,
-            &["field=\"value\""],
-            &Cs,
+            FieldSet::new(&["field=\"value\""], identify_callsite!(&Cs)),
             Kind::SPAN,
         );
 
@@ -637,8 +634,7 @@ mod tests {
             None,
             None,
             None,
-            &["field=\"value\""],
-            &Cs,
+            FieldSet::new(&["field=\"value\""], identify_callsite!(&Cs)),
             Kind::SPAN,
         );
 
@@ -658,8 +654,7 @@ mod tests {
             None,
             None,
             None,
-            &["field=\"value\""],
-            &Cs,
+            FieldSet::new(&["field=\"value\""], identify_callsite!(&Cs)),
             Kind::SPAN,
         );
 
@@ -679,8 +674,7 @@ mod tests {
             None,
             None,
             None,
-            &["field=\"value\""],
-            &Cs,
+            FieldSet::new(&["field=\"value\""], identify_callsite!(&Cs)),
             Kind::SPAN,
         );
 

--- a/tracing-fmt/src/filter/env.rs
+++ b/tracing-fmt/src/filter/env.rs
@@ -594,7 +594,7 @@ mod tests {
             None,
             None,
             None,
-            FieldSet::new(&[], identify_callsite!(&Cs)s),
+            FieldSet::new(&[], identify_callsite!(&Cs)),
             Kind::SPAN,
         );
 

--- a/tracing-fmt/src/filter/env.rs
+++ b/tracing-fmt/src/filter/env.rs
@@ -530,8 +530,8 @@ mod tests {
     use super::*;
     use default::NewRecorder;
     use span::*;
-    use tracing_core::*;
     use tracing_core::field::FieldSet;
+    use tracing_core::*;
 
     struct Cs;
 

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.0.1"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
-tracing = { version = "0.1", path = "../tracing" }
+tracing-core = { version = "0.1", path = "../tracing-core" }
 tracing-subscriber = { path = "../tracing-subscriber" }
 log = "0.4"

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -35,12 +35,11 @@ use std::{
 
 use tracing_core::{
     callsite::{self, Callsite},
-    dispatcher, field,
+    dispatcher, field, identify_callsite,
     metadata::Kind,
     span::{self, Id},
     subscriber::{self, Subscriber},
     Event, Metadata,
-    identify_callsite,
 };
 
 /// Format a log record as a trace event in the current span.


### PR DESCRIPTION


## Motivation

PR #106 broke some APIs that the nursery crates `tracing-fmt` and
`tracing-log` depended on. At the time, we didn't catch this, as those
crates still depended on `tokio-trace`/`tokio-trace-core` from
crates.io. However, after merging #101, which updated those crates to
use path dependencies on `tracing`/`tracing-core`, those crates broke. 

## Solution

This branch updates `tracing-fmt` and `tracing-log` to compile with the
changed APIs. `tracing-log` was also changed to depend on `tracing-core`
rather than `tracing`, as only the `core API is required by that crate,
and the `identify_callsite!` macro is not publically re-exported by 
`tracing`.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>