### PR TITLE
 fmt: support `tracing-log` `log.XXX` fields nicely (#193) 

### DIFF
--- a/tracing-fmt/Cargo.toml
+++ b/tracing-fmt/Cargo.toml
@@ -19,11 +19,12 @@ azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", bui
 maintenance = { status = "experimental" }
 
 [features]
-default = ["ansi", "chrono"]
+default = ["ansi", "chrono", "tracing-log"]
 ansi = ["ansi_term"]
 
 [dependencies]
 tracing-core = "0.1.2"
+tracing-log = { path = "../tracing-log", optional = true }
 ansi_term = { version = "0.11", optional = true }
 regex = "1"
 lazy_static = "1"

--- a/tracing-fmt/src/format.rs
+++ b/tracing-fmt/src/format.rs
@@ -127,7 +127,9 @@ where
         event: &Event,
     ) -> fmt::Result {
         #[cfg(feature = "tracing-log")]
-        let meta = event.normalized_metadata();
+        let normalized_meta = event.normalized_metadata();
+        #[cfg(feature = "tracing-log")]
+        let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
         #[cfg(not(feature = "tracing-log"))]
         let meta = event.metadata();
         time::write(&self.timer, writer)?;
@@ -158,7 +160,9 @@ where
         event: &Event,
     ) -> fmt::Result {
         #[cfg(feature = "tracing-log")]
-        let meta = event.normalized_metadata();
+        let normalized_meta = event.normalized_metadata();
+        #[cfg(feature = "tracing-log")]
+        let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
         #[cfg(not(feature = "tracing-log"))]
         let meta = event.metadata();
         time::write(&self.timer, writer)?;

--- a/tracing-fmt/src/format.rs
+++ b/tracing-fmt/src/format.rs
@@ -2,6 +2,8 @@
 
 use crate::span;
 use crate::time::{self, FormatTime, SystemTime};
+#[cfg(feature = "tracing-log")]
+use crate::tracing_log::NormalizeEvent;
 
 use std::fmt::{self, Write};
 use std::marker::PhantomData;
@@ -124,6 +126,9 @@ where
         writer: &mut dyn fmt::Write,
         event: &Event,
     ) -> fmt::Result {
+        #[cfg(feature = "tracing-log")]
+        let meta = event.normalized_metadata();
+        #[cfg(not(feature = "tracing-log"))]
         let meta = event.metadata();
         time::write(&self.timer, writer)?;
         write!(
@@ -152,6 +157,9 @@ where
         writer: &mut dyn fmt::Write,
         event: &Event,
     ) -> fmt::Result {
+        #[cfg(feature = "tracing-log")]
+        let meta = event.normalized_metadata();
+        #[cfg(not(feature = "tracing-log"))]
         let meta = event.metadata();
         time::write(&self.timer, writer)?;
         write!(

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -10,6 +10,8 @@ extern crate chrono;
 extern crate lock_api;
 extern crate owning_ref;
 extern crate parking_lot;
+#[cfg(feature = "tracing-log")]
+extern crate tracing_log;
 
 #[macro_use]
 extern crate lazy_static;

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 tracing-core = "0.1.2"
 tracing-subscriber = { path = "../tracing-subscriber" }
-log = "0.4"
+log = { version = "0.4", features = ["std"] }
 lazy_static = "1.3.0"
 
 [badges]

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -10,6 +10,9 @@ tracing-subscriber = { path = "../tracing-subscriber" }
 log = { version = "0.4", features = ["std"] }
 lazy_static = "1.3.0"
 
+[dev-dependencies]
+tracing = "0.1"
+
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
 maintenance = { status = "experimental" }

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 tracing-core = "0.1.2"
 tracing-subscriber = { path = "../tracing-subscriber" }
-log = { version = "0.4", features = ["std"] }
+log = "0.4"
 lazy_static = "1.3.0"
 
 [badges]

--- a/tracing-log/tests/log_tracer.rs
+++ b/tracing-log/tests/log_tracer.rs
@@ -56,6 +56,12 @@ impl Subscriber for TestSubscriber {
 fn normalized_metadata() {
     LogTracer::init().unwrap();
 
+    let my_file = if cfg!(windows) {
+        "tracing-log\\tests\\log_tracer.rs"
+    } else {
+        "tracing-log/tests/log_tracer.rs"
+    };
+
     let me = Arc::new(State {
         last_normalized_metadata: Mutex::new((false, None)),
     });
@@ -70,8 +76,8 @@ fn normalized_metadata() {
                 target: "log_tracer".to_string(),
                 level: Level::INFO,
                 module_path: Some("log_tracer".to_string()),
-                file: Some("tracing-log/tests/log_tracer.rs".to_string()),
-                line: Some(64),
+                file: Some(my_file.to_string()),
+                line: Some(70),
             }),
         );
 
@@ -84,8 +90,8 @@ fn normalized_metadata() {
                 target: "specified".to_string(),
                 level: Level::INFO,
                 module_path: Some("log_tracer".to_string()),
-                file: Some("tracing-log/tests/log_tracer.rs".to_string()),
-                line: Some(78),
+                file: Some(my_file.to_string()),
+                line: Some(84),
             }),
         );
 

--- a/tracing-log/tests/log_tracer.rs
+++ b/tracing-log/tests/log_tracer.rs
@@ -1,0 +1,101 @@
+use std::sync::{Arc, Mutex};
+use tracing::subscriber::with_default;
+use tracing_core::span::{Attributes, Record};
+use tracing_core::{span, Event, Level, Metadata, Subscriber};
+use tracing_log::{LogTracer, NormalizeEvent};
+
+struct State {
+    last_normalized_metadata: Mutex<(bool, Option<OwnedMetadata>)>,
+}
+
+#[derive(PartialEq, Debug)]
+struct OwnedMetadata {
+    name: String,
+    target: String,
+    level: Level,
+    module_path: Option<String>,
+    file: Option<String>,
+    line: Option<u32>,
+}
+
+struct TestSubscriber(Arc<State>);
+
+impl Subscriber for TestSubscriber {
+    fn enabled(&self, _: &Metadata) -> bool {
+        true
+    }
+
+    fn new_span(&self, _span: &Attributes) -> span::Id {
+        span::Id::from_u64(42)
+    }
+
+    fn record(&self, _span: &span::Id, _values: &Record) {}
+
+    fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
+
+    fn event(&self, event: &Event) {
+        *self.0.last_normalized_metadata.lock().unwrap() = (
+            event.is_log(),
+            event.normalized_metadata().map(|normalized| OwnedMetadata {
+                name: normalized.name().to_string(),
+                target: normalized.target().to_string(),
+                level: normalized.level().clone(),
+                module_path: normalized.module_path().map(String::from),
+                file: normalized.file().map(String::from),
+                line: normalized.line(),
+            }),
+        )
+    }
+
+    fn enter(&self, _span: &span::Id) {}
+
+    fn exit(&self, _span: &span::Id) {}
+}
+
+#[test]
+fn normalized_metadata() {
+    LogTracer::init().unwrap();
+
+    let me = Arc::new(State {
+        last_normalized_metadata: Mutex::new((false, None)),
+    });
+    let a = me.clone();
+    with_default(TestSubscriber(me), || {
+        log::info!("log info message");
+        last(
+            &a,
+            true,
+            Some(OwnedMetadata {
+                name: "log event".to_string(),
+                target: "log_tracer".to_string(),
+                level: Level::INFO,
+                module_path: Some("log_tracer".to_string()),
+                file: Some("tracing-log/tests/log_tracer.rs".to_string()),
+                line: Some(64),
+            }),
+        );
+
+        log::info!(target: "specified", "this time with a specified target");
+        last(
+            &a,
+            true,
+            Some(OwnedMetadata {
+                name: "log event".to_string(),
+                target: "specified".to_string(),
+                level: Level::INFO,
+                module_path: Some("log_tracer".to_string()),
+                file: Some("tracing-log/tests/log_tracer.rs".to_string()),
+                line: Some(78),
+            }),
+        );
+
+        tracing::info!("test with a tracing info");
+        last(&a, false, None);
+    })
+}
+
+fn last(state: &State, should_be_log: bool, expected: Option<OwnedMetadata>) {
+    let metadata = state.last_normalized_metadata.lock().unwrap();
+    assert_eq!(metadata.0, should_be_log);
+    assert_eq!(metadata.1, expected);
+}


### PR DESCRIPTION
These changes were merged in PR #193, but I accidentally undid the commit that merged that PR to master by doing a force push (i'm a fool). This re-merges them.

That PR was already approved.