### PR TITLE
core: add `Into` impls for `span::Current`

### DIFF
--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -278,3 +278,27 @@ impl Current {
         }
     }
 }
+
+impl<'a> Into<Option<&'a Id>> for &'a Current {
+    fn into(self) -> Option<&'a Id> {
+        self.id()
+    }
+}
+
+impl<'a> Into<Option<Id>> for &'a Current {
+    fn into(self) -> Option<Id> {
+        self.id().cloned()
+    }
+}
+
+impl Into<Option<Id>> for Current {
+    fn into(self) -> Option<Id> {
+        self.id().cloned()
+    }
+}
+
+impl<'a> Into<Option<&'static Metadata<'static>>> for &'a Current {
+    fn into(self) -> Option<&'static Metadata<'static>> {
+        self.metadata()
+    }
+}


### PR DESCRIPTION
This commit adds implementations of `Into<Option<Id>>`,
`Into<Option<&'a Id>>`, and `Into<Option<&'static Metadata<'static>>>`.
These should make using `span::Current` with functions like
`Span::record_follows_from` in `tracing` more fluid.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>