### PR TITLE
feature: include readme in doctests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,7 @@ jobs:
     install: rustup component add rustfmt-preview
     name: "rustfmt"
     rust: stable
+  - script: cargo test --features=doctest-readme --verbose --all
+    name: "doctest readme"
+    rust: nightly
+

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -54,6 +54,8 @@ release_max_level_info  = []
 release_max_level_debug = []
 release_max_level_trace = []
 
+doctest-readme = []
+
 [[bench]]
 name = "subscriber"
 harness = false

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -90,7 +90,7 @@ crate. Often, the process of converting a project to use `tracing` can begin
 with a simple drop-in replacement.
 
 Let's consider the `log` crate's yak-shaving
-[example](https://docs.rs/log/0.4.6/log/index.html#examples), tweeked to
+[example](https://docs.rs/log/0.4.6/log/index.html#examples), tweaked to
 support tracing:
 
 ```rust

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -91,7 +91,7 @@ with a simple drop-in replacement.
 
 Let's consider the `log` crate's yak-shaving
 [example](https://docs.rs/log/0.4.6/log/index.html#examples), tweaked to
-support tracing:
+use `tracing`:
 
 ```rust
 // Add a use statement so we get tracing version of macros

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -125,7 +125,7 @@ pub fn shave_the_yak(yak: &mut Yak) {
 }
 ```
 
-We can tweek it even further to better utilize features in tracing.
+We can tweak it even further to better utilize features in tracing.
 
 ```rust
 use tracing::{span, info, warn, Level};

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -90,24 +90,15 @@ crate. Often, the process of converting a project to use `tracing` can begin
 with a simple drop-in replacement.
 
 Let's consider the `log` crate's yak-shaving
-[example](https://docs.rs/log/0.4.6/log/index.html#examples), tweaked to
-use `tracing`:
+[example](https://docs.rs/log/0.4.6/log/index.html#examples), modified to use
+`tracing`:
 
 ```rust
 // Import `tracing`'s macros rather than `log`'s
 use tracing::{span, info, warn, Level};
 
-// Dummy impls to make the example compile
-#[derive(Debug)] pub struct Yak(String);
-impl Yak { fn shave(&mut self, _: u32) {} }
-fn find_a_razor() -> Result<u32, u32> { Ok(1) }
-
+// unchanged from here forward
 pub fn shave_the_yak(yak: &mut Yak) {
-    // Add a span and enter it to utilize scoped logging in tracing
-    let span = span!(Level::TRACE, "shave_the_yak", ?yak);
-    let _enter = span.enter();
-
-    // unchanged from here forward
     info!(target: "yak_events", "Commencing yak shaving for {:?}", yak);
 
     loop {
@@ -123,18 +114,20 @@ pub fn shave_the_yak(yak: &mut Yak) {
         }
     }
 }
+
+// Dummy impls to make the example compile
+#[derive(Debug)] pub struct Yak(String);
+impl Yak { fn shave(&mut self, _: u32) {} }
+fn find_a_razor() -> Result<u32, u32> { Ok(1) }
 ```
 
-We can tweak it even further to better utilize features in tracing.
+We can modify it even further to better utilize features in tracing.
 
 ```rust
 use tracing::{span, info, warn, Level};
 
-#[derive(Debug)] pub struct Yak(String);
-impl Yak { fn shave(&mut self, _: u32) {} }
-fn find_a_razor() -> Result<u32, u32> { Ok(1) }
-
 pub fn shave_the_yak(yak: &mut Yak) {
+    // create and enter a span to represent the scope
     let span = span!(Level::TRACE, "shave_the_yak", ?yak);
     let _enter = span.enter();
 
@@ -160,6 +153,10 @@ pub fn shave_the_yak(yak: &mut Yak) {
         }
     }
 }
+
+#[derive(Debug)] pub struct Yak(String);
+impl Yak { fn shave(&mut self, _: u32) {} }
+fn find_a_razor() -> Result<u32, u32> { Ok(1) }
 ```
 
 You can find further examples showing how to use this crate in the examples

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -121,7 +121,7 @@ impl Yak { fn shave(&mut self, _: u32) {} }
 fn find_a_razor() -> Result<u32, u32> { Ok(1) }
 ```
 
-We can modify it even further to better utilize features in tracing.
+We can change it even further to better utilize features in tracing.
 
 ```rust
 use tracing::{span, info, warn, Level};

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -94,7 +94,7 @@ Let's consider the `log` crate's yak-shaving
 use `tracing`:
 
 ```rust
-// Add a use statement so we get tracing version of macros
+// Import `tracing`'s macros rather than `log`'s
 use tracing::{span, info, warn, Level};
 
 // Dummy impls to make the example compile

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1,6 +1,8 @@
 #![doc(html_root_url = "https://docs.rs/tracing/0.1.0")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
+#![cfg_attr(feature = "doctest-readme", feature(external_doc))]
+
 //! A scoped, structured logging and diagnostics system.
 //!
 //! # Overview
@@ -391,6 +393,9 @@ pub mod field;
 pub mod level_filters;
 pub mod span;
 pub mod subscriber;
+
+#[cfg(feature = "doctest-readme")]
+mod readme_doctest;
 
 mod sealed {
     pub trait Sealed {}

--- a/tracing/src/readme_doctest.rs
+++ b/tracing/src/readme_doctest.rs
@@ -1,0 +1,2 @@
+#![cfg_attr(feature = "doctest-readme", doc(include = "../README.md"))]
+type _DoctestReadme = ();


### PR DESCRIPTION
Add a new feature `doctest-readme` which includes the README.md for the `tracing` crate as documentation for an empty module so that it can be treated as a doctest, verifying the examples. This change depends on some nightly only features.

Also adjusts the travis config so that on nightly we also run tests with the optional feature enabled so we verify that the examples in the readme don't become broken.