### PR TITLE
futures: add docs

### DIFF
--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -7,14 +7,14 @@ repository = "https://github.com/tokio-rs/tracing"
 documentation = "https://docs.rs/tracing-futures/0.0.1/tracing_futures"
 homepage = "https://tokio.rs"
 description = """
-Utilities for instrumenting `futures`
+Utilities for instrumenting `futures` with `tracing`.
 """
 categories = [
     "development-tools::debugging",
     "development-tools::profiling",
     "asynchronous",
 ]
-keywords = ["logging", "tracing"]
+keywords = ["logging", "tracing", "futures"]
 license = "MIT"
 
 [features]
@@ -36,3 +36,4 @@ tracing-core = "0.1.2"
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
+maintenance = { status = "experimental" }

--- a/tracing-futures/README.md
+++ b/tracing-futures/README.md
@@ -1,0 +1,37 @@
+# tracing-futures
+
+**Warning: Until `tracing-futures` has a 0.1.0 release on crates.io, please treat every release as potentially breaking.**
+
+Utilities for instrumenting futures-based code with [`tracing`].
+
+[![Crates.io][crates-badge]][crates-url]
+[![Documentation][docs-badge]][docs-url]
+[![MIT licensed][mit-badge]][mit-url]
+[![Build Status][azure-badge]][azure-url]
+[![Gitter chat][gitter-badge]][gitter-url]
+
+[Documentation][docs-url] |
+[Chat][gitter-url]
+
+[tracing]: https://github.com/tokio-rs/tracing/tree/master/tracing
+[tracing-fmt]: https://github.com/tokio-rs/tracing/tree/master/tracing-futures
+[crates-badge]: https://img.shields.io/crates/v/tracing-futures.svg
+[crates-url]: https://crates.io/crates/tracing-futures
+[docs-badge]: https://docs.rs/tracing-futures/badge.svg
+[docs-url]: https://docs.rs/tracing-futures
+[mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
+[mit-url]: LICENSE
+[azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master
+[azure-url]: https://dev.azure.com/tracing/tracing/_build/latest?definitionId=1&branchName=master
+[gitter-badge]: https://img.shields.io/gitter/room/tokio-rs/tracing.svg
+[gitter-url]: https://gitter.im/tokio-rs/tracing
+
+## License
+
+This project is licensed under the [MIT license](LICENSE).
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in Tracing by you, shall be licensed as MIT, without any additional
+terms or conditions.


### PR DESCRIPTION
This branch adds rudimentary documentation to the `tracing-futures`
crate.

The docs could probably stand to be made more detailed, but I think this
should at least be sufficient to release an alpha version.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>