### PR TITLE
tracing: bump deps

### DIFF
--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -29,7 +29,7 @@ cfg-if = "0.1.7"
 
 [dev-dependencies]
 ansi_term = "0.11"
-humantime = "1.1.1"
+humantime = "1.2"
 futures = "0.1"
 log = "0.4"
 criterion = { version = "0.2", default_features = false }


### PR DESCRIPTION
This bumps the dependency on `humantime` to the latest 
minor version.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
