### PR TITLE
chore: remove verbose from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rust:
 - nightly
 
 script:
-- cargo test --verbose --all
+- cargo test --all
 
 jobs:
   include:
@@ -18,7 +18,7 @@ jobs:
     install: rustup component add rustfmt-preview
     name: "rustfmt"
     rust: stable
-  - script: cargo test --features=doctest-readme --verbose --all
+  - script: cargo test --features=doctest-readme --all
     name: "doctest readme"
     rust: nightly
 


### PR DESCRIPTION
## Motivation

I found the `cargo test --verbose` output on CI very hard to
scroll through to find the errors describing why a build actually
failed. We rarely, if ever, need this level of output, IMO.

## Solution

This branch removes the `--verbose` flags from CI.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
