### PR TITLE
tracing: fix event macros with single local variables

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -1023,20 +1023,6 @@ macro_rules! event {
             { $($k).+ = $($field)*}
         )
     );
-    ($lvl:expr, ?$($k:ident).+ = $($field:tt)*) => (
-        $crate::event!(
-            target: module_path!(),
-            $lvl,
-            { ?$($k).+ = $($field)*}
-        )
-    );
-    ($lvl:expr, %$($k:ident).+ = $($field:tt)*) => (
-        $crate::event!(
-            target: module_path!(),
-            $lvl,
-            { %$($k).+ = $($field)*}
-        )
-    );
     ($lvl:expr, $($k:ident).+, $($field:tt)*) => (
         $crate::event!(
             target: module_path!(),
@@ -1057,6 +1043,15 @@ macro_rules! event {
             $lvl,
             { %$($k).+, $($field)*}
         )
+    );
+    ($lvl:expr, ?$($k:ident).+) => (
+        $crate::event!($lvl, ?$($k).+,)
+    );
+    ($lvl:expr, %$($k:ident).+) => (
+        $crate::event!($lvl, %$($k).+,)
+    );
+    ($lvl:expr, $($k:ident).+) => (
+        $crate::event!($lvl, $($k).+,)
     );
     ( $lvl:expr, $($arg:tt)+ ) => (
         $crate::event!(target: module_path!(), $lvl, { }, $($arg)+)
@@ -1210,20 +1205,6 @@ macro_rules! trace {
             { $($k).+ = $($field)*}
         )
     );
-    (?$($k:ident).+ = $($field:tt)*) => (
-        $crate::event!(
-            target: module_path!(),
-            $crate::Level::TRACE,
-            { ?$($k).+ = $($field)*}
-        )
-    );
-    (%$($k:ident).+ = $($field:tt)*) => (
-        $crate::event!(
-            target: module_path!(),
-            $crate::Level::TRACE,
-            { %$($k).+ = $($field)*}
-        )
-    );
     ($($k:ident).+, $($field:tt)*) => (
         $crate::event!(
             target: module_path!(),
@@ -1243,6 +1224,27 @@ macro_rules! trace {
             target: module_path!(),
             $crate::Level::TRACE,
             { %$($k).+, $($field)*}
+        )
+    );
+    (?$($k:ident).+) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::TRACE,
+            { ?$($k).+ }
+        )
+    );
+    (%$($k:ident).+) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::TRACE,
+            { %$($k).+ }
+        )
+    );
+    ($($k:ident).+) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::TRACE,
+            { $($k).+ }
         )
     );
     ($($arg:tt)+) => (
@@ -1422,6 +1424,27 @@ macro_rules! debug {
             target: module_path!(),
             $crate::Level::DEBUG,
             { %$($k).+, $($field)*}
+        )
+    );
+    (?$($k:ident).+) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::DEBUG,
+            { ?$($k).+ }
+        )
+    );
+    (%$($k:ident).+) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::DEBUG,
+            { %$($k).+ }
+        )
+    );
+    ($($k:ident).+) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::DEBUG,
+            { $($k).+ }
         )
     );
     ($($arg:tt)+) => (
@@ -1610,6 +1633,27 @@ macro_rules! info {
             { %$($k).+, $($field)*}
         )
     );
+    (?$($k:ident).+) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::INFO,
+            { ?$($k).+ }
+        )
+    );
+    (%$($k:ident).+) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::INFO,
+            { %$($k).+ }
+        )
+    );
+    ($($k:ident).+) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::INFO,
+            { $($k).+ }
+        )
+    );
     ($($arg:tt)+) => (
         $crate::event!(
             target: module_path!(),
@@ -1793,6 +1837,27 @@ macro_rules! warn {
             { %$($k).+, $($field)*}
         )
     );
+    (?$($k:ident).+) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::WARN,
+            { ?$($k).+ }
+        )
+    );
+    (%$($k:ident).+) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::WARN,
+            { %$($k).+ }
+        )
+    );
+    ($($k:ident).+) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::WARN,
+            { $($k).+ }
+        )
+    );
     ($($arg:tt)+) => (
         $crate::event!(
             target: module_path!(),
@@ -1969,6 +2034,27 @@ macro_rules! error {
             target: module_path!(),
             $crate::Level::ERROR,
             { %$($k).+, $($field)*}
+        )
+    );
+    (?$($k:ident).+) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::ERROR,
+            { ?$($k).+ }
+        )
+    );
+    (%$($k:ident).+) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::ERROR,
+            { %$($k).+ }
+        )
+    );
+    ($($k:ident).+) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::ERROR,
+            { $($k).+ }
         )
     );
     ($($arg:tt)+) => (

--- a/tracing/tests/macros.rs
+++ b/tracing/tests/macros.rs
@@ -281,6 +281,10 @@ fn event() {
     event!(target: "foo_events", Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     event!(target: "foo_events", Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     event!(target: "foo_events", Level::DEBUG, { foo = 2, bar.baz = 78, }, "quux");
+    let foo = 1;
+    event!(Level::DEBUG, ?foo);
+    event!(Level::DEBUG, %foo);
+    event!(Level::DEBUG, foo);
 }
 
 #[test]
@@ -303,6 +307,10 @@ fn trace() {
     trace!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     trace!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     trace!(target: "foo_events", { foo = 2, bar.baz = 78, }, "quux");
+    let foo = 1;
+    trace!(?foo);
+    trace!(%foo);
+    trace!(foo);
 }
 
 #[test]
@@ -325,6 +333,10 @@ fn debug() {
     debug!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     debug!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     debug!(target: "foo_events", { foo = 2, bar.baz = 78, }, "quux");
+    let foo = 1;
+    debug!(?foo);
+    debug!(%foo);
+    debug!(foo);
 }
 
 #[test]
@@ -347,6 +359,10 @@ fn info() {
     info!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     info!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     info!(target: "foo_events", { foo = 2, bar.baz = 78, }, "quux");
+    let foo = 1;
+    info!(?foo);
+    info!(%foo);
+    info!(foo);
 }
 
 #[test]
@@ -369,6 +385,10 @@ fn warn() {
     warn!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     warn!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     warn!(target: "foo_events", { foo = 2, bar.baz = 78, }, "quux");
+    let foo = 1;
+    warn!(?foo);
+    warn!(%foo);
+    warn!(foo);
 }
 
 #[test]
@@ -391,6 +411,10 @@ fn error() {
     error!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     error!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     error!(target: "foo_events", { foo = 2, bar.baz = 78, }, "quux");
+    let foo = 1;
+    error!(?foo);
+    error!(%foo);
+    error!(foo);
 }
 
 #[test]


### PR DESCRIPTION

## Motivation

The tracing event macros currently don't compile when invoked with a
single local variable, if there is no trailing comma. The macros fall
back to the format_args cases instead when a single local var name
appears.

## Solution

This branch fixes this issue by adding new macro arms, and additional
compile tests for this case.

Fixes #165 