### PR TITLE
 core: prepare to release 0.1.3 

### DIFF
--- a/tracing-core/CHANGELOG.md
+++ b/tracing-core/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.3 (August 8, 2019)
+
+### Added
+
+- `std::fmt::Display` implementation for `Level` (#194)
+- `std::str::FromStr` implementation for `Level` (#195)
+
 # 0.1.2 (July 10, 2019)
 
 ### Deprecated

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -8,13 +8,13 @@ name = "tracing-core"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-core/0.1.2/tracing_core"
+documentation = "https://docs.rs/tracing-core/0.1.3/tracing_core"
 description = """
 Core primitives for application-level tracing.
 """
@@ -23,7 +23,7 @@ categories = [
     "development-tools::profiling",
     "asynchronous",
 ]
-keywords = ["logging", "tracing"]
+keywords = ["logging", "tracing", "profiling"]
 edition = "2018"
 
 [badges]

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -52,16 +52,16 @@ API. However, this crate's API will change very infrequently, so it may be used
 when dependencies must be very stable.
 
 [`tracing`]: ../tracing
-[`Span`]: https://docs.rs/tracing-core/0.1.2/tracing_core/span/struct.Span.html
-[`Event`]: https://docs.rs/tracing-core/0.1.2/tracing_core/event/struct.Event.html
-[`Subscriber`]: https://docs.rs/tracing-core/0.1.2/tracing_core/subscriber/trait.Subscriber.html
-[`Metadata`]: https://docs.rs/tracing-core/0.1.2/tracing_core/metadata/struct.Metadata.html
-[`Callsite`]: https://docs.rs/tracing-core/0.1.2/tracing_core/callsite/trait.Callsite.html
-[`Field`]: https://docs.rs/tracing-core/0.1.2/tracing_core/field/struct.Field.html
-[`FieldSet`]: https://docs.rs/tracing-core/0.1.2/tracing_core/field/struct.FieldSet.html
-[`Value`]: https://docs.rs/tracing-core/0.1.2/tracing_core/field/trait.Value.html
-[`ValueSet`]: https://docs.rs/tracing-core/0.1.2/tracing_core/field/struct.ValueSet.html
-[`Dispatch`]: https://docs.rs/tracing-core/0.1.2/tracing_core/dispatcher/struct.Dispatch.html
+[`Span`]: https://docs.rs/tracing-core/0.1.3/tracing_core/span/struct.Span.html
+[`Event`]: https://docs.rs/tracing-core/0.1.3/tracing_core/event/struct.Event.html
+[`Subscriber`]: https://docs.rs/tracing-core/0.1.3/tracing_core/subscriber/trait.Subscriber.html
+[`Metadata`]: https://docs.rs/tracing-core/0.1.3/tracing_core/metadata/struct.Metadata.html
+[`Callsite`]: https://docs.rs/tracing-core/0.1.3/tracing_core/callsite/trait.Callsite.html
+[`Field`]: https://docs.rs/tracing-core/0.1.3/tracing_core/field/struct.Field.html
+[`FieldSet`]: https://docs.rs/tracing-core/0.1.3/tracing_core/field/struct.FieldSet.html
+[`Value`]: https://docs.rs/tracing-core/0.1.3/tracing_core/field/trait.Value.html
+[`ValueSet`]: https://docs.rs/tracing-core/0.1.3/tracing_core/field/struct.ValueSet.html
+[`Dispatch`]: https://docs.rs/tracing-core/0.1.3/tracing_core/dispatcher/struct.Dispatch.html
 
 ## License
 

--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -61,7 +61,7 @@ pub trait Callsite: Sync {
     /// Returns the [metadata] associated with the callsite.
     ///
     /// [metadata]: ../metadata/struct.Metadata.html
-    fn metadata(&self) -> &Metadata;
+    fn metadata(&self) -> &Metadata<'_>;
 }
 
 /// Uniquely identifies a [`Callsite`]
@@ -127,7 +127,7 @@ impl PartialEq for Identifier {
 impl Eq for Identifier {}
 
 impl fmt::Debug for Identifier {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Identifier({:p})", self.0)
     }
 }

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -238,7 +238,7 @@ pub struct SetGlobalDefaultError {
 }
 
 impl fmt::Display for SetGlobalDefaultError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("a global default trace dispatcher has already been set")
     }
 }
