### PR TITLE
core: change `Span` and `Event` metadata to be `'static`

### DIFF
--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -199,7 +199,7 @@ impl Dispatch {
     /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
     /// [`register_callsite`]: ../subscriber/trait.Subscriber.html#method.register_callsite
     #[inline]
-    pub fn register_callsite(&self, metadata: &Metadata) -> subscriber::Interest {
+    pub fn register_callsite(&self, metadata: &'static Metadata<'static>) -> subscriber::Interest {
         self.subscriber.register_callsite(metadata)
     }
 
@@ -358,7 +358,7 @@ where
 struct NoSubscriber;
 impl Subscriber for NoSubscriber {
     #[inline]
-    fn register_callsite(&self, _: &Metadata) -> subscriber::Interest {
+    fn register_callsite(&self, _: &'static Metadata<'static>) -> subscriber::Interest {
         subscriber::Interest::never()
     }
 
@@ -382,7 +382,10 @@ impl Subscriber for NoSubscriber {
 }
 
 impl Registrar {
-    pub(crate) fn try_register(&self, metadata: &Metadata) -> Option<subscriber::Interest> {
+    pub(crate) fn try_register(
+        &self,
+        metadata: &'static Metadata<'static>,
+    ) -> Option<subscriber::Interest> {
         self.0.upgrade().map(|s| s.register_callsite(metadata))
     }
 

--- a/tracing-core/src/event.rs
+++ b/tracing-core/src/event.rs
@@ -22,7 +22,7 @@ use {field, Metadata};
 #[derive(Debug)]
 pub struct Event<'a> {
     fields: &'a field::ValueSet<'a>,
-    metadata: &'a Metadata<'a>,
+    metadata: &'static Metadata<'static>,
     parent: Parent,
 }
 
@@ -30,7 +30,7 @@ impl<'a> Event<'a> {
     /// Constructs a new `Event` with the specified metadata and set of values,
     /// and observes it with the current subscriber.
     #[inline]
-    pub fn dispatch(metadata: &'a Metadata<'a>, fields: &'a field::ValueSet) {
+    pub fn dispatch(metadata: &'static Metadata<'static>, fields: &'a field::ValueSet) {
         let event = Event {
             metadata,
             fields,
@@ -46,7 +46,7 @@ impl<'a> Event<'a> {
     #[inline]
     pub fn child_of(
         parent: impl Into<Option<Id>>,
-        metadata: &'a Metadata<'a>,
+        metadata: &'static Metadata<'static>,
         fields: &'a field::ValueSet,
     ) {
         let parent = match parent.into() {
@@ -80,7 +80,7 @@ impl<'a> Event<'a> {
     /// Returns [metadata] describing this `Event`.
     ///
     /// [metadata]: ../metadata/struct.Metadata.html
-    pub fn metadata(&self) -> &Metadata {
+    pub fn metadata(&self) -> &'static Metadata<'static> {
         self.metadata
     }
 

--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -19,7 +19,7 @@ pub struct Id(NonZeroU64);
 /// created.
 #[derive(Debug)]
 pub struct Attributes<'a> {
-    metadata: &'a Metadata<'a>,
+    metadata: &'static Metadata<'static>,
     values: &'a field::ValueSet<'a>,
     parent: Parent,
 }
@@ -60,7 +60,7 @@ impl<'a> Into<Option<Id>> for &'a Id {
 impl<'a> Attributes<'a> {
     /// Returns `Attributes` describing a new child span of the current span,
     /// with the provided metadata and values.
-    pub fn new(metadata: &'a Metadata<'a>, values: &'a field::ValueSet<'a>) -> Self {
+    pub fn new(metadata: &'static Metadata<'static>, values: &'a field::ValueSet<'a>) -> Self {
         Attributes {
             metadata,
             values,
@@ -70,7 +70,7 @@ impl<'a> Attributes<'a> {
 
     /// Returns `Attributes` describing a new span at the root of its own trace
     /// tree, with the provided metadata and values.
-    pub fn new_root(metadata: &'a Metadata<'a>, values: &'a field::ValueSet<'a>) -> Self {
+    pub fn new_root(metadata: &'static Metadata<'static>, values: &'a field::ValueSet<'a>) -> Self {
         Attributes {
             metadata,
             values,
@@ -82,7 +82,7 @@ impl<'a> Attributes<'a> {
     /// parent span, with the provided metadata and values.
     pub fn child_of(
         parent: Id,
-        metadata: &'a Metadata<'a>,
+        metadata: &'static Metadata<'static>,
         values: &'a field::ValueSet<'a>,
     ) -> Self {
         Attributes {
@@ -93,7 +93,7 @@ impl<'a> Attributes<'a> {
     }
 
     /// Returns a reference to the new span's metadata.
-    pub fn metadata(&self) -> &Metadata<'a> {
+    pub fn metadata(&self) -> &'static Metadata<'static> {
         self.metadata
     }
 

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -108,7 +108,7 @@ pub trait Subscriber: 'static {
     /// [`Interest`]: struct.Interest.html
     /// [`enabled`]: #method.enabled
     /// [`rebuild_interest_cache`]: ../callsite/fn.rebuild_interest_cache.html
-    fn register_callsite(&self, metadata: &Metadata) -> Interest {
+    fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         match self.enabled(metadata) {
             true => Interest::always(),
             false => Interest::never(),

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -128,7 +128,7 @@ where
     E: FormatEvent<N> + 'static,
     F: Filter<N> + 'static,
 {
-    fn register_callsite(&self, metadata: &Metadata) -> Interest {
+    fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         self.filter.callsite_enabled(metadata, &self.ctx())
     }
 


### PR DESCRIPTION
## Motivation

Currently, the `span::Attributes` type in `tokio-trace-core` contains a
reference to `Metadata` with a generic lifetime `'a`. This means that if
a `Subscriber` wishes to store span metadata, it cannot simply store a
`&'static Metadata<'static>`. Instead, it must extract the individual
components from the metadata and store them in its own structure. In
addition, while the `name` and `FieldSet` in a `Metadata` are always
`'static`, the target and file path are not.  If the `Subscriber` needs
to store those values, they must be cloned into a `String` on the heap.

This is somewhat unergonomic for subscriber implementors, in comparison
to being able to use a `&'static Metadata<'static>` reference. In
addition, it implies additional overhead when using certain parts of a
span's metadata.

## Solution

This branch changes the `Metadata` fields in `Event` and `Attributes` to
be `'static`, and `Subscriber::register_callsite` to take an
`&'static Metadata<'static>`. Unlike PR #108, this branch leaves
`Metadata` generic over a lifetime, and `Subscriber::enabled` takes an
`&'a Metadata<'a>`.

Since subscribers are provided all span metadata as a static reference
in both `register_callsite` and `new_span`, they can clone _those_
static references, but `Subscriber::enabled` can still be called with
`Metadata` constructed from a `log::Record`. This means that log records
can still be filtered as normal. A different callsite, which does not
have metadata from the log record, is used when actually recording
events constructed from `log::Records`; in a follow-up, we can propagate
the log metadata as fields there.

Closes #78
Closes #108

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
