### PR TITLE
fmt: Support disabling the target in formatted output

### DIFF
--- a/tracing-fmt/src/format.rs
+++ b/tracing-fmt/src/format.rs
@@ -141,7 +141,7 @@ where
         time::write(&self.timer, writer)?;
         write!(
             writer,
-            "{} {}{}: l",
+            "{} {}{}: ",
             FmtLevel::new(meta.level(), self.ansi),
             FullCtx::new(&ctx, self.ansi),
             if self.display_target {

--- a/tracing-fmt/src/format.rs
+++ b/tracing-fmt/src/format.rs
@@ -65,6 +65,7 @@ pub struct Format<F = Full, T = SystemTime> {
     format: PhantomData<F>,
     timer: T,
     ansi: bool,
+    display_target: bool,
 }
 
 impl Default for Format<Full, SystemTime> {
@@ -73,6 +74,7 @@ impl Default for Format<Full, SystemTime> {
             format: PhantomData,
             timer: SystemTime,
             ansi: true,
+            display_target: true,
         }
     }
 }
@@ -86,6 +88,7 @@ impl<F, T> Format<F, T> {
             format: PhantomData,
             timer: self.timer,
             ansi: self.ansi,
+            display_target: self.display_target,
         }
     }
 
@@ -95,6 +98,7 @@ impl<F, T> Format<F, T> {
             format: self.format,
             timer,
             ansi: self.ansi,
+            display_target: self.display_target,
         }
     }
 
@@ -104,12 +108,21 @@ impl<F, T> Format<F, T> {
             format: self.format,
             timer: (),
             ansi: self.ansi,
+            display_target: self.display_target,
         }
     }
 
     /// Enable ANSI terminal colors for formatted output.
     pub fn with_ansi(self, ansi: bool) -> Format<F, T> {
         Format { ansi, ..self }
+    }
+
+    /// Display the target of events
+    pub fn with_target(self, display_target: bool) -> Format<F, T> {
+        Format {
+            display_target,
+            ..self
+        }
     }
 }
 
@@ -128,10 +141,14 @@ where
         time::write(&self.timer, writer)?;
         write!(
             writer,
-            "{} {}{}: ",
+            "{} {}{}: l",
             FmtLevel::new(meta.level(), self.ansi),
             FullCtx::new(&ctx, self.ansi),
-            meta.target()
+            if self.display_target {
+                meta.target()
+            } else {
+                ""
+            }
         )?;
         {
             let mut recorder = ctx.new_visitor(writer, true);
@@ -159,7 +176,11 @@ where
             "{} {}{}: ",
             FmtLevel::new(meta.level(), self.ansi),
             FmtCtx::new(&ctx, self.ansi),
-            meta.target()
+            if self.display_target {
+                meta.target()
+            } else {
+                ""
+            }
         )?;
         {
             let mut recorder = ctx.new_visitor(writer, true);

--- a/tracing-fmt/src/format.rs
+++ b/tracing-fmt/src/format.rs
@@ -117,7 +117,7 @@ impl<F, T> Format<F, T> {
         Format { ansi, ..self }
     }
 
-    /// Display the target of events
+    /// Sets whether or not an event's target is displayed.
     pub fn with_target(self, display_target: bool) -> Format<F, T> {
         Format {
             display_target,

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -272,7 +272,7 @@ where
         }
     }
 
-    /// Display the target of events
+    /// Sets whether or not an event's target is displayed.
     pub fn with_target(self, display_target: bool) -> Builder<N, format::Format<L, T>, F> {
         Builder {
             fmt_event: self.fmt_event.with_target(display_target),

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -271,6 +271,14 @@ where
             ..self
         }
     }
+
+    /// Display the target of events
+    pub fn with_target(self, display_target: bool) -> Builder<N, format::Format<L, T>, F> {
+        Builder {
+            fmt_event: self.fmt_event.with_target(display_target),
+            ..self
+        }
+    }
 }
 
 impl<N, E, F> Builder<N, E, F>


### PR DESCRIPTION
## Motivation

Being able to skip target in log messages sometimes make sense, this PR makes the default formats able to skip it.

## Solution

Adding an boolean option on the formats and the subscriber builder.

A few questions left:

* What could be the rationale to chose between an option on default formats or a dedicated format for log content? Displaying the target or not is about log content and precision, so it feels closer to _Full vs. Compact_ than for example to the ansi option. We obviously don't want a dedicated format for each option combination, so for now adding options seems better, but it feels a bit inconsistent.
* Current code may display an isolated " :  " between level and log if span context is empty and target is empty or disabled. It doesn't look good but we also probably want log format to be consistent, so I don't know if we can just skip it. The problem also exists before this change, so it may be handled separately.

