### PR TITLE
Use 'dyn' since trait objects without an explicit 'dyn' are deprecated

### DIFF
--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -341,7 +341,7 @@ impl<'a> LogVisitor<'a> {
 }
 
 impl<'a> Visit for LogVisitor<'a> {
-    fn record_debug(&mut self, _field: &Field, _value: &fmt::Debug) {}
+    fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {}
 
     fn record_u64(&mut self, field: &Field, value: u64) {
         if field == &self.fields.line {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation
since trait objects without an explicit 'dyn' are deprecated hence I added it before `fmt::Debug`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
