### PR TITLE
fmt: improve documentation

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,3 @@
+rename default crate?
+
+

--- a/TODO
+++ b/TODO
@@ -1,3 +1,0 @@
-rename default crate?
-
-

--- a/tracing-fmt/src/filter/env.rs
+++ b/tracing-fmt/src/filter/env.rs
@@ -1,3 +1,46 @@
+//! A filter based on a filter expression than can be read from an environment variable
+//!
+//! ## Filter syntax
+//!
+//! The filter is made of a list of directives. A directive is made of:
+//!
+//! * A level to use as filter (see [`LevelFilter`] for available levels)
+//! * An optional target to filter
+//! * An optional span to filter
+//! * An optional list of fields,
+//!
+//! It is represented by `target[span{key=value ...}]=level`
+//!
+//! A directive could hence be one of:
+//!
+//! * `info` with no filter, which makes it a global filter level
+//! * `target=info` to set info level for traces having a given target
+//! * `[span]=info` to set info level for traces in a given span
+//! * `[span{key}]=info` to set info level for traces having a given target having the
+//!   given key in their fields
+//! * `[span{key=value}]=info` to set info level for traces having a given target having
+//!   the given key with the given value in their fields
+//! * `[span{key1="value1" key2=value2}]=info` to set info level for traces having a
+//!   given target having the given key with the given value in their fields
+//!
+//! ## Filter definition
+//!
+//! By default, only errors are displayed (i.e. the default filter is `error`).
+//!
+//! The filter can be created from one of:
+//!
+//! * The `RUST_LOG` environment variable (like `env_logger` does), with `from_default_env`
+//! * Another environment variable with `from_env`
+//! * A string containing the filter with `new`
+//!
+//! There are `try_*` variants for each of these to get filter parsing errors, otherwise
+//! they are just ignored.
+//!
+//! To reload the filter at runtime, see [`reload`].
+//!
+//! [`LevelFilter`]: https://docs.rs/tracing/0.1.3/tracing/level_filters/struct.LevelFilter.html
+//! [`reload`]: ../reload/index.html
+
 use crate::{filter::Filter, span::Context};
 use regex::Regex;
 use tracing_core::{subscriber::Interest, Level, Metadata};

--- a/tracing-fmt/src/filter/env.rs
+++ b/tracing-fmt/src/filter/env.rs
@@ -2,36 +2,37 @@
 //!
 //! ## Filter syntax
 //!
-//! The filter is made of a list of directives. A directive is made of:
+//! The filter is made of a list of directives, separated by commas.
+//! A directive is made of:
 //!
 //! * A level to use as filter (see [`LevelFilter`] for available levels)
 //! * An optional target to filter
 //! * An optional span to filter
 //! * An optional list of fields,
 //!
-//! It is represented by `target[span{key=value ...}]=level`
+//! It is represented in with the `target[span{key=value ...}]=level` syntax.
 //!
 //! A directive could hence be one of:
 //!
-//! * `info` with no filter, which makes it a global filter level
+//! * `info` which specifies no filter, making it a global filter level
 //! * `target=info` to set info level for traces having a given target
 //! * `[span]=info` to set info level for traces in a given span
-//! * `[span{key}]=info` to set info level for traces having a given target having the
+//! * `[span{key}]=info` to set info level for traces having a given target, and the
 //!   given key in their fields
-//! * `[span{key=value}]=info` to set info level for traces having a given target having
+//! * `[span{key=value}]=info` to set info level for traces having a given target, and
 //!   the given key with the given value in their fields
 //! * `[span{key1="value1" key2=value2}]=info` to set info level for traces having a
-//!   given target having the given key with the given value in their fields
+//!   given target and the given keys with the given values in their fields
 //!
 //! ## Filter definition
 //!
 //! By default, only errors are displayed (i.e. the default filter is `error`).
 //!
-//! The filter can be created from one of:
+//! The filter can be created from:
 //!
-//! * The `RUST_LOG` environment variable (like `env_logger` does), with `from_default_env`
-//! * Another environment variable with `from_env`
-//! * A string containing the filter with `new`
+//! * The `RUST_LOG` environment variable (like `env_logger` does), with [`from_default_env`]
+//! * Another environment variable with [`from_env`]
+//! * A string containing the filter with [`new`]
 //!
 //! There are `try_*` variants for each of these to get filter parsing errors, otherwise
 //! they are just ignored.
@@ -40,6 +41,9 @@
 //!
 //! [`LevelFilter`]: https://docs.rs/tracing/0.1.3/tracing/level_filters/struct.LevelFilter.html
 //! [`reload`]: ../reload/index.html
