### PR TITLE
log: Remove filter in LogTracer

### DIFF
--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -274,6 +274,18 @@ pub struct TraceLoggerBuilder {
 
 // ===== impl LogTracer =====
 
+impl LogTracer {
+    pub fn new() -> Self {
+        Self { _p: () }
+    }
+}
+
+impl Default for LogTracer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl log::Log for LogTracer {
     fn enabled(&self, _metadata: &log::Metadata) -> bool {
         // Use log::set_max_level to filter LogTracing's input
@@ -297,18 +309,6 @@ impl log::Log for LogTracer {
     }
 
     fn flush(&self) {}
-}
-
-impl LogTracer {
-    pub fn new() -> Self {
-        Self { _p: () }
-    }
-}
-
-impl Default for LogTracer {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 // ===== impl TraceLogger =====

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -289,7 +289,7 @@ impl LogTracer {
     /// Creates a new `LogTracer` that can then be used as a logger for the `log` crate.
     ///
     /// It is generally simpler to use the [`init`] or [`init_with_filter`] methods
-    /// that will create the `LogTracer` and set it as global logger.
+    /// which will create the `LogTracer` and set it as the global logger.
     ///
     /// Logger setup without the initialization methods can be done with:
     ///

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -286,7 +286,7 @@ pub struct TraceLoggerBuilder {
 static LOGGER: LogTracer = LogTracer { _p: () };
 
 impl LogTracer {
-    /// Creates a new `LogTracer` that can then be used as logger for the `log` crate.
+    /// Creates a new `LogTracer` that can then be used as a logger for the `log` crate.
     ///
     /// It is generally simpler to use the [`init`] or [`init_with_filter`] methods
     /// that will create the `LogTracer` and set it as global logger.

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -1,6 +1,25 @@
 //! Adapters for connecting unstructured log records from the `log` crate into
 //! the `tracing` ecosystem.
-//!
+//! 
+//! ## Convert log records to tracing `Event`s
+//! 
+//! To make logs seen as tracing events, set up `LogTracer` as logger by calling
+//! its [`init`] or [`init_with_filter`] methods.
+//! 
+//! ```rust
+//! # use std::error::Error;
+//! use tracing_log::LogTracer;
+//! use log;
+//! 
+//! # fn main() -> Result<(), Box<Error>> {
+//! LogTracer::init()?;
+//! 
+//! // will be available for Subscribers as a tracing Event
+//! log::trace!("an example trace log");
+//! # Ok(())
+//! # }
+//! ```
+//! 
 //! This conversion does not convert unstructured data in log records (such as
 //! values passed as format arguments to the `log!` macro) to structured
 //! `tracing` fields. However, it *does* attach these new events to to the
@@ -8,6 +27,12 @@
 //! primary use-case for this library: making it possible to locate the log
 //! records emitted by dependencies which use `log` within the context of a
 //! trace.
+//! 
+//! ## Convert tracing `Event`s to logs
+//! 
+//! This conversion can be done with [`TraceLogger`].
+//! 
+//! ## Caution: Mixing both conversions
 //!
 //! Note that logger implementations that convert log records to trace events
 //! should not be used with `Subscriber`s that convert trace events _back_ into
@@ -19,6 +44,10 @@
 //! `log` crate is desired, either the `log` crate should not be used to
 //! implement this logging, or an additional layer of filtering will be
 //! required to avoid infinitely converting between `Event` and `log::Record`.
+//! 
+//! [`init`]: struct.LogTracer.html#method.init
+//! [`init_with_filter`]: struct.LogTracer.html#method.init_with_filter
+//! [`TraceLogger`]: struct.TraceLogger.html
 extern crate log;
 extern crate tracing_core;
 extern crate tracing_subscriber;
@@ -43,34 +72,6 @@ use tracing_core::{
     subscriber::{self, Subscriber},
     Event, Metadata,
 };
-
-static LOGGER: LogTracer = LogTracer { _p: () };
-
-/// Sets up `LogTracer` as global logger for the `log` crate,
-/// with the given level as max level filter.
-///
-/// Setting a global logger can only be done once.
-///
-/// The `level` parameter controls which levels will be passed
-/// to `tracing`.
-pub fn init_logger_with_filter(level: log::LevelFilter) -> Result<(), log::SetLoggerError> {
-    log::set_logger(&LOGGER)?;
-    log::set_max_level(level);
-    Ok(())
-}
-
-/// Sets up `LogTracer` as global logger for the `log` crate.
-///
-/// Setting a global logger can only be done once.
-///
-/// This will forward all logs to `tracing` and let the subscribers
-/// do the filtering. If you know in advance you want to filter some log levels,
-/// use [`init_logger_with_filter`] instead.
-///
-/// [`init_logger_with_filter`]: ../fn.init_logger_with_filter.html
-pub fn init_logger() -> Result<(), log::SetLoggerError> {
-    init_logger_with_filter(log::LevelFilter::Trace)
-}
 
 /// Format a log record as a trace event in the current span.
 pub fn format_trace(record: &log::Record) -> io::Result<()> {
@@ -247,8 +248,15 @@ impl AsTrace for log::Level {
     }
 }
 
-/// A simple "logger" that converts all log records into `tracing` `Event`s,
-/// with an optional level filter.
+/// A simple "logger" that converts all log records into `tracing` `Event`s.
+/// 
+/// Can be initialized with:
+/// 
+/// * [`init`] if you want to convert all logs and do the filtering in a subscriber
+/// * [`init_with_filter`] if you know in advance a log level you want to filter
+///
+/// [`init`]: ../fn.init.html
+/// [`init_with_filter`]: ../fn.init_with_filter.html
 #[derive(Debug)]
 pub struct LogTracer {
     _p: (),
@@ -274,9 +282,74 @@ pub struct TraceLoggerBuilder {
 
 // ===== impl LogTracer =====
 
+// Static logger for `LogTrace`
+static LOGGER: LogTracer = LogTracer { _p: () };
+
 impl LogTracer {
+    /// Creates a new `LogTracer` that can then be used as logger for the `log` crate.
+    /// 
+    /// It is generally simpler to use the [`init`] or [`init_with_filter`] methods
+    /// that will create the `LogTracer` and set it as global logger.
+    /// 
+    /// Logger setup without the initialization methods can be done with:
+    ///
+    /// ```rust
+    /// # use std::error::Error;
+    /// use tracing_log::LogTracer;
+    /// use log;
+    /// 
+    /// # fn main() -> Result<(), Box<Error>> {
+    /// let logger = LogTracer::new();
+    /// log::set_boxed_logger(Box::new(logger))?;
+    /// log::set_max_level(log::LevelFilter::Trace);
+    ///
+    /// // will be available for Subscribers as a tracing Event
+    /// log::trace!("an example trace log");
+    /// # Ok(())
+    /// # }
+    /// ```
+    /// 
+    /// [`init`]: #method.init
+    /// [`init_with_filter`]: .#method.init_with_filter
     pub fn new() -> Self {
         Self { _p: () }
+    }
+
+    /// Sets up `LogTracer` as global logger for the `log` crate,
+    /// with the given level as max level filter.
+    ///
+    /// Setting a global logger can only be done once.
+    pub fn init_with_filter(level: log::LevelFilter) -> Result<(), log::SetLoggerError> {
+        log::set_logger(&LOGGER)?;
+        log::set_max_level(level);
+        Ok(())
+    }
+
+    /// Sets up `LogTracer` as global logger for the `log` crate.
+    ///
+    /// Setting a global logger can only be done once.
+    /// 
+    /// ```rust
+    /// # use std::error::Error;
+    /// use tracing_log::LogTracer;
+    /// use log;
+    /// 
+    /// # fn main() -> Result<(), Box<Error>> {
+    /// LogTracer::init()?;
+    /// 
+    /// // will be available for Subscribers as a tracing Event
+    /// log::trace!("an example trace log");
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// This will forward all logs to `tracing` and let the subscribers
+    /// do the filtering. If you know in advance you want to filter some log levels,
+    /// use [`init_with_filter`] instead.
+    ///
+    /// [`init_with_filter`]: #method.init_with_filter
+    pub fn init() -> Result<(), log::SetLoggerError> {
+        Self::init_with_filter(log::LevelFilter::Trace)
     }
 }
 

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -344,7 +344,7 @@ impl LogTracer {
     /// ```
     ///
     /// This will forward all logs to `tracing` and let the subscribers
-    /// do the filtering. If you know in advance you want to filter some log levels,
+    /// determine if they are enabled. If you know in advance you want to filter some log levels,
     /// use [`init_with_filter`] instead.
     ///
     /// [`init_with_filter`]: #method.init_with_filter

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -3,8 +3,8 @@
 //!
 //! ## Convert log records to tracing `Event`s
 //!
-//! To make logs seen as tracing events, set up `LogTracer` as logger by calling
-//! its [`init`] or [`init_with_filter`] methods.
+//! To convert [`log::Record`]s as [`tracing::Event`]s, set `LogTracer` as the default
+//! logger by calling its [`init`] or [`init_with_filter`] methods.
 //!
 //! ```rust
 //! # use std::error::Error;
@@ -30,7 +30,8 @@
 //!
 //! ## Convert tracing `Event`s to logs
 //!
-//! This conversion can be done with [`TraceLogger`].
+//! This conversion can be done with [`TraceLogger`], a [`Subscriber`] which
+//! records `tracing` spans and events and outputs log records.
 //!
 //! ## Caution: Mixing both conversions
 //!
@@ -48,6 +49,8 @@
 //! [`init`]: struct.LogTracer.html#method.init
 //! [`init_with_filter`]: struct.LogTracer.html#method.init_with_filter
 //! [`TraceLogger`]: struct.TraceLogger.html
+//! [`tracing::Event`]: https://docs.rs/tracing/0.1.3/tracing/struct.Event.html
+//! [`log::Record`]: https://docs.rs/log/0.4.7/log/struct.Record.html
 extern crate log;
 extern crate tracing_core;
 extern crate tracing_subscriber;

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -325,7 +325,7 @@ impl LogTracer {
         Ok(())
     }
 
-    /// Sets up `LogTracer` as global logger for the `log` crate.
+    /// Sets a `LogTracer` as the global logger for the `log` crate.
     ///
     /// Setting a global logger can only be done once.
     ///

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -343,7 +343,7 @@ impl LogTracer {
     /// # }
     /// ```
     ///
-    /// This will forward all logs to `tracing` and let the subscribers
+    /// This will forward all logs to `tracing` and lets the current `Subscriber`
     /// determine if they are enabled. If you know in advance you want to filter some log levels,
     /// use [`init_with_filter`] instead.
     ///

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -1,25 +1,25 @@
 //! Adapters for connecting unstructured log records from the `log` crate into
 //! the `tracing` ecosystem.
-//! 
+//!
 //! ## Convert log records to tracing `Event`s
-//! 
+//!
 //! To make logs seen as tracing events, set up `LogTracer` as logger by calling
 //! its [`init`] or [`init_with_filter`] methods.
-//! 
+//!
 //! ```rust
 //! # use std::error::Error;
 //! use tracing_log::LogTracer;
 //! use log;
-//! 
+//!
 //! # fn main() -> Result<(), Box<Error>> {
 //! LogTracer::init()?;
-//! 
+//!
 //! // will be available for Subscribers as a tracing Event
 //! log::trace!("an example trace log");
 //! # Ok(())
 //! # }
 //! ```
-//! 
+//!
 //! This conversion does not convert unstructured data in log records (such as
 //! values passed as format arguments to the `log!` macro) to structured
 //! `tracing` fields. However, it *does* attach these new events to to the
@@ -27,11 +27,11 @@
 //! primary use-case for this library: making it possible to locate the log
 //! records emitted by dependencies which use `log` within the context of a
 //! trace.
-//! 
+//!
 //! ## Convert tracing `Event`s to logs
-//! 
+//!
 //! This conversion can be done with [`TraceLogger`].
-//! 
+//!
 //! ## Caution: Mixing both conversions
 //!
 //! Note that logger implementations that convert log records to trace events
@@ -44,7 +44,7 @@
 //! `log` crate is desired, either the `log` crate should not be used to
 //! implement this logging, or an additional layer of filtering will be
 //! required to avoid infinitely converting between `Event` and `log::Record`.
-//! 
+//!
 //! [`init`]: struct.LogTracer.html#method.init
 //! [`init_with_filter`]: struct.LogTracer.html#method.init_with_filter
 //! [`TraceLogger`]: struct.TraceLogger.html
@@ -249,9 +249,9 @@ impl AsTrace for log::Level {
 }
 
 /// A simple "logger" that converts all log records into `tracing` `Event`s.
-/// 
+///
 /// Can be initialized with:
-/// 
+///
 /// * [`init`] if you want to convert all logs and do the filtering in a subscriber
 /// * [`init_with_filter`] if you know in advance a log level you want to filter
 ///
@@ -287,17 +287,17 @@ static LOGGER: LogTracer = LogTracer { _p: () };
 
 impl LogTracer {
     /// Creates a new `LogTracer` that can then be used as logger for the `log` crate.
-    /// 
+    ///
     /// It is generally simpler to use the [`init`] or [`init_with_filter`] methods
     /// that will create the `LogTracer` and set it as global logger.
-    /// 
+    ///
     /// Logger setup without the initialization methods can be done with:
     ///
     /// ```rust
     /// # use std::error::Error;
     /// use tracing_log::LogTracer;
     /// use log;
-    /// 
+    ///
     /// # fn main() -> Result<(), Box<Error>> {
     /// let logger = LogTracer::new();
     /// log::set_boxed_logger(Box::new(logger))?;
@@ -308,7 +308,7 @@ impl LogTracer {
     /// # Ok(())
     /// # }
     /// ```
-    /// 
+    ///
     /// [`init`]: #method.init
     /// [`init_with_filter`]: .#method.init_with_filter
     pub fn new() -> Self {
@@ -328,15 +328,15 @@ impl LogTracer {
     /// Sets up `LogTracer` as global logger for the `log` crate.
     ///
     /// Setting a global logger can only be done once.
-    /// 
+    ///
     /// ```rust
     /// # use std::error::Error;
     /// use tracing_log::LogTracer;
     /// use log;
-    /// 
+    ///
     /// # fn main() -> Result<(), Box<Error>> {
     /// LogTracer::init()?;
-    /// 
+    ///
     /// // will be available for Subscribers as a tracing Event
     /// log::trace!("an example trace log");
     /// # Ok(())


### PR DESCRIPTION
## Motivation

As we started discussing in #197, setting up level filter for log is a bit complicated, and currently has to be done twice (not counting optional filtering in subscriber):

* Once in `log` with `log::set_max_level`
* Once in `tracing_log` with `LogTracer::with_filter`

Both use `log::LevelFilter` and have exactly the same behavior (but a different default level).

## Solution

This PR removes the filter in `LogTracer`, and adds a function to allow easily setting up a logger and a filter directly from `tracing_log`.

The equivalent in the `env_logger` crate are:

```rust
pub fn try_init() -> Result<(), SetLoggerError> {
    try_init_from_env(Env::default())
}

pub fn init() {
    try_init().expect("env_logger::init should not be called after logger initialized");
}
```

We may want to stay close as it is a well known way to set up a logger. Do you think we need `try_init/init` as well?
