### PR TITLE
subscriber: add an abstraction for building visitors

### DIFF
--- a/tracing-fmt/examples/custom_visitor.rs
+++ b/tracing-fmt/examples/custom_visitor.rs
@@ -1,0 +1,68 @@
+#![deny(rust_2018_idioms)]
+use tracing::{debug, error, info, span, trace, warn, Level};
+
+#[tracing::instrument]
+fn shave(yak: usize) -> bool {
+    debug!(
+        message = "hello! I'm gonna shave a yak.",
+        excitement = "yay!"
+    );
+    if yak == 3 {
+        warn!(target: "yak_events", "could not locate yak!");
+        false
+    } else {
+        trace!(target: "yak_events", "yak shaved successfully");
+        true
+    }
+}
+
+fn shave_all(yaks: usize) -> usize {
+    let span = span!(Level::TRACE, "shaving_yaks", yaks_to_shave = yaks);
+    let _enter = span.enter();
+
+    info!("shaving yaks");
+
+    let mut num_shaved = 0;
+    for yak in 1..=yaks {
+        let shaved = shave(yak);
+        trace!(target: "yak_events", yak, shaved);
+
+        if !shaved {
+            error!(message = "failed to shave yak!", yak);
+        } else {
+            num_shaved += 1;
+        }
+
+        trace!(target: "yak_events", yaks_shaved = num_shaved);
+    }
+
+    num_shaved
+}
+
+fn main() {
+    use tracing_fmt::format;
+    use tracing_subscriber::prelude::*;
+
+    let formatter =
+        // Construct a custom formatter for `Debug` fields
+        format::debug_fn(|writer, field, value| write!(writer, "{}: {:?}", field, value))
+            // Use the `tracing_subscriber::MakeFmtExt` trait to wrap the
+            // formatter so that a delimiter is added between fields.
+            .delimited(", ");
+
+    let subscriber = tracing_fmt::FmtSubscriber::builder()
+        .fmt_fields(formatter)
+        .finish();
+
+    tracing::subscriber::with_default(subscriber, || {
+        let number_of_yaks = 3;
+        debug!("preparing to shave {} yaks", number_of_yaks);
+
+        let number_shaved = shave_all(number_of_yaks);
+
+        debug!(
+            message = "yak shaving completed.",
+            all_yaks_shaved = number_shaved == number_of_yaks,
+        );
+    });
+}

--- a/tracing-fmt/examples/custom_visitor.rs
+++ b/tracing-fmt/examples/custom_visitor.rs
@@ -46,8 +46,10 @@ fn main() {
     let formatter =
         // Construct a custom formatter for `Debug` fields
         format::debug_fn(|writer, field, value| write!(writer, "{}: {:?}", field, value))
-            // Use the `tracing_subscriber::MakeFmtExt` trait to wrap the
-            // formatter so that a delimiter is added between fields.
+            // Use `tracing-subscriber`'s extension traits to add delimiters
+            // between fields, and ensure that fields named "message" are
+            // formatted using fmt::Display.
+            .display_messages()
             .delimited(", ");
 
     let subscriber = tracing_fmt::FmtSubscriber::builder()

--- a/tracing-subscriber/src/field/debug.rs
+++ b/tracing-subscriber/src/field/debug.rs
@@ -14,6 +14,8 @@ pub struct Alt<V>(V);
 // === impl Alt ===
 //
 impl<V> Alt<V> {
+    /// Wraps the provided visitor so that any `fmt::Debug` fields are formated
+    /// using the alternative (`:#`) formatter.
     pub fn new(inner: V) -> Self {
         Alt(inner)
     }

--- a/tracing-subscriber/src/field/debug.rs
+++ b/tracing-subscriber/src/field/debug.rs
@@ -1,3 +1,4 @@
+//! `MakeVisitor` wrappers for working with `fmt::Debug` fields.
 use super::{MakeVisitor, VisitFmt, VisitOutput, VisitWrite};
 use tracing_core::field::{Field, Visit};
 

--- a/tracing-subscriber/src/field/debug.rs
+++ b/tracing-subscriber/src/field/debug.rs
@@ -1,0 +1,97 @@
+use super::{MakeVisitor, VisitFmt, VisitOutput, VisitWrite};
+use tracing_core::field::{Field, Visit};
+
+use std::{fmt, io};
+
+/// A visitor wrapper that ensures any `fmt::Debug` fields are formatted using
+/// the alternate (`:#`) formatter.
+#[derive(Debug, Clone)]
+pub struct Alt<V>(V);
+
+// TODO(eliza): When `error` as a primitive type is stable, add a
+// `DisplayErrors` wrapper...
+
+// === impl Alt ===
+//
+impl<V> Alt<V> {
+    pub fn new(inner: V) -> Self {
+        Alt(inner)
+    }
+}
+
+impl<T, V> MakeVisitor<T> for Alt<V>
+where
+    V: MakeVisitor<T>,
+{
+    type Visitor = Alt<V::Visitor>;
+
+    #[inline]
+    fn make_visitor(&self, target: T) -> Self::Visitor {
+        Alt(self.0.make_visitor(target))
+    }
+}
+
+impl<V> Visit for Alt<V>
+where
+    V: Visit,
+{
+    #[inline]
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.0.record_i64(field, value)
+    }
+
+    #[inline]
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.0.record_u64(field, value)
+    }
+
+    #[inline]
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.0.record_bool(field, value)
+    }
+
+    /// Visit a string value.
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.0.record_str(field, value)
+    }
+
+    // TODO(eliza): add RecordError when stable
+    // fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+    //     self.record_debug(field, &format_args!("{}", value))
+    // }
+
+    #[inline]
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.0.record_debug(field, &format_args!("{:#?}", value))
+    }
+}
+
+impl<V, O> VisitOutput<O> for Alt<V>
+where
+    V: VisitOutput<O>,
+{
+    #[inline]
+    fn finish(self) -> O {
+        self.0.finish()
+    }
+}
+
+impl<V> VisitWrite for Alt<V>
+where
+    V: VisitWrite,
+{
+    #[inline]
+    fn writer(&mut self) -> &mut dyn io::Write {
+        self.0.writer()
+    }
+}
+
+impl<V> VisitFmt for Alt<V>
+where
+    V: VisitFmt,
+{
+    #[inline]
+    fn writer(&mut self) -> &mut dyn fmt::Write {
+        self.0.writer()
+    }
+}

