### PR TITLE
core: add `Subscriber::try_close`

### DIFF
--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -315,13 +315,35 @@ impl Dispatch {
     /// This calls the [`drop_span`]  function on the [`Subscriber`] that this
     ///  `Dispatch` forwards to.
     ///
+    /// **Note:** the [`try_close`] function is functionally identical, but
+    /// returns `true` if the span is now closed.
+    ///
     /// [span ID]: ../span/struct.Id.html
     /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
     /// [`clone_span`]: ../subscriber/trait.Subscriber.html#method.clone_span
     /// [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
+    /// [`try_close`]: #method.try_close
     #[inline]
     pub fn drop_span(&self, id: span::Id) {
-        self.subscriber.drop_span(id)
+        self.subscriber.drop_span(id);
+    }
+
+    /// Notifies the subscriber that a [span ID] has been dropped, and returns
+    /// `true` if there are now 0 IDs referring to that span.
+    ///
+    /// This function is guaranteed to only be called with span IDs that were
+    /// returned by this `Dispatch`'s [`new_span`] function.
+    ///
+    /// This calls the [`try_close`]  function on the [`Subscriber`] that this
+    ///  `Dispatch` forwards to.
+    ///
+    /// [span ID]: ../span/struct.Id.html
+    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
+    /// [`try_close`]: ../subscriber/trait.Subscriber.html#method.try_close
+    /// [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
+    #[inline]
+    pub fn try_close(&self, id: span::Id) -> bool {
+        self.subscriber.try_close(id)
     }
 
     /// Returns `true` if this `Dispatch` forwards to a `Subscriber` of type

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -292,8 +292,10 @@ impl Dispatch {
 
     /// Notifies the subscriber that a [span ID] has been cloned.
     ///
-    /// This function is guaranteed to only be called with span IDs that were
-    /// returned by this `Dispatch`'s [`new_span`] function.
+    /// This function must only be called with span IDs that were returned by
+    /// this `Dispatch`'s [`new_span`] function. The `tracing` crate upholds
+    /// this guarantee and any other libraries implementing instrumentation APIs
+    /// must as well.
     ///
     /// This calls the [`clone_span`] function on the `Subscriber` that this
     /// `Dispatch` forwards to.
@@ -309,8 +311,10 @@ impl Dispatch {
 
     /// Notifies the subscriber that a [span ID] has been dropped.
     ///
-    /// This function is guaranteed to only be called with span IDs that were
-    /// returned by this `Dispatch`'s [`new_span`] function.
+    /// This function must only be called with span IDs that were returned by
+    /// this `Dispatch`'s [`new_span`] function. The `tracing` crate upholds
+    /// this guarantee and any other libraries implementing instrumentation APIs
+    /// must as well.
     ///
     /// This calls the [`drop_span`]  function on the [`Subscriber`] that this
     ///  `Dispatch` forwards to.
@@ -331,8 +335,10 @@ impl Dispatch {
     /// Notifies the subscriber that a [span ID] has been dropped, and returns
     /// `true` if there are now 0 IDs referring to that span.
     ///
-    /// This function is guaranteed to only be called with span IDs that were
-    /// returned by this `Dispatch`'s [`new_span`] function.
+    /// This function must only be called with span IDs that were returned by
+    /// this `Dispatch`'s [`new_span`] function. The `tracing` crate upholds
+    /// this guarantee and any other libraries implementing instrumentation APIs
+    /// must as well.
     ///
     /// This calls the [`try_close`]  function on the [`Subscriber`] that this
     ///  `Dispatch` forwards to.

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -33,8 +33,40 @@ use std::any::{Any, TypeId};
 /// not be needed by the implementations of `enter` and `exit`, the subscriber
 /// may freely discard that data without allocating space to store it.
 ///
+/// ## Overriding default impls
+///
+/// Some trait methods on `Subscriber` have default implementations, either in
+/// order to reduce the surface area of implementing `Subscriber`, or for
+/// backward-compatibility reasons. However, many subscribers will likely want
+/// to override these default implementations.
+///
+/// The following methods are likely of interest:
+///
+/// - [`register_callsite`] is called once for each callsite from which a span
+///   event may originate, and returns an [`Interest`] value describing whether or
+///   not the subscriber wishes to see events or spans from that callsite. By
+///   default, it calls [`enabled`], and returns `Interest::always()` if
+///   `enabled` returns true, or `Interest::never()` if enabled returns false.
+///   However, if the subscriber's interest can change dynamically at runtime,
+///   it may want to override this function to return `Interest::sometimes()`.
+///   Additionally, subscribers which wish to perform a behaviour once for each
+///   callsite, such as allocating storage for data related to that callsite,
+///   can perform it in `register_callsite`.
+/// - [`clone_span`] is called every time a span ID is cloned, and [`try_close`]
+///   is called when a span ID is dropped. By default, these functions do
+///   nothing. However, they can be used to implement reference counting for
+///   spans, allowing subscribers to free storage for span data and to determine
+///   when a span has _closed_ permanently (rather than being exited).
+///   Subscribers which store per-span data or which need to track span closures
+///   should override these functions together.
+///
 /// [ID]: ../span/struct.Id.html
 /// [`new_span`]: trait.Subscriber.html#method.new_span
+/// [`register_callsite]: trait.Subscriber.html#method.register_callsite
+/// [`Interest`]: struct.Interest.html
+/// [`enabled`]: trait.Subscriber.html#method.enabled
+/// [`clone_span`]: trait.Subscriber.html#method.clone_span
+/// [`try_close`]: trait.Subscriber.html#method.try_close
 pub trait Subscriber: 'static {
     // === Span registry methods ==============================================
 
@@ -273,7 +305,7 @@ pub trait Subscriber: 'static {
     /// identity function, passing through the identifier. However, it can be
     /// used in conjunction with [`try_close`] to track the number of handles
     /// capable of `enter`ing a span. When all the handles have been dropped
-    /// (i.e., `drop_span` has been called one more time than `clone_span` for a
+    /// (i.e., `try_close` has been called one more time than `clone_span` for a
     /// given ID), the subscriber may assume that the span will not be entered
     /// again. It is then free to deallocate storage for data associated with
     /// that span, write data from that span to IO, and so on.
@@ -283,7 +315,7 @@ pub trait Subscriber: 'static {
     /// what that means for the specified pointer.
     ///
     /// [span ID]: ../span/struct.Id.html
-    /// [`try_close`]: trait.Subscriber.html#method.drop_span
+    /// [`try_close`]: trait.Subscriber.html#method.try_close
     fn clone_span(&self, id: &span::Id) -> span::Id {
         id.clone()
     }
@@ -301,25 +333,30 @@ pub trait Subscriber: 'static {
     /// Notifies the subscriber that a [`span ID`] has been dropped, and returns
     /// `true` if there are now 0 IDs that refer to that span.
     ///
+    /// Higher-level libraries providing functionality for composing multiple
+    /// subscriber implementations may use this return value to notify any
+    /// "layered" subscribers that this subscriber considers the span closed.
+    ///
     /// The default implementation of this method calls the subscriber's
     /// [`drop_span`] method and returns `false`. This means that, unless the
     /// subscriber overrides the default implementation, close notifications
     /// will never be sent to any layered subscribers. In general, if the
     /// subscriber tracks reference counts, this method should be implemented,
     /// rather than `drop_span`.
+    ///
     /// This function is guaranteed to only be called with span IDs that were
     /// returned by this subscriber's `new_span` function.
     ///
     /// It's guaranteed that if this function has been called once more than the
     /// number of times `clone_span` was called with the same `id`, then no more
-    /// spans using that `id` exist. This means that it can be used in
-    /// conjunction with [`clone_span`] to track the number of handles
-    /// capable of `enter`ing a span. When all the handles have been dropped
-    /// (i.e., `try_close` has been called one more time than `clone_span` for a
-    /// given ID), the subscriber may assume that the span will not be entered
-    /// again, and should return `true`. It is then free to deallocate storage
-    /// for data associated with  that span, write data from that span to IO,
-    /// and so on.
+    /// handles that can enter the span with that `id` exist. This means that it
+    /// can be used in  conjunction with [`clone_span`] to track the number of
+    /// handles capable of `enter`ing a span. When all the handles have been
+    /// dropped (i.e., `try_close` has been called one more time than
+    /// `clone_span` for a given ID), the subscriber may assume that the span
+    /// will not be entered again, and should return `true`. It is then free to
+    /// deallocate storage for data associated with  that span, write data from
+    /// that span to IO, and so on.
     ///
     /// **Note**: since this function is called when spans are dropped,
     /// implementations should ensure that they are unwind-safe. Panicking from
@@ -328,6 +365,7 @@ pub trait Subscriber: 'static {
     ///
     /// [span ID]: ../span/struct.Id.html
     /// [`clone_span`]: trait.Subscriber.html#method.clone_span
+    /// [`drop_span`]: trait.Subscriber.html#method.drop_span
     fn try_close(&self, id: span::Id) -> bool {
         let _ = self.drop_span(id);
         false

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -293,17 +293,20 @@ pub trait Subscriber: 'static {
     /// Although using it won’t cause compilation warning, new code should
     /// call or implement [`try_close`] instead.
     ///
-    /// The default implementation of this function simply calls `try_close` and
-    /// ignores the return value.
+    /// The default implementation of this function does nothing.
     ///
     /// [`try_close`]: trait.Subscriber.html#method.try_close
-    fn drop_span(&self, id: span::Id) {
-        self.try_close(id);
-    }
+    fn drop_span(&self, _id: span::Id) {}
 
     /// Notifies the subscriber that a [`span ID`] has been dropped, and returns
     /// `true` if there are now 0 IDs that refer to that span.
     ///
+    /// The default implementation of this method calls the subscriber's
+    /// [`drop_span`] method and returns `false`. This means that, unless the
+    /// subscriber overrides the default implementation, close notifications
+    /// will never be sent to any layered subscribers. In general, if the
+    /// subscriber tracks reference counts, this method should be implemented,
+    /// rather than `drop_span`.
     /// This function is guaranteed to only be called with span IDs that were
     /// returned by this subscriber's `new_span` function.
     ///
@@ -326,7 +329,7 @@ pub trait Subscriber: 'static {
     /// [span ID]: ../span/struct.Id.html
     /// [`clone_span`]: trait.Subscriber.html#method.clone_span
     fn try_close(&self, id: span::Id) -> bool {
-        let _ = id;
+        let _ = self.drop_span(id);
         false
     }
 


### PR DESCRIPTION
## Motivation

As discussed in #136, a proposed `Layer` trait for composing
subscribers required should probably _not_ be responsible for
managing ref-counts and determining span closures. Instead, the root
subscriber should be responsible for this, and `Layer`s should be able
to opt into a callback that's notified _when_ a span is closed. 

Adding a callback that's called on closure to `Layer` requires modifying
the `Subscriber` trait to allow indicating when a span closes.

## Solution

This branch attempts to do this without a breaking change, by adding a new
`try_close` trait method to `Subscriber`. `try_close` is identical to
`drop_span` except that it returns a boolean value, set to `true` if the
span has closed. 

The `try_close` default implementation simply returns `false`, so that
if subscribers don't care about tracking ref counts, close notifications
will never be triggered. The default implementation of `drop_span` is
changed to call `self.try_close(...)` and ignore the return value. 

The `drop_span` documentation now indicates that it is "soft deprecated"
similarly to `std::error::Error`'s `description` method. This encourages
subscribers to implement the new API, but isn't a breaking change.
Existing _callers_ of `drop_span` are still able to call it without
causing issues, as the `Layered::drop_span` will always call `try_close`
on the inner subscriber, in order to forward the closure notification to
the layer if the span closes.
