### PR TITLE
attributes: prepare to release 0.1.1

### DIFF
--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Using the `#[instrument]` attribute on `async fn`s no longer requires a
   feature flag (#258)
 
+### Fixed
+
+- The `#[instrumented]` macro now works on generic functions (#262)
+
 # 0.1.0 (August 8, 2019)
 
 - Initial release

--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.1 (August 9, 2019)
+
+### Changed
+
+- Using the `#[instrument]` attribute on `async fn`s no longer requires a
+  feature flag (#258)
+
 # 0.1.0 (August 8, 2019)
 
 - Initial release

--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Fixed
 
-- The `#[instrumented]` macro now works on generic functions (#262)
+- The `#[instrument]` macro now works on generic functions (#262)
 
 # 0.1.0 (August 8, 2019)
 

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-attributes"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "Tokio Contributors <team@tokio.rs>",
     "Eliza Weisman <eliza@buoyant.io>",

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.1")]
 #![deny(missing_debug_implementations, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
# 0.1.1 (August 9, 2019)

### Changed

- Using the `#[instrument]` attribute on `async fn`s no longer requires a
  feature flag (#258)

### Fixed

- The `#[instrument]` macro now works on generic functions (#262)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