--- a/tracing-subscriber/src/field/delimited.rs
+++ b/tracing-subscriber/src/field/delimited.rs
@@ -1,0 +1,170 @@
+use super::{MakeVisitor, VisitFmt, VisitOutput};
+
+use std::fmt;
+use tracing_core::field::{Field, Visit};
+
+#[derive(Debug, Clone)]
+pub struct Delimited<D, V> {
+    delimiter: D,
+    inner: V,
+}
+
+#[derive(Debug)]
+pub struct VisitDelimited<D, V> {
+    delimiter: D,
+    seen: bool,
+    inner: V,
+    err: fmt::Result,
+}
+
+// === impl Delimited ===
+
+impl<D, V, T> MakeVisitor<T> for Delimited<D, V>
+where
+    D: AsRef<str> + Clone,
+    V: MakeVisitor<T>,
+    V::Visitor: VisitFmt,
+{
+    type Visitor = VisitDelimited<D, V::Visitor>;
+    fn make_visitor(&self, target: T) -> Self::Visitor {
+        let inner = self.inner.make_visitor(target);
+        VisitDelimited::new(self.delimiter.clone(), inner)
+    }
+}
+
+impl<D, V> Delimited<D, V> {
+    pub fn new(delimiter: D, inner: V) -> Self {
+        Self { delimiter, inner }
+    }
+}
+
+// === impl VisitDelimited ===
+
+impl<D, V> VisitDelimited<D, V> {
+    pub fn new(delimiter: D, inner: V) -> Self {
+        Self {
+            delimiter,
+            inner,
+            seen: false,
+            err: Ok(()),
+        }
+    }
+
+    fn delimit(&mut self)
+    where
+        V: VisitFmt,
+        D: AsRef<str>,
+    {
+        if self.err.is_err() {
+            return;
+        }
+
+        if self.seen {
+            self.err = self.inner.writer().write_str(self.delimiter.as_ref());
+        }
+
+        self.seen = true;
+    }
+}
+
+impl<D, V> Visit for VisitDelimited<D, V>
+where
+    V: VisitFmt,
+    D: AsRef<str>,
+{
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.delimit();
+        self.inner.record_i64(field, value);
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.delimit();
+        self.inner.record_u64(field, value);
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.delimit();
+        self.inner.record_bool(field, value);
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.delimit();
+        self.inner.record_str(field, value);
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.delimit();
+        self.inner.record_debug(field, value);
+    }
+}
+
+impl<D, V> VisitOutput<fmt::Result> for VisitDelimited<D, V>
+where
+    V: VisitFmt,
+    D: AsRef<str>,
+{
+    fn finish(self) -> fmt::Result {
+        self.err?;
+        self.inner.finish()
+    }
+}
+
+impl<D, V> VisitFmt for VisitDelimited<D, V>
+where
+    V: VisitFmt,
+    D: AsRef<str>,
+{
+    fn writer(&mut self) -> &mut dyn fmt::Write {
+        self.inner.writer()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::field::{test_util::*, MakeOutput};
+
+    #[test]
+    fn delimited_visitor() {
+        let mut s = String::new();
+        let visitor = DebugVisitor::new(&mut s);
+        let mut visitor = VisitDelimited::new(", ", visitor);
+
+        TestAttrs1::with(|attrs| attrs.record(&mut visitor));
+        visitor.finish().unwrap();
+
+        assert_eq!(
+            s.as_str(),
+            "question=\"life, the universe, and everything\", tricky=true, can_you_do_it=true"
+        );
+    }
+
+    #[test]
+    fn delimited_new_visitor() {
+        let make = Delimited::new("; ", MakeDebug);
+
+        TestAttrs1::with(|attrs| {
+            let mut s = String::new();
+            {
+                let mut v = make.make_visitor(&mut s);
+                attrs.record(&mut v);
+            }
+            assert_eq!(
+                s.as_str(),
+                "question=\"life, the universe, and everything\"; tricky=true; can_you_do_it=true"
+            );
+        });
+
+        TestAttrs2::with(|attrs| {
+            let mut s = String::new();
+            {
+                let mut v = make.make_visitor(&mut s);
+                attrs.record(&mut v);
+            }
+            assert_eq!(
+                s.as_str(),
+                "question=None; question.answer=42; tricky=true; can_you_do_it=false"
+            );
+        });
+    }
+}

--- a/tracing-subscriber/src/field/delimited.rs
+++ b/tracing-subscriber/src/field/delimited.rs
@@ -1,3 +1,4 @@
+//! A `MakeVisitor` wrapper that separates formatted fields with a delimiter.
 use super::{MakeVisitor, VisitFmt, VisitOutput};
 
 use std::fmt;
@@ -37,6 +38,10 @@ where
 }
 
 impl<D, V> Delimited<D, V> {
+    /// Returns a new [`MakeVisitor`] implementation that wraps `inner` so that
+    /// it will format each visited field separated by the provided `delimiter`.
+    ///
+    /// [`MakeVisitor`]: ../trait.MakeVisitor.html
     pub fn new(delimiter: D, inner: V) -> Self {
         Self { delimiter, inner }
     }
@@ -45,6 +50,10 @@ impl<D, V> Delimited<D, V> {
 // === impl VisitDelimited ===
 
 impl<D, V> VisitDelimited<D, V> {
+    /// Returns a new [`Visit`] implementation that wraps `inner` so that
+    /// each formatted field is separated by the provided `delimiter`.
+    ///
+    /// [`Visit`]: https://docs.rs/tracing-core/0.1.6/tracing_core/field/trait.Visit.html
     pub fn new(delimiter: D, inner: V) -> Self {
         Self {
             delimiter,

--- a/tracing-subscriber/src/field/delimited.rs
+++ b/tracing-subscriber/src/field/delimited.rs
@@ -126,7 +126,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::field::{test_util::*, MakeOutput};
+    use crate::field::test_util::*;
 
     #[test]
     fn delimited_visitor() {

--- a/tracing-subscriber/src/field/delimited.rs
+++ b/tracing-subscriber/src/field/delimited.rs
@@ -3,12 +3,16 @@ use super::{MakeVisitor, VisitFmt, VisitOutput};
 use std::fmt;
 use tracing_core::field::{Field, Visit};
 
+/// A `MakeVisitor` wrapper that wraps a visitor that writes formatted output so
+/// that a delimiter is inserted between writing formatted field values.
 #[derive(Debug, Clone)]
 pub struct Delimited<D, V> {
     delimiter: D,
     inner: V,
 }
 
+/// A visitor wrapper that inserts a delimiter after the wrapped visitor formats
+/// a field value.
 #[derive(Debug)]
 pub struct VisitDelimited<D, V> {
     delimiter: D,

--- a/tracing-subscriber/src/field/display.rs
+++ b/tracing-subscriber/src/field/display.rs
@@ -1,3 +1,4 @@
+//! `MakeVisitor` wrappers for working with `fmt::Displag` fields.
 use super::{MakeVisitor, VisitFmt, VisitOutput, VisitWrite};
 use tracing_core::field::{Field, Visit};
 
@@ -14,6 +15,10 @@ pub struct Messages<V>(V);
 // === impl Messages ===
 //
 impl<V> Messages<V> {
+    /// Returns a new [`MakeVisitor`] implementation that will wrap `inner` so
+    /// that any strings named `message` are formatted using `fmt::Display`.
+    ///
+    /// [`MakeVisitor`]: ../trait.MakeVisitor.html
     pub fn new(inner: V) -> Self {
         Messages(inner)
     }

--- a/tracing-subscriber/src/field/display.rs
+++ b/tracing-subscriber/src/field/display.rs
@@ -1,0 +1,101 @@
+use super::{MakeVisitor, VisitFmt, VisitOutput, VisitWrite};
+use tracing_core::field::{Field, Visit};
+
+use std::{fmt, io};
+
+/// A visitor wrapper that ensures any strings named "message" are formatted
+/// using `fmt::Display`
+#[derive(Debug, Clone)]
+pub struct Messages<V>(V);
+
+// TODO(eliza): When `error` as a primitive type is stable, add a
+// `DisplayErrors` wrapper...
+
+// === impl Messages ===
+//
+impl<V> Messages<V> {
+    pub fn new(inner: V) -> Self {
+        Messages(inner)
+    }
+}
+
+impl<T, V> MakeVisitor<T> for Messages<V>
+where
+    V: MakeVisitor<T>,
+{
+    type Visitor = Messages<V::Visitor>;
+
+    #[inline]
+    fn make_visitor(&self, target: T) -> Self::Visitor {
+        Messages(self.0.make_visitor(target))
+    }
+}
+
+impl<V> Visit for Messages<V>
+where
+    V: Visit,
+{
+    #[inline]
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.0.record_i64(field, value)
+    }
+
+    #[inline]
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.0.record_u64(field, value)
+    }
+
+    #[inline]
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.0.record_bool(field, value)
+    }
+
+    /// Visit a string value.
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.0.record_debug(field, &format_args!("{}", value))
+        } else {
+            self.0.record_str(field, value)
+        }
+    }
+
+    // TODO(eliza): add RecordError when stable
+    // fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+    //     self.record_debug(field, &format_args!("{}", value))
+    // }
+
+    #[inline]
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.0.record_debug(field, value)
+    }
+}
+
+impl<V, O> VisitOutput<O> for Messages<V>
+where
+    V: VisitOutput<O>,
+{
+    #[inline]
+    fn finish(self) -> O {
+        self.0.finish()
+    }
+}
+
+impl<V> VisitWrite for Messages<V>
+where
+    V: VisitWrite,
+{
+    #[inline]
+    fn writer(&mut self) -> &mut dyn io::Write {
+        self.0.writer()
+    }
+}
+
+impl<V> VisitFmt for Messages<V>
+where
+    V: VisitFmt,
+{
+    #[inline]
+    fn writer(&mut self) -> &mut dyn fmt::Write {
+        self.0.writer()
+    }
+}

--- a/tracing-subscriber/src/field/mod.rs
+++ b/tracing-subscriber/src/field/mod.rs
@@ -1,3 +1,7 @@
+//! Utilities for working with [fields] and [field visitors].
+//!
+//! [field]: https://docs.rs/tracing-core/latest/tracing_core/field/index.html
+//! [field visitors]: https://docs.rs/tracing-core/latest/tracing_core/field/trait.Visit.html
 use std::{fmt, io};
 use tracing_core::{
     field::{Field, Visit},
@@ -46,6 +50,37 @@ pub trait VisitOutput<Out>: Visit {
     }
 }
 
+/// Extension trait implemented by types which can be recorded by a [visitor].
+///
+/// This allows writing code that is generic over `tracing_core`'s
+/// [`span::Attributes`], [`span::Record`], and [`Event`] types. These types all
+/// provide inherent `record` methods that allow a visitor to record their
+/// fields, but there is no common trait representing this.
+///
+/// With `RecordFields`, we can write code like this:
+/// ```
+/// use tracing_core::field::Visit;
+/// # use tracing_core::field::Field;
+/// use tracing_subscriber::field::RecordFields;
+///
+/// struct MyVisitor {
+///     // ...
+/// }
+/// # impl MyVisitor { fn new() -> Self { Self{} } }
+/// impl Visit for MyVisitor {
+///     // ...
+/// # fn record_debug(&mut self, _: &Field, _: &dyn std::fmt::Debug) {}
+/// }
+///
+/// fn record_with_my_visitor<R>(r: R)
+/// where
+///     R: RecordFields,
+/// {
+///     let mut visitor = MyVisitor::new();
+///     r.record(&mut visitor);
+/// }
+/// # fn main() {}
+/// ```
 pub trait RecordFields: crate::sealed::Sealed<RecordFieldsMarker> {
     fn record(&self, visitor: &mut dyn Visit);
 }

--- a/tracing-subscriber/src/field/mod.rs
+++ b/tracing-subscriber/src/field/mod.rs
@@ -113,6 +113,20 @@ pub trait VisitFmt: VisitOutput<fmt::Result> {
     fn writer(&mut self) -> &mut dyn fmt::Write;
 }
 
+pub trait MakeFmtExt<T>
+where
+    Self: MakeVisitor<T> + Sized,
+    Self::Visitor: VisitFmt,
+    Self: crate::sealed::Sealed<MakeFmtMarker<T>>,
+{
+    fn delimited<D>(self, delimiter: D) -> delimited::Delimited<D, Self>
+    where
+        D: AsRef<str> + Clone,
+    {
+        delimited::Delimited::new(delimiter, self)
+    }
+}
+
 // === impl RecordFields ===
 
 impl<'a> crate::sealed::Sealed<RecordFieldsMarker> for Event<'a> {}
@@ -171,6 +185,26 @@ where
     M: MakeVisitor<T>,
     M::Visitor: VisitOutput<Out>,
 {
+}
+
+impl<T, M> crate::sealed::Sealed<MakeFmtMarker<T>> for M
+where
+    M: MakeVisitor<T> + Sized,
+    M::Visitor: VisitFmt,
+{
+}
+
+impl<T, M> MakeFmtExt<T> for M
+where
+    M: MakeVisitor<T> + Sized,
+    M::Visitor: VisitFmt,
+    M: crate::sealed::Sealed<MakeFmtMarker<T>>,
+{
+}
+
+#[doc(hidden)]
+pub struct MakeFmtMarker<T> {
+    _p: std::marker::PhantomData<T>,
 }
 
 #[doc(hidden)]

--- a/tracing-subscriber/src/field/mod.rs
+++ b/tracing-subscriber/src/field/mod.rs
@@ -8,6 +8,7 @@ use tracing_core::{
     span::{Attributes, Record},
     Event,
 };
+pub mod debug;
 pub mod delimited;
 pub mod display;
 
@@ -118,6 +119,10 @@ where
     Self: MakeVisitor<T> + Sized,
     Self: crate::sealed::Sealed<MakeExtMarker<T>>,
 {
+    fn debug_alt(self) -> debug::Alt<Self> {
+        debug::Alt::new(self)
+    }
+
     fn display_messages(self) -> display::Messages<Self> {
         display::Messages::new(self)
     }

--- a/tracing-subscriber/src/field/mod.rs
+++ b/tracing-subscriber/src/field/mod.rs
@@ -1,6 +1,6 @@
 //! Utilities for working with [fields] and [field visitors].
 //!
-//! [field]: https://docs.rs/tracing-core/latest/tracing_core/field/index.html
+//! [fields]: https://docs.rs/tracing-core/latest/tracing_core/field/index.html
 //! [field visitors]: https://docs.rs/tracing-core/latest/tracing_core/field/trait.Visit.html
 use std::{fmt, io};
 pub use tracing_core::field::Visit;
@@ -55,9 +55,9 @@ pub trait VisitOutput<Out>: Visit {
 /// Extension trait implemented by types which can be recorded by a [visitor].
 ///
 /// This allows writing code that is generic over `tracing_core`'s
-/// [`span::Attributes`], [`span::Record`], and [`Event`] types. These types all
-/// provide inherent `record` methods that allow a visitor to record their
-/// fields, but there is no common trait representing this.
+/// [`span::Attributes`][attr], [`span::Record`][rec], and [`Event`][event]
+/// types. These types all provide inherent `record` methods that allow a
+/// visitor to record their fields, but there is no common trait representing this.
 ///
 /// With `RecordFields`, we can write code like this:
 /// ```
@@ -83,6 +83,10 @@ pub trait VisitOutput<Out>: Visit {
 /// }
 /// # fn main() {}
 /// ```
+/// [visitor]: https://docs.rs/tracing-core/latest/tracing_core/field/trait.Visit.html
+/// [attr]: https://docs.rs/tracing-core/latest/tracing_core/span/struct.Attributes.html
+/// [rec]: https://docs.rs/tracing-core/latest/tracing_core/span/struct.Record.html
+/// [event]: https://docs.rs/tracing-core/latest/tracing_core/event/struct.Event.html
 pub trait RecordFields: crate::sealed::Sealed<RecordFieldsMarker> {
     /// Record all the fields in `self` with the provided `visitor`.
     fn record(&self, visitor: &mut dyn Visit);

--- a/tracing-subscriber/src/field/mod.rs
+++ b/tracing-subscriber/src/field/mod.rs
@@ -205,11 +205,13 @@ where
 {
 }
 
+#[derive(Debug)]
 #[doc(hidden)]
 pub struct MakeExtMarker<T> {
     _p: std::marker::PhantomData<T>,
 }
 
+#[derive(Debug)]
 #[doc(hidden)]
 pub struct RecordFieldsMarker {
     _p: (),
@@ -225,11 +227,11 @@ pub(in crate::field) mod test_util {
         metadata::{Kind, Level, Metadata},
     };
 
-    pub struct TestAttrs1;
-    pub struct TestAttrs2;
+    pub(crate) struct TestAttrs1;
+    pub(crate) struct TestAttrs2;
 
     impl TestAttrs1 {
-        pub fn with<T>(f: impl FnOnce(Attributes) -> T) -> T {
+        pub(crate) fn with<T>(f: impl FnOnce(Attributes<'_>) -> T) -> T {
             let fieldset = TEST_META_1.fields();
             let values = &[
                 (
@@ -253,7 +255,7 @@ pub(in crate::field) mod test_util {
     }
 
     impl TestAttrs2 {
-        pub fn with<T>(f: impl FnOnce(Attributes) -> T) -> T {
+        pub(crate) fn with<T>(f: impl FnOnce(Attributes<'_>) -> T) -> T {
             let fieldset = TEST_META_1.fields();
             let none = tracing_core::field::debug(&Option::<&str>::None);
             let values = &[
@@ -296,19 +298,19 @@ pub(in crate::field) mod test_util {
             unimplemented!()
         }
 
-        fn metadata(&self) -> &Metadata {
+        fn metadata(&self) -> &Metadata<'_> {
             &TEST_META_1
         }
     }
 
-    pub struct MakeDebug;
-    pub struct DebugVisitor<'a> {
+    pub(crate) struct MakeDebug;
+    pub(crate) struct DebugVisitor<'a> {
         writer: &'a mut dyn fmt::Write,
         err: fmt::Result,
     }
 
     impl<'a> DebugVisitor<'a> {
-        pub fn new(writer: &'a mut dyn fmt::Write) -> Self {
+        pub(crate) fn new(writer: &'a mut dyn fmt::Write) -> Self {
             Self {
                 writer,
                 err: Ok(()),

--- a/tracing-subscriber/src/field/mod.rs
+++ b/tracing-subscriber/src/field/mod.rs
@@ -136,6 +136,16 @@ impl<'a> RecordFields for Record<'a> {
     }
 }
 
+impl<'a, F> crate::sealed::Sealed<RecordFieldsMarker> for &'a F where F: RecordFields {}
+impl<'a, F> RecordFields for &'a F
+where
+    F: RecordFields,
+{
+    fn record(&self, visitor: &mut dyn Visit) {
+        F::record(*self, visitor)
+    }
+}
+
 // === blanket impls ===
 
 impl<T, V, F> MakeVisitor<T> for F

--- a/tracing-subscriber/src/field/mod.rs
+++ b/tracing-subscriber/src/field/mod.rs
@@ -216,7 +216,7 @@ pub(in crate::field) mod test_util {
     use super::*;
     use tracing_core::{
         callsite::Callsite,
-        field::Value,
+        field::{Field, Value},
         metadata::{Kind, Level, Metadata},
     };
 

--- a/tracing-subscriber/src/field/mod.rs
+++ b/tracing-subscriber/src/field/mod.rs
@@ -4,7 +4,7 @@
 //! [field visitors]: https://docs.rs/tracing-core/latest/tracing_core/field/trait.Visit.html
 use std::{fmt, io};
 use tracing_core::{
-    field::Visit,
+    field::{Field, Visit},
     span::{Attributes, Record},
     Event,
 };

--- a/tracing-subscriber/src/field/mod.rs
+++ b/tracing-subscriber/src/field/mod.rs
@@ -1,0 +1,241 @@
+use std::{fmt, io};
+use tracing_core::{
+    field::{Field, Visit},
+    span::{Attributes, Record},
+    Event,
+};
+
+pub mod delimited;
+
+pub trait MakeVisitor<T> {
+    type Visitor: Visit;
+
+    fn make_visitor(&self, target: T) -> Self::Visitor;
+}
+
+pub trait VisitOutput<Out>: Visit {
+    fn finish(self) -> Out;
+
+    fn visit<R>(mut self, fields: &R) -> Out
+    where
+        R: RecordFields,
+        Self: Sized,
+    {
+        fields.record(&mut self);
+        self.finish()
+    }
+}
+
+pub trait RecordFields {
+    fn record(&self, visitor: &mut dyn Visit);
+}
+
+pub trait MakeOutput<T, Out>
+where
+    Self: MakeVisitor<T> + crate::sealed::Sealed<(T, Out)>,
+    Self::Visitor: VisitOutput<Out>,
+{
+    // fn delimited<D>(&self, delimiter: D) -> Delimited<D, Self>
+    // where
+    //     Self: Clone + Sized,
+    //     VisitDelimited<D, Self::Visitor>: Visit,
+    //     D: Clone,
+    // {
+    //     Delimited {
+    //         delimiter,
+    //         inner: self.clone(),
+    //     }
+    // }
+
+    fn visit_with<F>(&self, target: T, fields: &F) -> Out
+    where
+        F: RecordFields,
+    {
+        let mut v = self.make_visitor(target);
+        fields.record(&mut v);
+        v.finish()
+    }
+}
+
+pub trait VisitWrite: VisitOutput<Result<(), io::Error>> {
+    fn writer(&mut self) -> &mut dyn io::Write;
+}
+
+pub trait VisitFmt: VisitOutput<fmt::Result> {
+    fn writer(&mut self) -> &mut dyn fmt::Write;
+}
+
+// === impl RecordFields ===
+
+// impl<'a> crate::sealed::Sealed for Event<'a> {}
+impl<'a> RecordFields for Event<'a> {
+    fn record(&self, visitor: &mut dyn Visit) {
+        Event::record(&self, visitor)
+    }
+}
+
+// impl<'a> crate::sealed::Sealed for Attributes<'a> {}
+impl<'a> RecordFields for Attributes<'a> {
+    fn record(&self, visitor: &mut dyn Visit) {
+        Attributes::record(&self, visitor)
+    }
+}
+
+// impl<'a> crate::sealed::Sealed for Record<'a> {}
+impl<'a> RecordFields for Record<'a> {
+    fn record(&self, visitor: &mut dyn Visit) {
+        Record::record(&self, visitor)
+    }
+}
+
+impl<T, V, F> MakeVisitor<T> for F
+where
+    F: Fn(T) -> V,
+    V: Visit,
+{
+    type Visitor = V;
+    fn make_visitor(&self, target: T) -> Self::Visitor {
+        (self)(target)
+    }
+}
+
+impl<T, Out, M> crate::sealed::Sealed<(T, Out)> for M
+where
+    M: MakeVisitor<T>,
+    M::Visitor: VisitOutput<Out>,
+{
+}
+
+impl<T, Out, M> MakeOutput<T, Out> for M
+where
+    M: MakeVisitor<T>,
+    M::Visitor: VisitOutput<Out>,
+{
+}
+
+#[cfg(test)]
+#[macro_use]
+pub(in crate::field) mod test_util {
+    use super::*;
+    use tracing_core::{
+        callsite::Callsite,
+        field::Value,
+        metadata::{self, Kind, Level, Metadata},
+    };
+
+    pub struct TestAttrs1;
+    pub struct TestAttrs2;
+
+    impl TestAttrs1 {
+        pub fn with<T>(f: impl FnOnce(Attributes) -> T) -> T {
+            let fieldset = TEST_META_1.fields();
+            let values = &[
+                (
+                    &fieldset.field("question").unwrap(),
+                    Some(&"life, the universe, and everything" as &dyn Value),
+                ),
+                (&fieldset.field("question.answer").unwrap(), None),
+                (
+                    &fieldset.field("tricky").unwrap(),
+                    Some(&true as &dyn Value),
+                ),
+                (
+                    &fieldset.field("can_you_do_it").unwrap(),
+                    Some(&true as &dyn Value),
+                ),
+            ];
+            let valueset = fieldset.value_set(values);
+            let attrs = tracing_core::span::Attributes::new(&TEST_META_1, &valueset);
+            f(attrs)
+        }
+    }
+
+    impl TestAttrs2 {
+        pub fn with<T>(f: impl FnOnce(Attributes) -> T) -> T {
+            let fieldset = TEST_META_1.fields();
+            let none = tracing_core::field::debug(&Option::<&str>::None);
+            let values = &[
+                (
+                    &fieldset.field("question").unwrap(),
+                    Some(&none as &dyn Value),
+                ),
+                (
+                    &fieldset.field("question.answer").unwrap(),
+                    Some(&42 as &dyn Value),
+                ),
+                (
+                    &fieldset.field("tricky").unwrap(),
+                    Some(&true as &dyn Value),
+                ),
+                (
+                    &fieldset.field("can_you_do_it").unwrap(),
+                    Some(&false as &dyn Value),
+                ),
+            ];
+            let valueset = fieldset.value_set(values);
+            let attrs = tracing_core::span::Attributes::new(&TEST_META_1, &valueset);
+            f(attrs)
+        }
+    }
+
+    struct TestCallsite1;
+    static TEST_CALLSITE_1: &'static dyn Callsite = &TestCallsite1;
+    static TEST_META_1: Metadata<'static> = tracing_core::metadata! {
+        name: "field_test1",
+        target: module_path!(),
+        level: Level::INFO,
+        fields: &["question", "question.answer", "tricky", "can_you_do_it"],
+        callsite: TEST_CALLSITE_1,
+        kind: Kind::SPAN,
+    };
+
+    impl Callsite for TestCallsite1 {
+        fn set_interest(&self, _: tracing_core::subscriber::Interest) {
+            unimplemented!()
+        }
+
+        fn metadata(&self) -> &Metadata {
+            &TEST_META_1
+        }
+    }
+
+    pub struct MakeDebug;
+    pub struct DebugVisitor<'a> {
+        writer: &'a mut dyn fmt::Write,
+        err: fmt::Result,
+    }
+
+    impl<'a> DebugVisitor<'a> {
+        pub fn new(writer: &'a mut dyn fmt::Write) -> Self {
+            Self {
+                writer,
+                err: Ok(()),
+            }
+        }
+    }
+
+    impl<'a> Visit for DebugVisitor<'a> {
+        fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+            write!(&mut self.writer, "{}={:?}", field, value).unwrap();
+        }
+    }
+
+    impl<'a> VisitOutput<fmt::Result> for DebugVisitor<'a> {
+        fn finish(self) -> fmt::Result {
+            self.err
+        }
+    }
+
+    impl<'a> VisitFmt for DebugVisitor<'a> {
+        fn writer(&mut self) -> &mut dyn fmt::Write {
+            self.writer
+        }
+    }
+
+    impl<'a> MakeVisitor<&'a mut dyn fmt::Write> for MakeDebug {
+        type Visitor = DebugVisitor<'a>;
+        fn make_visitor(&self, w: &'a mut dyn fmt::Write) -> DebugVisitor<'a> {
+            DebugVisitor::new(w)
+        }
+    }
+}

--- a/tracing-subscriber/src/field/mod.rs
+++ b/tracing-subscriber/src/field/mod.rs
@@ -4,7 +4,7 @@
 //! [field visitors]: https://docs.rs/tracing-core/latest/tracing_core/field/trait.Visit.html
 use std::{fmt, io};
 use tracing_core::{
-    field::{Field, Visit},
+    field::Visit,
     span::{Attributes, Record},
     Event,
 };
@@ -92,18 +92,8 @@ where
     Self: MakeVisitor<T> + crate::sealed::Sealed<(T, Out)>,
     Self::Visitor: VisitOutput<Out>,
 {
-    // fn delimited<D>(&self, delimiter: D) -> Delimited<D, Self>
-    // where
-    //     Self: Clone + Sized,
-    //     VisitDelimited<D, Self::Visitor>: Visit,
-    //     D: Clone,
-    // {
-    //     Delimited {
-    //         delimiter,
-    //         inner: self.clone(),
-    //     }
-    // }
-
+    /// Visits all fields in `fields` with a new visitor constructed from
+    /// `target`.
     fn visit_with<F>(&self, target: T, fields: &F) -> Out
     where
         F: RecordFields,
@@ -112,10 +102,13 @@ where
     }
 }
 
+/// Extension trait implemented by visitors to indicate that they write to an
+/// `io::Write` instance, and allow access to that writer.
 pub trait VisitWrite: VisitOutput<Result<(), io::Error>> {
     fn writer(&mut self) -> &mut dyn io::Write;
 }
-
+/// Extension trait implemented by visitors to indicate that they write to a
+/// `fmt::Write` instance, and allow access to that writer.
 pub trait VisitFmt: VisitOutput<fmt::Result> {
     fn writer(&mut self) -> &mut dyn fmt::Write;
 }
@@ -182,7 +175,7 @@ pub(in crate::field) mod test_util {
     use tracing_core::{
         callsite::Callsite,
         field::Value,
-        metadata::{self, Kind, Level, Metadata},
+        metadata::{Kind, Level, Metadata},
     };
 
     pub struct TestAttrs1;

--- a/tracing-subscriber/src/field/mod.rs
+++ b/tracing-subscriber/src/field/mod.rs
@@ -26,7 +26,7 @@ pub trait VisitOutput<Out>: Visit {
     }
 }
 
-pub trait RecordFields {
+pub trait RecordFields: crate::sealed::Sealed<RecordFieldsMarker> {
     fn record(&self, visitor: &mut dyn Visit);
 }
 
@@ -67,21 +67,21 @@ pub trait VisitFmt: VisitOutput<fmt::Result> {
 
 // === impl RecordFields ===
 
-// impl<'a> crate::sealed::Sealed for Event<'a> {}
+impl<'a> crate::sealed::Sealed<RecordFieldsMarker> for Event<'a> {}
 impl<'a> RecordFields for Event<'a> {
     fn record(&self, visitor: &mut dyn Visit) {
         Event::record(&self, visitor)
     }
 }
 
-// impl<'a> crate::sealed::Sealed for Attributes<'a> {}
+impl<'a> crate::sealed::Sealed<RecordFieldsMarker> for Attributes<'a> {}
 impl<'a> RecordFields for Attributes<'a> {
     fn record(&self, visitor: &mut dyn Visit) {
         Attributes::record(&self, visitor)
     }
 }
 
-// impl<'a> crate::sealed::Sealed for Record<'a> {}
+impl<'a> crate::sealed::Sealed<RecordFieldsMarker> for Record<'a> {}
 impl<'a> RecordFields for Record<'a> {
     fn record(&self, visitor: &mut dyn Visit) {
         Record::record(&self, visitor)
@@ -111,6 +111,11 @@ where
     M: MakeVisitor<T>,
     M::Visitor: VisitOutput<Out>,
 {
+}
+
+#[doc(hidden)]
+pub struct RecordFieldsMarker {
+    _p: (),
 }
 
 #[cfg(test)]

--- a/tracing-subscriber/src/fmt/format.rs
+++ b/tracing-subscriber/src/fmt/format.rs
@@ -1,6 +1,7 @@
 //! Formatters for logging `tracing` events.
-use crate::span;
-use crate::time::{self, FormatTime, SystemTime};
+use super::span;
+use super::time::{self, FormatTime, SystemTime};
+use crate::field::{MakeOutput, MakeVisitor, RecordFields, VisitFmt, VisitOutput};
 use std::fmt::{self, Write};
 use std::marker::PhantomData;
 use tracing_core::{
@@ -9,7 +10,6 @@ use tracing_core::{
 };
 #[cfg(feature = "tracing-log")]
 use tracing_log::NormalizeEvent;
-use tracing_subscriber::field::{MakeOutput, MakeVisitor, RecordFields, VisitFmt, VisitOutput};
 
 #[cfg(feature = "ansi")]
 use ansi_term::{Colour, Style};
@@ -346,13 +346,13 @@ impl<'a> field::Visit for Visitor<'a> {
     }
 }
 
-impl<'a> tracing_subscriber::field::VisitOutput<fmt::Result> for Visitor<'a> {
+impl<'a> crate::field::VisitOutput<fmt::Result> for Visitor<'a> {
     fn finish(self) -> fmt::Result {
         self.result
     }
 }
 
-impl<'a> tracing_subscriber::field::VisitFmt for Visitor<'a> {
+impl<'a> crate::field::VisitFmt for Visitor<'a> {
     fn writer(&mut self) -> &mut dyn fmt::Write {
         self.writer
     }

--- a/tracing-subscriber/src/fmt/format.rs
+++ b/tracing-subscriber/src/fmt/format.rs
@@ -323,9 +323,7 @@ impl DefaultFields {
     ///
     /// [`FormatFields`]: trait.FormatFields.html
     pub fn new() -> Self {
-        Self {
-            _private: (),
-        }
+        Self { _private: () }
     }
 }
 

--- a/tracing-subscriber/src/fmt/format.rs
+++ b/tracing-subscriber/src/fmt/format.rs
@@ -376,7 +376,6 @@ impl<'a> fmt::Debug for Visitor<'a> {
     }
 }
 
-
 struct FmtCtx<'a, N> {
     ctx: &'a span::Context<'a, N>,
     #[cfg(feature = "ansi")]
@@ -611,7 +610,6 @@ impl<'a, F> fmt::Debug for FieldFnVisitor<'a, F> {
             .finish()
     }
 }
-
 
 #[cfg(test)]
 mod test {

--- a/tracing-subscriber/src/fmt/format.rs
+++ b/tracing-subscriber/src/fmt/format.rs
@@ -302,18 +302,19 @@ where
 /// [`FormatFields`]: trait.FormatFields.html
 #[derive(Debug)]
 pub struct DefaultFields;
+
 /// The [visitor] produced by [`DefaultFields`]'s [`MakeVisitor`] implementation.
 ///
 /// [visitor]: ../../field/trait.Visit.html
 /// [`DefaultFields`]: struct.DefaultFields.html
 /// [`MakeVisitor`]: ../../field/trait.MakeVisitor.html
-pub struct Visitor<'a> {
+pub struct DefaultVisitor<'a> {
     writer: &'a mut dyn Write,
     is_empty: bool,
     result: fmt::Result,
 }
 
-impl<'a> Visitor<'a> {
+impl<'a> DefaultVisitor<'a> {
     /// Returns a new default visitor that formats to the provided `writer`.
     ///
     /// # Arguments
@@ -338,7 +339,7 @@ impl<'a> Visitor<'a> {
 }
 
 impl<'a> MakeVisitor<&'a mut dyn Write> for DefaultFields {
-    type Visitor = Visitor<'a>;
+    type Visitor = DefaultVisitor<'a>;
 
     #[inline]
     fn make_visitor(&self, target: &'a mut dyn Write) -> Self::Visitor {
@@ -346,7 +347,7 @@ impl<'a> MakeVisitor<&'a mut dyn Write> for DefaultFields {
     }
 }
 
-impl<'a> field::Visit for Visitor<'a> {
+impl<'a> field::Visit for DefaultVisitor<'a> {
     fn record_str(&mut self, field: &Field, value: &str) {
         if self.result.is_err() {
             return;
@@ -387,21 +388,21 @@ impl<'a> field::Visit for Visitor<'a> {
     }
 }
 
-impl<'a> crate::field::VisitOutput<fmt::Result> for Visitor<'a> {
+impl<'a> crate::field::VisitOutput<fmt::Result> for DefaultVisitor<'a> {
     fn finish(self) -> fmt::Result {
         self.result
     }
 }
 
-impl<'a> crate::field::VisitFmt for Visitor<'a> {
+impl<'a> crate::field::VisitFmt for DefaultVisitor<'a> {
     fn writer(&mut self) -> &mut dyn fmt::Write {
         self.writer
     }
 }
 
-impl<'a> fmt::Debug for Visitor<'a> {
+impl<'a> fmt::Debug for DefaultVisitor<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Visitor")
+        f.debug_struct("DefaultVisitor")
             .field("writer", &format_args!("<dyn fmt::Write>"))
             .field("is_empty", &self.is_empty)
             .field("result", &self.result)

--- a/tracing-subscriber/src/fmt/format.rs
+++ b/tracing-subscriber/src/fmt/format.rs
@@ -270,6 +270,8 @@ where
     }
 }
 
+/// The default formatting for fields.
+#[derive(Debug)]
 pub struct DefaultFields;
 
 pub struct Visitor<'a> {

--- a/tracing-subscriber/src/fmt/format.rs
+++ b/tracing-subscriber/src/fmt/format.rs
@@ -579,12 +579,16 @@ where
         self.result
     }
 }
+
 impl<'a, F> VisitFmt for FieldFnVisitor<'a, F>
 where
     F: Fn(&mut dyn fmt::Write, &Field, &dyn fmt::Debug) -> fmt::Result,
 {
     fn writer(&mut self) -> &mut dyn fmt::Write {
         &mut *self.writer
+    }
+}
+
 #[cfg(test)]
 mod test {
 

--- a/tracing-subscriber/src/fmt/format.rs
+++ b/tracing-subscriber/src/fmt/format.rs
@@ -301,7 +301,11 @@ where
 ///
 /// [`FormatFields`]: trait.FormatFields.html
 #[derive(Debug)]
-pub struct DefaultFields;
+pub struct DefaultFields {
+    // reserve the ability to add fields to this without causing a breaking
+    // change in the future.
+    _private: (),
+}
 
 /// The [visitor] produced by [`DefaultFields`]'s [`MakeVisitor`] implementation.
 ///
@@ -313,6 +317,34 @@ pub struct DefaultVisitor<'a> {
     is_empty: bool,
     result: fmt::Result,
 }
+
+impl DefaultFields {
+    /// Returns a new default [`FormatFields`] implementation.
+    ///
+    /// [`FormatFields`]: trait.FormatFields.html
+    pub fn new() -> Self {
+        Self {
+            _private: (),
+        }
+    }
+}
+
+impl Default for DefaultFields {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'a> MakeVisitor<&'a mut dyn Write> for DefaultFields {
+    type Visitor = DefaultVisitor<'a>;
+
+    #[inline]
+    fn make_visitor(&self, target: &'a mut dyn Write) -> Self::Visitor {
+        DefaultVisitor::new(target, true)
+    }
+}
+
+// === impl DefaultVisitor ===
 
 impl<'a> DefaultVisitor<'a> {
     /// Returns a new default visitor that formats to the provided `writer`.
@@ -335,15 +367,6 @@ impl<'a> DefaultVisitor<'a> {
         } else {
             self.result = write!(self.writer, " ");
         }
-    }
-}
-
-impl<'a> MakeVisitor<&'a mut dyn Write> for DefaultFields {
-    type Visitor = DefaultVisitor<'a>;
-
-    #[inline]
-    fn make_visitor(&self, target: &'a mut dyn Write) -> Self::Visitor {
-        Visitor::new(target, true)
     }
 }
 

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -30,7 +30,7 @@ pub use self::{
 
 /// A `Subscriber` that logs formatted representations of `tracing` events.
 ///
-/// This consists of an inner`Formatter` wrapped in a layer that performs filtering.
+/// This consists of an inner `Formatter` wrapped in a layer that performs filtering.
 #[derive(Debug)]
 pub struct Subscriber<
     N = format::DefaultFields,

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -398,6 +398,24 @@ where
 impl<N, E, F, W> Builder<N, E, F, W> {
     /// Sets the Visitor that the subscriber being built will use to record
     /// fields.
+    ///
+    /// For example:
+    /// ```rust
+    /// use tracing_fmt::{FmtSubscriber, format};
+    /// use tracing_subscriber::prelude::*;
+    ///
+    /// let formatter =
+    ///     // Construct a custom formatter for `Debug` fields
+    ///     format::debug_fn(|writer, field, value| write!(writer, "{}: {:?}", field, value))
+    ///         // Use the `tracing_subscriber::MakeFmtExt` trait to wrap the
+    ///         // formatter so that a delimiter is added between fields.
+    ///         .delimited(", ");
+    ///
+    /// let subscriber = FmtSubscriber::builder()
+    ///     .fmt_fields(formatter)
+    ///     .finish();
+    /// # drop(subscriber)
+    /// ```
     pub fn fmt_fields<N2>(self, fmt_fields: N2) -> Builder<N2, E, F>
     where
         N2: for<'writer> FormatFields<'writer> + 'static,

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -291,7 +291,7 @@ impl Default for Builder {
     fn default() -> Self {
         Builder {
             filter: Subscriber::DEFAULT_MAX_LEVEL,
-            fmt_fields: format::DefaultFields,
+            fmt_fields: format::DefaultFields::default(),
             fmt_event: format::Format::default(),
             settings: Settings::default(),
             make_writer: io::stdout,

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -404,7 +404,7 @@ impl<N, E, F, W> Builder<N, E, F, W> {
     ///
     /// For example:
     /// ```rust
-    /// use tracing_fmt::{FmtSubscriber, format};
+    /// use tracing_subscriber::fmt::{Subscriber, format};
     /// use tracing_subscriber::prelude::*;
     ///
     /// let formatter =
@@ -414,7 +414,7 @@ impl<N, E, F, W> Builder<N, E, F, W> {
     ///         // formatter so that a delimiter is added between fields.
     ///         .delimited(", ");
     ///
-    /// let subscriber = FmtSubscriber::builder()
+    /// let subscriber = Subscriber::builder()
     ///     .fmt_fields(formatter)
     ///     .finish();
     /// # drop(subscriber)

--- a/tracing-subscriber/src/fmt/span.rs
+++ b/tracing-subscriber/src/fmt/span.rs
@@ -313,7 +313,7 @@ impl Store {
     /// recently emptied span will be reused. Otherwise, a new allocation will
     /// be added to the slab.
     #[inline]
-    pub fn new_span<F>(&self, attrs: &Attributes<'_>, fmt_fields: &F) -> Id
+    pub(crate) fn new_span<F>(&self, attrs: &Attributes<'_>, fmt_fields: &F) -> Id
     where
         F: for<'writer> FormatFields<'writer>,
     {
@@ -390,7 +390,7 @@ impl Store {
 
     /// Records that the span with the given `id` has the given `fields`.
     #[inline]
-    pub fn record<F>(&self, id: &Id, fields: &Record<'_>, fmt_fields: &F)
+    pub(crate) fn record<F>(&self, id: &Id, fields: &Record<'_>, fmt_fields: &F)
     where
         F: for<'writer> FormatFields<'writer>,
     {

--- a/tracing-subscriber/src/fmt/span.rs
+++ b/tracing-subscriber/src/fmt/span.rs
@@ -11,7 +11,7 @@ use std::collections::HashSet;
 pub(crate) use tracing_core::span::{Attributes, Current, Id, Record};
 use tracing_core::{dispatcher, Metadata};
 
-use crate::format::FormatFields;
+use super::format::FormatFields;
 
 pub struct Span<'a> {
     lock: OwningHandle<RwLockReadGuard<'a, Slab>, RwLockReadGuard<'a, Slot>>,
@@ -225,7 +225,7 @@ impl<'a, F> Context<'a, F> {
     }
 
     /// Executes a closure with the reference to the current span.
-    pub fn with_current<F, R>(&self, f: F) -> Option<R>
+    pub fn with_current<N, R>(&self, f: N) -> Option<R>
     where
         N: FnOnce((&Id, Span<'_>)) -> R,
     {

--- a/tracing-subscriber/src/fmt/span.rs
+++ b/tracing-subscriber/src/fmt/span.rs
@@ -20,7 +20,7 @@ pub struct Span<'a> {
 #[derive(Debug)]
 pub struct Context<'a, N> {
     store: &'a Store,
-    new_visitor: &'a N,
+    make_visitor: &'a N,
 }
 
 /// Stores data associated with currently-active spans.
@@ -244,21 +244,18 @@ impl<'a, N> Context<'a, N> {
             .ok()?
     }
 
-    pub(crate) fn new(store: &'a Store, new_visitor: &'a N) -> Self {
-        Self { store, new_visitor }
+    pub(crate) fn new(store: &'a Store, make_visitor: &'a N) -> Self {
+        Self {
+            store,
+            make_visitor,
+        }
     }
 
-    /// Returns a new visitor that formats span fields to the provided writer.
-    /// The visitor configuration is provided by the subscriber.
-    pub fn new_visitor<'writer>(
-        &self,
-        writer: &'writer mut dyn fmt::Write,
-        is_empty: bool,
-    ) -> N::Visitor
+    pub fn make_visitor<'writer>(&self, writer: &'writer mut dyn fmt::Write) -> N::Visitor
     where
-        N: super::NewVisitor<'writer>,
+        N: crate::field::MakeVisitor<&'writer mut dyn fmt::Write>,
     {
-        self.new_visitor.make(writer, is_empty)
+        self.make_visitor.make_visitor(writer)
     }
 }
 
@@ -311,9 +308,9 @@ impl Store {
     /// recently emptied span will be reused. Otherwise, a new allocation will
     /// be added to the slab.
     #[inline]
-    pub(crate) fn new_span<N>(&self, attrs: &Attributes<'_>, new_visitor: &N) -> Id
+    pub fn new_span<N>(&self, attrs: &Attributes<'_>, make_visitor: &N) -> Id
     where
-        N: for<'a> super::NewVisitor<'a>,
+        N: for<'a> crate::field::MakeVisitor<&'a mut dyn fmt::Write>,
     {
         let mut span = Some(Data::new(attrs, self));
 
@@ -343,7 +340,7 @@ impl Store {
                             // Is our snapshot still valid?
                             if self.next.compare_and_swap(head, next, Ordering::Release) == head {
                                 // We can finally fill the slot!
-                                slot.fill(span.take().unwrap(), attrs, new_visitor);
+                                slot.fill(span.take().unwrap(), attrs, make_visitor);
                                 return idx_to_id(head);
                             }
                         }
@@ -360,7 +357,7 @@ impl Store {
                 let len = this.slab.len();
 
                 // Insert the span into a new slot.
-                let slot = Slot::new(span.take().unwrap(), attrs, new_visitor);
+                let slot = Slot::new(span.take().unwrap(), attrs, make_visitor);
                 this.slab.push(RwLock::new(slot));
                 // TODO: can we grow the slab in chunks to avoid having to
                 // realloc as often?
@@ -390,7 +387,7 @@ impl Store {
     #[inline]
     pub(crate) fn record<N>(&self, id: &Id, fields: &Record<'_>, new_recorder: &N)
     where
-        N: for<'a> super::NewVisitor<'a>,
+        N: for<'a> crate::field::MakeVisitor<&'a mut dyn fmt::Write>,
     {
         let slab = try_lock!(self.inner.read(), else return);
         let slot = slab.write_slot(id_to_idx(id));
@@ -481,13 +478,13 @@ impl Drop for Data {
 }
 
 impl Slot {
-    fn new<N>(mut data: Data, attrs: &Attributes<'_>, new_visitor: &N) -> Self
+    fn new<N>(mut data: Data, attrs: &Attributes<'_>, make_visitor: &N) -> Self
     where
-        N: for<'a> super::NewVisitor<'a>,
+        N: for<'a> crate::field::MakeVisitor<&'a mut dyn fmt::Write>,
     {
         let mut fields = String::new();
         {
-            let mut recorder = new_visitor.make(&mut fields, true);
+            let mut recorder = make_visitor.make_visitor(&mut fields);
             attrs.record(&mut recorder);
         }
         if fields.is_empty() {
@@ -506,13 +503,13 @@ impl Slot {
         }
     }
 
-    fn fill<N>(&mut self, mut data: Data, attrs: &Attributes<'_>, new_visitor: &N) -> usize
+    fn fill<N>(&mut self, mut data: Data, attrs: &Attributes<'_>, make_visitor: &N) -> usize
     where
-        N: for<'a> super::NewVisitor<'a>,
+        N: for<'a> crate::field::MakeVisitor<&'a mut dyn fmt::Write>,
     {
         let fields = &mut self.fields;
         {
-            let mut recorder = new_visitor.make(fields, true);
+            let mut recorder = make_visitor.make_visitor(fields);
             attrs.record(&mut recorder);
         }
         if fields.is_empty() {
@@ -524,9 +521,9 @@ impl Slot {
         }
     }
 
-    fn record<N>(&mut self, fields: &Record<'_>, new_visitor: &N)
+    fn record<N>(&mut self, fields: &Record<'_>, make_visitor: &N)
     where
-        N: for<'a> super::NewVisitor<'a>,
+        N: for<'a> crate::field::MakeVisitor<&'a mut dyn fmt::Write>,
     {
         let state = &mut self.span;
         let buf = &mut self.fields;
@@ -534,7 +531,7 @@ impl Slot {
             State::Empty(_) => return,
             State::Full(ref mut data) => {
                 {
-                    let mut recorder = new_visitor.make(buf, data.is_empty);
+                    let mut recorder = make_visitor.make_visitor(buf);
                     fields.record(&mut recorder);
                 }
                 if buf.is_empty() {

--- a/tracing-subscriber/src/fmt/span.rs
+++ b/tracing-subscriber/src/fmt/span.rs
@@ -11,6 +11,8 @@ use std::collections::HashSet;
 pub(crate) use tracing_core::span::{Attributes, Current, Id, Record};
 use tracing_core::{dispatcher, Metadata};
 
+use crate::format::FormatFields;
+
 pub struct Span<'a> {
     lock: OwningHandle<RwLockReadGuard<'a, Slab>, RwLockReadGuard<'a, Slot>>,
 }
@@ -18,9 +20,9 @@ pub struct Span<'a> {
 /// Represents the `Subscriber`'s view of the current span context to a
 /// formatter.
 #[derive(Debug)]
-pub struct Context<'a, N> {
+pub struct Context<'a, F> {
     store: &'a Store,
-    make_visitor: &'a N,
+    fmt_fields: &'a F,
 }
 
 /// Stores data associated with currently-active spans.
@@ -190,7 +192,7 @@ impl<'a> fmt::Debug for Span<'a> {
 
 // ===== impl Context =====
 
-impl<'a, N> Context<'a, N> {
+impl<'a, F> Context<'a, F> {
     /// Applies a function to each span in the current trace context.
     ///
     /// The function is applied in order, beginning with the root of the trace,
@@ -201,9 +203,9 @@ impl<'a, N> Context<'a, N> {
     ///
     /// Note that if we are currently unwinding, this will do nothing, rather
     /// than potentially causing a double panic.
-    pub fn visit_spans<F, E>(&self, mut f: F) -> Result<(), E>
+    pub fn visit_spans<N, E>(&self, mut f: N) -> Result<(), E>
     where
-        F: FnMut(&Id, Span<'_>) -> Result<(), E>,
+        N: FnMut(&Id, Span<'_>) -> Result<(), E>,
     {
         CONTEXT
             .try_with(|current| {
@@ -225,7 +227,7 @@ impl<'a, N> Context<'a, N> {
     /// Executes a closure with the reference to the current span.
     pub fn with_current<F, R>(&self, f: F) -> Option<R>
     where
-        F: FnOnce((&Id, Span<'_>)) -> R,
+        N: FnOnce((&Id, Span<'_>)) -> R,
     {
         // If the lock is poisoned or the thread local has already been
         // destroyed, we might be in the middle of unwinding, so this
@@ -244,18 +246,21 @@ impl<'a, N> Context<'a, N> {
             .ok()?
     }
 
-    pub(crate) fn new(store: &'a Store, make_visitor: &'a N) -> Self {
-        Self {
-            store,
-            make_visitor,
-        }
+    pub(crate) fn new(store: &'a Store, fmt_fields: &'a F) -> Self {
+        Self { store, fmt_fields }
     }
+}
 
-    pub fn make_visitor<'writer>(&self, writer: &'writer mut dyn fmt::Write) -> N::Visitor
+impl<'ctx, 'writer, F> FormatFields<'writer> for Context<'ctx, F>
+where
+    F: FormatFields<'writer>,
+{
+    #[inline]
+    fn format_fields<R>(&self, writer: &'writer mut dyn fmt::Write, fields: R) -> fmt::Result
     where
-        N: crate::field::MakeVisitor<&'writer mut dyn fmt::Write>,
+        R: crate::field::RecordFields,
     {
-        self.make_visitor.make_visitor(writer)
+        self.fmt_fields.format_fields(writer, fields)
     }
 }
 
@@ -308,9 +313,9 @@ impl Store {
     /// recently emptied span will be reused. Otherwise, a new allocation will
     /// be added to the slab.
     #[inline]
-    pub fn new_span<N>(&self, attrs: &Attributes<'_>, make_visitor: &N) -> Id
+    pub fn new_span<F>(&self, attrs: &Attributes<'_>, fmt_fields: &F) -> Id
     where
-        N: for<'a> crate::field::MakeVisitor<&'a mut dyn fmt::Write>,
+        F: for<'writer> FormatFields<'writer>,
     {
         let mut span = Some(Data::new(attrs, self));
 
@@ -340,7 +345,7 @@ impl Store {
                             // Is our snapshot still valid?
                             if self.next.compare_and_swap(head, next, Ordering::Release) == head {
                                 // We can finally fill the slot!
-                                slot.fill(span.take().unwrap(), attrs, make_visitor);
+                                slot.fill(span.take().unwrap(), attrs, fmt_fields);
                                 return idx_to_id(head);
                             }
                         }
@@ -357,7 +362,7 @@ impl Store {
                 let len = this.slab.len();
 
                 // Insert the span into a new slot.
-                let slot = Slot::new(span.take().unwrap(), attrs, make_visitor);
+                let slot = Slot::new(span.take().unwrap(), attrs, fmt_fields);
                 this.slab.push(RwLock::new(slot));
                 // TODO: can we grow the slab in chunks to avoid having to
                 // realloc as often?
@@ -385,14 +390,14 @@ impl Store {
 
     /// Records that the span with the given `id` has the given `fields`.
     #[inline]
-    pub(crate) fn record<N>(&self, id: &Id, fields: &Record<'_>, new_recorder: &N)
+    pub fn record<F>(&self, id: &Id, fields: &Record<'_>, fmt_fields: &F)
     where
-        N: for<'a> crate::field::MakeVisitor<&'a mut dyn fmt::Write>,
+        F: for<'writer> FormatFields<'writer>,
     {
         let slab = try_lock!(self.inner.read(), else return);
         let slot = slab.write_slot(id_to_idx(id));
         if let Some(mut slot) = slot {
-            slot.record(fields, new_recorder);
+            slot.record(fields, fmt_fields);
         }
     }
 
@@ -478,15 +483,14 @@ impl Drop for Data {
 }
 
 impl Slot {
-    fn new<N>(mut data: Data, attrs: &Attributes<'_>, make_visitor: &N) -> Self
+    fn new<F>(mut data: Data, attrs: &Attributes<'_>, fmt_fields: &F) -> Self
     where
-        N: for<'a> crate::field::MakeVisitor<&'a mut dyn fmt::Write>,
+        F: for<'writer> FormatFields<'writer>,
     {
         let mut fields = String::new();
-        {
-            let mut recorder = make_visitor.make_visitor(&mut fields);
-            attrs.record(&mut recorder);
-        }
+        fmt_fields
+            .format_fields(&mut fields, attrs)
+            .expect("formatting to string should not fail");
         if fields.is_empty() {
             data.is_empty = false;
         }
@@ -503,15 +507,14 @@ impl Slot {
         }
     }
 
-    fn fill<N>(&mut self, mut data: Data, attrs: &Attributes<'_>, make_visitor: &N) -> usize
+    fn fill<F>(&mut self, mut data: Data, attrs: &Attributes<'_>, fmt_fields: &F) -> usize
     where
-        N: for<'a> crate::field::MakeVisitor<&'a mut dyn fmt::Write>,
+        F: for<'writer> FormatFields<'writer>,
     {
         let fields = &mut self.fields;
-        {
-            let mut recorder = make_visitor.make_visitor(fields);
-            attrs.record(&mut recorder);
-        }
+        fmt_fields
+            .format_fields(fields, attrs)
+            .expect("formatting to string should not fail");
         if fields.is_empty() {
             data.is_empty = false;
         }
@@ -521,19 +524,18 @@ impl Slot {
         }
     }
 
-    fn record<N>(&mut self, fields: &Record<'_>, make_visitor: &N)
+    fn record<F>(&mut self, fields: &Record<'_>, fmt_fields: &F)
     where
-        N: for<'a> crate::field::MakeVisitor<&'a mut dyn fmt::Write>,
+        F: for<'writer> FormatFields<'writer>,
     {
         let state = &mut self.span;
         let buf = &mut self.fields;
         match state {
             State::Empty(_) => return,
             State::Full(ref mut data) => {
-                {
-                    let mut recorder = make_visitor.make_visitor(buf);
-                    fields.record(&mut recorder);
-                }
+                fmt_fields
+                    .format_fields(buf, fields)
+                    .expect("formatting to string should not fail");
                 if buf.is_empty() {
                     data.is_empty = false;
                 }

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -93,6 +93,7 @@ macro_rules! try_lock {
     };
 }
 
+pub mod field;
 pub mod filter;
 #[cfg(feature = "fmt")]
 pub mod fmt;

--- a/tracing-subscriber/src/prelude.rs
+++ b/tracing-subscriber/src/prelude.rs
@@ -3,6 +3,10 @@
 //! This brings into scope a number of extension traits that define methods on
 //! types defined here and in other crates.
 
+pub use crate::field::{
+    MakeFmtExt as __tracing_subscriber_field_RecordFieldsExt,
+    RecordFields as __tracing_subscriber_field_RecordFields,
+};
 pub use crate::layer::{
     Layer as __tracing_subscriber_Layer, SubscriberExt as __tracing_subscriber_SubscriberExt,
 };

--- a/tracing-subscriber/src/prelude.rs
+++ b/tracing-subscriber/src/prelude.rs
@@ -4,7 +4,7 @@
 //! types defined here and in other crates.
 
 pub use crate::field::{
-    MakeFmtExt as __tracing_subscriber_field_RecordFieldsExt,
+    MakeExt as __tracing_subscriber_field_MakeExt,
     RecordFields as __tracing_subscriber_field_RecordFields,
 };
 pub use crate::layer::{


### PR DESCRIPTION
## Motivation

The `tracing-fmt` crate crate currently uses a `NewVisitor` trait to
abstract over constructing field visitors of different types or with
different configurations:
https://github.com/tokio-rs/tracing/blob/d51d4d69d81ce2e4c6c7166fe70c58a1f881d668/tracing-fmt/src/lib.rs#L192-L196

There have been other use-cases where having this abstraction seems
valuable. For example, issue #73 is a proposal for adding utilities for
wrapping a visitor to skip a set of excluded field names. A `MakeVisitor`
abstraction would allow us to provide much more ergonomic APIs for
composing this kind of visitor behaviour.

Additionally, the current trait in `tracing-fmt` is tied pretty closely
to `tracing-fmt- specific behaviour. A generalized version of this trait
should be generic over the input type used to build the visitor.

## Solution

This PR adds a new `MakeVisitor` trait in `tracing-subscriber`.
`MakeVisitor` generalizes the `NewVisitor` trait in `tracing-fmt` to
represent constructing visitors for arbitrary targets. In addition, I've
added some additional traits representing common patterns for visitors,
such as those that format to a `fmt::Write` instance or write to an IO
stream, or those that produce output once a set of fields have been
visited. I've also added some extension traits & combinators to make
composing visitors easier, and to demonstrate that the trait in this
branch can be used for implementing this kind of wrapper.

I've also rewritten the `tracing-fmt` crate to use the new
`tracing-subscriber::MakeVisitor` trait rather than its homegrown
`fmt`-specifc version.

Closes: #240 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>