### PR TITLE
log: Fix inverted module_path and file in AsTrace implementation

### DIFF
--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -184,9 +184,9 @@ impl<'a> AsTrace for log::Record<'a> {
             "log record",
             self.target(),
             self.level().as_trace(),
-            self.module_path(),
-            self.line(),
             self.file(),
+            self.line(),
+            self.module_path(),
             field::FieldSet::new(FIELD_NAMES, cs_id),
             Kind::EVENT,
         )


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

The metadata produced for logs by `as_trace` (used for filtering), when using `tracing-log`, have inverted file and module path fields:

```
Metadata { name: "log record", target: "tokio_reactor", level: Level(Trace),
  module_path: "/.../.cargo/registry/src/github.com-.../tokio-reactor-0.1.9/src/lib.rs",
  location: tokio_reactor:390, [...] }
```

## Solution

It is fixed by passing them in the right order in the `Metadata` constructor.
