### PR TITLE
tracing: prepare to release 0.1.3

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 0.1.3 (July 11, 2019)
+
+### Added
+
+- Log messages when a subscriber indicates that a span has closed, when the
+  `log` feature flag is enabled (#180).
+
+### Changed
+
+- `tracing-core` minimum dependency version to 0.1.2 (#174).
+
+### Fixed
+
+- Fixed an issue where event macro invocations with a single field, using local
+  variable shorthand, would recur infinitely (#166).
+- Fixed uses of deprecated `tracing-core` APIs (#174).
+
 # 0.1.2 (July 6, 2019)
 
 ### Added

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,13 +8,13 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing/0.1.2/tracing"
+documentation = "https://docs.rs/tracing/0.1.3/tracing"
 description = """
 A scoped, structured logging and diagnostics system.
 """

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.3")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(feature = "doctest-readme", feature(external_doc))]


### PR DESCRIPTION
# 0.1.3 (July 11, 2019)

### Added

- Log messages when a subscriber indicates that a span has closed, when the
  `log` feature flag is enabled (#180).

### Changed

- `tracing-core` minimum dependency version to 0.1.2 (#174).

### Fixed

- Fixed an issue where event macro invocations with a single field, using local
  variable shorthand, would recur infinitely (#166).
- Fixed uses of deprecated `tracing-core` APIs (#174).
