### PR TITLE
fmt: add support for `Subscriber::current_span`

### DIFF
--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -190,6 +190,15 @@ where
         span::pop(id);
     }
 
+    fn current_span(&self) -> span::Current {
+        if let Some(id) = span::current() {
+            if let Some(meta) = self.spans.get(&id).map(|span| span.metadata()) {
+                return span::Current::new(id, meta);
+            }
+        }
+        span::Current::none()
+    }
+
     fn clone_span(&self, id: &span::Id) -> span::Id {
         if let Some(span) = self.spans.get(id) {
             span.clone_ref()

--- a/tracing-fmt/src/span.rs
+++ b/tracing-fmt/src/span.rs
@@ -7,8 +7,8 @@ use std::{
 use owning_ref::OwningHandle;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
+pub(crate) use tracing_core::span::{Attributes, Current, Id, Record};
 use tracing_core::{dispatcher, Metadata};
-pub(crate) use tracing_core::span::{Attributes, Id, Record, Current};
 
 pub struct Span<'a> {
     lock: OwningHandle<RwLockReadGuard<'a, Slab>, RwLockReadGuard<'a, Slot>>,

--- a/tracing-fmt/src/span.rs
+++ b/tracing-fmt/src/span.rs
@@ -8,7 +8,7 @@ use owning_ref::OwningHandle;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use tracing_core::{dispatcher, Metadata};
-pub(crate) use tracing_core::span::{Attributes, Id, Record};
+pub(crate) use tracing_core::span::{Attributes, Id, Record, Current};
 
 pub struct Span<'a> {
     lock: OwningHandle<RwLockReadGuard<'a, Slab>, RwLockReadGuard<'a, Slot>>,


### PR DESCRIPTION

## Motivation

The `Subscriber::current_span` method was added in `tracing-core` 0.1.1.
Subscribers which track the current span should provide implementations
of this macro, to allow the use of `Span::current` by instrumentation.

## Solution

This branch adds an implementation of `Subscriber::current_span` to the
`FmtSubscriber` type in `tracing::fmt`.