### PR TITLE
fmt: Rename default module to format

### DIFF
--- a/tracing-fmt/src/filter/env.rs
+++ b/tracing-fmt/src/filter/env.rs
@@ -526,7 +526,7 @@ impl fmt::Display for LevelFilter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::default::NewRecorder;
+    use crate::format::NewRecorder;
     use crate::span::*;
     use tracing_core::field::FieldSet;
     use tracing_core::*;

--- a/tracing-fmt/src/format.rs
+++ b/tracing-fmt/src/format.rs
@@ -1,3 +1,5 @@
+//! Default formatters for logs
+
 use crate::span;
 use crate::time::{self, FormatTime, SystemTime};
 use crate::FormatEvent;

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -19,8 +19,8 @@ use tracing_core::{field, subscriber::Interest, Event, Metadata};
 
 use std::{any::TypeId, cell::RefCell, fmt, io};
 
-pub mod format;
 pub mod filter;
+pub mod format;
 mod span;
 pub mod time;
 
@@ -69,11 +69,8 @@ pub struct FmtSubscriber<
 }
 
 #[derive(Debug, Default)]
-pub struct Builder<
-    N = format::NewRecorder,
-    E = format::Format<format::Full>,
-    F = filter::EnvFilter,
-> {
+pub struct Builder<N = format::NewRecorder, E = format::Format<format::Full>, F = filter::EnvFilter>
+{
     new_visitor: N,
     fmt_event: E,
     filter: F,


### PR DESCRIPTION
## Motivation

This PR renames the `default` module to `format` because `default` seems not descriptive enough (and actually contains formatting tools!). Although `default::Format` might make sense, `
default::Full` or  `default::Compact` could probably be more suited in `format::`.