### PR TITLE
chore: add `edition = "2018` to Cargo.tomls

### DIFF
--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -19,6 +19,7 @@ Core primitives for application-level tracing.
 """
 categories = ["development-tools::debugging"]
 keywords = ["logging", "tracing"]
+edition = "2018"
 
 [dependencies]
 lazy_static = "1.0.0"

--- a/tracing-fmt/Cargo.toml
+++ b/tracing-fmt/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tracing-fmt"
 version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
+edition = "2018"
 
 [features]
 default = ["ansi", "chrono"]

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tracing-futures"
 version = "0.0.1"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
+edition = "2018"
 
 [features]
 default = ["tokio"]

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tracing-log"
 version = "0.0.1"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
+edition = "2018"
 
 [dependencies]
 tracing-core = { version = "0.1", path = "../tracing-core" }

--- a/tracing-macros/Cargo.toml
+++ b/tracing-macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tracing-macros"
 version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
+edition = "2018"
 
 [dependencies]
 tracing = { version = "0.1", path = "../tracing" }

--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -3,6 +3,7 @@ name = "tracing-serde"
 version = "0.1.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
+edition = "2018"
 
 [dependencies]
 serde = "1"

--- a/tracing-slog/Cargo.toml
+++ b/tracing-slog/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tracing-slog"
 version = "0.1.0"
 authors = ["David Barsky <dbarsky@amazon.com>"]
+edition = "2018"
 
 [dependencies]
 tracing = { version = "0.1", path = "../tracing" }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tracing-subscriber"
 version = "0.0.1"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
+edition = "2018"
 
 [dependencies]
 tracing = { version = "0.1", path = "../tracing" }

--- a/tracing-tower-http/Cargo.toml
+++ b/tracing-tower-http/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tracing-tower-http"
 version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
+edition = "2018"
 
 [dependencies]
 

--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tracing-tower"
 version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
+edition = "2018"
 
 [dependencies]
 tracing = { version = "0.1", path = "../tracing" }

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -20,6 +20,7 @@ A scoped, structured logging and diagnostics system.
 """
 categories = ["development-tools::debugging", "asynchronous"]
 keywords = ["logging", "tracing"]
+edition = "2018"
 
 [dependencies]
 tracing-core = { version = "0.1", path = "../tracing-core" }

--- a/tracing/test-log-support/Cargo.toml
+++ b/tracing/test-log-support/Cargo.toml
@@ -4,6 +4,7 @@
 name = "test_log_support"
 version = "0.1.0"
 publish = false
+edition = "2018"
 
 [dependencies]
 tracing = { path = "..", features = ["log"] }

--- a/tracing/test_static_max_level_features/Cargo.toml
+++ b/tracing/test_static_max_level_features/Cargo.toml
@@ -4,6 +4,7 @@
 name = "test_cargo_max_level_features"
 version = "0.1.0"
 publish = false
+edition = "2018"
 
 [dependencies.tracing]
 path = ".."


### PR DESCRIPTION
## Motivation

#122 updated all crates to use Rust 2018 syntax, but I neglected to add
`edition = "2018"` to the `Cargo.toml`s. 

## Solution

This fixes that.