### PR TITLE
tracing: prepare to release 0.1.4

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.4 (August 8, 2019)
+
+### Added
+
+- `#[instrument]` attribute for automatically adding spans to functions (#253)
+
 # 0.1.3 (July 11, 2019)
 
 ### Added

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,13 +8,13 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing/0.1.3/tracing"
+documentation = "https://docs.rs/tracing/0.1.4/tracing"
 description = """
 A scoped, structured logging and diagnostics system.
 """

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -47,7 +47,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing = "0.1.3"
+tracing = "0.1.4"
 ```
 
 This crate provides macros for creating `Span`s and `Event`s, which represent

--- a/tracing/benches/subscriber.rs
+++ b/tracing/benches/subscriber.rs
@@ -16,16 +16,16 @@ use tracing::{field, span, Event, Id, Metadata};
 struct EnabledSubscriber;
 
 impl tracing::Subscriber for EnabledSubscriber {
-    fn new_span(&self, span: &span::Attributes) -> Id {
+    fn new_span(&self, span: &span::Attributes<'_>) -> Id {
         let _ = span;
         Id::from_u64(0xDEADFACE)
     }
 
-    fn event(&self, event: &Event) {
+    fn event(&self, event: &Event<'_>) {
         let _ = event;
     }
 
-    fn record(&self, span: &Id, values: &span::Record) {
+    fn record(&self, span: &Id, values: &span::Record<'_>) {
         let _ = (span, values);
     }
 
@@ -33,7 +33,7 @@ impl tracing::Subscriber for EnabledSubscriber {
         let _ = (span, follows);
     }
 
-    fn enabled(&self, metadata: &Metadata) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
         let _ = metadata;
         true
     }
@@ -60,18 +60,18 @@ impl<'a> field::Visit for Visitor<'a> {
 }
 
 impl tracing::Subscriber for VisitingSubscriber {
-    fn new_span(&self, span: &span::Attributes) -> Id {
+    fn new_span(&self, span: &span::Attributes<'_>) -> Id {
         let mut visitor = Visitor(self.0.lock().unwrap());
         span.record(&mut visitor);
         Id::from_u64(0xDEADFACE)
     }
 
-    fn record(&self, _span: &Id, values: &span::Record) {
+    fn record(&self, _span: &Id, values: &span::Record<'_>) {
         let mut visitor = Visitor(self.0.lock().unwrap());
         values.record(&mut visitor);
     }
 
-    fn event(&self, event: &Event) {
+    fn event(&self, event: &Event<'_>) {
         let mut visitor = Visitor(self.0.lock().unwrap());
         event.record(&mut visitor);
     }
@@ -80,7 +80,7 @@ impl tracing::Subscriber for VisitingSubscriber {
         let _ = (span, follows);
     }
 
-    fn enabled(&self, metadata: &Metadata) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
         let _ = metadata;
         true
     }

--- a/tracing/examples/counters.rs
+++ b/tracing/examples/counters.rs
@@ -52,7 +52,7 @@ impl<'a> Visit for Count<'a> {
 }
 
 impl CounterSubscriber {
-    fn visitor(&self) -> Count {
+    fn visitor(&self) -> Count<'_> {
         Count {
             counters: self.counters.0.read().unwrap(),
         }
@@ -60,7 +60,7 @@ impl CounterSubscriber {
 }
 
 impl Subscriber for CounterSubscriber {
-    fn register_callsite(&self, meta: &Metadata) -> subscriber::Interest {
+    fn register_callsite(&self, meta: &Metadata<'_>) -> subscriber::Interest {
         let mut interest = subscriber::Interest::never();
         for key in meta.fields() {
             let name = key.name();
@@ -77,7 +77,7 @@ impl Subscriber for CounterSubscriber {
         interest
     }
 
-    fn new_span(&self, new_span: &span::Attributes) -> Id {
+    fn new_span(&self, new_span: &span::Attributes<'_>) -> Id {
         new_span.record(&mut self.visitor());
         let id = self.ids.fetch_add(1, Ordering::SeqCst);
         Id::from_u64(id as u64)
@@ -87,15 +87,15 @@ impl Subscriber for CounterSubscriber {
         // unimplemented
     }
 
-    fn record(&self, _: &Id, values: &span::Record) {
+    fn record(&self, _: &Id, values: &span::Record<'_>) {
         values.record(&mut self.visitor())
     }
 
-    fn event(&self, event: &Event) {
+    fn event(&self, event: &Event<'_>) {
         event.record(&mut self.visitor())
     }
 
-    fn enabled(&self, metadata: &Metadata) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
         metadata.fields().iter().any(|f| f.name().contains("count"))
     }
 

--- a/tracing/examples/sloggish/sloggish_subscriber.rs
+++ b/tracing/examples/sloggish/sloggish_subscriber.rs
@@ -10,14 +10,14 @@
 //!
 //! [`slog-term`]: https://docs.rs/slog-term/2.4.0/slog_term/
 //! [`slog` README]: https://github.com/slog-rs/slog#terminal-output-example
-use ansi_term;
-use humantime;
 use self::ansi_term::{Color, Style};
 use super::tracing::{
     self,
     field::{Field, Visit},
     Id, Level, Subscriber,
 };
+use ansi_term;
+use humantime;
 
 use std::{
     cell::RefCell,

--- a/tracing/src/field.rs
+++ b/tracing/src/field.rs
@@ -17,14 +17,14 @@ pub trait AsField: crate::sealed::Sealed {
     ///
     /// If `metadata` defines this field, then the field is returned. Otherwise,
     /// this returns `None`.
-    fn as_field(&self, metadata: &Metadata) -> Option<Field>;
+    fn as_field(&self, metadata: &Metadata<'_>) -> Option<Field>;
 }
 
 // ===== impl AsField =====
 
 impl AsField for Field {
     #[inline]
-    fn as_field(&self, metadata: &Metadata) -> Option<Field> {
+    fn as_field(&self, metadata: &Metadata<'_>) -> Option<Field> {
         if self.callsite() == metadata.callsite() {
             Some(self.clone())
         } else {
@@ -35,7 +35,7 @@ impl AsField for Field {
 
 impl<'a> AsField for &'a Field {
     #[inline]
-    fn as_field(&self, metadata: &Metadata) -> Option<Field> {
+    fn as_field(&self, metadata: &Metadata<'_>) -> Option<Field> {
         if self.callsite() == metadata.callsite() {
             Some((*self).clone())
         } else {
@@ -46,7 +46,7 @@ impl<'a> AsField for &'a Field {
 
 impl AsField for str {
     #[inline]
-    fn as_field(&self, metadata: &Metadata) -> Option<Field> {
+    fn as_field(&self, metadata: &Metadata<'_>) -> Option<Field> {
         metadata.fields().field(&self)
     }
 }

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.3")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.4")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 
@@ -197,13 +197,13 @@
 //!
 //! For example:
 //! ```
-//! use tracing::instrument;
+//! use tracing::{info, instrument};
 //!
 //! #[instrument]
 //! pub fn my_function(my_arg: usize) {
 //!     // This event will be recorded inside a span named `my_function` with the
 //!     // field `my_arg`.
-//!     tracing::info!("inside my_function!");
+//!     info!("inside my_function!");
 //!     // ...
 //! }
 //! # fn main() {}

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -359,7 +359,7 @@
 //! [static verbosity level]: level_filters/index.html#compile-time-filters
 #[macro_use]
 extern crate cfg_if;
-extern crate tracing_core;
+use tracing_core;
 
 #[cfg(feature = "log")]
 #[doc(hidden)]

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -116,22 +116,11 @@
 //! [dependencies]
 //! tracing = "0.1"
 //! ```
-//!
-//! Next, add this to your crate:
-//!
-//! ```rust
-//! #[macro_use]
-//! extern crate tracing;
-//! # fn main() {}
-//! ```
-//!
 //! `Span`s are constructed using the `span!` macro, and then _entered_
 //! to indicate that some code takes place within the context of that `Span`:
 //!
 //! ```rust
-//! # #[macro_use]
-//! # extern crate tracing;
-//! # use tracing::Level;
+//! use tracing::{span, Level};
 //! # fn main() {
 //! // Construct a new span named "my span" with trace log level.
 //! let span = span!(Level::TRACE, "my span");
@@ -150,10 +139,8 @@
 //! event is dropped:
 //!
 //! ```rust
-//! # #[macro_use]
-//! # extern crate tracing;
 //! # fn main() {
-//! use tracing::Level;
+//! use tracing::{event, Level};
 //! event!(Level::INFO, "something has happened!");
 //! # }
 //! ```
@@ -167,9 +154,7 @@
 //! Let's consider the `log` crate's yak-shaving example:
 //!
 //! ```rust
-//! #[macro_use]
-//! extern crate tracing;
-//! use tracing::Level;
+//! use tracing::{info, span, warn, Level};
 //!
 //! # #[derive(Debug)] pub struct Yak(String);
 //! # impl Yak { fn shave(&mut self, _: u32) {} }
@@ -204,7 +189,27 @@
 //! # }
 //! ```
 //!
-//! You can find examples showing how to use this crate in the examples
+//! The [`#[instrument]`][instrument] attribute provides an easy way to
+//! add `tracing` spans to functions. A function annotated with `#[instrument]`
+//! will create and enter a span with that function's name every time the
+//! function is called, with arguments to that function will be recorded as
+//! fields using `fmt::Debug`.
+//!
+//! For example:
+//! ```
+//! use tracing::instrument;
+//!
+//! #[instrument]
+//! pub fn my_function(my_arg: usize) {
+//!     // This event will be recorded inside a span named `my_function` with the
+//!     // field `my_arg`.
+//!     tracing::info!("inside my_function!");
+//!     // ...
+//! }
+//! # fn main() {}
+//! ```
+//!
+//! You can find more examples showing how to use this crate in the examples
 //! directory.
 //!
 //! ## In libraries
@@ -259,8 +264,6 @@
 //! of the closure. For example:
 //!
 //! ```rust
-//! #[macro_use]
-//! extern crate tracing;
 //! # pub struct FooSubscriber;
 //! # use tracing::{span::{Id, Attributes, Record}, Metadata};
 //! # impl tracing::Subscriber for FooSubscriber {
@@ -325,15 +328,19 @@
 //! The following crate feature flags are available:
 //!
 //! * A set of features controlling the [static verbosity level].
-//! * `log` causes trace instrumentation points to emit [`log`] records as well
+//! * `log`: causes trace instrumentation points to emit [`log`] records as well
 //!   as trace events. This is intended for use in libraries whose users may be
 //!   using either `tracing` or `log`.
 //!   **Note:** `log` support will not work when `tracing` is renamed in `Cargo.toml`,
 //!   due to oddities in macro expansion.
+//! * `async-await`: enables support for instrumenting `async fn`s with the
+//!   [`#[instrument]`][instrument] attribute.
+//!   **Note**: this also requires the [`tracing-futures`] crate with the
+//!   `std-future` feature flag enabled.
 //!
 //! ```toml
 //! [dependencies]
-//! tracing = { version = "0.1", features = ["log"] }
+//! tracing = { version = "0.1", features = ["log", "async-await"] }
 //! ```
 //!
 //! [`log`]: https://docs.rs/log/0.4.6/log/
@@ -357,6 +364,7 @@
 //! [`tracing-log`]: https://github.com/tokio-rs/tracing/tree/master/tracing-log
 //! [`tracing-timing`]: https://crates.io/crates/tracing-timing
 //! [static verbosity level]: level_filters/index.html#compile-time-filters
+//! [instrument]: https://docs.rs/tracing-attributes/0.1.0/tracing_attributes/attr.instrument.html
 #[macro_use]
 extern crate cfg_if;
 use tracing_core;

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -401,7 +401,7 @@ impl Span {
     /// [field values]: ../field/struct.ValueSet.html
     /// [`follows_from`]: ../struct.Span.html#method.follows_from
     #[inline]
-    pub fn new(meta: &'static Metadata<'static>, values: &field::ValueSet) -> Span {
+    pub fn new(meta: &'static Metadata<'static>, values: &field::ValueSet<'_>) -> Span {
         let new_span = Attributes::new(meta, values);
         Self::make(meta, new_span)
     }
@@ -416,7 +416,7 @@ impl Span {
     /// [field values]: ../field/struct.ValueSet.html
     /// [`follows_from`]: ../struct.Span.html#method.follows_from
     #[inline]
-    pub fn new_root(meta: &'static Metadata<'static>, values: &field::ValueSet) -> Span {
+    pub fn new_root(meta: &'static Metadata<'static>, values: &field::ValueSet<'_>) -> Span {
         Self::make(meta, Attributes::new_root(meta, values))
     }
 
@@ -432,7 +432,7 @@ impl Span {
     pub fn child_of(
         parent: impl Into<Option<Id>>,
         meta: &'static Metadata<'static>,
-        values: &field::ValueSet,
+        values: &field::ValueSet<'_>,
     ) -> Span {
         let new_span = match parent.into() {
             Some(parent) => Attributes::child_of(parent, meta, values),
@@ -492,7 +492,7 @@ impl Span {
         })
     }
 
-    fn make(meta: &'static Metadata<'static>, new_span: Attributes) -> Span {
+    fn make(meta: &'static Metadata<'static>, new_span: Attributes<'_>) -> Span {
         let attrs = &new_span;
         let inner = dispatcher::get_default(move |dispatch| {
             let id = dispatch.new_span(attrs);
@@ -683,7 +683,7 @@ impl Span {
     }
 
     /// Visit all the fields in the span
-    pub fn record_all(&self, values: &field::ValueSet) -> &Self {
+    pub fn record_all(&self, values: &field::ValueSet<'_>) -> &Self {
         let record = Record::new(values);
         if let Some(ref inner) = self.inner {
             inner.record(&record);
@@ -781,7 +781,7 @@ impl Hash for Span {
 }
 
 impl fmt::Debug for Span {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut span = f.debug_struct("Span");
         if let Some(ref meta) = self.meta {
             span.field("name", &meta.name())
@@ -877,7 +877,7 @@ impl Inner {
         self.id.clone()
     }
 
-    fn record(&self, values: &Record) {
+    fn record(&self, values: &Record<'_>) {
         self.subscriber.record(&self.id, values)
     }
 

--- a/tracing/tests/subscriber.rs
+++ b/tracing/tests/subscriber.rs
@@ -12,27 +12,27 @@ fn event_macros_dont_infinite_loop() {
     // won't cause an infinite loop of events.
     struct TestSubscriber;
     impl Subscriber for TestSubscriber {
-        fn register_callsite(&self, _: &Metadata) -> Interest {
+        fn register_callsite(&self, _: &Metadata<'_>) -> Interest {
             // Always return sometimes so that `enabled` will be called
             // (which can loop).
             Interest::sometimes()
         }
 
-        fn enabled(&self, meta: &Metadata) -> bool {
+        fn enabled(&self, meta: &Metadata<'_>) -> bool {
             assert!(meta.fields().iter().any(|f| f.name() == "foo"));
             event!(Level::TRACE, bar = false);
             true
         }
 
-        fn new_span(&self, _: &span::Attributes) -> span::Id {
+        fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
             span::Id::from_u64(0xAAAA)
         }
 
-        fn record(&self, _: &span::Id, _: &span::Record) {}
+        fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
 
         fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
 
-        fn event(&self, event: &Event) {
+        fn event(&self, event: &Event<'_>) {
             assert!(event.metadata().fields().iter().any(|f| f.name() == "foo"));
             event!(Level::TRACE, baz = false);
         }

--- a/tracing/tests/support/event.rs
+++ b/tracing/tests/support/event.rs
@@ -78,7 +78,7 @@ impl MockEvent {
         }
     }
 
-    pub(in crate::support) fn check(&mut self, event: &tracing::Event) {
+    pub(in crate::support) fn check(&mut self, event: &tracing::Event<'_>) {
         let meta = event.metadata();
         let name = meta.name();
         self.metadata
@@ -93,7 +93,7 @@ impl MockEvent {
 }
 
 impl fmt::Display for MockEvent {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "an event{}", self.metadata)
     }
 }

--- a/tracing/tests/support/field.rs
+++ b/tracing/tests/support/field.rs
@@ -118,7 +118,7 @@ impl Expect {
 }
 
 impl fmt::Display for MockValue {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             MockValue::I64(v) => write!(f, "i64 = {:?}", v),
             MockValue::U64(v) => write!(f, "u64 = {:?}", v),
@@ -215,7 +215,7 @@ impl<'a> From<&'a dyn Value> for MockValue {
 }
 
 impl fmt::Display for Expect {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "fields ")?;
         let entries = self
             .fields

--- a/tracing/tests/support/metadata.rs
+++ b/tracing/tests/support/metadata.rs
@@ -9,7 +9,7 @@ pub struct Expect {
 }
 
 impl Expect {
-    pub(in crate::support) fn check(&self, actual: &Metadata, ctx: fmt::Arguments) {
+    pub(in crate::support) fn check(&self, actual: &Metadata<'_>, ctx: fmt::Arguments<'_>) {
         if let Some(ref expected_name) = self.name {
             let name = actual.name();
             assert!(
@@ -46,7 +46,7 @@ impl Expect {
 }
 
 impl fmt::Display for Expect {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(ref name) = self.name {
             write!(f, " named `{}`", name)?;
         }

--- a/tracing/tests/support/mod.rs
+++ b/tracing/tests/support/mod.rs
@@ -5,8 +5,6 @@ mod metadata;
 pub mod span;
 pub mod subscriber;
 
-
-
 #[derive(Debug, Eq, PartialEq)]
 pub(in crate::support) enum Parent {
     ContextualRoot,

--- a/tracing/tests/support/mod.rs
+++ b/tracing/tests/support/mod.rs
@@ -5,7 +5,7 @@ mod metadata;
 pub mod span;
 pub mod subscriber;
 
-extern crate tracing_core;
+
 
 #[derive(Debug, Eq, PartialEq)]
 pub(in crate::support) enum Parent {

--- a/tracing/tests/support/span.rs
+++ b/tracing/tests/support/span.rs
@@ -100,14 +100,14 @@ impl MockSpan {
         }
     }
 
-    pub(in crate::support) fn check_metadata(&self, actual: &tracing::Metadata) {
+    pub(in crate::support) fn check_metadata(&self, actual: &tracing::Metadata<'_>) {
         self.metadata.check(actual, format_args!("span {}", self));
         assert!(actual.is_span(), "expected a span but got {:?}", actual);
     }
 }
 
 impl fmt::Display for MockSpan {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.metadata.name.is_some() {
             write!(f, "a span{}", self.metadata)
         } else {
@@ -160,7 +160,7 @@ impl NewSpan {
 }
 
 impl fmt::Display for NewSpan {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "a new span{}", self.span.metadata)?;
         if !self.fields.is_empty() {
             write!(f, " with {}", self.fields)?;

--- a/tracing/tests/support/subscriber.rs
+++ b/tracing/tests/support/subscriber.rs
@@ -35,7 +35,7 @@ struct SpanState {
     refs: usize,
 }
 
-struct Running<F: Fn(&Metadata) -> bool> {
+struct Running<F: Fn(&Metadata<'_>) -> bool> {
     spans: Mutex<HashMap<Id, SpanState>>,
     expected: Arc<Mutex<VecDeque<Expect>>>,
     current: Mutex<Vec<Id>>,
@@ -43,23 +43,23 @@ struct Running<F: Fn(&Metadata) -> bool> {
     filter: F,
 }
 
-pub struct MockSubscriber<F: Fn(&Metadata) -> bool> {
+pub struct MockSubscriber<F: Fn(&Metadata<'_>) -> bool> {
     expected: VecDeque<Expect>,
     filter: F,
 }
 
 pub struct MockHandle(Arc<Mutex<VecDeque<Expect>>>);
 
-pub fn mock() -> MockSubscriber<fn(&Metadata) -> bool> {
+pub fn mock() -> MockSubscriber<fn(&Metadata<'_>) -> bool> {
     MockSubscriber {
         expected: VecDeque::new(),
-        filter: (|_: &Metadata| true) as for<'r, 's> fn(&'r Metadata<'s>) -> _,
+        filter: (|_: &Metadata<'_>| true) as for<'r, 's> fn(&'r Metadata<'s>) -> _,
     }
 }
 
 impl<F> MockSubscriber<F>
 where
-    F: Fn(&Metadata) -> bool + 'static,
+    F: Fn(&Metadata<'_>) -> bool + 'static,
 {
     pub fn enter(mut self, span: MockSpan) -> Self {
         self.expected.push_back(Expect::Enter(span));
@@ -110,7 +110,7 @@ where
 
     pub fn with_filter<G>(self, filter: G) -> MockSubscriber<G>
     where
-        G: Fn(&Metadata) -> bool + 'static,
+        G: Fn(&Metadata<'_>) -> bool + 'static,
     {
         MockSubscriber {
             filter,
@@ -139,13 +139,13 @@ where
 
 impl<F> Subscriber for Running<F>
 where
-    F: Fn(&Metadata) -> bool + 'static,
+    F: Fn(&Metadata<'_>) -> bool + 'static,
 {
-    fn enabled(&self, meta: &Metadata) -> bool {
+    fn enabled(&self, meta: &Metadata<'_>) -> bool {
         (self.filter)(meta)
     }
 
-    fn record(&self, id: &Id, values: &span::Record) {
+    fn record(&self, id: &Id, values: &span::Record<'_>) {
         let spans = self.spans.lock().unwrap();
         let mut expected = self.expected.lock().unwrap();
         let span = spans
@@ -170,7 +170,7 @@ where
         }
     }
 
-    fn event(&self, event: &Event) {
+    fn event(&self, event: &Event<'_>) {
         let name = event.metadata().name();
         println!("event: {};", name);
         match self.expected.lock().unwrap().pop_front() {
@@ -237,7 +237,7 @@ where
         // TODO: it should be possible to expect spans to follow from other spans
     }
 
-    fn new_span(&self, span: &Attributes) -> Id {
+    fn new_span(&self, span: &Attributes<'_>) -> Id {
         let meta = span.metadata();
         let id = self.ids.fetch_add(1, Ordering::SeqCst);
         let id = Id::from_u64(id as u64);


### PR DESCRIPTION
This branch prepares to release 0.1.4 of `tracing`, and includes an edition idioms fix & docs updates. 

# Changelog

### Added

- `#[instrument]` attribute for automatically adding spans to functions (#253)