### PR TITLE
core: support `no-std` + `alloc`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,8 @@ stages:
            displayName: "Test log support"
          - bash: cd tracing/test_static_max_level_features && cargo test
            displayName: "Test static max level features"
+         - bash: cd tracing-core && cargo test --no-default-features
+           displayName: "Test tracing-core no-std support"
      - job: custom_nightly
        pool:
          vmImage: ubuntu-16.04

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -26,10 +26,18 @@ categories = [
 keywords = ["logging", "tracing", "profiling"]
 edition = "2018"
 
+[features]
+default = ["std"]
+std = []
+
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
 lazy_static = "1"
+
+[target.'cfg(not(feature = "std"))'.dependencies]
+spin = "0.5"
+lazy_static = { version = "1", features = ["spin_no_std"] }
 

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -46,10 +46,32 @@ The crate provides:
 In addition, it defines the global callsite registry and per-thread current
 dispatcher which other components of the tracing system rely on.
 
+## Usage
+
 Application authors will typically not use this crate directly. Instead, they
 will use the [`tracing`] crate, which provides a much more fully-featured
 API. However, this crate's API will change very infrequently, so it may be used
 when dependencies must be very stable.
+
+`Subscriber` implementations may depend on `tracing-core` rather than `tracing`,
+as the additional APIs provided by `tracing` are primarily useful for
+instrumenting libraries and applications, and are generally not necessary for
+`Subscriber` implementations.
+
+###  Crate Feature Flags
+
+The following crate feature flags are available:
+
+* `std`: Depend on the Rust standard library (enabled by default).
+
+   `no_std` users may disable this feature with `default-features = false`:
+
+  ```toml
+  [dependencies]
+  tracing-core = { version = "0.1.4", default-features = false }
+  ```
+
+  **Note**:`tracing-core`'s `no_std` support requires `liballoc`.
 
 [`tracing`]: ../tracing
 [`Span`]: https://docs.rs/tracing-core/0.1.3/tracing_core/span/struct.Span.html

--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -1,15 +1,16 @@
 //! Callsites represent the source locations from which spans or events
 //! originate.
-use crate::{
-    dispatcher::{self, Dispatch, Registrar},
-    subscriber::Interest,
-    Metadata,
-};
-use std::{
+use crate::std::{
     fmt,
     hash::{Hash, Hasher},
     ptr,
     sync::Mutex,
+    vec::Vec,
+};
+use crate::{
+    dispatcher::{self, Dispatch, Registrar},
+    subscriber::Interest,
+    Metadata,
 };
 
 lazy_static! {

--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -1,6 +1,6 @@
 //! Callsites represent the source locations from which spans or events
 //! originate.
-use crate::std::{
+use crate::stdlib::{
     fmt,
     hash::{Hash, Hasher},
     ptr,

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -68,6 +68,7 @@
 //! # let my_dispatch = dispatcher::Dispatch::new(my_subscriber);
 //! // no default subscriber
 //!
+//! # #[cfg(feature = "std")]
 //! dispatcher::with_default(&my_dispatch, || {
 //!     // my_subscriber is the default
 //! });
@@ -113,6 +114,10 @@
 //! # }
 //! ```
 //!
+//! **Note**: the thread-local scoped dispatcher (`with_default`) requires the
+//! Rust standard library. `no_std` users should use [`set_global_default`]
+//! instead.
+//!
 //! Finally, `tokio` users should note that versions of `tokio` >= 0.1.22
 //! support an `experimental-tracing` feature flag. When this flag is enabled,
 //! the `tokio` runtime's thread pool will automatically propagate the default
@@ -138,14 +143,19 @@ use crate::{
     Event, Metadata,
 };
 
-use std::{
+use crate::std::{
     any::Any,
-    cell::{Cell, RefCell},
-    error, fmt,
+    fmt,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc, Weak,
     },
+};
+
+#[cfg(feature = "std")]
+use crate::std::{
+    cell::{Cell, RefCell},
+    error,
 };
 
 /// `Dispatch` trace data to a [`Subscriber`].
@@ -156,6 +166,7 @@ pub struct Dispatch {
     subscriber: Arc<dyn Subscriber + Send + Sync>,
 }
 
+#[cfg(feature = "std")]
 thread_local! {
     static CURRENT_STATE: State = State {
         default: RefCell::new(Dispatch::none()),
@@ -171,6 +182,7 @@ const INITIALIZED: usize = 2;
 static mut GLOBAL_DISPATCH: Option<Dispatch> = None;
 
 /// The dispatch state of a thread.
+#[cfg(feature = "std")]
 struct State {
     /// This thread's current default dispatcher.
     default: RefCell<Dispatch>,
@@ -186,6 +198,7 @@ struct State {
 
 /// A guard that resets the current default dispatcher to the prior
 /// default dispatcher when dropped.
+#[cfg(feature = "std")]
 struct ResetGuard(Option<Dispatch>);
 
 /// Sets this dispatch as the default for the duration of a closure.
@@ -193,9 +206,14 @@ struct ResetGuard(Option<Dispatch>);
 /// The default dispatcher is used when creating a new [span] or
 /// [`Event`].
 ///
+/// **Note**: This function requires the Rust standard library. `no_std` users
+/// should use [`set_global_default`] instead.
+///
 /// [span]: ../span/index.html
 /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
 /// [`Event`]: ../event/struct.Event.html
+/// [`set_global_default`]: ../fn.set_global_default.html
+#[cfg(feature = "std")]
 pub fn with_default<T>(dispatcher: &Dispatch, f: impl FnOnce() -> T) -> T {
     // When this guard is dropped, the default dispatcher will be reset to the
     // prior default. Using this (rather than simply resetting after calling
@@ -243,6 +261,7 @@ impl fmt::Display for SetGlobalDefaultError {
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for SetGlobalDefaultError {}
 
 /// Executes a closure with a reference to this thread's current [dispatcher].
@@ -252,6 +271,7 @@ impl error::Error for SetGlobalDefaultError {}
 /// with `Dispatch::none` rather than the previously set dispatcher.
 ///
 /// [dispatcher]: ../dispatcher/struct.Dispatch.html
+#[cfg(feature = "std")]
 pub fn get_default<T, F>(mut f: F) -> T
 where
     F: FnMut(&Dispatch) -> T,
@@ -274,14 +294,10 @@ where
 
                 let mut default = state.default.borrow_mut();
 
-                if default.is::<NoSubscriber>() && GLOBAL_INIT.load(Ordering::SeqCst) == INITIALIZED
-                {
-                    // don't redo this call on the next check
-                    unsafe {
-                        *default = GLOBAL_DISPATCH
-                            .as_ref()
-                            .expect("invariant violated: GLOBAL_DISPATCH must be initialized before GLOBAL_INIT is set")
-                            .clone()
+                if default.is::<NoSubscriber>() {
+                    if let Some(global) = get_global() {
+                        // don't redo this call on the next check
+                        *default = global.clone();
                     }
                 }
                 f(&*default)
@@ -290,6 +306,34 @@ where
             }
         })
         .unwrap_or_else(|_| f(&Dispatch::none()))
+}
+
+/// Executes a closure with a reference to the current [dispatcher].
+///
+/// [dispatcher]: ../dispatcher/struct.Dispatch.html
+#[cfg(not(feature = "std"))]
+pub fn get_default<T, F>(mut f: F) -> T
+where
+    F: FnMut(&Dispatch) -> T,
+{
+    if let Some(d) = get_global() {
+        f(d)
+    } else {
+        f(&Dispatch::none())
+    }
+}
+
+fn get_global() -> Option<&'static Dispatch> {
+    if GLOBAL_INIT.load(Ordering::SeqCst) != INITIALIZED {
+        return None;
+    }
+    unsafe {
+        // This is safe given the invariant that setting the global dispatcher
+        // also sets `GLOBAL_INIT` to `INITIALIZED`.
+        Some(GLOBAL_DISPATCH.as_ref().expect(
+            "invariant violated: GLOBAL_DISPATCH must be initialized before GLOBAL_INIT is set",
+        ))
+    }
 }
 
 pub(crate) struct Registrar(Weak<dyn Subscriber + Send + Sync>);
@@ -568,6 +612,7 @@ impl Registrar {
 
 // ===== impl State =====
 
+#[cfg(feature = "std")]
 impl State {
     /// Replaces the current default dispatcher on this thread with the provided
     /// dispatcher.Any
@@ -588,6 +633,7 @@ impl State {
 
 // ===== impl ResetGuard =====
 
+#[cfg(feature = "std")]
 impl Drop for ResetGuard {
     #[inline]
     fn drop(&mut self) {
@@ -602,6 +648,8 @@ impl Drop for ResetGuard {
 #[cfg(test)]
 mod test {
     use super::*;
+    #[cfg(feature = "std")]
+    use crate::std::sync::atomic::{AtomicUsize, Ordering};
     use crate::{
         callsite::Callsite,
         metadata::{Kind, Level, Metadata},
@@ -609,7 +657,6 @@ mod test {
         subscriber::{Interest, Subscriber},
         Event,
     };
-    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn dispatch_is() {
@@ -642,6 +689,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn events_dont_infinite_loop() {
         // This test ensures that an event triggered within a subscriber
         // won't cause an infinite loop of events.
@@ -680,6 +728,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn spans_dont_infinite_loop() {
         // This test ensures that a span created within a subscriber
         // won't cause an infinite loop of new spans.
@@ -740,7 +789,10 @@ mod test {
             fn enter(&self, _: &span::Id) {}
             fn exit(&self, _: &span::Id) {}
         }
+        #[cfg(feature = "std")]
         struct TestSubscriberB;
+
+        #[cfg(feature = "std")]
         impl Subscriber for TestSubscriberB {
             fn enabled(&self, _: &Metadata<'_>) -> bool {
                 true
@@ -765,6 +817,7 @@ mod test {
             )
         });
 
+        #[cfg(feature = "std")]
         with_default(&Dispatch::new(TestSubscriberB), || {
             get_default(|current| {
                 assert!(

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -143,7 +143,7 @@ use crate::{
     Event, Metadata,
 };
 
-use crate::std::{
+use crate::stdlib::{
     any::Any,
     fmt,
     sync::{
@@ -153,7 +153,7 @@ use crate::std::{
 };
 
 #[cfg(feature = "std")]
-use crate::std::{
+use crate::stdlib::{
     cell::{Cell, RefCell},
     error,
 };
@@ -649,7 +649,7 @@ impl Drop for ResetGuard {
 mod test {
     use super::*;
     #[cfg(feature = "std")]
-    use crate::std::sync::atomic::{AtomicUsize, Ordering};
+    use crate::stdlib::sync::atomic::{AtomicUsize, Ordering};
     use crate::{
         callsite::Callsite,
         metadata::{Kind, Level, Metadata},

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -38,7 +38,7 @@
 //! [`event`]:  ../subscriber/trait.Subscriber.html#method.record
 //! [`Visit`]: trait.Visit.html
 use crate::callsite;
-use crate::std::{
+use crate::stdlib::{
     borrow::Borrow,
     fmt,
     hash::{Hash, Hasher},
@@ -670,7 +670,7 @@ impl_valid_len! {
 mod test {
     use super::*;
     use crate::metadata::{Kind, Level, Metadata};
-    use crate::std::{borrow::ToOwned, string::String};
+    use crate::stdlib::{borrow::ToOwned, string::String};
 
     struct TestCallsite1;
     static TEST_CALLSITE_1: TestCallsite1 = TestCallsite1;
@@ -771,7 +771,7 @@ mod test {
 
         struct MyVisitor;
         impl Visit for MyVisitor {
-            fn record_debug(&mut self, field: &Field, _: &dyn (crate::std::fmt::Debug)) {
+            fn record_debug(&mut self, field: &Field, _: &dyn (crate::stdlib::fmt::Debug)) {
                 assert_eq!(field.callsite(), TEST_META_1.callsite())
             }
         }
@@ -790,7 +790,7 @@ mod test {
         let valueset = fields.value_set(values);
         let mut result = String::new();
         valueset.record(&mut |_: &Field, value: &dyn fmt::Debug| {
-            use crate::std::fmt::Write;
+            use crate::stdlib::fmt::Write;
             write!(&mut result, "{:?}", value).unwrap();
         });
         assert_eq!(result, "123".to_owned());

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -38,7 +38,7 @@
 //! [`event`]:  ../subscriber/trait.Subscriber.html#method.record
 //! [`Visit`]: trait.Visit.html
 use crate::callsite;
-use std::{
+use crate::std::{
     borrow::Borrow,
     fmt,
     hash::{Hash, Hasher},
@@ -670,6 +670,7 @@ impl_valid_len! {
 mod test {
     use super::*;
     use crate::metadata::{Kind, Level, Metadata};
+    use crate::std::{borrow::ToOwned, string::String};
 
     struct TestCallsite1;
     static TEST_CALLSITE_1: TestCallsite1 = TestCallsite1;
@@ -770,7 +771,7 @@ mod test {
 
         struct MyVisitor;
         impl Visit for MyVisitor {
-            fn record_debug(&mut self, field: &Field, _: &dyn (::std::fmt::Debug)) {
+            fn record_debug(&mut self, field: &Field, _: &dyn (crate::std::fmt::Debug)) {
                 assert_eq!(field.callsite(), TEST_META_1.callsite())
             }
         }
@@ -789,7 +790,7 @@ mod test {
         let valueset = fields.value_set(values);
         let mut result = String::new();
         valueset.record(&mut |_: &Field, value: &dyn fmt::Debug| {
-            use std::fmt::Write;
+            use crate::std::fmt::Write;
             write!(&mut result, "{:?}", value).unwrap();
         });
         assert_eq!(result, "123".to_owned());

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -218,7 +218,7 @@ pub mod field;
 pub mod metadata;
 mod parent;
 pub mod span;
-pub(crate) mod std;
+pub(crate) mod stdlib;
 pub mod subscriber;
 
 pub use self::{

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -26,14 +26,35 @@
 //! In addition, it defines the global callsite registry and per-thread current
 //! dispatcher which other components of the tracing system rely on.
 //!
+//! ## Usage
+//!
 //! Application authors will typically not use this crate directly. Instead,
-//! they will use the `tracing` crate, which provides a much more
+//! they will use the [`tracing`] crate, which provides a much more
 //! fully-featured API. However, this crate's API will change very infrequently,
 //! so it may be used when dependencies must be very stable.
+//!
+//! `Subscriber` implementations may depend on `tracing-core` rather than
+//! `tracing`, as the additional APIs provided by `tracing` are primarily useful
+//! for instrumenting libraries and applications, and are generally not
+//! necessary for `Subscriber` implementations.
 //!
 //! The [`tokio-rs/tracing`] repository contains less stable crates designed to
 //! be used with the `tracing` ecosystem. It includes a collection of
 //! `Subscriber` implementations, as well as utility and adapter crates.
+//!
+//! ### Crate Feature Flags
+//!
+//! The following crate feature flags are available:
+//!
+//! * `std`: Depend on the Rust standard library (enabled by default).
+//!
+//!   `no_std` users may disable this feature with `default-features = false`:
+//!
+//!   ```toml
+//!   [dependencies]
+//!   tracing-core = { version = "0.1.4", default-features = false }
+//!   ```
+//!   **Note**:`tracing-core`'s `no_std` support requires `liballoc`.
 //!
 //! [`Span`]: span/struct.Span.html
 //! [`Event`]: event/struct.Event.html
@@ -47,6 +68,11 @@
 //! [`Dispatch`]: dispatcher/struct.Dispatch.html
 //! [`tokio-rs/tracing`]: https://github.com/tokio-rs/tracing
 //! [`tracing`]: https://crates.io/crates/tracing
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 #[macro_use]
 extern crate lazy_static;
 
@@ -192,6 +218,7 @@ pub mod field;
 pub mod metadata;
 mod parent;
 pub mod span;
+pub(crate) mod std;
 pub mod subscriber;
 
 pub use self::{

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -1,6 +1,6 @@
 //! Metadata describing trace data.
 use super::{callsite, field};
-use crate::std::{fmt, str::FromStr};
+use crate::stdlib::{fmt, str::FromStr};
 
 /// Metadata describing a [span] or [event].
 ///
@@ -274,7 +274,7 @@ impl fmt::Display for Level {
 }
 
 #[cfg(feature = "std")]
-impl crate::std::error::Error for ParseLevelError {}
+impl crate::stdlib::error::Error for ParseLevelError {}
 
 impl FromStr for Level {
     type Err = ParseLevelError;

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -1,6 +1,6 @@
 //! Metadata describing trace data.
 use super::{callsite, field};
-use std::{fmt, str::FromStr};
+use crate::std::{fmt, str::FromStr};
 
 /// Metadata describing a [span] or [event].
 ///
@@ -273,7 +273,8 @@ impl fmt::Display for Level {
     }
 }
 
-impl std::error::Error for ParseLevelError {}
+#[cfg(feature = "std")]
+impl crate::std::error::Error for ParseLevelError {}
 
 impl FromStr for Level {
     type Err = ParseLevelError;

--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -1,6 +1,6 @@
 //! Spans represent periods of time in the execution of a program.
 use crate::parent::Parent;
-use crate::std::num::NonZeroU64;
+use crate::stdlib::num::NonZeroU64;
 use crate::{field, Metadata};
 
 /// Identifies a span within the context of a subscriber.

--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -1,7 +1,7 @@
 //! Spans represent periods of time in the execution of a program.
 use crate::parent::Parent;
+use crate::std::num::NonZeroU64;
 use crate::{field, Metadata};
-use std::num::NonZeroU64;
 
 /// Identifies a span within the context of a subscriber.
 ///

--- a/tracing-core/src/std.rs
+++ b/tracing-core/src/std.rs
@@ -1,0 +1,69 @@
+//! Re-exports either the Rust `std` library or `core` and `alloc` when `std` is
+//! disabled.
+//!
+//! `crate::std::...` should be used rather than `std::` when adding code that
+//! will be available with the standard library disabled.
+#[cfg(feature = "std")]
+pub(crate) use std::*;
+
+#[cfg(not(feature = "std"))]
+pub(crate) use self::no_std::*;
+
+#[cfg(not(feature = "std"))]
+mod no_std {
+    // We pre-emptively export everything from libcore/liballoc, (even modules
+    // we aren't using currently) to make adding new code easier. Therefore,
+    // some of these imports will be unused.
+    #![allow(unused_imports)]
+
+    pub(crate) use core::{
+        any, array, ascii, cell, char, clone, cmp, convert, default, f32, f64, ffi, future, hash,
+        hint, i128, i16, i8, isize, iter, marker, mem, num, ops, option, pin, ptr, result, task,
+        time, u128, u16, u32, u8, usize,
+    };
+
+    pub(crate) use alloc::{boxed, collections, rc, string, vec};
+
+    pub(crate) mod borrow {
+        pub(crate) use alloc::borrow::*;
+        pub(crate) use core::borrow::*;
+    }
+
+    pub(crate) mod fmt {
+        pub(crate) use alloc::fmt::*;
+        pub(crate) use core::fmt::*;
+    }
+
+    pub(crate) mod slice {
+        pub(crate) use alloc::slice::*;
+        pub(crate) use core::slice::*;
+    }
+
+    pub(crate) mod str {
+        pub(crate) use alloc::str::*;
+        pub(crate) use core::str::*;
+    }
+
+    pub(crate) mod sync {
+        pub(crate) use alloc::sync::*;
+        pub(crate) use core::sync::*;
+        pub(crate) use spin::MutexGuard;
+
+        #[derive(Debug, Default)]
+        pub(crate) struct Mutex<T> {
+            inner: spin::Mutex<T>,
+        }
+
+        impl<T> Mutex<T> {
+            pub(crate) fn new(data: T) -> Self {
+                Self {
+                    inner: spin::Mutex::new(data),
+                }
+            }
+
+            pub(crate) fn lock(&self) -> Result<MutexGuard<T>, ()> {
+                Ok(self.inner.lock())
+            }
+        }
+    }
+}

--- a/tracing-core/src/stdlib.rs
+++ b/tracing-core/src/stdlib.rs
@@ -53,6 +53,11 @@ mod no_std {
         pub(crate) use core::sync::*;
         pub(crate) use spin::MutexGuard;
 
+        /// This wraps `spin::Mutex` to return a `Result`, so that it can be
+        /// used with code written against `std::sync::Mutex`.
+        ///
+        /// Since `spin::Mutex` doesn't support poisoning, the `Result` returned
+        /// by `lock` will always be `Ok`.
         #[derive(Debug, Default)]
         pub(crate) struct Mutex<T> {
             inner: spin::Mutex<T>,

--- a/tracing-core/src/stdlib.rs
+++ b/tracing-core/src/stdlib.rs
@@ -1,8 +1,12 @@
 //! Re-exports either the Rust `std` library or `core` and `alloc` when `std` is
 //! disabled.
 //!
-//! `crate::std::...` should be used rather than `std::` when adding code that
+//! `crate::stdlib::...` should be used rather than `std::` when adding code that
 //! will be available with the standard library disabled.
+//!
+//! Note that this module is called `stdlib` rather than `std`, as Rust 1.34.0
+//! does not permit redefining the name `stdlib` (although this works on the
+//! latest stable Rust).
 #[cfg(feature = "std")]
 pub(crate) use std::*;
 

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -1,7 +1,7 @@
 //! Subscribers collect and record trace data.
 use crate::{span, Event, Metadata};
 
-use crate::std::any::{Any, TypeId};
+use crate::stdlib::any::{Any, TypeId};
 
 /// Trait representing the functions required to collect trace data.
 ///

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -1,7 +1,7 @@
 //! Subscribers collect and record trace data.
 use crate::{span, Event, Metadata};
 
-use std::any::{Any, TypeId};
+use crate::std::any::{Any, TypeId};
 
 /// Trait representing the functions required to collect trace data.
 ///

--- a/tracing-core/tests/macros.rs
+++ b/tracing-core/tests/macros.rs
@@ -1,7 +1,6 @@
-#[macro_use]
-extern crate tracing_core;
 use tracing_core::{
     callsite::Callsite,
+    metadata,
     metadata::{Kind, Level, Metadata},
     subscriber::Interest,
 };


### PR DESCRIPTION
## Motivation

Users have expressed interest in using `tracing` on no_std platforms
with `liballoc`.

## Solution

This branch adds `no_std` support to `tracing-core` by adding a `std`
feature flag (on by default) which can be disabled to use `libcore` +
`liballoc` instead of `libstd`.

When the `std` feature is disabled, `tracing-core` will use
`spin::Mutex` rather than `std::sync::Mutex`, and the thread-local
scoped dispatcher will be disabled (since it necessitates a defined OS
threading model, which may not exist on `no_std` platforms).

Refs: #213

Signed-off-by: Eliza Weisman <eliza@buoyant.io>