+//! [`from_default_env`]: struct.EnvFilter.html#method.from_default_env
+//! [`from_env`]: struct.EnvFilter.html#method.from_env
+//! [`new`]: struct.EnvFilter.html#method.new
 
 use crate::{filter::Filter, span::Context};
 use regex::Regex;

--- a/tracing-fmt/src/filter/reload.rs
+++ b/tracing-fmt/src/filter/reload.rs
@@ -1,3 +1,5 @@
+//! Reload filters in `FmtSubscriber`
+
 use crate::{filter::Filter, span::Context};
 use parking_lot::RwLock;
 use std::{

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -1,3 +1,96 @@
+//! A `tracing` subscriber that formats and logs trace data
+//!
+//! This crates provides a configurable subscriber for tracing events,
+//! allowing to output formatted logs and provided other logging-oriented
+//! features, likes filter with live reloading.
+//!
+//! ## Subscriber setup
+//!
+//! You can setup the subscriber with:
+//!
+//! ```rust
+//! # use std::error::Error;
+//! use tracing_fmt::FmtSubscriber;
+//! use tracing::subscriber::set_global_default;
+//! use tracing::info;
+//!
+//! # fn main() -> Result<(), Box<Error>> {
+//! let my_subscriber = FmtSubscriber::builder().finish();
+//!
+//! set_global_default(my_subscriber)?;
+//!
+//! info!("an example trace log");
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! By default, it will display timestamps and use ansi terminal formatting.
+//! These options are configurable in the [`Builder`].
+//!
+//! ## Event formatting
+//!
+//! Two log formats are provided by default:
+//!
+//! * Full (used by default), which includes all fields in each event and its containing
+//! spans
+//! * Compact which includes only the fields from the most-recently-entered
+//!
+//! To use the `compact` format, use the [`compact`] method on the subscriber builder.
+//!
+//! You can write your own formatting by implementing [`FormatEvent`] and passing it
+//! when building `FmtSubscriber` with  [`on_event`].
+//!
+//! ## Filtering
+//!
+//! A filtering mechanism is provided by [`EnvFilter`], which
+//! allows filtering events to display by level, target, span
+//! field presence and field value, possibly based on an environment
+//! variable value. See `env` module for
+//! more information.
+//!
+//! For example:
+//!
+//! ```rust
+//! # use std::error::Error;
+//! use tracing_fmt::FmtSubscriber;
+//! use tracing_fmt::filter::env::EnvFilter;
+//!
+//! # fn main() -> Result<(), Box<Error>> {
+//! let filter = EnvFilter::new("info");
+//! let my_subscriber = FmtSubscriber::builder().with_filter(filter).finish();
+//! // Now all log equals or higher than info will be displayed
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! You can define your own filter by implementing [`Filter`].
+//!
+//! ## Filter reload
+//!
+//! The subscriber includes a filter reloading mechanism. You need to call the
+//! `with_filter_reloading` on the builder.
+//!
+//! ```rust
+//! # use std::error::Error;
+//! use tracing_fmt::FmtSubscriber;
+//!
+//! # fn main() -> Result<(), Box<Error>> {
+//! let my_subscriber = FmtSubscriber::builder().with_filter_reloading().finish();
+//! let reload_handle = my_subscriber.reload_handle();
+//!
+//! // You can now at, at any time, reload the filter configuration with:
+//! reload_handle.reload("error,[myspan]=info")?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [`FormatEvent`]: trait.FormatEvent.html
+//! [`Builder`]: struct.Builder.html
+//! [`compact`]: struct.Builder.html#method.compact
+//! [`on_event`]: struct.Builder.html#method.on_event
+//! [`with_filter_reloading`]: struct.Builder.html#method.with_filter_reloading
+//! [`Filter`]: trait.Filter.html
+
 extern crate tracing_core;
 #[cfg(test)]
 #[macro_use]

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -1,8 +1,8 @@
 //! A `tracing` subscriber that formats and logs trace data
 //!
 //! This crates provides a configurable subscriber for tracing events,
-//! allowing to output formatted logs and provided other logging-oriented
-//! features, likes filter with live reloading.
+//! allowing to output formatted logs and providing other logging-oriented
+//! features, like filters with live reloading.
 //!
 //! ## Subscriber setup
 //!
@@ -24,12 +24,12 @@
 //! # }
 //! ```
 //!
+//! ## Event formatting
+//!
 //! By default, it will display timestamps and use ansi terminal formatting.
 //! These options are configurable in the [`Builder`].
 //!
-//! ## Event formatting
-//!
-//! Two log formats are provided by default:
+//! For the actual log content, two formats are provided by default:
 //!
 //! * Full (used by default), which includes all fields in each event and its containing
 //! spans


### PR DESCRIPTION
## Motivation

Adds a bit of docs about `tracing_fmt` features, especially the env filter.