### PR TITLE
tracing: prepare to release 0.1.2

### DIFF
--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 serde = "1"
-tracing-core = { version = "0.1", path = "../tracing-core" }
+tracing-core = "0.1"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.1.2 (July 6, 2019)
+
+### Added
+
+- `Span::none()` constructor, which does not require metadata and
+  returns a completely empty span (#147).
+- `Span::current()` function, returning the current span if it is
+  known to the subscriber (#148).
+
+### Fixed
+
+- Broken macro imports when used prefixed with `tracing::` (#152).
+
 # 0.1.1 (July 3, 2019)
 
 ### Changed

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -18,7 +18,11 @@ documentation = "https://docs.rs/tracing/0.1.1/tracing"
 description = """
 A scoped, structured logging and diagnostics system.
 """
-categories = ["development-tools::debugging", "asynchronous"]
+categories = [
+    "development-tools::debugging",
+    "development-tools::profiling",
+    "asynchronous",
+]
 keywords = ["logging", "tracing"]
 edition = "2018"
 

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,13 +8,13 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing/0.1.1/tracing"
+documentation = "https://docs.rs/tracing/0.1.2/tracing"
 description = """
 A scoped, structured logging and diagnostics system.
 """

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -23,7 +23,7 @@ keywords = ["logging", "tracing"]
 edition = "2018"
 
 [dependencies]
-tracing-core = { version = "0.1", path = "../tracing-core" }
+tracing-core = "0.1.1"
 log = { version = "0.4", optional = true }
 cfg-if = "0.1.9"
 

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -47,7 +47,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing = "0.1"
+tracing = "0.1.2"
 ```
 
 This crate provides macros for creating `Span`s and `Event`s, which represent

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.2")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(feature = "doctest-readme", feature(external_doc))]


### PR DESCRIPTION
### Added

- `Span::none()` constructor, which does not require metadata and
  returns a completely empty span (#147).
- `Span::current()` function, returning the current span if it is
  known to the subscriber (#148).

### Fixed

- Broken macro imports when used prefixed with `tracing::` (#152).