### PR TITLE
tracing-log: Add `log` metadata values to the dispatched `Event`.

### DIFF
--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 tracing-core = { version = "0.1", path = "../tracing-core" }
 tracing-subscriber = { path = "../tracing-subscriber" }
 log = "0.4"
+lazy_static = "1.3.0"

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -61,9 +61,30 @@ pub fn format_trace(record: &log::Record) -> io::Result<()> {
     let key = fields
         .field(&"message")
         .expect("log record fields must have a message");
+    let target_key = fields
+        .field(&"log.target")
+        .expect("log record fields must have a target");
+    let module_key = fields
+        .field(&"log.module_path")
+        .expect("log record fields must have a module_path");
+    let file_key = fields
+        .field(&"log.file")
+        .expect("log record fields must have a file");
+    let line_key = fields
+        .field(&"log.line")
+        .expect("log record fields must have a line");
     Event::dispatch(
         &meta,
-        &fields.value_set(&[(&key, Some(record.args() as &dyn field::Value))]),
+        &fields.value_set(&[
+            (&key, Some(record.args() as &dyn field::Value)),
+            (&target_key, Some(&record.target())),
+            (&module_key, record.module_path().as_ref()
+                              .map(|s| s as &dyn field::Value)),
+            (&file_key, record.file().as_ref()
+                              .map(|s| s as &dyn field::Value)),
+            (&line_key, record.line().as_ref()
+                              .map(|s| s as &dyn field::Value)),
+        ]),
     );
     Ok(())
 }

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -58,12 +58,15 @@ pub fn format_trace(record: &log::Record) -> io::Result<()> {
         log::Level::Warn => *WARN_CS,
         log::Level::Error => *ERROR_CS,
     };
-    let module = record
-        .module_path()
-        .as_ref()
-        .map(|s| s as &dyn field::Value);
-    let file = record.file().as_ref().map(|s| s as &dyn field::Value);
-    let line = record.line().as_ref().map(|s| s as &dyn field::Value);
+
+    let log_module = record.module_path();
+    let log_file = record.file();
+    let log_line = record.line();
+
+    let module = log_module.as_ref().map(|s| s as &dyn field::Value);
+    let file = log_file.as_ref().map(|s| s as &dyn field::Value);
+    let line = log_line.as_ref().map(|s| s as &dyn field::Value);
+
     let meta = cs.metadata();
     Event::dispatch(
         &meta,

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -78,12 +78,21 @@ pub fn format_trace(record: &log::Record) -> io::Result<()> {
         &fields.value_set(&[
             (&key, Some(record.args() as &dyn field::Value)),
             (&target_key, Some(&record.target())),
-            (&module_key, record.module_path().as_ref()
-                              .map(|s| s as &dyn field::Value)),
-            (&file_key, record.file().as_ref()
-                              .map(|s| s as &dyn field::Value)),
-            (&line_key, record.line().as_ref()
-                              .map(|s| s as &dyn field::Value)),
+            (
+                &module_key,
+                record
+                    .module_path()
+                    .as_ref()
+                    .map(|s| s as &dyn field::Value),
+            ),
+            (
+                &file_key,
+                record.file().as_ref().map(|s| s as &dyn field::Value),
+            ),
+            (
+                &line_key,
+                record.line().as_ref().map(|s| s as &dyn field::Value),
+            ),
         ]),
     );
     Ok(())


### PR DESCRIPTION
## Motivation

It would be nice if `Event`s created by `tracing-log` (which are derived from `log::Record`) include the additional metadata that `log` includes: target, module, file, and line information. This can be used by subscribers to print this metadata to make the events look more like tracing events. 

In fact, the static `Callsite` in `tracing-log` includes those as fields, so I hoped this was the intended behaviour.

## Solution

This follows the same patterns as existed for adding values to the `ValueSet` included with a dispatched event.
