### PR TITLE
core: prepare for 0.1.1

### DIFF
--- a/tracing-core/CHANGELOG.md
+++ b/tracing-core/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.1.1 (July 6, 2019)
+
+### Added
+
+- `Subscriber::current_span` API to return the current span (#148).
+- `span::Current` type, representing the `Subscriber`'s view of the current
+  span (#148).
+
+### Fixed
+
+- Typos and broken links in documentation (#123, #124, #128, #154)
+
 # 0.1.0 (June 27, 2019)
 
 - Initial release

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -11,15 +11,24 @@ name = "tracing-core"
 version = "0.1.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
+readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
 documentation = "https://docs.rs/tracing-core/0.1.0/tracing_core"
 description = """
 Core primitives for application-level tracing.
 """
-categories = ["development-tools::debugging"]
+categories = [
+    "development-tools::debugging",
+    "development-tools::profiling",
+    "asynchronous",
+]
 keywords = ["logging", "tracing"]
 edition = "2018"
+[badges]
+travis-ci = { repository = "tokio-rs/tracing", branch = "master" }
+maintenance = { status = "actively-developed" }
 
 [dependencies]
 lazy_static = "1.0.0"
+

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -30,5 +30,5 @@ travis-ci = { repository = "tokio-rs/tracing", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-lazy_static = "1.0.0"
+lazy_static = "1"
 

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -8,13 +8,13 @@ name = "tracing-core"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-core/0.1.0/tracing_core"
+documentation = "https://docs.rs/tracing-core/0.1.1/tracing_core"
 description = """
 Core primitives for application-level tracing.
 """

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -6,7 +6,7 @@ Core primitives for application-level tracing.
 [![MIT licensed][mit-badge]][mit-url]
 [![Gitter chat][gitter-badge]][gitter-url]
 
-[Documentation](https://docs.rs/tracing-core/0.1.0/tracing_core/index.html)
+[Documentation](https://docs.rs/tracing-core/0.1.1/tracing_core/index.html)
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-core.svg
 [crates-url]: https://crates.io/crates/tracing-core
@@ -45,16 +45,16 @@ API. However, this crate's API will change very infrequently, so it may be used
 when dependencies must be very stable.
 
 [`tracing`]: ../tracing
-[`Span`]: https://docs.rs/tracing-core/0.1.0/tracing_core/span/struct.Span.html
-[`Event`]: https://docs.rs/tracing-core/0.1.0/tracing_core/event/struct.Event.html
-[`Subscriber`]: https://docs.rs/tracing-core/0.1.0/tracing_core/subscriber/trait.Subscriber.html
-[`Metadata`]: https://docs.rs/tracing-core/0.1.0/tracing_core/metadata/struct.Metadata.html
-[`Callsite`]: https://docs.rs/tracing-core/0.1.0/tracing_core/callsite/trait.Callsite.html
-[`Field`]: https://docs.rs/tracing-core/0.1.0/tracing_core/field/struct.Field.html
-[`FieldSet`]: https://docs.rs/tracing-core/0.1.0/tracing_core/field/struct.FieldSet.html
-[`Value`]: https://docs.rs/tracing-core/0.1.0/tracing_core/field/trait.Value.html
-[`ValueSet`]: https://docs.rs/tracing-core/0.1.0/tracing_core/field/struct.ValueSet.html
-[`Dispatch`]: https://docs.rs/tracing-core/0.1.0/tracing_core/dispatcher/struct.Dispatch.html
+[`Span`]: https://docs.rs/tracing-core/0.1.1/tracing_core/span/struct.Span.html
+[`Event`]: https://docs.rs/tracing-core/0.1.1/tracing_core/event/struct.Event.html
+[`Subscriber`]: https://docs.rs/tracing-core/0.1.1/tracing_core/subscriber/trait.Subscriber.html
+[`Metadata`]: https://docs.rs/tracing-core/0.1.1/tracing_core/metadata/struct.Metadata.html
+[`Callsite`]: https://docs.rs/tracing-core/0.1.1/tracing_core/callsite/trait.Callsite.html
+[`Field`]: https://docs.rs/tracing-core/0.1.1/tracing_core/field/struct.Field.html
+[`FieldSet`]: https://docs.rs/tracing-core/0.1.1/tracing_core/field/struct.FieldSet.html
+[`Value`]: https://docs.rs/tracing-core/0.1.1/tracing_core/field/trait.Value.html
+[`ValueSet`]: https://docs.rs/tracing-core/0.1.1/tracing_core/field/struct.ValueSet.html
+[`Dispatch`]: https://docs.rs/tracing-core/0.1.1/tracing_core/dispatcher/struct.Dispatch.html
 
 ## License
 

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -3,21 +3,28 @@
 Core primitives for application-level tracing.
 
 [![Crates.io][crates-badge]][crates-url]
+[![Documentation][docs-badge]][docs-url]
 [![MIT licensed][mit-badge]][mit-url]
+[![Build Status][travis-badge]][travis-url]
 [![Gitter chat][gitter-badge]][gitter-url]
 
-[Documentation](https://docs.rs/tracing-core/0.1.1/tracing_core/index.html)
+[Documentation][docs-url] |
+[Chat][gitter-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-core.svg
 [crates-url]: https://crates.io/crates/tracing-core
+[docs-badge]: https://docs.rs/tracing-core/badge.svg
+[docs-url]: https://docs.rs/tracing-core
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
+[travis-badge]: https://travis-ci.org/tokio-rs/tracing.svg?branch=master
+[travis-url]: https://travis-ci.org/tokio-rs/tracing/branches
 [gitter-badge]: https://img.shields.io/gitter/room/tokio-rs/tracing.svg
-[gitter-url]: https://gitter.im/tokio-rs/tracubg
+[gitter-url]: https://gitter.im/tokio-rs/tracing
 
 ## Overview
 
-`tracing` is a framework for instrumenting Rust programs to collect
+[`tracing`] is a framework for instrumenting Rust programs to collect
 structured, event-based diagnostic information. This crate defines the core
 primitives of `tracing`.
 

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tracing-core/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-core/0.1.1")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
This branch prepares `tracing-core` to release v0.1.1, and makes a few
minor README and crates.io metadata improvements.

Changelog:

### Added

- `Subscriber::current_span` API to return the current span (#148).
- `span::Current` type, representing the `Subscriber`'s view of the current
  span (#148).

### Fixed

- Typos and broken links in documentation (#123, #124, #128, #154)