### PR TITLE
Add generics to instrumented methods.

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -139,6 +139,12 @@ pub fn instrument(args: TokenStream, item: TokenStream) -> TokenStream {
     let FnDecl {
         output: return_type,
         inputs: params,
+        generics:
+            syn::Generics {
+                params: gen_params,
+                where_clause,
+                ..
+            },
         ..
     } = *decl;
     let param_names: Vec<Ident> = params
@@ -173,7 +179,9 @@ pub fn instrument(args: TokenStream, item: TokenStream) -> TokenStream {
 
     quote_spanned!(call_site=>
         #(#attrs) *
-        #vis #constness #unsafety #asyncness #abi fn #ident(#params) #return_type {
+        #vis #constness #unsafety #asyncness #abi fn #ident<#gen_params>(#params) #return_type
+        #where_clause
+        {
             let __tracing_attr_span = tracing::span!(
                 target: #target,
                 #level,

--- a/tracing-attributes/tests/instrument.rs
+++ b/tracing-attributes/tests/instrument.rs
@@ -89,6 +89,9 @@ fn fields() {
 
 #[test]
 fn generics() {
+    #[derive(Debug)]
+    struct Foo;
+
     #[instrument]
     fn my_fn<S, T: std::fmt::Debug>(arg1: S, arg2: T)
     where
@@ -102,7 +105,7 @@ fn generics() {
         .new_span(
             span.clone().with_field(
                 field::mock("arg1")
-                    .with_value(&format_args!("2"))
+                    .with_value(&format_args!("Foo"))
                     .and(field::mock("arg2").with_value(&format_args!("false"))),
             ),
         )
@@ -113,7 +116,7 @@ fn generics() {
         .run_with_handle();
 
     with_default(subscriber, || {
-        my_fn(2, false);
+        my_fn(Foo, false);
     });
 
     handle.assert_finished();

--- a/tracing-attributes/tests/instrument.rs
+++ b/tracing-attributes/tests/instrument.rs
@@ -86,3 +86,35 @@ fn fields() {
 
     handle.assert_finished();
 }
+
+#[test]
+fn generics() {
+    #[instrument]
+    fn my_fn<S, T: std::fmt::Debug>(arg1: S, arg2: T)
+    where
+        S: std::fmt::Debug,
+    {
+    }
+
+    let span = span::mock().named("my_fn");
+
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(
+            span.clone().with_field(
+                field::mock("arg1")
+                    .with_value(&format_args!("2"))
+                    .and(field::mock("arg2").with_value(&format_args!("false"))),
+            ),
+        )
+        .enter(span.clone())
+        .exit(span.clone())
+        .drop_span(span)
+        .done()
+        .run_with_handle();
+
+    with_default(subscriber, || {
+        my_fn(2, false);
+    });
+
+    handle.assert_finished();
+}


### PR DESCRIPTION
## Motivation

Want to be able to use the amazing `#[instrument]` attribute on functions which have generics/bounds.

## Solution

Add these to the proc macro.
