### PR TITLE
prepare to release tracing 0.1.1

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.1.1 (July 3, 2019)
+
+### Changed
+
+- `lazy_static` dependency to 1.3.0 (#143) .
+
+### Fixed
+
+- Compilation errors when the `log` feature is enabled (#131).
+- Unclear wording and typos in documentation (#124, #128, #142).
+
 # 0.1.0 (June 27, 2019)
 
 - Initial release

--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Changed
 
-- `lazy_static` dependency to 1.3.0 (#143) .
+- `cfg_if` dependency to 0.1.9.
 
 ### Fixed
 

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,13 +8,13 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing/0.1.0/tracing"
+documentation = "https://docs.rs/tracing/0.1.1/tracing"
 description = """
 A scoped, structured logging and diagnostics system.
 """

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -25,7 +25,7 @@ edition = "2018"
 [dependencies]
 tracing-core = { version = "0.1", path = "../tracing-core" }
 log = { version = "0.4", optional = true }
-cfg-if = "0.1.7"
+cfg-if = "0.1.9"
 
 [dev-dependencies]
 ansi_term = "0.11"

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.1")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(feature = "doctest-readme", feature(external_doc))]


### PR DESCRIPTION
This branch prepares tracing to release version 0.1.1, to get the fixes for log support out.
