### PR TITLE
meta: README and badges tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,15 @@
 Application-level tracing for Rust.
 
 [![Crates.io][crates-badge]][crates-url]
+[![Documentation][docs-badge]][docs-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
 
-[crates-badge]: https://img.shields.io/crates/v/tracing-core.svg
-[crates-url]: https://crates.io/crates/tracing-core
+[crates-badge]: https://img.shields.io/crates/v/tracing.svg
+[crates-url]: https://crates.io/crates/tracing
+[docs-badge]: https://docs.rs/tracing/badge.svg
+[docs-url]: https://docs.rs/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ Application-level tracing for Rust.
 
 [![Crates.io][crates-badge]][crates-url]
 [![MIT licensed][mit-badge]][mit-url]
-[![Build Status][travis-badge]][travis-url]
+[![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-core.svg
 [crates-url]: https://crates.io/crates/tracing-core
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
-[travis-badge]: https://travis-ci.org/tokio-rs/tracing.svg?branch=master
-[travis-url]: https://travis-ci.org/tokio-rs/tracing/branches
+[azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master
+[azure-url]: https://dev.azure.com/tracing/tracing/_build/latest?definitionId=1&branchName=master
 [gitter-badge]: https://img.shields.io/gitter/room/tokio-rs/tracing.svg
 [gitter-url]: https://gitter.im/tokio-rs/tracing
 

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -27,7 +27,6 @@ keywords = ["logging", "tracing"]
 edition = "2018"
 
 [badges]
-travis-ci = { repository = "tokio-rs/tracing", branch = "master" }
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
 maintenance = { status = "actively-developed" }
 

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -25,8 +25,10 @@ categories = [
 ]
 keywords = ["logging", "tracing"]
 edition = "2018"
+
 [badges]
 travis-ci = { repository = "tokio-rs/tracing", branch = "master" }
+azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -5,7 +5,7 @@ Core primitives for application-level tracing.
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
 [![MIT licensed][mit-badge]][mit-url]
-[![Build Status][travis-badge]][travis-url]
+[![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
 
 [Documentation][docs-url] |
@@ -17,8 +17,8 @@ Core primitives for application-level tracing.
 [docs-url]: https://docs.rs/tracing-core
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
-[travis-badge]: https://travis-ci.org/tokio-rs/tracing.svg?branch=master
-[travis-url]: https://travis-ci.org/tokio-rs/tracing/branches
+[azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master
+[azure-url]: https://dev.azure.com/tracing/tracing/_build/latest?definitionId=1&branchName=master
 [gitter-badge]: https://img.shields.io/gitter/room/tokio-rs/tracing.svg
 [gitter-url]: https://gitter.im/tokio-rs/tracing
 

--- a/tracing-env-logger/Cargo.toml
+++ b/tracing-env-logger/Cargo.toml
@@ -19,3 +19,4 @@ tokio = "0.1.22"
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
+maintenance = { status = "experimental" }

--- a/tracing-env-logger/Cargo.toml
+++ b/tracing-env-logger/Cargo.toml
@@ -16,3 +16,6 @@ tracing-subscriber = { path = "../tracing-subscriber" }
 hyper = "=0.12.25"
 futures = "0.1"
 tokio = "0.1.22"
+
+[badges]
+azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-fmt/Cargo.toml
+++ b/tracing-fmt/Cargo.toml
@@ -14,7 +14,8 @@ categories = [
 ]
 keywords = ["logging", "tracing"]
 
-[badges] 
+[badges]
+azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
 maintenance = { status = "experimental" }
 
 [features]

--- a/tracing-fmt/README.md
+++ b/tracing-fmt/README.md
@@ -8,7 +8,7 @@ that formats, colors, and logs trace data.
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
 [![MIT licensed][mit-badge]][mit-url]
-[![Build Status][travis-badge]][travis-url]
+[![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
 
 [Documentation][docs-url] |
@@ -22,8 +22,8 @@ that formats, colors, and logs trace data.
 [docs-url]: https://docs.rs/tracing-fmt
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
-[travis-badge]: https://travis-ci.org/tokio-rs/tracing.svg?branch=master
-[travis-url]: https://travis-ci.org/tokio-rs/tracing/branches
+[azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master
+[azure-url]: https://dev.azure.com/tracing/tracing/_build/latest?definitionId=1&branchName=master
 [gitter-badge]: https://img.shields.io/gitter/room/tokio-rs/tracing.svg
 [gitter-url]: https://gitter.im/tokio-rs/tracing
 

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -20,3 +20,6 @@ tokio-executor = { version = "0.1", optional = true }
 tokio = "0.1.22"
 tracing-fmt = { path = "../tracing-fmt" }
 tracing-core = "0.1.2"
+
+[badges]
+azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -12,3 +12,4 @@ lazy_static = "1.3.0"
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
+maintenance = { status = "experimental" }

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -9,3 +9,6 @@ tracing-core = "0.1.2"
 tracing-subscriber = { path = "../tracing-subscriber" }
 log = "0.4"
 lazy_static = "1.3.0"
+
+[badges]
+azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-macros/Cargo.toml
+++ b/tracing-macros/Cargo.toml
@@ -13,3 +13,4 @@ env_logger = "0.5"
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
+maintenance = { status = "experimental" }

--- a/tracing-macros/Cargo.toml
+++ b/tracing-macros/Cargo.toml
@@ -10,3 +10,6 @@ tracing = { version = "0.1", path = "../tracing" }
 [dev-dependencies]
 tracing-log = { path = "../tracing-log" }
 env_logger = "0.5"
+
+[badges]
+azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-proc-macros/Cargo.toml
+++ b/tracing-proc-macros/Cargo.toml
@@ -20,3 +20,4 @@ humantime = "1.1.1"
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
+maintenance = { status = "experimental" }

--- a/tracing-proc-macros/Cargo.toml
+++ b/tracing-proc-macros/Cargo.toml
@@ -17,3 +17,6 @@ tracing-fmt = { path = "../tracing-fmt" }
 env_logger = "0.5"
 ansi_term = "0.11"
 humantime = "1.1.1"
+
+[badges]
+azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -12,3 +12,6 @@ tracing-core = "0.1.2"
 [dev-dependencies]
 serde_json = "1.0"
 tracing = "0.1.3"
+
+[badges]
+azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -15,3 +15,4 @@ tracing = "0.1.3"
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
+maintenance = { status = "experimental" }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -10,3 +10,6 @@ tracing-core = "0.1.2"
 [dev-dependencies]
 tracing-log = { path = "../tracing-log" }
 tracing = "0.1"
+
+[badges]
+azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -13,3 +13,4 @@ tracing = "0.1"
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
+maintenance = { status = "experimental" }

--- a/tracing-tower-http/Cargo.toml
+++ b/tracing-tower-http/Cargo.toml
@@ -29,3 +29,4 @@ env_logger = "0.5"
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
+maintenance = { status = "experimental" }

--- a/tracing-tower-http/Cargo.toml
+++ b/tracing-tower-http/Cargo.toml
@@ -26,3 +26,6 @@ tokio-io = "0.1"
 ansi_term = "0.11"
 humantime = "1.1.1"
 env_logger = "0.5"
+
+[badges]
+azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -33,3 +33,4 @@ env_logger = "0.5"
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
+maintenance = { status = "experimental" }

--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -30,3 +30,6 @@ tokio-io = "0.1"
 ansi_term = "0.11"
 humantime = "1.1.1"
 env_logger = "0.5"
+
+[badges]
+azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -62,5 +62,6 @@ name = "no_subscriber"
 harness = false
 
 [badges]
+azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
 travis-ci = { repository = "tokio-rs/tracing", branch = "master" }
 maintenance = { status = "actively-developed" }

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -63,5 +63,4 @@ harness = false
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
-travis-ci = { repository = "tokio-rs/tracing", branch = "master" }
 maintenance = { status = "actively-developed" }

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -5,7 +5,7 @@ Application-level tracing for Rust.
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
 [![MIT licensed][mit-badge]][mit-url]
-[![Build Status][travis-badge]][travis-url]
+[![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
 
 [Documentation][docs-url] |
@@ -17,8 +17,8 @@ Application-level tracing for Rust.
 [docs-url]: https://docs.rs/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
-[travis-badge]: https://travis-ci.org/tokio-rs/tracing.svg?branch=master
-[travis-url]: https://travis-ci.org/tokio-rs/tracing/branches
+[azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master
+[azure-url]: https://dev.azure.com/tracing/tracing/_build/latest?definitionId=1&branchName=master
 [gitter-badge]: https://img.shields.io/gitter/room/tokio-rs/tracing.svg
 [gitter-url]: https://gitter.im/tokio-rs/tracing
 


### PR DESCRIPTION
This branch makes a few small README and Cargo.toml changes:
* Add Azure Pipelines build status badges to Cargo.tomls
* Change README build status badges to Azure Pipelines
* Add "maintenance: experimental" badges to unreleased crates
* Link to `tracing` docs and crates.io page in the root README, 
  rather than `tracing-core`.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>