### PR TITLE
chore: un-path-dep tracing

### DIFF
--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -11,4 +11,4 @@ tracing-core = "0.1.2"
 
 [dev-dependencies]
 serde_json = "1.0"
-tracing = { version = "0.1", path = "../tracing" }
+tracing = "0.1.3"

--- a/tracing-slog/Cargo.toml
+++ b/tracing-slog/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["David Barsky <dbarsky@amazon.com>"]
 edition = "2018"
 
 [dependencies]
-tracing = { version = "0.1", path = "../tracing" }
+tracing = "0.1.3"


### PR DESCRIPTION
Now that `tracing` 0.1.3 is released, this branch removes path 
dependencies on `tracing` from other crates in the repo.
