### PR TITLE
[RFC] subscriber: remove ref-counting from Layer

### DIFF
--- a/tracing-env-logger/Cargo.toml
+++ b/tracing-env-logger/Cargo.toml
@@ -9,7 +9,7 @@ env_logger = "0.5"
 log = "0.4"
 
 [dev-dependencies]
-tracing = "0.1"
+tracing = { version = "0.1", path = "../tracing" }
 tracing-fmt = { path = "../tracing-fmt" }
 tracing-futures = { path = "../tracing-futures" }
 tracing-subscriber = { path = "../tracing-subscriber" }

--- a/tracing-fmt/Cargo.toml
+++ b/tracing-fmt/Cargo.toml
@@ -9,7 +9,7 @@ default = ["ansi", "chrono"]
 ansi = ["ansi_term"]
 
 [dependencies]
-tracing-core = "0.1"
+tracing-core = { version = "0.1", path = "../tracing-core" }
 ansi_term = { version = "0.11", optional = true }
 regex = "1"
 lazy_static = "1"

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -9,7 +9,7 @@ default = ["tokio"]
 
 [dependencies]
 futures = "0.1"
-tracing = "0.1"
+tracing = { version = "0.1", path = "../tracing" }
 tokio = { version = "0.1", optional = true }
 tokio-executor = { version = "0.1", optional = true }
 

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 edition = "2018"
 
 [dependencies]
-tracing-core = "0.1"
+tracing-core = { version = "0.1", path = "../tracing-core" }
 tracing-subscriber = { path = "../tracing-subscriber" }
 log = "0.4"
 lazy_static = "1.3.0"

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 edition = "2018"
 
 [dependencies]
-tracing-core = "0.1"
+tracing-core = { version = "0.1", path = "../tracing-core" }
 
 [dev-dependencies]
 tracing-log = { path = "../tracing-log" }

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -268,7 +268,7 @@ where
     fn try_close(&self, id: span::Id) -> bool {
         let id2 = id.clone();
         if self.inner.try_close(id) {
-            self.layer.close(id2, self.ctx())
+            self.layer.close(id2, self.ctx());
             true
         } else {
             false

--- a/tracing-tower-http/Cargo.toml
+++ b/tracing-tower-http/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 edition = "2018"
 
 [dependencies]
-tracing = "0.1"
+tracing = { version = "0.1", path = "../tracing" }
 tracing-futures = { path = "../tracing-futures" }
 futures = "0.1"
 tower-service = "0.2"

--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 edition = "2018"
 
 [dependencies]
-tracing = "0.1"
+tracing = { version = "0.1", path = "../tracing" }
 tracing-futures = { path = "../tracing-futures" }
 futures = "0.1"
 tower-service = "0.2"

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -27,7 +27,7 @@ keywords = ["logging", "tracing"]
 edition = "2018"
 
 [dependencies]
-tracing-core = "0.1.1"
+tracing-core = { version = "0.1.1", path = "../tracing-core" }
 log = { version = "0.4", optional = true }
 cfg-if = "0.1.9"
 


### PR DESCRIPTION
## Motivation

As I mentioned in https://github.com/tokio-rs/tracing/pull/136#discussion_r300158248, the
`Layer` trait proposed in #136 should probably _not_ be responsible for
managing ref-counts and determining span closures. Instead, the root
subscriber should be responsible for this, and `Layer`s should be able
to opt into a callback that's notified _when_ a span is closed. 

## Solution

Adding a callback that's called on closure to `Layer` requires modifying
the `Subscriber` trait to allow indicating when a span closes. This
branch attempts to do this without a breaking change, by adding a new
`try_close` trait method to `Subscriber`. `try_close` is identical to
`drop_span` except that it returns a boolean value, set to `true` if the
span has closed. 

The `try_close` default implementation simply returns `false`, so that
if subscribers don't care about tracking ref counts, close notifications
will never be triggered. The default implementation of `drop_span` is
changed to call `self.try_close(...)` and ignore the return value. 

The `drop_span` documentation now indicates that it is "soft deprecated"
similarly to `std::error::Error`'s `description` method. This encourages
subscribers to implement the new API, but isn't a breaking change.
Existing _callers_ of `drop_span` are still able to call it without
causing issues, as the `Layered::drop_span` will always call `try_close`
on the inner subscriber, in order to forward the closure notification to
the layer if the span closes.

I've also updated the `tracing::span::Span` type to use `try_close`, so
that if the `log` feature flag is enabled and a subscriber is set, spans
will now log when they are closed. This may be useful in cases where
tracing is being used for purposes like metrics and logs are emitted by
a `log` logger consuming `tracing` log output. I've updated the
`test-log-support` test crate to also test this.

If we decide to move forward with this approach, we can land the changes
to `tracing-core` in a separate branch, and then merge the changes to
`tracing` and `tracing-subscriber` as self-contained follow-ups.