### PR TITLE
chore: update everything to use `try_close`

### DIFF
--- a/tracing-fmt/Cargo.toml
+++ b/tracing-fmt/Cargo.toml
@@ -9,7 +9,7 @@ default = ["ansi", "chrono"]
 ansi = ["ansi_term"]
 
 [dependencies]
-tracing-core = "0.1"
+tracing-core = "0.1.2"
 ansi_term = { version = "0.11", optional = true }
 regex = "1"
 lazy_static = "1"

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -206,8 +206,8 @@ where
         id.clone()
     }
 
-    fn drop_span(&self, id: span::Id) {
-        self.spans.drop_span(id);
+    fn try_close(&self, id: span::Id) -> bool {
+        self.spans.drop_span(id)
     }
 
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -16,4 +16,4 @@ tokio-executor = { version = "0.1", optional = true }
 [dev-dependencies]
 tokio = "0.1.22"
 tracing-fmt = { path = "../tracing-fmt" }
-tracing-core = "0.1"
+tracing-core = "0.1.2"

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 edition = "2018"
 
 [dependencies]
-tracing-core = "0.1"
+tracing-core = "0.1.2"
 tracing-subscriber = { path = "../tracing-subscriber" }
 log = "0.4"
 lazy_static = "1.3.0"

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -579,7 +579,7 @@ impl Subscriber for TraceLogger {
         id.clone()
     }
 
-    fn drop_span(&self, id: Id) {
+    fn try_close(&self, id: Id) -> bool {
         let mut spans = self.spans.lock().unwrap();
         if spans.contains_key(&id) {
             if spans.get(&id).unwrap().ref_count == 1 {
@@ -587,11 +587,12 @@ impl Subscriber for TraceLogger {
                 if self.settings.log_span_closes {
                     span.finish();
                 }
+                return true;
             } else {
                 spans.get_mut(&id).unwrap().ref_count -= 1;
             }
-            return;
         }
+        false
     }
 }
 

--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 serde = "1"
-tracing-core = "0.1"
+tracing-core = "0.1.2"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -27,7 +27,7 @@ keywords = ["logging", "tracing"]
 edition = "2018"
 
 [dependencies]
-tracing-core = "0.1.1"
+tracing-core = "0.1.2"
 log = { version = "0.4", optional = true }
 cfg-if = "0.1.9"
 

--- a/tracing/examples/sloggish/sloggish_subscriber.rs
+++ b/tracing/examples/sloggish/sloggish_subscriber.rs
@@ -278,4 +278,9 @@ impl Subscriber for SloggishSubscriber {
         // TODO: unify stack with current span
         self.current.exit();
     }
+
+    fn try_close(&self, _id: tracing::Id) -> bool {
+        // TODO: GC unneeded spans.
+        false
+    }
 }

--- a/tracing/examples/sloggish/sloggish_subscriber.rs
+++ b/tracing/examples/sloggish/sloggish_subscriber.rs
@@ -278,8 +278,4 @@ impl Subscriber for SloggishSubscriber {
         // TODO: unify stack with current span
         self.current.exit();
     }
-
-    fn drop_span(&self, _id: tracing::Id) {
-        // TODO: GC unneeded spans.
-    }
 }

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -884,7 +884,7 @@ impl Hash for Inner {
 
 impl Drop for Inner {
     fn drop(&mut self) {
-        self.subscriber.drop_span(self.id.clone());
+        let _ = self.subscriber.try_close(self.id.clone());
     }
 }
 

--- a/tracing/tests/support/subscriber.rs
+++ b/tracing/tests/support/subscriber.rs
@@ -81,6 +81,7 @@ where
         self
     }
 
+    #[allow(deprecated)]
     pub fn drop_span(mut self, span: MockSpan) -> Self {
         self.expected.push_back(Expect::DropSpan(span));
         self


### PR DESCRIPTION

## Motivation

`tracing-core` 0.1.2 deprecated the `Subscriber::drop_span` function in
favour of `try_close`.

## Solution

This branch updates all other crates to depend on core 0.1.2, and
replaces uses of `drop_span` with `try_close`.

