### PR TITLE
tracing: prepare to release 0.1.5

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 0.1.5 (August 9, 2019)
+
+### Added
+
+- Support for `no-std` + `liballoc` (#263)
+
+### Changed
+
+- Using the `#[instrument]` attribute on `async fn`s no longer requires a
+  feature flag (#258)
+
+### Fixed
+
+- The `#[instrument]` macro now works on generic functions (#262)
+
 # 0.1.4 (August 8, 2019)
 
 ### Added

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,13 +8,13 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing/0.1.4/tracing"
+documentation = "https://docs.rs/tracing/0.1.5/tracing"
 description = """
 A scoped, structured logging and diagnostics system.
 """

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -47,7 +47,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing = "0.1.4"
+tracing = "0.1.5"
 ```
 
 This crate provides macros for creating `Span`s and `Event`s, which represent

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.4")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.5")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
### Added

- Support for `no-std` + `liballoc` (#263)

### Changed

- Using the `#[instrument]` attribute on `async fn`s no longer requires a
  feature flag (#258)

### Fixed

- The `#[instrument]` macro now works on generic functions (#262)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
