### PR TITLE
core: prepare to release 0.1.4

### DIFF
--- a/tracing-attributes/test_async_await/Cargo.toml
+++ b/tracing-attributes/test_async_await/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 [dev-dependencies]
 tokio-test = { git = "https://github.com/tokio-rs/tokio.git" }
 tracing = "0.1"
-tracing-core = "0.1.2"
+tracing-core = "0.1"
 tracing-futures = { path = "../../tracing-futures", features = ["std-future"] }
 tracing-attributes = { path = ".." }
 test_std_future = { path = "../../tracing-futures/test_std_future" }

--- a/tracing-core/CHANGELOG.md
+++ b/tracing-core/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.1.4 (August 9, 2019)
+
+### Added
+
+- Support for `no-std` + `liballoc` (#256)
+
+### Fixed
+
+- Broken links in RustDoc (#259)
+
 # 0.1.3 (August 8, 2019)
 
 ### Added

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -8,13 +8,13 @@ name = "tracing-core"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-core/0.1.3/tracing_core"
+documentation = "https://docs.rs/tracing-core/0.1.4/tracing_core"
 description = """
 Core primitives for application-level tracing.
 """

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -74,16 +74,16 @@ The following crate feature flags are available:
   **Note**:`tracing-core`'s `no_std` support requires `liballoc`.
 
 [`tracing`]: ../tracing
-[`Span`]: https://docs.rs/tracing-core/0.1.3/tracing_core/span/struct.Span.html
-[`Event`]: https://docs.rs/tracing-core/0.1.3/tracing_core/event/struct.Event.html
-[`Subscriber`]: https://docs.rs/tracing-core/0.1.3/tracing_core/subscriber/trait.Subscriber.html
-[`Metadata`]: https://docs.rs/tracing-core/0.1.3/tracing_core/metadata/struct.Metadata.html
-[`Callsite`]: https://docs.rs/tracing-core/0.1.3/tracing_core/callsite/trait.Callsite.html
-[`Field`]: https://docs.rs/tracing-core/0.1.3/tracing_core/field/struct.Field.html
-[`FieldSet`]: https://docs.rs/tracing-core/0.1.3/tracing_core/field/struct.FieldSet.html
-[`Value`]: https://docs.rs/tracing-core/0.1.3/tracing_core/field/trait.Value.html
-[`ValueSet`]: https://docs.rs/tracing-core/0.1.3/tracing_core/field/struct.ValueSet.html
-[`Dispatch`]: https://docs.rs/tracing-core/0.1.3/tracing_core/dispatcher/struct.Dispatch.html
+[`Span`]: https://docs.rs/tracing-core/0.1.4/tracing_core/span/struct.Span.html
+[`Event`]: https://docs.rs/tracing-core/0.1.4/tracing_core/event/struct.Event.html
+[`Subscriber`]: https://docs.rs/tracing-core/0.1.4/tracing_core/subscriber/trait.Subscriber.html
+[`Metadata`]: https://docs.rs/tracing-core/0.1.4/tracing_core/metadata/struct.Metadata.html
+[`Callsite`]: https://docs.rs/tracing-core/0.1.4/tracing_core/callsite/trait.Callsite.html
+[`Field`]: https://docs.rs/tracing-core/0.1.4/tracing_core/field/struct.Field.html
+[`FieldSet`]: https://docs.rs/tracing-core/0.1.4/tracing_core/field/struct.FieldSet.html
+[`Value`]: https://docs.rs/tracing-core/0.1.4/tracing_core/field/trait.Value.html
+[`ValueSet`]: https://docs.rs/tracing-core/0.1.4/tracing_core/field/struct.ValueSet.html
+[`Dispatch`]: https://docs.rs/tracing-core/0.1.4/tracing_core/dispatcher/struct.Dispatch.html
 
 ## License
 

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tracing-core/0.1.3")]
+#![doc(html_root_url = "https://docs.rs/tracing-core/0.1.4")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
Changes:

### Added

- Support for `no-std` + `liballoc` (#256)

### Fixed

- Broken links in RustDoc (#259)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
