### PR TITLE
change Metadata to always be 'static

### DIFF
--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -61,7 +61,7 @@ pub trait Callsite: Sync {
     /// Returns the [metadata] associated with the callsite.
     ///
     /// [metadata]: ../metadata/struct.Metadata.html
-    fn metadata(&self) -> &Metadata;
+    fn metadata(&self) -> &'static Metadata;
 }
 
 /// Uniquely identifies a [`Callsite`]

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -199,7 +199,7 @@ impl Dispatch {
     /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
     /// [`register_callsite`]: ../subscriber/trait.Subscriber.html#method.register_callsite
     #[inline]
-    pub fn register_callsite(&self, metadata: &Metadata) -> subscriber::Interest {
+    pub fn register_callsite(&self, metadata: &'static Metadata) -> subscriber::Interest {
         self.subscriber.register_callsite(metadata)
     }
 
@@ -252,7 +252,7 @@ impl Dispatch {
     /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
     /// [`enabled`]: ../subscriber/trait.Subscriber.html#method.enabled
     #[inline]
-    pub fn enabled(&self, metadata: &Metadata) -> bool {
+    pub fn enabled(&self, metadata: &'static Metadata) -> bool {
         self.subscriber.enabled(metadata)
     }
 
@@ -358,7 +358,7 @@ where
 struct NoSubscriber;
 impl Subscriber for NoSubscriber {
     #[inline]
-    fn register_callsite(&self, _: &Metadata) -> subscriber::Interest {
+    fn register_callsite(&self, _: &'static Metadata) -> subscriber::Interest {
         subscriber::Interest::never()
     }
 
@@ -373,7 +373,7 @@ impl Subscriber for NoSubscriber {
     fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
 
     #[inline]
-    fn enabled(&self, _metadata: &Metadata) -> bool {
+    fn enabled(&self, _metadata: &'static Metadata) -> bool {
         false
     }
 
@@ -382,7 +382,7 @@ impl Subscriber for NoSubscriber {
 }
 
 impl Registrar {
-    pub(crate) fn try_register(&self, metadata: &Metadata) -> Option<subscriber::Interest> {
+    pub(crate) fn try_register(&self, metadata: &'static Metadata) -> Option<subscriber::Interest> {
         self.0.upgrade().map(|s| s.register_callsite(metadata))
     }
 
@@ -461,7 +461,7 @@ mod test {
 
     impl Callsite for TestCallsite {
         fn set_interest(&self, _: Interest) {}
-        fn metadata(&self) -> &Metadata {
+        fn metadata(&self) -> &'static Metadata {
             &TEST_META
         }
     }
@@ -472,7 +472,7 @@ mod test {
         // won't cause an infinite loop of events.
         struct TestSubscriber;
         impl Subscriber for TestSubscriber {
-            fn enabled(&self, _: &Metadata) -> bool {
+            fn enabled(&self, _: &'static Metadata) -> bool {
                 true
             }
 
@@ -520,7 +520,7 @@ mod test {
 
         struct TestSubscriber;
         impl Subscriber for TestSubscriber {
-            fn enabled(&self, _: &Metadata) -> bool {
+            fn enabled(&self, _: &'static Metadata) -> bool {
                 true
             }
 
@@ -553,7 +553,7 @@ mod test {
     fn global_dispatch() {
         struct TestSubscriberA;
         impl Subscriber for TestSubscriberA {
-            fn enabled(&self, _: &Metadata) -> bool {
+            fn enabled(&self, _: &'static Metadata) -> bool {
                 true
             }
             fn new_span(&self, _: &span::Attributes) -> span::Id {
@@ -567,7 +567,7 @@ mod test {
         }
         struct TestSubscriberB;
         impl Subscriber for TestSubscriberB {
-            fn enabled(&self, _: &Metadata) -> bool {
+            fn enabled(&self, _: &'static Metadata) -> bool {
                 true
             }
             fn new_span(&self, _: &span::Attributes) -> span::Id {

--- a/tracing-core/src/event.rs
+++ b/tracing-core/src/event.rs
@@ -22,7 +22,7 @@ use {field, Metadata};
 #[derive(Debug)]
 pub struct Event<'a> {
     fields: &'a field::ValueSet<'a>,
-    metadata: &'a Metadata<'a>,
+    metadata: &'static Metadata,
     parent: Parent,
 }
 
@@ -30,7 +30,7 @@ impl<'a> Event<'a> {
     /// Constructs a new `Event` with the specified metadata and set of values,
     /// and observes it with the current subscriber.
     #[inline]
-    pub fn dispatch(metadata: &'a Metadata<'a>, fields: &'a field::ValueSet) {
+    pub fn dispatch(metadata: &'static Metadata, fields: &'a field::ValueSet) {
         let event = Event {
             metadata,
             fields,
@@ -46,7 +46,7 @@ impl<'a> Event<'a> {
     #[inline]
     pub fn child_of(
         parent: impl Into<Option<Id>>,
-        metadata: &'a Metadata<'a>,
+        metadata: &'static Metadata,
         fields: &'a field::ValueSet,
     ) {
         let parent = match parent.into() {
@@ -80,7 +80,7 @@ impl<'a> Event<'a> {
     /// Returns [metadata] describing this `Event`.
     ///
     /// [metadata]: ../metadata/struct.Metadata.html
-    pub fn metadata(&self) -> &Metadata {
+    pub fn metadata(&self) -> &'static Metadata {
         self.metadata
     }
 

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -681,7 +681,7 @@ mod test {
             unimplemented!()
         }
 
-        fn metadata(&self) -> &Metadata {
+        fn metadata(&self) -> &'static Metadata {
             &TEST_META_1
         }
     }
@@ -702,7 +702,7 @@ mod test {
             unimplemented!()
         }
 
-        fn metadata(&self) -> &Metadata {
+        fn metadata(&self) -> &'static Metadata {
             &TEST_META_2
         }
     }

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -66,7 +66,7 @@ extern crate lazy_static;
 /// }
 /// impl callsite::Callsite for MyCallsite {
 /// # fn set_interest(&self, _: Interest) { unimplemented!() }
-/// # fn metadata(&self) -> &Metadata { unimplemented!() }
+/// # fn metadata(&self) -> &'static Metadata { unimplemented!() }
 ///     // ...
 /// }
 ///
@@ -100,7 +100,7 @@ macro_rules! identify_callsite {
 /// # pub struct MyCallsite { }
 /// # impl Callsite for MyCallsite {
 /// # fn set_interest(&self, _: Interest) { unimplemented!() }
-/// # fn metadata(&self) -> &Metadata { unimplemented!() }
+/// # fn metadata(&self) -> &'static Metadata { unimplemented!() }
 /// # }
 /// #
 /// static FOO_CALLSITE: MyCallsite = MyCallsite {

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -47,24 +47,24 @@ use std::fmt;
 /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
 /// [`id`]: struct.Metadata.html#method.id
 /// [callsite identifier]: ../callsite/struct.Identifier.html
-pub struct Metadata<'a> {
+pub struct Metadata {
     /// The name of the span described by this metadata.
     name: &'static str,
 
     /// The part of the system that the span that this metadata describes
     /// occurred in.
-    target: &'a str,
+    target: &'static str,
 
     /// The level of verbosity of the described span.
     level: Level,
 
     /// The name of the Rust module where the span occurred, or `None` if this
     /// could not be determined.
-    module_path: Option<&'a str>,
+    module_path: Option<&'static str>,
 
     /// The name of the source code file where the span occurred, or `None` if
     /// this could not be determined.
-    file: Option<&'a str>,
+    file: Option<&'static str>,
 
     /// The line number in the source code file where the span occurred, or
     /// `None` if this could not be determined.
@@ -86,18 +86,19 @@ pub struct Kind(KindInner);
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Level(LevelInner);
 
+
 // ===== impl Metadata =====
 
-impl<'a> Metadata<'a> {
+impl Metadata {
     /// Construct new metadata for a span or event, with a name, target, level, field
     /// names, and optional source code location.
     pub const fn new(
         name: &'static str,
-        target: &'a str,
+        target: &'static str,
         level: Level,
-        file: Option<&'a str>,
+        file: Option<&'static str>,
         line: Option<u32>,
-        module_path: Option<&'a str>,
+        module_path: Option<&'static str>,
         fields: field::FieldSet,
         kind: Kind,
     ) -> Self {
@@ -133,19 +134,19 @@ impl<'a> Metadata<'a> {
     ///
     /// Typically, this is the module path, but alternate targets may be set
     /// when spans or events are constructed.
-    pub fn target(&self) -> &'a str {
+    pub fn target(&self) -> &'static str {
         self.target
     }
 
     /// Returns the path to the Rust module where the span occurred, or
     /// `None` if the module path is unknown.
-    pub fn module_path(&self) -> Option<&'a str> {
+    pub fn module_path(&self) -> Option<&'static str> {
         self.module_path
     }
 
     /// Returns the name of the source code file where the span
     /// occurred, or `None` if the file is unknown
-    pub fn file(&self) -> Option<&'a str> {
+    pub fn file(&self) -> Option<&'static str> {
         self.file
     }
 
@@ -173,7 +174,7 @@ impl<'a> Metadata<'a> {
     }
 }
 
-impl<'a> fmt::Debug for Metadata<'a> {
+impl fmt::Debug for Metadata {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut meta = f.debug_struct("Metadata");
         meta.field("name", &self.name)

--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -19,7 +19,7 @@ pub struct Id(NonZeroU64);
 /// created.
 #[derive(Debug)]
 pub struct Attributes<'a> {
-    metadata: &'a Metadata<'a>,
+    metadata: &'static Metadata,
     values: &'a field::ValueSet<'a>,
     parent: Parent,
 }
@@ -60,7 +60,7 @@ impl<'a> Into<Option<Id>> for &'a Id {
 impl<'a> Attributes<'a> {
     /// Returns `Attributes` describing a new child span of the current span,
     /// with the provided metadata and values.
-    pub fn new(metadata: &'a Metadata<'a>, values: &'a field::ValueSet<'a>) -> Self {
+    pub fn new(metadata: &'static Metadata, values: &'a field::ValueSet<'a>) -> Self {
         Attributes {
             metadata,
             values,
@@ -70,7 +70,7 @@ impl<'a> Attributes<'a> {
 
     /// Returns `Attributes` describing a new span at the root of its own trace
     /// tree, with the provided metadata and values.
-    pub fn new_root(metadata: &'a Metadata<'a>, values: &'a field::ValueSet<'a>) -> Self {
+    pub fn new_root(metadata: &'static Metadata, values: &'a field::ValueSet<'a>) -> Self {
         Attributes {
             metadata,
             values,
@@ -82,7 +82,7 @@ impl<'a> Attributes<'a> {
     /// parent span, with the provided metadata and values.
     pub fn child_of(
         parent: Id,
-        metadata: &'a Metadata<'a>,
+        metadata: &'static Metadata,
         values: &'a field::ValueSet<'a>,
     ) -> Self {
         Attributes {
@@ -93,7 +93,7 @@ impl<'a> Attributes<'a> {
     }
 
     /// Returns a reference to the new span's metadata.
-    pub fn metadata(&self) -> &Metadata<'a> {
+    pub fn metadata(&self) -> &'static Metadata {
         self.metadata
     }
 

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -108,7 +108,7 @@ pub trait Subscriber: 'static {
     /// [`Interest`]: struct.Interest.html
     /// [`enabled`]: #method.enabled
     /// [`rebuild_interest_cache`]: ../callsite/fn.rebuild_interest_cache.html
-    fn register_callsite(&self, metadata: &Metadata) -> Interest {
+    fn register_callsite(&self, metadata: &'static Metadata) -> Interest {
         match self.enabled(metadata) {
             true => Interest::always(),
             false => Interest::never(),
@@ -135,7 +135,7 @@ pub trait Subscriber: 'static {
     /// [interested]: struct.Interest.html
     /// [`Interest::sometimes`]: struct.Interest.html#method.sometimes
     /// [`register_callsite`]: #method.register_callsite
-    fn enabled(&self, metadata: &Metadata) -> bool;
+    fn enabled(&self, metadata: &'static Metadata) -> bool;
 
     /// Visit the construction of a new span, returning a new [span ID] for the
     /// span being constructed.

--- a/tracing-core/tests/macros.rs
+++ b/tracing-core/tests/macros.rs
@@ -16,7 +16,7 @@ fn metadata_macro_api() {
         fn set_interest(&self, _: Interest) {
             unimplemented!("test")
         }
-        fn metadata(&self) -> &Metadata {
+        fn metadata(&self) -> &'static Metadata {
             unimplemented!("test")
         }
     }

--- a/tracing-fmt/src/filter/env.rs
+++ b/tracing-fmt/src/filter/env.rs
@@ -115,7 +115,7 @@ impl EnvFilter {
 
     fn directives_for<'a>(
         &'a self,
-        metadata: &'a Metadata<'a>,
+        metadata: &'static Metadata,
     ) -> impl Iterator<Item = &'a Directive> + 'a {
         let target = metadata.target();
         let name = metadata.name();
@@ -156,7 +156,7 @@ impl Default for EnvFilter {
 }
 
 impl<N> Filter<N> for EnvFilter {
-    fn callsite_enabled(&self, metadata: &Metadata, _: &Context<N>) -> Interest {
+    fn callsite_enabled(&self, metadata: &'static Metadata, _: &Context<N>) -> Interest {
         if !self.includes_span_directive && self.max_level < *metadata.level() {
             return Interest::never();
         }
@@ -185,7 +185,7 @@ impl<N> Filter<N> for EnvFilter {
         interest
     }
 
-    fn enabled<'a>(&self, metadata: &Metadata, ctx: &Context<'a, N>) -> bool {
+    fn enabled<'a>(&self, metadata: &'static Metadata, ctx: &Context<'a, N>) -> bool {
         for directive in self.directives_for(metadata) {
             let accepts_level = directive.level >= *metadata.level();
             match directive.in_span.as_ref() {
@@ -537,7 +537,7 @@ mod tests {
 
     impl Callsite for Cs {
         fn set_interest(&self, _interest: Interest) {}
-        fn metadata(&self) -> &Metadata {
+        fn metadata(&self) -> &'static Metadata {
             unimplemented!()
         }
     }

--- a/tracing-fmt/src/filter/mod.rs
+++ b/tracing-fmt/src/filter/mod.rs
@@ -3,7 +3,7 @@ use span;
 use tracing_core::{subscriber::Interest, Metadata};
 
 pub trait Filter<N> {
-    fn callsite_enabled(&self, metadata: &Metadata, ctx: &span::Context<N>) -> Interest {
+    fn callsite_enabled(&self, metadata: &'static Metadata, ctx: &span::Context<N>) -> Interest {
         if self.enabled(metadata, ctx) {
             Interest::always()
         } else {
@@ -11,7 +11,7 @@ pub trait Filter<N> {
         }
     }
 
-    fn enabled(&self, metadata: &Metadata, ctx: &span::Context<N>) -> bool;
+    fn enabled(&self, metadata: &'static Metadata, ctx: &span::Context<N>) -> bool;
 }
 
 pub mod env;
@@ -21,10 +21,10 @@ pub use self::{env::EnvFilter, reload::ReloadFilter};
 
 impl<'a, F, N> Filter<N> for F
 where
-    F: Fn(&Metadata, &span::Context<N>) -> bool,
+    F: Fn(&'static Metadata, &span::Context<N>) -> bool,
     N: ::NewVisitor<'a>,
 {
-    fn enabled(&self, metadata: &Metadata, ctx: &span::Context<N>) -> bool {
+    fn enabled(&self, metadata: &'static Metadata, ctx: &span::Context<N>) -> bool {
         (self)(metadata, ctx)
     }
 }

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -128,11 +128,11 @@ where
     E: FormatEvent<N> + 'static,
     F: Filter<N> + 'static,
 {
-    fn register_callsite(&self, metadata: &Metadata) -> Interest {
+    fn register_callsite(&self, metadata: &'static Metadata) -> Interest {
         self.filter.callsite_enabled(metadata, &self.ctx())
     }
 
-    fn enabled(&self, metadata: &Metadata) -> bool {
+    fn enabled(&self, metadata: &'static Metadata) -> bool {
         self.filter.enabled(metadata, &self.ctx())
     }
 

--- a/tracing-futures/src/test_support/metadata.rs
+++ b/tracing-futures/src/test_support/metadata.rs
@@ -9,7 +9,7 @@ pub struct Expect {
 }
 
 impl Expect {
-    pub(in test_support) fn check(&self, actual: &Metadata, ctx: fmt::Arguments) {
+    pub(in test_support) fn check(&self, actual: &'static Metadata, ctx: fmt::Arguments) {
         if let Some(ref expected_name) = self.name {
             let name = actual.name();
             assert!(

--- a/tracing-futures/src/test_support/subscriber.rs
+++ b/tracing-futures/src/test_support/subscriber.rs
@@ -34,30 +34,30 @@ struct SpanState {
     refs: usize,
 }
 
-struct Running<F: Fn(&Metadata) -> bool> {
+struct Running<F: Fn(&'static Metadata) -> bool> {
     spans: Mutex<HashMap<Id, SpanState>>,
     expected: Arc<Mutex<VecDeque<Expect>>>,
     ids: AtomicUsize,
     filter: F,
 }
 
-pub struct MockSubscriber<F: Fn(&Metadata) -> bool> {
+pub struct MockSubscriber<F: Fn(&'static Metadata) -> bool> {
     expected: VecDeque<Expect>,
     filter: F,
 }
 
 pub struct MockHandle(Arc<Mutex<VecDeque<Expect>>>);
 
-pub fn mock() -> MockSubscriber<fn(&Metadata) -> bool> {
+pub fn mock() -> MockSubscriber<fn(&'static Metadata) -> bool> {
     MockSubscriber {
         expected: VecDeque::new(),
-        filter: (|_: &Metadata| true) as for<'r, 's> fn(&'r Metadata<'s>) -> _,
+        filter: (|_: &'static Metadata| true) as for<'r, 's> fn(&'r Metadata<'s>) -> _,
     }
 }
 
 impl<F> MockSubscriber<F>
 where
-    F: Fn(&Metadata) -> bool + 'static,
+    F: Fn(&'static Metadata) -> bool + 'static,
 {
     pub fn enter(mut self, span: MockSpan) -> Self {
         self.expected.push_back(Expect::Enter(span));
@@ -107,7 +107,7 @@ where
 
     pub fn with_filter<G>(self, filter: G) -> MockSubscriber<G>
     where
-        G: Fn(&Metadata) -> bool,
+        G: Fn(&'static Metadata) -> bool,
     {
         MockSubscriber {
             filter,
@@ -135,9 +135,9 @@ where
 
 impl<F> Subscriber for Running<F>
 where
-    F: Fn(&Metadata) -> bool + 'static,
+    F: Fn(&'static Metadata) -> bool + 'static,
 {
-    fn enabled(&self, meta: &Metadata) -> bool {
+    fn enabled(&self, meta: &'static Metadata) -> bool {
         (self.filter)(meta)
     }
 

--- a/tracing-serde/examples/serde_shaved_yak.rs
+++ b/tracing-serde/examples/serde_shaved_yak.rs
@@ -23,7 +23,7 @@ pub struct JsonSubscriber {
 }
 
 impl Subscriber for JsonSubscriber {
-    fn enabled(&self, metadata: &Metadata) -> bool {
+    fn enabled(&self, metadata: &'static Metadata) -> bool {
         let json = json!({
         "enabled": {
             "metadata": metadata.as_serde(),

--- a/tracing/benches/subscriber.rs
+++ b/tracing/benches/subscriber.rs
@@ -33,7 +33,7 @@ impl tracing::Subscriber for EnabledSubscriber {
         let _ = (span, follows);
     }
 
-    fn enabled(&self, metadata: &Metadata) -> bool {
+    fn enabled(&self, metadata: &'static Metadata) -> bool {
         let _ = metadata;
         true
     }
@@ -80,7 +80,7 @@ impl tracing::Subscriber for VisitingSubscriber {
         let _ = (span, follows);
     }
 
-    fn enabled(&self, metadata: &Metadata) -> bool {
+    fn enabled(&self, metadata: &'static Metadata) -> bool {
         let _ = metadata;
         true
     }

--- a/tracing/examples/counters.rs
+++ b/tracing/examples/counters.rs
@@ -60,7 +60,7 @@ impl CounterSubscriber {
 }
 
 impl Subscriber for CounterSubscriber {
-    fn register_callsite(&self, meta: &Metadata) -> subscriber::Interest {
+    fn register_callsite(&self, meta: &'static Metadata) -> subscriber::Interest {
         let mut interest = subscriber::Interest::never();
         for key in meta.fields() {
             let name = key.name();
@@ -95,7 +95,7 @@ impl Subscriber for CounterSubscriber {
         event.record(&mut self.visitor())
     }
 
-    fn enabled(&self, metadata: &Metadata) -> bool {
+    fn enabled(&self, metadata: &'static Metadata) -> bool {
         metadata.fields().iter().any(|f| f.name().contains("count"))
     }
 

--- a/tracing/src/field.rs
+++ b/tracing/src/field.rs
@@ -17,14 +17,14 @@ pub trait AsField: ::sealed::Sealed {
     ///
     /// If `metadata` defines this field, then the field is returned. Otherwise,
     /// this returns `None`.
-    fn as_field(&self, metadata: &Metadata) -> Option<Field>;
+    fn as_field(&self, metadata: &'static Metadata) -> Option<Field>;
 }
 
 // ===== impl AsField =====
 
 impl AsField for Field {
     #[inline]
-    fn as_field(&self, metadata: &Metadata) -> Option<Field> {
+    fn as_field(&self, metadata: &'static Metadata) -> Option<Field> {
         if self.callsite() == metadata.callsite() {
             Some(self.clone())
         } else {
@@ -35,7 +35,7 @@ impl AsField for Field {
 
 impl<'a> AsField for &'a Field {
     #[inline]
-    fn as_field(&self, metadata: &Metadata) -> Option<Field> {
+    fn as_field(&self, metadata: &'static Metadata) -> Option<Field> {
         if self.callsite() == metadata.callsite() {
             Some((*self).clone())
         } else {
@@ -46,7 +46,7 @@ impl<'a> AsField for &'a Field {
 
 impl AsField for str {
     #[inline]
-    fn as_field(&self, metadata: &Metadata) -> Option<Field> {
+    fn as_field(&self, metadata: &'static Metadata) -> Option<Field> {
         metadata.fields().field(&self)
     }
 }

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -254,7 +254,7 @@
 //! #   fn record(&self, _: &Id, _: &Record) {}
 //! #   fn event(&self, _: &tracing::Event) {}
 //! #   fn record_follows_from(&self, _: &Id, _: &Id) {}
-//! #   fn enabled(&self, _: &Metadata) -> bool { false }
+//! #   fn enabled(&self, _: &'static Metadata) -> bool { false }
 //! #   fn enter(&self, _: &Id) {}
 //! #   fn exit(&self, _: &Id) {}
 //! # }

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -2020,15 +2020,13 @@ macro_rules! callsite {
         };
         use $crate::{callsite, subscriber::Interest, Metadata};
         struct MyCallsite;
-        static META: Metadata<'static> = {
-            metadata! {
-                name: $name,
-                target: $target,
-                level: $lvl,
-                fields: fieldset!( $($fields)* ),
-                callsite: &MyCallsite,
-                kind: $kind,
-            }
+        static META: Metadata = metadata! {
+            name: $name,
+            target: $target,
+            level: $lvl,
+            fields: fieldset!( $($fields)* ),
+            callsite: &MyCallsite,
+            kind: $kind,
         };
         // FIXME: Rust 1.34 deprecated ATOMIC_USIZE_INIT. When Tokio's minimum
         // supported version is 1.34, replace this with the const fn `::new`.
@@ -2055,7 +2053,7 @@ macro_rules! callsite {
                 INTEREST.store(interest, Ordering::SeqCst);
             }
 
-            fn metadata(&self) -> &Metadata {
+            fn metadata(&self) -> &'static Metadata {
                 &META
             }
         }

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -328,7 +328,7 @@ pub struct Span {
     ///
     /// If this is `None`, then the span has either closed or was never enabled.
     inner: Option<Inner>,
-    meta: &'static Metadata<'static>,
+    meta: &'static Metadata,
 }
 
 /// A handle representing the capacity to enter a span which is known to exist.
@@ -379,7 +379,7 @@ impl Span {
     /// [field values]: ../field/struct.ValueSet.html
     /// [`follows_from`]: ../struct.Span.html#method.follows_from
     #[inline]
-    pub fn new(meta: &'static Metadata<'static>, values: &field::ValueSet) -> Span {
+    pub fn new(meta: &'static Metadata, values: &field::ValueSet) -> Span {
         let new_span = Attributes::new(meta, values);
         Self::make(meta, new_span)
     }
@@ -394,7 +394,7 @@ impl Span {
     /// [field values]: ../field/struct.ValueSet.html
     /// [`follows_from`]: ../struct.Span.html#method.follows_from
     #[inline]
-    pub fn new_root(meta: &'static Metadata<'static>, values: &field::ValueSet) -> Span {
+    pub fn new_root(meta: &'static Metadata, values: &field::ValueSet) -> Span {
         Self::make(meta, Attributes::new_root(meta, values))
     }
 
@@ -409,7 +409,7 @@ impl Span {
     /// [`follows_from`]: ../struct.Span.html#method.follows_from
     pub fn child_of(
         parent: impl Into<Option<Id>>,
-        meta: &'static Metadata<'static>,
+        meta: &'static Metadata,
         values: &field::ValueSet,
     ) -> Span {
         let new_span = match parent.into() {
@@ -421,11 +421,11 @@ impl Span {
 
     /// Constructs a new disabled span.
     #[inline(always)]
-    pub fn new_disabled(meta: &'static Metadata<'static>) -> Span {
+    pub fn new_disabled(meta: &'static Metadata) -> Span {
         Span { inner: None, meta }
     }
 
-    fn make(meta: &'static Metadata<'static>, new_span: Attributes) -> Span {
+    fn make(meta: &'static Metadata, new_span: Attributes) -> Span {
         let attrs = &new_span;
         let inner = ::dispatcher::get_default(move |dispatch| {
             let id = dispatch.new_span(attrs);
@@ -646,7 +646,7 @@ impl Span {
     }
 
     /// Returns this span's `Metadata`, if it is enabled.
-    pub fn metadata(&self) -> Option<&'static Metadata<'static>> {
+    pub fn metadata(&self) -> Option<&'static Metadata> {
         if self.inner.is_some() {
             Some(self.meta)
         } else {

--- a/tracing/test-log-support/tests/log_no_trace.rs
+++ b/tracing/test-log-support/tests/log_no_trace.rs
@@ -13,7 +13,7 @@ struct State {
 struct Logger(Arc<State>);
 
 impl Log for Logger {
-    fn enabled(&self, _: &Metadata) -> bool {
+    fn enabled(&self, _: &'static Metadata) -> bool {
         true
     }
 

--- a/tracing/test_static_max_level_features/tests/test.rs
+++ b/tracing/test_static_max_level_features/tests/test.rs
@@ -12,7 +12,7 @@ struct State {
 struct TestSubscriber(Arc<State>);
 
 impl Subscriber for TestSubscriber {
-    fn enabled(&self, _: &Metadata) -> bool {
+    fn enabled(&self, _: &'static Metadata) -> bool {
         true
     }
 

--- a/tracing/tests/subscriber.rs
+++ b/tracing/tests/subscriber.rs
@@ -12,13 +12,13 @@ fn event_macros_dont_infinite_loop() {
     // won't cause an infinite loop of events.
     struct TestSubscriber;
     impl Subscriber for TestSubscriber {
-        fn register_callsite(&self, _: &Metadata) -> Interest {
+        fn register_callsite(&self, _: &'static Metadata) -> Interest {
             // Always return sometimes so that `enabled` will be called
             // (which can loop).
             Interest::sometimes()
         }
 
-        fn enabled(&self, meta: &Metadata) -> bool {
+        fn enabled(&self, meta: &'static Metadata) -> bool {
             assert!(meta.fields().iter().any(|f| f.name() == "foo"));
             event!(Level::TRACE, bar = false);
             true

--- a/tracing/tests/support/metadata.rs
+++ b/tracing/tests/support/metadata.rs
@@ -9,7 +9,7 @@ pub struct Expect {
 }
 
 impl Expect {
-    pub(in support) fn check(&self, actual: &Metadata, ctx: fmt::Arguments) {
+    pub(in support) fn check(&self, actual: &'static Metadata, ctx: fmt::Arguments) {
         if let Some(ref expected_name) = self.name {
             let name = actual.name();
             assert!(

--- a/tracing/tests/support/subscriber.rs
+++ b/tracing/tests/support/subscriber.rs
@@ -35,7 +35,7 @@ struct SpanState {
     refs: usize,
 }
 
-struct Running<F: Fn(&Metadata) -> bool> {
+struct Running<F: Fn(&'static Metadata) -> bool> {
     spans: Mutex<HashMap<Id, SpanState>>,
     expected: Arc<Mutex<VecDeque<Expect>>>,
     current: Mutex<Vec<Id>>,
@@ -43,23 +43,23 @@ struct Running<F: Fn(&Metadata) -> bool> {
     filter: F,
 }
 
-pub struct MockSubscriber<F: Fn(&Metadata) -> bool> {
+pub struct MockSubscriber<F: Fn(&'static Metadata) -> bool> {
     expected: VecDeque<Expect>,
     filter: F,
 }
 
 pub struct MockHandle(Arc<Mutex<VecDeque<Expect>>>);
 
-pub fn mock() -> MockSubscriber<fn(&Metadata) -> bool> {
+pub fn mock() -> MockSubscriber<fn(&'static Metadata) -> bool> {
     MockSubscriber {
         expected: VecDeque::new(),
-        filter: (|_: &Metadata| true) as for<'r, 's> fn(&'r Metadata<'s>) -> _,
+        filter: (|_: &'static Metadata| true) as for<'r, 's> fn(&'r Metadata<'s>) -> _,
     }
 }
 
 impl<F> MockSubscriber<F>
 where
-    F: Fn(&Metadata) -> bool + 'static,
+    F: Fn(&'static Metadata) -> bool + 'static,
 {
     pub fn enter(mut self, span: MockSpan) -> Self {
         self.expected.push_back(Expect::Enter(span));
@@ -109,7 +109,7 @@ where
 
     pub fn with_filter<G>(self, filter: G) -> MockSubscriber<G>
     where
-        G: Fn(&Metadata) -> bool + 'static,
+        G: Fn(&'static Metadata) -> bool + 'static,
     {
         MockSubscriber {
             filter,
@@ -138,9 +138,9 @@ where
 
 impl<F> Subscriber for Running<F>
 where
-    F: Fn(&Metadata) -> bool + 'static,
+    F: Fn(&'static Metadata) -> bool + 'static,
 {
-    fn enabled(&self, meta: &Metadata) -> bool {
+    fn enabled(&self, meta: &'static Metadata) -> bool {
         (self.filter)(meta)
     }
 


### PR DESCRIPTION
## Motivation

Currently, the `span::Attributes` type in `tokio-trace-core` contains a
reference to `Metadata` with a generic lifetime `'a`. This means that if
a `Subscriber` wishes to store span metadata, it cannot simply store a
`&'static Metadata<'static>`. Instead, it must extract the individual
components from the metadata and store them in its own structure. In
addition, while the `name` and `FieldSet` in a `Metadata` are always
`'static`, the target and file path are not.  If the `Subscriber` needs
to store those values, they must be cloned into a `String` on the heap.

This is somewhat unergonomic for subscriber implementors, in comparison
to being able to use a `&'static Metadata<'static>` reference. In
addition, it implies additional overhead when using certain parts of a
span's metadata.

## Solution

This branch changes all `Metadata` fields to be 'static, and all APIs 
taking or returning &Metadata to take or return `&'static Metadata`. Log
metadata with a non-'static lifetime is now propagated as fields rather 
than as metadata.

Closes #78 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>