### PR TITLE
Remove need to typehint Timer

### DIFF
--- a/tracing-fmt/src/default.rs
+++ b/tracing-fmt/src/default.rs
@@ -37,11 +37,11 @@ pub struct Format<F = Full, T = SystemTime> {
     timer: T,
 }
 
-impl<T: Default> Default for Format<Full, T> {
+impl Default for Format<Full, SystemTime> {
     fn default() -> Self {
         Format {
             format: PhantomData,
-            timer: T::default(),
+            timer: SystemTime,
         }
     }
 }

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -388,6 +388,21 @@ mod test {
     use tracing_core::dispatcher::Dispatch;
 
     #[test]
+    fn impls() {
+        let f = default::Format::default().with_timer(time::Uptime::default());
+        let subscriber = FmtSubscriber::builder().on_event(f).finish();
+        let _dispatch = Dispatch::new(subscriber);
+
+        let f = default::Format::default();
+        let subscriber = FmtSubscriber::builder().on_event(f).finish();
+        let _dispatch = Dispatch::new(subscriber);
+
+        let f = default::Format::default().compact();
+        let subscriber = FmtSubscriber::builder().on_event(f).finish();
+        let _dispatch = Dispatch::new(subscriber);
+    }
+
+    #[test]
     fn subscriber_downcasts() {
         let subscriber = FmtSubscriber::new();
         let dispatch = Dispatch::new(subscriber);


### PR DESCRIPTION
With the previous implementation of `Default` for `fmt::default::Format`, users would have to explicitly type out what timer they want when calling `Format::default`, even if they then immediately go on to use `with_timer`. This PR changes the implementation of `Default` to use `SystemTime` like the default generic types on `Format` itself.