### PR TITLE
fmt: Add `with_ansi` builder flag

### DIFF
--- a/tracing-fmt/src/default.rs
+++ b/tracing-fmt/src/default.rs
@@ -78,7 +78,7 @@ impl<F, T> Format<F, T> {
         }
     }
 
-    /// Enable ANSI encoding for formatted events.
+    /// Enable ANSI terminal colors for formatted output.
     pub fn with_ansi(self, ansi: bool) -> Format<F, T> {
         Format { ansi, ..self }
     }

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -294,6 +294,15 @@ where
             settings: self.settings,
         }
     }
+
+    /// Enable ANSI encoding for formatted events.
+    #[cfg(feature = "ansi")]
+    pub fn with_ansi(self, ansi: bool) -> Builder<N, default::Format<L, T>, F> {
+        Builder {
+            fmt_event: self.fmt_event.with_ansi(ansi),
+            ..self
+        }
+    }
 }
 
 impl<N, E, F> Builder<N, E, F>


### PR DESCRIPTION
This adds a `with_ansi` builder argument that can be used to enable and disable ansi dynamically without having to recompile with a different feature flag. There is a bit of duplicated code but I think for the moment it is fine since I suspect this file will get a rewrite at some point. @hawkw if you'd like me to reduce that I can.

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>
