### PR TITLE
core: prepare to release 0.1.2

### DIFF
--- a/tracing-core/CHANGELOG.md
+++ b/tracing-core/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.1.2 (July 10, 2019)
+
+### Deprecated
+
+- `Subscriber::drop_span` in favor of new `Subscriber::try_close` (#168)
+
+### Added
+
+- `Into<Option<&Id>>`, `Into<Option<Id>>`, and
+  `Into<Option<&'static Metadata<'static>>>` impls for `span::Current` (#170)
+- `Subscriber::try_close` method (#153)
+- Improved documentation for `dispatcher` (#171)
+
 # 0.1.1 (July 6, 2019)
 
 ### Added

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -8,13 +8,13 @@ name = "tracing-core"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-core/0.1.1/tracing_core"
+documentation = "https://docs.rs/tracing-core/0.1.2/tracing_core"
 description = """
 Core primitives for application-level tracing.
 """

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -52,16 +52,16 @@ API. However, this crate's API will change very infrequently, so it may be used
 when dependencies must be very stable.
 
 [`tracing`]: ../tracing
-[`Span`]: https://docs.rs/tracing-core/0.1.1/tracing_core/span/struct.Span.html
-[`Event`]: https://docs.rs/tracing-core/0.1.1/tracing_core/event/struct.Event.html
-[`Subscriber`]: https://docs.rs/tracing-core/0.1.1/tracing_core/subscriber/trait.Subscriber.html
-[`Metadata`]: https://docs.rs/tracing-core/0.1.1/tracing_core/metadata/struct.Metadata.html
-[`Callsite`]: https://docs.rs/tracing-core/0.1.1/tracing_core/callsite/trait.Callsite.html
-[`Field`]: https://docs.rs/tracing-core/0.1.1/tracing_core/field/struct.Field.html
-[`FieldSet`]: https://docs.rs/tracing-core/0.1.1/tracing_core/field/struct.FieldSet.html
-[`Value`]: https://docs.rs/tracing-core/0.1.1/tracing_core/field/trait.Value.html
-[`ValueSet`]: https://docs.rs/tracing-core/0.1.1/tracing_core/field/struct.ValueSet.html
-[`Dispatch`]: https://docs.rs/tracing-core/0.1.1/tracing_core/dispatcher/struct.Dispatch.html
+[`Span`]: https://docs.rs/tracing-core/0.1.2/tracing_core/span/struct.Span.html
+[`Event`]: https://docs.rs/tracing-core/0.1.2/tracing_core/event/struct.Event.html
+[`Subscriber`]: https://docs.rs/tracing-core/0.1.2/tracing_core/subscriber/trait.Subscriber.html
+[`Metadata`]: https://docs.rs/tracing-core/0.1.2/tracing_core/metadata/struct.Metadata.html
+[`Callsite`]: https://docs.rs/tracing-core/0.1.2/tracing_core/callsite/trait.Callsite.html
+[`Field`]: https://docs.rs/tracing-core/0.1.2/tracing_core/field/struct.Field.html
+[`FieldSet`]: https://docs.rs/tracing-core/0.1.2/tracing_core/field/struct.FieldSet.html
+[`Value`]: https://docs.rs/tracing-core/0.1.2/tracing_core/field/trait.Value.html
+[`ValueSet`]: https://docs.rs/tracing-core/0.1.2/tracing_core/field/struct.ValueSet.html
+[`Dispatch`]: https://docs.rs/tracing-core/0.1.2/tracing_core/dispatcher/struct.Dispatch.html
 
 ## License
 

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tracing-core/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/tracing-core/0.1.2")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
# 0.1.2 (July 10, 2019)

### Deprecated

- `Subscriber::drop_span` in favor of new `Subscriber::try_close` (#168)

### Added

- `Into<Option<&Id>>`, `Into<Option<Id>>`, and
  `Into<Option<&'static Metadata<'static>>>` impls for `span::Current` (#170)
- `Subscriber::try_close` method (#153)
- Improved documentation for `dispatcher` (#171)
