### PR TITLE
tracing: when log support is enabled, log closes

### DIFF
--- a/tracing/test-log-support/src/lib.rs
+++ b/tracing/test-log-support/src/lib.rs
@@ -1,0 +1,54 @@
+extern crate log;
+use log::{LevelFilter, Log, Metadata, Record};
+use std::sync::{Arc, Mutex};
+
+pub struct Test {
+    state: Arc<State>,
+}
+
+struct State {
+    last_log: Mutex<Option<String>>,
+}
+
+struct Logger(Arc<State>);
+
+impl Log for Logger {
+    fn enabled(&self, _: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        let line = format!("{}", record.args());
+        println!("{:<5} {} {}", record.level(), record.target(), line);
+        if let Ok(mut last) = self.0.last_log.lock() {
+            *last = Some(line);
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+impl Test {
+    pub fn start() -> Self {
+        let me = Arc::new(State {
+            last_log: Mutex::new(None),
+        });
+        let state = me.clone();
+        log::set_boxed_logger(Box::new(Logger(me))).unwrap();
+        log::set_max_level(LevelFilter::Trace);
+        Test {
+            state,
+        }
+    }
+
+    pub fn assert_logged(&self, expected: &str) {
+        let last = match self.state.last_log.lock().unwrap().take() {
+            Some(last) => last,
+            _ => panic!("test failed: expected \"{}\", but nothing was logged", expected),
+        };
+
+        assert_eq!(last.as_str().trim(), expected);
+    }
+
+}
+

--- a/tracing/test-log-support/tests/log_with_trace.rs
+++ b/tracing/test-log-support/tests/log_with_trace.rs
@@ -5,8 +5,27 @@ extern crate test_log_support;
 use test_log_support::Test;
 use tracing::Level;
 
+pub struct NopSubscriber;
+
+impl tracing::Subscriber for NopSubscriber {
+    fn enabled(&self, _: &tracing::Metadata) -> bool {
+        true
+    }
+    fn new_span(&self, _: &tracing::span::Attributes) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+    fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record) {}
+    fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+    fn event(&self, _: &tracing::Event) {}
+    fn enter(&self, _: &tracing::span::Id) {}
+    fn exit(&self, _: &tracing::span::Id) {}
+    fn try_close(&self, _: tracing::span::Id) -> bool { true }
+}
+
 #[test]
 fn test_always_log() {
+    tracing::subscriber::set_global_default(NopSubscriber).expect("set global should succeed");
+
     let test = Test::start();
 
     error!(foo = 5);
@@ -19,7 +38,7 @@ fn test_always_log() {
     test.assert_logged("hello world; thingy=42 other_thingy=666");
 
     let foo = span!(Level::TRACE, "foo");
-    test.assert_logged("foo;");
+    test.assert_logged("++ foo;");
 
     foo.in_scope(|| {
         test.assert_logged("-> foo");
@@ -29,8 +48,15 @@ fn test_always_log() {
     });
     test.assert_logged("<- foo");
 
-    span!(Level::TRACE, "foo", bar = 3, baz = false);
-    test.assert_logged("foo; bar=3 baz=false");
+    drop(foo);
+    test.assert_logged("-- foo");
+
+
+    let foo = span!(Level::TRACE, "foo", bar = 3, baz = false);
+    test.assert_logged("++ foo; bar=3 baz=false");
+
+    drop(foo);
+    test.assert_logged("-- foo");
 
     // TODO(#1138): determine a new syntax for uninitialized span fields, and
     // re-enable these.


### PR DESCRIPTION
## Motivation

The `log` compatibility feature in the `tracing` logs when spans are
entered or exited, but does not track the full span lifecycle. This is
largely because there was not previously any way for the `tracing` crate
to be made aware of span closes.

## Solution

#153 added the `try_close` method to `Subscriber`, allowing subscribers
to communicate when spans are closed. This commit changes the `log`
compatibility feature in `tracing` to log when spans are closed, if a
subscriber is active and informs it of span closures.

I've also added tests for this.
