### PR TITLE
log: Add `std` feature.

### DIFF
--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 tracing-core = "0.1.2"
 tracing-subscriber = { path = "../tracing-subscriber" }
-log = "0.4"
+log = { version = "0.4", features = ["std"] }
 lazy_static = "1.3.0"
 
 [badges]


### PR DESCRIPTION
## Motivation

Fix for #216 

## Solution

Adds the `log/std` feature.

Side note: how did the CI pass previously? This doesn't even compile on my machine?