### PR TITLE
core: deprecate `drop_span`

### DIFF
--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -328,7 +328,9 @@ impl Dispatch {
     /// [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
     /// [`try_close`]: #method.try_close
     #[inline]
+    #[deprecated(since = "0.1.2", note = "use `Dispatch::try_close` instead")]
     pub fn drop_span(&self, id: span::Id) {
+        #[allow(deprecated)]
         self.subscriber.drop_span(id);
     }
 

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -328,6 +328,7 @@ pub trait Subscriber: 'static {
     /// The default implementation of this function does nothing.
     ///
     /// [`try_close`]: trait.Subscriber.html#method.try_close
+    #[deprecated(since = "0.1.2", note = "use `Subscriber::try_close` instead")]
     fn drop_span(&self, _id: span::Id) {}
 
     /// Notifies the subscriber that a [`span ID`] has been dropped, and returns
@@ -367,6 +368,7 @@ pub trait Subscriber: 'static {
     /// [`clone_span`]: trait.Subscriber.html#method.clone_span
     /// [`drop_span`]: trait.Subscriber.html#method.drop_span
     fn try_close(&self, id: span::Id) -> bool {
+        #[allow(deprecated)]
         let _ = self.drop_span(id);
         false
     }


### PR DESCRIPTION
As discussed in [PR 149], we determined that the `Subscriber::drop_span`
method should be deprecated in favour of `try_close`. This commit
deprecates it.

[PR 149]: https://github.com/tokio-rs/tracing/pull/149#discussion_r300802298

Signed-off-by: Eliza Weisman <eliza@buoyant.io>