### PR TITLE
futures: Change examples to use `set_global_default`.

### DIFF
--- a/tracing-futures/examples/proxy_server.rs
+++ b/tracing-futures/examples/proxy_server.rs
@@ -114,14 +114,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         });
 
     let subscriber = tracing_fmt::FmtSubscriber::builder().finish();
-    tracing::subscriber::with_default(subscriber, || {
-        let done = done.instrument(span!(
-            Level::TRACE,
-            "proxy",
-            listen_addr = field::debug(&listen_addr)
-        ));
-        tokio::run(done);
-    });
+    let _ = tracing::subscriber::set_global_default(subscriber);
+    let done = done.instrument(span!(
+        Level::TRACE,
+        "proxy",
+        listen_addr = field::debug(&listen_addr)
+    ));
+    tokio::run(done);
 
     Ok(())
 }

--- a/tracing-futures/examples/spawny-thing.rs
+++ b/tracing-futures/examples/spawny-thing.rs
@@ -38,7 +38,6 @@ fn subtask(number: usize) -> impl Future<Item = usize, Error = ()> {
 
 fn main() {
     let subscriber = tracing_fmt::FmtSubscriber::builder().finish();
-    tracing::subscriber::with_default(subscriber, || {
-        tokio::run(parent_task(10));
-    });
+    let _ = tracing::subscriber::set_global_default(subscriber);
+    tokio::run(parent_task(10));
 }


### PR DESCRIPTION
## Motivation

The tracing-futures examples either need the tokio `experimental-tracing` flag set, or to use a global default subscriber.
## Solution

Use `set_global_default` in the examples, which is the simplest and probably the clearest for people getting started.
