### PR TITLE
Re-enable cargo checks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,28 +1,26 @@
 stages:
-# Blocked on https://github.com/crate-ci/azure-pipelines/pull/42
-# See also https://github.com/tokio-rs/tracing/pull/191#issuecomment-513872071
-# When we bring these back, add check as a dependency for the other stages
-# - stage: check
-#   displayName: Compilation check
-#   dependsOn: []
-#   jobs:
-#     - template: azure/cargo-check.yml@templates
-#       parameters:
-#         name: cargo_check
-#         benches: true
-# # This represents the minimum Rust version supported.
-# # Tests are not run as tests may require newer versions of rust.
-# - stage: msrv
-#   displayName: "Minimum supported Rust version"
-#   dependsOn: []
-#   jobs:
-#     - template: azure/cargo-check.yml@templates
-#       parameters:
-#        rust: 1.34.0
+ - stage: check
+   displayName: Compilation check
+   dependsOn: []
+   jobs:
+     - template: azure/cargo-check.yml@templates
+       parameters:
+         name: cargo_check
+         benches: true
+         all_features: false
+ # This represents the minimum Rust version supported.
+ # Tests are not run as tests may require newer versions of rust.
+ - stage: msrv
+   displayName: "Minimum supported Rust version"
+   dependsOn: check
+   jobs:
+     - template: azure/cargo-check.yml@templates
+       parameters:
+         rust: 1.34.0
+         all_features: false
  - stage: custom
    displayName: "Special tests"
-   # dependsOn: check
-   dependsOn: []
+   dependsOn: check
    jobs:
      - job: custom_stable
        pool:
@@ -51,8 +49,7 @@ stages:
            displayName: "Test std::future support for tracing-futures"
  - stage: style
    displayName: Style linting
-   # dependsOn: check
-   dependsOn: []
+   dependsOn: check
    jobs:
     - template: azure/rustfmt.yml@templates
       parameters:
@@ -69,8 +66,7 @@ stages:
         allow_fail: true
  - stage: test
    displayName: Test suite
-   # dependsOn: check
-   dependsOn: []
+   dependsOn: check
    jobs:
      - template: azure/tests.yml@templates
  - stage: coverage


### PR DESCRIPTION
Brings back `cargo check` as discussed here: https://github.com/tokio-rs/tracing/pull/191#issuecomment-513897819 now that https://github.com/crate-ci/azure-pipelines/pull/42 has landed.