### PR TITLE
core: minor doc fixes

### DIFF
--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -132,7 +132,7 @@
 //! currently default `Dispatch`. This is used primarily by `tracing`
 //! instrumentation.
 //!
-//! [`Subscriber`]: ../subscriber/struct.Subscriber.html
+//! [`Subscriber`]: struct.Subscriber.html
 //! [`with_default`]: fn.with_default.html
 //! [`set_global_default`]: fn.set_global_default.html
 //! [`get_default`]: fn.get_default.html
@@ -160,7 +160,7 @@ use crate::stdlib::{
 
 /// `Dispatch` trace data to a [`Subscriber`].
 ///
-/// [`Subscriber`]: ../subscriber/trait.Subscriber.html
+/// [`Subscriber`]: trait.Subscriber.html
 #[derive(Clone)]
 pub struct Dispatch {
     subscriber: Arc<dyn Subscriber + Send + Sync>,

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -221,14 +221,17 @@ pub mod span;
 pub(crate) mod stdlib;
 pub mod subscriber;
 
+#[doc(inline)]
 pub use self::{
     callsite::Callsite,
     dispatcher::Dispatch,
     event::Event,
     field::Field,
-    metadata::{Kind, Level, Metadata},
-    subscriber::{Interest, Subscriber},
+    metadata::{Level, Metadata},
+    subscriber::Subscriber,
 };
+
+pub use self::{metadata::Kind, subscriber::Interest};
 
 mod sealed {
     pub trait Sealed {}

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -62,7 +62,7 @@ use crate::stdlib::any::{Any, TypeId};
 ///
 /// [ID]: ../span/struct.Id.html
 /// [`new_span`]: trait.Subscriber.html#method.new_span
-/// [`register_callsite]: trait.Subscriber.html#method.register_callsite
+/// [`register_callsite`]: trait.Subscriber.html#method.register_callsite
 /// [`Interest`]: struct.Interest.html
 /// [`enabled`]: trait.Subscriber.html#method.enabled
 /// [`clone_span`]: trait.Subscriber.html#method.clone_span
@@ -451,8 +451,8 @@ impl dyn Subscriber {
 /// `Subscriber`s return an `Interest` from their [`register_callsite`] methods
 /// in order to determine whether that span should be enabled or disabled.
 ///
-/// [`Subscriber`] trait.Subscriber.html
-/// [clone_span]: trait.Subscriber.html#method.register_callsite
+/// [`Subscriber`] ../trait.Subscriber.html
+/// [clone_span]: ../trait.Subscriber.html#method.register_callsite
 #[derive(Clone, Debug)]
 pub struct Interest(InterestKind);
 


### PR DESCRIPTION
This branch makes some minor tweaks to the `tracing-core` RustDoc,
including fixing some broken links, and using `#[doc(inline)]` on some
of the more important re-exports so they're highlighted front and centre
in the docs.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>