### PR TITLE
chore: remove remaining references to tracing-nursery

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,7 +34,7 @@ Output of `uname -a` (UNIX), or version and 32 or 64-bit (Windows)
 ### Crates
 
 <!--
-If known, please specify the affected tracing-nursery crates. Otherwise, delete this
+If known, please specify the affected tracing crates. Otherwise, delete this
 section.
 -->
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,8 +9,8 @@ about: I have a suggestion (and may want to implement it 🙂)!
 ### Crates
 
 <!--
-If known, please specify the tracing-nursery crate or crates the new feature
-should be added to. Otherwise, delete this section.
+If known, please specify the tracing crate or crates the new feature should
+be added to. Otherwise, delete this section.
 -->
 
 ### Motivation

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ the requirements below.
 
 Bug fixes and new features should include tests.
 
-Contributors guide: https://github.com/tokio-rs/tracing-nursery/blob/master/CONTRIBUTING.md
+Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
 -->
 
 ## Motivation

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -4,7 +4,7 @@
 
 //! Core primitives for `tracing`.
 //!
-//! `tracing` is a framework for instrumenting Rust programs to collect
+//! [`tracing`] is a framework for instrumenting Rust programs to collect
 //! structured, event-based diagnostic information. This crate defines the core
 //! primitives of `tracing`.
 //!
@@ -31,7 +31,7 @@
 //! fully-featured API. However, this crate's API will change very infrequently,
 //! so it may be used when dependencies must be very stable.
 //!
-//! The [`tracing-nursery`] repository contains less stable crates designed to
+//! The [`tokio-rs/tracing`] repository contains less stable crates designed to
 //! be used with the `tracing` ecosystem. It includes a collection of
 //! `Subscriber` implementations, as well as utility and adapter crates.
 //!
@@ -45,7 +45,8 @@
 //! [`Value`]: field/trait.Value.html
 //! [`ValueSet`]: field/struct.ValueSet.html
 //! [`Dispatch`]: dispatcher/struct.Dispatch.html
-//! [`tracing-nursery`]: https://github.com/tokio-rs/tracing-nursery
+//! [`tokio-rs/tracing`]: https://github.com/tokio-rs/tracing
+//! [`tracing`]: https://github.com/tokio-rs/tracing
 #[macro_use]
 extern crate lazy_static;
 


### PR DESCRIPTION
This branch removes all remaining references to the
non-existent `tracing-nursery` repository that weren't
removed in #142 and #141.

Closes #125 