@@ -344,7 +344,7 @@ impl Dispatch {
     /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
     /// [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
     #[inline]
-    pub fn new_span(&self, span: &span::Attributes) -> span::Id {
+    pub fn new_span(&self, span: &span::Attributes<'_>) -> span::Id {
         self.subscriber.new_span(span)
     }
 
@@ -356,7 +356,7 @@ impl Dispatch {
     /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
     /// [`record`]: ../subscriber/trait.Subscriber.html#method.record
     #[inline]
-    pub fn record(&self, span: &span::Id, values: &span::Record) {
+    pub fn record(&self, span: &span::Id, values: &span::Record<'_>) {
         self.subscriber.record(span, values)
     }
 
@@ -383,7 +383,7 @@ impl Dispatch {
     /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
     /// [`enabled`]: ../subscriber/trait.Subscriber.html#method.enabled
     #[inline]
-    pub fn enabled(&self, metadata: &Metadata) -> bool {
+    pub fn enabled(&self, metadata: &Metadata<'_>) -> bool {
         self.subscriber.enabled(metadata)
     }
 
@@ -396,7 +396,7 @@ impl Dispatch {
     /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
     /// [`event`]: ../subscriber/trait.Subscriber.html#method.event
     #[inline]
-    pub fn event(&self, event: &Event) {
+    pub fn event(&self, event: &Event<'_>) {
         self.subscriber.event(event)
     }
 
@@ -512,7 +512,7 @@ impl Dispatch {
 }
 
 impl fmt::Debug for Dispatch {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Dispatch(...)")
     }
 }
@@ -534,18 +534,18 @@ impl Subscriber for NoSubscriber {
         subscriber::Interest::never()
     }
 
-    fn new_span(&self, _: &span::Attributes) -> span::Id {
+    fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
         span::Id::from_u64(0xDEAD)
     }
 
-    fn event(&self, _event: &Event) {}
+    fn event(&self, _event: &Event<'_>) {}
 
-    fn record(&self, _span: &span::Id, _values: &span::Record) {}
+    fn record(&self, _span: &span::Id, _values: &span::Record<'_>) {}
 
     fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
 
     #[inline]
-    fn enabled(&self, _metadata: &Metadata) -> bool {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
         false
     }
 
@@ -636,7 +636,7 @@ mod test {
 
     impl Callsite for TestCallsite {
         fn set_interest(&self, _: Interest) {}
-        fn metadata(&self) -> &Metadata {
+        fn metadata(&self) -> &Metadata<'_> {
             &TEST_META
         }
     }
@@ -647,19 +647,19 @@ mod test {
         // won't cause an infinite loop of events.
         struct TestSubscriber;
         impl Subscriber for TestSubscriber {
-            fn enabled(&self, _: &Metadata) -> bool {
+            fn enabled(&self, _: &Metadata<'_>) -> bool {
                 true
             }
 
-            fn new_span(&self, _: &span::Attributes) -> span::Id {
+            fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
                 span::Id::from_u64(0xAAAA)
             }
 
-            fn record(&self, _: &span::Id, _: &span::Record) {}
+            fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
 
             fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
 
-            fn event(&self, _: &Event) {
+            fn event(&self, _: &Event<'_>) {
                 static EVENTS: AtomicUsize = AtomicUsize::new(0);
                 assert_eq!(
                     EVENTS.fetch_add(1, Ordering::Relaxed),
@@ -695,11 +695,11 @@ mod test {
 
         struct TestSubscriber;
         impl Subscriber for TestSubscriber {
-            fn enabled(&self, _: &Metadata) -> bool {
+            fn enabled(&self, _: &Metadata<'_>) -> bool {
                 true
             }
 
-            fn new_span(&self, _: &span::Attributes) -> span::Id {
+            fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
                 static NEW_SPANS: AtomicUsize = AtomicUsize::new(0);
                 assert_eq!(
                     NEW_SPANS.fetch_add(1, Ordering::Relaxed),
@@ -710,11 +710,11 @@ mod test {
                 span::Id::from_u64(0xAAAA)
             }
 
-            fn record(&self, _: &span::Id, _: &span::Record) {}
+            fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
 
             fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
 
-            fn event(&self, _: &Event) {}
+            fn event(&self, _: &Event<'_>) {}
 
             fn enter(&self, _: &span::Id) {}
 
@@ -728,29 +728,29 @@ mod test {
     fn global_dispatch() {
         struct TestSubscriberA;
         impl Subscriber for TestSubscriberA {
-            fn enabled(&self, _: &Metadata) -> bool {
+            fn enabled(&self, _: &Metadata<'_>) -> bool {
                 true
             }
-            fn new_span(&self, _: &span::Attributes) -> span::Id {
+            fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
                 span::Id::from_u64(1)
             }
-            fn record(&self, _: &span::Id, _: &span::Record) {}
+            fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
             fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
-            fn event(&self, _: &Event) {}
+            fn event(&self, _: &Event<'_>) {}
             fn enter(&self, _: &span::Id) {}
             fn exit(&self, _: &span::Id) {}
         }
         struct TestSubscriberB;
         impl Subscriber for TestSubscriberB {
-            fn enabled(&self, _: &Metadata) -> bool {
+            fn enabled(&self, _: &Metadata<'_>) -> bool {
                 true
             }
-            fn new_span(&self, _: &span::Attributes) -> span::Id {
+            fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
                 span::Id::from_u64(1)
             }
-            fn record(&self, _: &span::Id, _: &span::Record) {}
+            fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
             fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
-            fn event(&self, _: &Event) {}
+            fn event(&self, _: &Event<'_>) {}
             fn enter(&self, _: &span::Id) {}
             fn exit(&self, _: &span::Id) {}
         }

--- a/tracing-core/src/event.rs
+++ b/tracing-core/src/event.rs
@@ -30,7 +30,7 @@ impl<'a> Event<'a> {
     /// Constructs a new `Event` with the specified metadata and set of values,
     /// and observes it with the current subscriber.
     #[inline]
-    pub fn dispatch(metadata: &'static Metadata<'static>, fields: &'a field::ValueSet) {
+    pub fn dispatch(metadata: &'static Metadata<'static>, fields: &'a field::ValueSet<'_>) {
         let event = Event {
             metadata,
             fields,
@@ -47,7 +47,7 @@ impl<'a> Event<'a> {
     pub fn child_of(
         parent: impl Into<Option<Id>>,
         metadata: &'static Metadata<'static>,
-        fields: &'a field::ValueSet,
+        fields: &'a field::ValueSet<'_>,
     ) {
         let parent = match parent.into() {
             Some(p) => Parent::Explicit(p),

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -346,7 +346,7 @@ where
 }
 
 impl<T: fmt::Display> fmt::Debug for DisplayValue<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
@@ -365,7 +365,7 @@ where
 }
 
 impl<T: fmt::Debug> fmt::Debug for DebugValue<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self.0)
     }
 }
@@ -390,7 +390,7 @@ impl Field {
 }
 
 impl fmt::Display for Field {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad(self.name())
     }
 }
@@ -526,7 +526,7 @@ impl<'a> IntoIterator for &'a FieldSet {
 }
 
 impl fmt::Debug for FieldSet {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FieldSet")
             .field("names", &self.names)
             .field("callsite", &self.callsite)
@@ -535,7 +535,7 @@ impl fmt::Debug for FieldSet {
 }
 
 impl fmt::Display for FieldSet {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_set()
             .entries(self.names.iter().map(display))
             .finish()
@@ -609,7 +609,7 @@ impl<'a> ValueSet<'a> {
 }
 
 impl<'a> fmt::Debug for ValueSet<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.values
             .iter()
             .fold(&mut f.debug_struct("ValueSet"), |dbg, (key, v)| {
@@ -624,7 +624,7 @@ impl<'a> fmt::Debug for ValueSet<'a> {
 }
 
 impl<'a> fmt::Display for ValueSet<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.values
             .iter()
             .fold(&mut f.debug_map(), |dbg, (key, v)| {
@@ -687,7 +687,7 @@ mod test {
             unimplemented!()
         }
 
-        fn metadata(&self) -> &Metadata {
+        fn metadata(&self) -> &Metadata<'_> {
             &TEST_META_1
         }
     }
@@ -708,7 +708,7 @@ mod test {
             unimplemented!()
         }
 
-        fn metadata(&self) -> &Metadata {
+        fn metadata(&self) -> &Metadata<'_> {
             &TEST_META_2
         }
     }

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tracing-core/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/tracing-core/0.1.3")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 
@@ -46,7 +46,7 @@
 //! [`ValueSet`]: field/struct.ValueSet.html
 //! [`Dispatch`]: dispatcher/struct.Dispatch.html
 //! [`tokio-rs/tracing`]: https://github.com/tokio-rs/tracing
-//! [`tracing`]: https://github.com/tokio-rs/tracing
+//! [`tracing`]: https://crates.io/crates/tracing
 #[macro_use]
 extern crate lazy_static;
 

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -174,7 +174,7 @@ impl<'a> Metadata<'a> {
 }
 
 impl<'a> fmt::Debug for Metadata<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut meta = f.debug_struct("Metadata");
         meta.field("name", &self.name)
             .field("target", &self.target)
@@ -262,7 +262,7 @@ impl Level {
 }
 
 impl fmt::Display for Level {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Level::TRACE => f.pad("TRACE"),
             Level::DEBUG => f.pad("DEBUG"),
@@ -331,7 +331,7 @@ pub struct ParseLevelError {
 }
 
 impl fmt::Display for ParseLevelError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad(
             "error parsing level: expected one of \"error\", \"warn\", \
              \"info\", \"debug\", \"trace\", or a number 1-5",

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -165,7 +165,7 @@ pub trait Subscriber: 'static {
     /// [interested]: struct.Interest.html
     /// [`Interest::sometimes`]: struct.Interest.html#method.sometimes
     /// [`register_callsite`]: #method.register_callsite
-    fn enabled(&self, metadata: &Metadata) -> bool;
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool;
 
     /// Visit the construction of a new span, returning a new [span ID] for the
     /// span being constructed.
@@ -191,7 +191,7 @@ pub trait Subscriber: 'static {
     /// [`Attributes`]: ../span/struct.Attributes.html
     /// [visitor]: ../field/trait.Visit.html
     /// [`record` method]: ../span/struct.Attributes.html#method.record
-    fn new_span(&self, span: &span::Attributes) -> span::Id;
+    fn new_span(&self, span: &span::Attributes<'_>) -> span::Id;
 
     // === Notification methods ===============================================
 
@@ -232,7 +232,7 @@ pub trait Subscriber: 'static {
     /// [visitor]: ../field/trait.Visit.html
     /// [`record`]: ../span/struct.Attributes.html#method.record
     /// [`record` method]: ../span/struct.Record.html#method.record
-    fn record(&self, span: &span::Id, values: &span::Record);
+    fn record(&self, span: &span::Id, values: &span::Record<'_>);
 
     /// Adds an indication that `span` follows from the span with the id
     /// `follows`.
@@ -272,7 +272,7 @@ pub trait Subscriber: 'static {
     /// [visitor]: ../field/trait.Visit.html
     /// [`record` method]: ../event/struct.Event.html#method.record
     /// [`dispatch` method]: ../event/struct.Event.html#method.dispatch
-    fn event(&self, event: &Event);
+    fn event(&self, event: &Event<'_>);
 
     /// Records that a span has been entered.
     ///

--- a/tracing-core/tests/macros.rs
+++ b/tracing-core/tests/macros.rs
@@ -16,7 +16,7 @@ fn metadata_macro_api() {
         fn set_interest(&self, _: Interest) {
             unimplemented!("test")
         }
-        fn metadata(&self) -> &Metadata {
+        fn metadata(&self) -> &Metadata<'_> {
             unimplemented!("test")
         }
     }


### PR DESCRIPTION
A new release of `tracing` is planned to add the `#[instrument]` attribute. Since there have been a couple additions to `tracing-core` since the last release, I've prepared a new version of `tracing-core` as well.

I've also run `cargo fix --edition` on `tracing-core` pre-release.

# Changelog:

### Added

- `std::fmt::Display` implementation for `Level` (#194)
- `std::str::FromStr` implementation for `Level` (#195)