### PR TITLE
futures: prepare to release alpha.1

### DIFF
--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "tracing-futures"
-version = "0.0.1"
-authors = ["Eliza Weisman <eliza@buoyant.io>"]
+version = "0.0.1-alpha.1"
+authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"
-documentation = "https://docs.rs/tracing-futures/0.0.1/tracing_futures"
+documentation = "https://docs.rs/tracing-futures/0.0.1-alpha.1/tracing_futures"
+readme = "README.md"
 homepage = "https://tokio.rs"
 description = """
 Utilities for instrumenting `futures` with `tracing`.

--- a/tracing-futures/README.md
+++ b/tracing-futures/README.md
@@ -13,8 +13,7 @@ Utilities for instrumenting futures-based code with [`tracing`].
 [Documentation][docs-url] |
 [Chat][gitter-url]
 
-[tracing]: https://github.com/tokio-rs/tracing/tree/master/tracing
-[tracing-fmt]: https://github.com/tokio-rs/tracing/tree/master/tracing-futures
+[`tracing`]: https://github.com/tokio-rs/tracing/tree/master/tracing
 [crates-badge]: https://img.shields.io/crates/v/tracing-futures.svg
 [crates-url]: https://crates.io/crates/tracing-futures
 [docs-badge]: https://docs.rs/tracing-futures/badge.svg


### PR DESCRIPTION
This commit prepares `tracing-futures` for an alpha crates.io release.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>