### PR TITLE
subscriber: prepare to release v0.0.1-alpha.1

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 tracing-core = "0.1.2"
 
 [dev-dependencies]
-tracing-log = { path = "../tracing-log" }
 tracing = "0.1"
 
 [badges]

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,8 +1,20 @@
 [package]
 name = "tracing-subscriber"
-version = "0.0.1"
-authors = ["Eliza Weisman <eliza@buoyant.io>"]
+version = "0.0.1-alpha.1"
+authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
+license = "MIT"
+readme = "README.md"
+documentation = "https://docs.rs/tracing-subscriber/0.0.1-alpha.1/tracing-subscriber"
+description = """
+Utilities for implementing and composing `tracing` subscribers.
+"""
+categories = [
+    "development-tools::debugging",
+    "development-tools::profiling",
+    "asynchronous",
+]
+keywords = ["logging", "tracing", "metrics", "subscriber"]
 
 [dependencies]
 tracing-core = "0.1.2"

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -1,0 +1,39 @@
+# tracing-subscriber
+
+**Warning: Until `tracing-subscriber` has a 0.1.0 release on crates.io, please treat every release as potentially breaking.**
+
+Utilities for implementing and composing [`tracing`][tracing] subscribers.
+
+[![Crates.io][crates-badge]][crates-url]
+[![Documentation][docs-badge]][docs-url]
+[![MIT licensed][mit-badge]][mit-url]
+[![Build Status][azure-badge]][azure-url]
+[![Gitter chat][gitter-badge]][gitter-url]
+![maintenance status][maint-badge]
+
+[Documentation][docs-url] |
+[Chat][gitter-url]
+
+[tracing]: https://github.com/tokio-rs/tracing/tree/master/tracing
+[tracing-fmt]: https://github.com/tokio-rs/tracing/tree/master/tracing-subscriber
+[crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
+[crates-url]: https://crates.io/crates/tracing-subscriber
+[docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
+[docs-url]: https://docs.rs/tracing-subscriber
+[mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
+[mit-url]: LICENSE
+[azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master
+[azure-url]: https://dev.azure.com/tracing/tracing/_build/latest?definitionId=1&branchName=master
+[gitter-badge]: https://img.shields.io/gitter/room/tokio-rs/tracing.svg
+[gitter-url]: https://gitter.im/tokio-rs/tracing
+[maint-badge]: https://img.shields.io/badge/maintenance-experimental-blue.svg
+
+## License
+
+This project is licensed under the [MIT license](LICENSE).
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in Tracing by you, shall be licensed as MIT, without any additional
+terms or conditions.

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -1,4 +1,17 @@
-//! Utilities and helpers for implementing and composing subscribers.
+//! Utilities for implementing and composing [`tracing`] subscribers.
+//!
+//! [`tracing`] is a framework for instrumenting Rust programs to collect
+//! scoped, structured, and async-aware diagnostics. The [`Subscriber`] trait
+//! represents the functionality necessary to collect this trace data. This
+//! crate contains tools for composing subscribers out of smaller units of
+//! behaviour, and batteries-included implementations of common subscriber
+//! functionality.
+//!
+//! `tracing-subscriber` is intended for use by both `Subscriber` authors and
+//! application authors using `tracing` to instrument their applications.
+//!
+//! [`tracing`]: https://docs.rs/tracing/0.1.3/tracing/
+//! [`Subscriber`]: https://docs.rs/tracing/0.1.3/tracing/subscriber/trait.Subscriber.html
 use tracing_core::span::Id;
 
 pub mod layer;


### PR DESCRIPTION
## Motivation

There's been demand for a crates.io release of the `tracing-subscriber`
crate, particularly so that the `Layer` type (which is relatively
stable) may be used in other crates.

## Solution

This branch prepares `tracing-subscriber` to release an alpha. I've
updated the documentation and Cargo.toml, and added a README.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
