### PR TITLE
chore: allow nightly build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ script:
 - cargo test --all
 
 jobs:
+  allow-failures:
+  - rust: nightly
   include:
   - script:
     - (cd tracing/test-log-support && cargo test)
@@ -26,4 +28,3 @@ jobs:
   - script: cargo test --features=doctest-readme --all
     name: "doctest readme"
     rust: nightly
-


### PR DESCRIPTION

## Motivation

Recent CI builds have failed on nightly due to a compiler bug:
https://github.com/tokio-rs/tracing/pull/174#issuecomment-51058427

In general, nightly Rust is unstable, and it may often fail for reasons
that are not our fault. We shouldn't block merging branches on nightly
failures, when they are often spurious or unrelated to `tracing`. It is,
however, still good to look at these builds when possible.

## Solution

This branch allows failures on `nightly` CI builds. 

This means that the readme-doctest build is also allowed to fail, which
is a shame. It would be good to find a solution for testing readme
examples that doesn't require `nightly` Rust. I have some ideas for this
that I'll try to address in a subsequent branch.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
