### PR TITLE
log: prepare to release tracing-log 0.0.1-alpha.1

### DIFF
--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tracing-log"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-log/0.0.1/tracing_log"
+documentation = "https://docs.rs/tracing-log/0.0.1-alpha.1/tracing_log"
 description = """
 Provides compatibility between `tracing` and the `log` crate.
 """

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -1,24 +1,25 @@
 [package]
 name = "tracing-log"
 version = "0.0.1"
-authors = ["Eliza Weisman <eliza@buoyant.io>"]
+authors = ["Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
 documentation = "https://docs.rs/tracing-log/0.0.1/tracing_log"
 description = """
-Provides compatibility between `tracing` and `log` crate
+Provides compatibility between `tracing` and the `log` crate.
 """
 categories = [
     "development-tools::debugging",
     "asynchronous",
 ]
-keywords = ["logging", "tracing"]
+keywords = ["logging", "tracing", "log"]
 license = "MIT"
+readme = "README.md"
 
 [dependencies]
 tracing-core = "0.1.2"
-tracing-subscriber = { path = "../tracing-subscriber" }
+tracing-subscriber = "0.0.1-alpha.2"
 log = { version = "0.4", features = ["std"] }
 lazy_static = "1.3.0"
 

--- a/tracing-log/README.md
+++ b/tracing-log/README.md
@@ -1,0 +1,61 @@
+# tracing-log
+
+**Warning: Until `tracing-log` has a 0.1.0 release on crates.io, please treat every release as potentially breaking.**
+
+[`log`] compatibility for [`tracing`].
+
+[![Crates.io][crates-badge]][crates-url]
+[![Documentation][docs-badge]][docs-url]
+[![MIT licensed][mit-badge]][mit-url]
+[![Build Status][azure-badge]][azure-url]
+[![Gitter chat][gitter-badge]][gitter-url]
+![maintenance status][maint-badge]
+
+[Documentation][docs-url] |
+[Chat][gitter-url]
+
+[crates-badge]: https://img.shields.io/crates/v/tracing-log.svg
+[crates-url]: https://crates.io/crates/tracing-log
+[docs-badge]: https://docs.rs/tracing-log/badge.svg
+[docs-url]: https://docs.rs/tracing-log
+[mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
+[mit-url]: LICENSE
+[azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master
+[azure-url]: https://dev.azure.com/tracing/tracing/_build/latest?definitionId=1&branchName=master
+[gitter-badge]: https://img.shields.io/gitter/room/tokio-rs/tracing.svg
+[gitter-url]: https://gitter.im/tokio-rs/tracing
+[maint-badge]: https://img.shields.io/badge/maintenance-experimental-blue.svg
+
+## Overview
+
+[`tracing`] is a framework for instrumenting Rust programs with context-aware,
+structured, event-based diagnostic information. This crate provides
+compatibility layers for using `tracing` alongside the logging facade provided
+by the [`log`] crate.
+
+This crate provides:
+
+- [`LogTracer`], a [`log::Log`] implementation that consumes [`log::Record`]s
+  and outputs them as [`tracing::Event`].
+- [`TraceLogger`], a [`tracing::Subscriber`] implementation that outputs
+  [`log::Record`]s as [`tracing::Event`]s, allowing an existing logger
+  implementation to be used to record trace events.
+
+[`tracing`]: https://crates.io/crates/tracing
+[`log`]: https://crates.io/crates/log
+[`LogTracer`]: https://docs.rs/tracing-log/latest/tracing_log/struct.LogTracer.html
+[`TraceLogger`]: https://docs.rs/tracing-log/latest/tracing_log/struct.TraceLogger.html
+[`log::Log`]: https://docs.rs/log/latest/log/trait.Log.html
+[`log::Record`]: https://docs.rs/log/latest/log/struct.Record.html
+[`tracing::Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
+[`tracing::Event`]: https://docs.rs/tracing/latest/tracing/struct.Event.html
+
+## License
+
+This project is licensed under the [MIT license](LICENSE).
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in Tracing by you, shall be licensed as MIT, without any additional
+terms or conditions.

--- a/tracing-log/README.md
+++ b/tracing-log/README.md
@@ -37,8 +37,8 @@ This crate provides:
 
 - [`LogTracer`], a [`log::Log`] implementation that consumes [`log::Record`]s
   and outputs them as [`tracing::Event`].
-- [`TraceLogger`], a [`tracing::Subscriber`] implementation that outputs
-  [`log::Record`]s as [`tracing::Event`]s, allowing an existing logger
+- [`TraceLogger`], a [`tracing::Subscriber`] implementation that consumes
+  [`tracing::Event`]s and outputs [`log::Record`], allowing an existing logger
   implementation to be used to record trace events.
 
 [`tracing`]: https://crates.io/crates/tracing

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -1,3 +1,6 @@
+#![doc(html_root_url = "https://docs.rs/tracing-log/0.0.1-alpha.1")]
+#![deny(missing_debug_implementations, unreachable_pub)]
+#![cfg_attr(test, deny(warnings))]
 //! Adapters for connecting unstructured log records from the `log` crate into
 //! the `tracing` ecosystem.
 //!

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -15,8 +15,8 @@
 //!
 //! - [`LogTracer`], a [`log::Log`] implementation that consumes [`log::Record`]s
 //!   and outputs them as [`tracing::Event`].
-//! - [`TraceLogger`], a [`tracing::Subscriber`] implementation that outputs
-//!   [`log::Record`]s as [`tracing::Event`]s, allowing an existing logger
+//! - [`TraceLogger`], a [`tracing::Subscriber`] implementation that consumes
+//!   [`tracing::Event`]s and outputs [`log::Record`], allowing an existing logger
 //!   implementation to be used to record trace events.
 //!
 //! ## Usage

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -1,7 +1,24 @@
 //! Adapters for connecting unstructured log records from the `log` crate into
 //! the `tracing` ecosystem.
 //!
-//! ## Convert log records to tracing `Event`s
+//! ## Overview
+//!
+//! [`tracing`] is a framework for instrumenting Rust programs with context-aware,
+//! structured, event-based diagnostic information. This crate provides
+//! compatibility layers for using `tracing` alongside the logging facade provided
+//! by the [`log`] crate.
+//!
+//! This crate provides:
+//!
+//! - [`LogTracer`], a [`log::Log`] implementation that consumes [`log::Record`]s
+//!   and outputs them as [`tracing::Event`].
+//! - [`TraceLogger`], a [`tracing::Subscriber`] implementation that outputs
+//!   [`log::Record`]s as [`tracing::Event`]s, allowing an existing logger
+//!   implementation to be used to record trace events.
+//!
+//! ## Usage
+//!
+//! ### Convert log records to tracing `Event`s
 //!
 //! To convert [`log::Record`]s as [`tracing::Event`]s, set `LogTracer` as the default
 //! logger by calling its [`init`] or [`init_with_filter`] methods.
@@ -28,12 +45,12 @@
 //! records emitted by dependencies which use `log` within the context of a
 //! trace.
 //!
-//! ## Convert tracing `Event`s to logs
+//! ### Convert tracing `Event`s to logs
 //!
 //! This conversion can be done with [`TraceLogger`], a [`Subscriber`] which
 //! records `tracing` spans and events and outputs log records.
 //!
-//! ## Caution: Mixing both conversions
+//! ### Caution: Mixing both conversions
 //!
 //! Note that logger implementations that convert log records to trace events
 //! should not be used with `Subscriber`s that convert trace events _back_ into
@@ -48,9 +65,15 @@
 //!
 //! [`init`]: struct.LogTracer.html#method.init
 //! [`init_with_filter`]: struct.LogTracer.html#method.init_with_filter
+//! [`LogTracer`]: struct.LogTracer.html
 //! [`TraceLogger`]: struct.TraceLogger.html
-//! [`tracing::Event`]: https://docs.rs/tracing/0.1.3/tracing/struct.Event.html
-//! [`log::Record`]: https://docs.rs/log/0.4.7/log/struct.Record.html
+//! [`tracing`]: https://crates.io/crates/tracing
+//! [`log`]: https://crates.io/crates/log
+//! [`log::Log`]: https://docs.rs/log/latest/log/trait.Log.html
+//! [`log::Record`]: https://docs.rs/log/latest/log/struct.Record.html
+//! [`tracing::Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
+//! [`Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
+//! [`tracing::Event`]: https://docs.rs/tracing/latest/tracing/struct.Event.html
 extern crate log;
 extern crate tracing_core;
 extern crate tracing_subscriber;
@@ -69,9 +92,13 @@ use tracing_core::{
 };
 
 pub mod log_tracer;
-pub use self::log_tracer::LogTracer;
 pub mod trace_logger;
-pub use self::trace_logger::{Builder as TraceLoggerBuilder, TraceLogger};
+
+#[doc(inline)]
+pub use self::{
+    log_tracer::LogTracer,
+    trace_logger::{Builder as TraceLoggerBuilder, TraceLogger},
+};
 
 /// Format a log record as a trace event in the current span.
 pub fn format_trace(record: &log::Record) -> io::Result<()> {

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -74,10 +74,6 @@
 //! [`tracing::Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
 //! [`Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
 //! [`tracing::Event`]: https://docs.rs/tracing/latest/tracing/struct.Event.html
-extern crate log;
-extern crate tracing_core;
-extern crate tracing_subscriber;
-
 use lazy_static::lazy_static;
 
 use std::{fmt, io};
@@ -95,10 +91,7 @@ pub mod log_tracer;
 pub mod trace_logger;
 
 #[doc(inline)]
-pub use self::{
-    log_tracer::LogTracer,
-    trace_logger::{Builder as TraceLoggerBuilder, TraceLogger},
-};
+pub use self::{log_tracer::LogTracer, trace_logger::TraceLogger};
 
 /// Format a log record as a trace event in the current span.
 pub fn format_trace(record: &log::Record) -> io::Result<()> {

--- a/tracing-log/src/trace_logger.rs
+++ b/tracing-log/src/trace_logger.rs
@@ -18,7 +18,7 @@ use tracing_core::{
 pub struct TraceLogger {
     settings: Builder,
     spans: Mutex<HashMap<Id, SpanLineBuilder>>,
-    current: tracing_subscriber::CurrentSpanPerThread,
+    current: tracing_subscriber::CurrentSpan,
     next_id: AtomicUsize,
 }
 

--- a/tracing-log/src/trace_logger.rs
+++ b/tracing-log/src/trace_logger.rs
@@ -22,6 +22,7 @@ pub struct TraceLogger {
     next_id: AtomicUsize,
 }
 
+#[derive(Debug)]
 pub struct Builder {
     log_span_closes: bool,
     log_enters: bool,
@@ -116,6 +117,7 @@ impl Default for TraceLogger {
     }
 }
 
+#[derive(Debug)]
 struct SpanLineBuilder {
     parent: Option<Id>,
     ref_count: usize,
@@ -364,5 +366,16 @@ impl<'a> fmt::Display for LogEvent<'a> {
 
         self.0.record(&mut format_fields);
         Ok(())
+    }
+}
+
+impl fmt::Debug for TraceLogger {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("TraceLogger")
+            .field("settings", &self.settings)
+            .field("spans", &self.spans)
+            .field("current", &self.current.id())
+            .field("next_id", &self.next_id)
+            .finish()
     }
 }

--- a/tracing-log/tests/log_tracer.rs
+++ b/tracing-log/tests/log_tracer.rs
@@ -21,19 +21,19 @@ struct OwnedMetadata {
 struct TestSubscriber(Arc<State>);
 
 impl Subscriber for TestSubscriber {
-    fn enabled(&self, _: &Metadata) -> bool {
+    fn enabled(&self, _: &Metadata<'_>) -> bool {
         true
     }
 
-    fn new_span(&self, _span: &Attributes) -> span::Id {
+    fn new_span(&self, _span: &Attributes<'_>) -> span::Id {
         span::Id::from_u64(42)
     }
 
-    fn record(&self, _span: &span::Id, _values: &Record) {}
+    fn record(&self, _span: &span::Id, _values: &Record<'_>) {}
 
     fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
 
-    fn event(&self, event: &Event) {
+    fn event(&self, event: &Event<'_>) {
         *self.0.last_normalized_metadata.lock().unwrap() = (
             event.is_log(),
             event.normalized_metadata().map(|normalized| OwnedMetadata {


### PR DESCRIPTION
This PR prepares the `tracing-log` crate to publish an alpha release to
crates.io. 

I realised this was necessary as I wanted to publish a new alpha of
`tracing-fmt`, and that crate now depends on `tracing-log`.

I've also done some cleanup & added some documentation. 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
