### PR TITLE
core: prepare v0.1.0 release

### DIFF
--- a/tracing-core/CHANGELOG.md
+++ b/tracing-core/CHANGELOG.md
@@ -1,22 +1,3 @@
-# 0.2.0 (April 21, 2019)
-
-### Breaking Changes
-- Remove `Callsite::clear_interest` and `Callsite::add_interest` (#1039)
-- `metadata!` macro now requires a `Kind` field (#1046)
-
-### Added
-- Add a function to rebuild cached interest (#1039)
-- Add overrideable downcasting to `Subscriber`s (#974)
-- Add slightly more useful debug impls (#1014)
-- Introduce callsite classification in metadata (#1046)
-
-### Fixed
-- `fmt::Debug` impls for `field::Display` and `field::Debug` not passing through
-  to the inner value (#992)
-- Entering a `Dispatch` function unsets the default dispatcher for the duration
-  of the function (so that events inside the subscriber cannot cause infinite
-  loops) (#1033)
-
-# 0.1.0 (March 13, 2019)
+# 0.1.0 (June 27, 2019)
 
 - Initial release

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-core/0.2.0/tracing_core"
+documentation = "https://docs.rs/tracing-core/0.1.0/tracing_core"
 description = """
 Core primitives for application-level tracing.
 """

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -2,7 +2,7 @@
 
 Core primitives for `tracing`.
 
-[Documentation](https://docs.rs/tracing-core/0.2.0/tracing_core/index.html)
+[Documentation](https://docs.rs/tracing-core/0.1.0/tracing_core/index.html)
 
 ## Overview
 
@@ -33,17 +33,17 @@ will use the [`tracing`] crate, which provides a much more fully-featured
 API. However, this crate's API will change very infrequently, so it may be used
 when dependencies must be very stable.
 
-[`tracing`]: ../
-[`Span`]: https://docs.rs/tracing-core/0.2.0/tracing_core/span/struct.Span.html
-[`Event`]: https://docs.rs/tracing-core/0.2.0/tracing_core/event/struct.Event.html
-[`Subscriber`]: https://docs.rs/tracing-core/0.2.0/tracing_core/subscriber/trait.Subscriber.html
-[`Metadata`]: https://docs.rs/tracing-core/0.2.0/tracing_core/metadata/struct.Metadata.html
-[`Callsite`]: https://docs.rs/tracing-core/0.2.0/tracing_core/callsite/trait.Callsite.html
-[`Field`]: https://docs.rs/tracing-core/0.2.0/tracing_core/field/struct.Field.html
-[`FieldSet`]: https://docs.rs/tracing-core/0.2.0/tracing_core/field/struct.FieldSet.html
-[`Value`]: https://docs.rs/tracing-core/0.2.0/tracing_core/field/trait.Value.html
-[`ValueSet`]: https://docs.rs/tracing-core/0.2.0/tracing_core/field/struct.ValueSet.html
-[`Dispatch`]: https://docs.rs/tracing-core/0.2.0/tracing_core/dispatcher/struct.Dispatch.html
+[`tracing`]: ../tracing
+[`Span`]: https://docs.rs/tracing-core/0.1.0/tracing_core/span/struct.Span.html
+[`Event`]: https://docs.rs/tracing-core/0.1.0/tracing_core/event/struct.Event.html
+[`Subscriber`]: https://docs.rs/tracing-core/0.1.0/tracing_core/subscriber/trait.Subscriber.html
+[`Metadata`]: https://docs.rs/tracing-core/0.1.0/tracing_core/metadata/struct.Metadata.html
+[`Callsite`]: https://docs.rs/tracing-core/0.1.0/tracing_core/callsite/trait.Callsite.html
+[`Field`]: https://docs.rs/tracing-core/0.1.0/tracing_core/field/struct.Field.html
+[`FieldSet`]: https://docs.rs/tracing-core/0.1.0/tracing_core/field/struct.FieldSet.html
+[`Value`]: https://docs.rs/tracing-core/0.1.0/tracing_core/field/trait.Value.html
+[`ValueSet`]: https://docs.rs/tracing-core/0.1.0/tracing_core/field/struct.ValueSet.html
+[`Dispatch`]: https://docs.rs/tracing-core/0.1.0/tracing_core/dispatcher/struct.Dispatch.html
 
 ## License
 


### PR DESCRIPTION
0.1.0 (June 27, 2019)

- Initial release

Signed-off-by: Eliza Weisman <eliza@buoyant.io>