### PR TITLE
fmt: prepare to release tracing-fmt 0.0.1-alpha.3

### DIFF
--- a/tracing-fmt/Cargo.toml
+++ b/tracing-fmt/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "tracing-fmt"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 edition = "2018"
 license = "MIT"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-fmt/0.0.1-alpha.2/tracing_fmt"
+documentation = "https://docs.rs/tracing-fmt/0.0.1-alpha.3/tracing_fmt"
 description = """
 A (currently experimental) `tracing` subscriber that formats and logs trace data
 """
@@ -27,7 +27,7 @@ ansi = ["ansi_term"]
 
 [dependencies]
 tracing-core = "0.1.2"
-tracing-log = { path = "../tracing-log", optional = true }
+tracing-log = { version = "0.0.1-alpha.1", optional = true }
 ansi_term = { version = "0.11", optional = true }
 regex = "1"
 lazy_static = "1"

--- a/tracing-fmt/Cargo.toml
+++ b/tracing-fmt/Cargo.toml
@@ -15,6 +15,7 @@ categories = [
     "asynchronous",
 ]
 keywords = ["logging", "tracing"]
+readme = "README.md"
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-fmt/README.md
+++ b/tracing-fmt/README.md
@@ -2,7 +2,7 @@
 
 **Warning: Until `tracing-fmt` has a 0.1.0 release on crates.io, please treat every release as potentially breaking.**
 
-A (currently experimental) [tracing] subscriber
+A (currently experimental) [`tracing`][tracing] subscriber
 that formats, colors, and logs trace data.
 
 [![Crates.io][crates-badge]][crates-url]
@@ -14,7 +14,7 @@ that formats, colors, and logs trace data.
 [Documentation][docs-url] |
 [Chat][gitter-url]
 
-[tracing]: https://github.com/tokio-rs/tracing/tree/master/tracing
+[tracing]: https://crates.io/crates/tracing
 [tracing-fmt]: https://github.com/tokio-rs/tracing/tree/master/tracing-fmt
 [crates-badge]: https://img.shields.io/crates/v/tracing-fmt.svg
 [crates-url]: https://crates.io/crates/tracing-fmt
@@ -26,6 +26,13 @@ that formats, colors, and logs trace data.
 [azure-url]: https://dev.azure.com/tracing/tracing/_build/latest?definitionId=1&branchName=master
 [gitter-badge]: https://img.shields.io/gitter/room/tokio-rs/tracing.svg
 [gitter-url]: https://gitter.im/tokio-rs/tracing
+
+## Overview
+
+[`tracing`][tracing] is a framework for instrumenting Rust programs with context-aware,
+structured, event-based diagnostic information. This crate provides an
+implementation of the [`Subscriber`] trait that records `tracing`'s `Event`s
+and `Span`s by formatting them as text and logging them to stdout.
 
 ## License
 

--- a/tracing-fmt/examples/yak_shave.rs
+++ b/tracing-fmt/examples/yak_shave.rs
@@ -1,6 +1,6 @@
 #[macro_use]
 extern crate tracing;
-extern crate tracing_fmt;
+use tracing_fmt;
 
 use tracing::Level;
 

--- a/tracing-fmt/examples/yak_shave.rs
+++ b/tracing-fmt/examples/yak_shave.rs
@@ -1,8 +1,4 @@
-#[macro_use]
-extern crate tracing;
-use tracing_fmt;
-
-use tracing::Level;
+use tracing::{span, trace, debug, info, warn, error, Level};
 
 fn shave(yak: usize) -> bool {
     let span = span!(Level::TRACE, "shave", yak = yak);

--- a/tracing-fmt/examples/yak_shave.rs
+++ b/tracing-fmt/examples/yak_shave.rs
@@ -1,4 +1,4 @@
-use tracing::{span, trace, debug, info, warn, error, Level};
+use tracing::{debug, error, info, span, trace, warn, Level};
 
 fn shave(yak: usize) -> bool {
     let span = span!(Level::TRACE, "shave", yak = yak);

--- a/tracing-fmt/src/filter/env.rs
+++ b/tracing-fmt/src/filter/env.rs
@@ -1,4 +1,5 @@
 use crate::{filter::Filter, span::Context};
+use lazy_static::lazy_static;
 use regex::Regex;
 use tracing_core::{subscriber::Interest, Level, Metadata};
 
@@ -154,7 +155,7 @@ impl Default for EnvFilter {
 }
 
 impl<N> Filter<N> for EnvFilter {
-    fn callsite_enabled(&self, metadata: &Metadata, _: &Context<N>) -> Interest {
+    fn callsite_enabled(&self, metadata: &Metadata<'_>, _: &Context<'_, N>) -> Interest {
         if !self.includes_span_directive && self.max_level < *metadata.level() {
             return Interest::never();
         }
@@ -183,7 +184,7 @@ impl<N> Filter<N> for EnvFilter {
         interest
     }
 
-    fn enabled<'a>(&self, metadata: &Metadata, ctx: &Context<'a, N>) -> bool {
+    fn enabled<'a>(&self, metadata: &Metadata<'_>, ctx: &Context<'a, N>) -> bool {
         for directive in self.directives_for(metadata) {
             let accepts_level = directive.level >= *metadata.level();
             match directive.in_span.as_ref() {
@@ -253,7 +254,7 @@ fn try_parse_directives(spec: &str) -> Result<Vec<Directive>, ParseError> {
 }
 
 impl fmt::Display for EnvFilter {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut directives = self.directives.iter();
         if let Some(d) = directives.next() {
             write!(f, "{}", d)?;
@@ -390,7 +391,7 @@ impl Default for Directive {
 }
 
 impl fmt::Display for Directive {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut write_equals = false;
 
         if let Some(ref tgt) = self.target {
@@ -443,7 +444,7 @@ impl From<env::VarError> for FromEnvError {
 }
 
 impl fmt::Display for FromEnvError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
             ErrorKind::Parse(ref p) => p.fmt(f),
             ErrorKind::Env(ref e) => e.fmt(f),
@@ -479,7 +480,7 @@ impl ParseError {
 }
 
 impl fmt::Display for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "invalid filter directive '{}'", self.directive)
     }
 }
@@ -511,7 +512,7 @@ impl PartialOrd<Level> for LevelFilter {
 }
 
 impl fmt::Display for LevelFilter {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             LevelFilter::Off => f.pad("off"),
             LevelFilter::Level(Level::ERROR) => f.pad("error"),
@@ -535,7 +536,7 @@ mod tests {
 
     impl Callsite for Cs {
         fn set_interest(&self, _interest: Interest) {}
-        fn metadata(&self) -> &Metadata {
+        fn metadata(&self) -> &Metadata<'_> {
             unimplemented!()
         }
     }

--- a/tracing-fmt/src/filter/mod.rs
+++ b/tracing-fmt/src/filter/mod.rs
@@ -3,7 +3,7 @@ use crate::span;
 use tracing_core::{subscriber::Interest, Metadata};
 
 pub trait Filter<N> {
-    fn callsite_enabled(&self, metadata: &Metadata, ctx: &span::Context<N>) -> Interest {
+    fn callsite_enabled(&self, metadata: &Metadata<'_>, ctx: &span::Context<'_, N>) -> Interest {
         if self.enabled(metadata, ctx) {
             Interest::always()
         } else {
@@ -11,7 +11,7 @@ pub trait Filter<N> {
         }
     }
 
-    fn enabled(&self, metadata: &Metadata, ctx: &span::Context<N>) -> bool;
+    fn enabled(&self, metadata: &Metadata<'_>, ctx: &span::Context<'_, N>) -> bool;
 }
 
 pub mod env;
@@ -21,10 +21,10 @@ pub use self::{env::EnvFilter, reload::ReloadFilter};
 
 impl<'a, F, N> Filter<N> for F
 where
-    F: Fn(&Metadata, &span::Context<N>) -> bool,
+    F: Fn(&Metadata<'_>, &span::Context<'_, N>) -> bool,
     N: crate::NewVisitor<'a>,
 {
-    fn enabled(&self, metadata: &Metadata, ctx: &span::Context<N>) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>, ctx: &span::Context<'_, N>) -> bool {
         (self)(metadata, ctx)
     }
 }
@@ -39,7 +39,7 @@ pub struct NoFilter {
 }
 
 impl<N> Filter<N> for NoFilter {
-    fn enabled(&self, _: &Metadata, _: &span::Context<N>) -> bool {
+    fn enabled(&self, _: &Metadata<'_>, _: &span::Context<'_, N>) -> bool {
         true
     }
 }

--- a/tracing-fmt/src/filter/mod.rs
+++ b/tracing-fmt/src/filter/mod.rs
@@ -1,7 +1,9 @@
+//! Filter implementations for determining what spans and events to record.
 use crate::span;
 
 use tracing_core::{subscriber::Interest, Metadata};
 
+/// A policy for determining what spans and events should be enabled.
 pub trait Filter<N> {
     fn callsite_enabled(&self, metadata: &Metadata<'_>, ctx: &span::Context<'_, N>) -> Interest {
         if self.enabled(metadata, ctx) {
@@ -17,6 +19,7 @@ pub trait Filter<N> {
 pub mod env;
 pub mod reload;
 
+#[doc(inline)]
 pub use self::{env::EnvFilter, reload::ReloadFilter};
 
 impl<'a, F, N> Filter<N> for F

--- a/tracing-fmt/src/filter/reload.rs
+++ b/tracing-fmt/src/filter/reload.rs
@@ -41,11 +41,11 @@ impl<F, N> Filter<N> for ReloadFilter<F, N>
 where
     F: Filter<N>,
 {
-    fn callsite_enabled(&self, metadata: &Metadata, ctx: &Context<N>) -> Interest {
+    fn callsite_enabled(&self, metadata: &Metadata<'_>, ctx: &Context<'_, N>) -> Interest {
         self.inner.read().callsite_enabled(metadata, ctx)
     }
 
-    fn enabled(&self, metadata: &Metadata, ctx: &Context<N>) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>, ctx: &Context<'_, N>) -> bool {
         self.inner.read().enabled(metadata, ctx)
     }
 }
@@ -136,7 +136,7 @@ where
 // ===== impl Error =====
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         error::Error::description(self).fmt(f)
     }
 }
@@ -153,6 +153,7 @@ impl error::Error for Error {
 mod test {
     use crate::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use tracing::trace;
     use tracing_core::{
         dispatcher::{self, Dispatch},
         Metadata,
@@ -168,11 +169,11 @@ mod test {
             Two,
         }
         impl<N> filter::Filter<N> for Filter {
-            fn callsite_enabled(&self, _: &Metadata, _: &Context<N>) -> Interest {
+            fn callsite_enabled(&self, _: &Metadata<'_>, _: &Context<'_, N>) -> Interest {
                 Interest::sometimes()
             }
 
-            fn enabled(&self, _: &Metadata, _: &Context<N>) -> bool {
+            fn enabled(&self, _: &Metadata<'_>, _: &Context<'_, N>) -> bool {
                 match self {
                     Filter::One => FILTER1_CALLS.fetch_add(1, Ordering::Relaxed),
                     Filter::Two => FILTER2_CALLS.fetch_add(1, Ordering::Relaxed),

--- a/tracing-fmt/src/format.rs
+++ b/tracing-fmt/src/format.rs
@@ -1,5 +1,4 @@
-//! Default formatters for logs
-
+//! Formatters for logging `tracing` events.
 use crate::span;
 use crate::time::{self, FormatTime, SystemTime};
 #[cfg(feature = "tracing-log")]

--- a/tracing-fmt/src/format.rs
+++ b/tracing-fmt/src/format.rs
@@ -3,7 +3,7 @@
 use crate::span;
 use crate::time::{self, FormatTime, SystemTime};
 #[cfg(feature = "tracing-log")]
-use crate::tracing_log::NormalizeEvent;
+use tracing_log::NormalizeEvent;
 
 use std::fmt::{self, Write};
 use std::marker::PhantomData;
@@ -26,18 +26,20 @@ pub trait FormatEvent<N> {
     /// Write a log message for `Event` in `Context` to the given `Write`.
     fn format_event(
         &self,
-        ctx: &span::Context<N>,
+        ctx: &span::Context<'_, N>,
         writer: &mut dyn fmt::Write,
-        event: &Event,
+        event: &Event<'_>,
     ) -> fmt::Result;
 }
 
-impl<N> FormatEvent<N> for fn(&span::Context<N>, &mut dyn fmt::Write, &Event) -> fmt::Result {
+impl<N> FormatEvent<N>
+    for fn(&span::Context<'_, N>, &mut dyn fmt::Write, &Event<'_>) -> fmt::Result
+{
     fn format_event(
         &self,
-        ctx: &span::Context<N>,
+        ctx: &span::Context<'_, N>,
         writer: &mut dyn fmt::Write,
-        event: &Event,
+        event: &Event<'_>,
     ) -> fmt::Result {
         (*self)(ctx, writer, event)
     }
@@ -135,9 +137,9 @@ where
 {
     fn format_event(
         &self,
-        ctx: &span::Context<N>,
+        ctx: &span::Context<'_, N>,
         writer: &mut dyn fmt::Write,
-        event: &Event,
+        event: &Event<'_>,
     ) -> fmt::Result {
         #[cfg(feature = "tracing-log")]
         let normalized_meta = event.normalized_metadata();
@@ -172,9 +174,9 @@ where
 {
     fn format_event(
         &self,
-        ctx: &span::Context<N>,
+        ctx: &span::Context<'_, N>,
         writer: &mut dyn fmt::Write,
-        event: &Event,
+        event: &Event<'_>,
     ) -> fmt::Result {
         #[cfg(feature = "tracing-log")]
         let normalized_meta = event.normalized_metadata();
@@ -256,7 +258,7 @@ impl<'a> field::Visit for Recorder<'a> {
     }
 }
 
-struct FmtCtx<'a, N: 'a> {
+struct FmtCtx<'a, N> {
     ctx: &'a span::Context<'a, N>,
     ansi: bool,
 }
@@ -272,7 +274,7 @@ impl<'a, N> fmt::Display for FmtCtx<'a, N>
 where
     N: crate::NewVisitor<'a>,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut seen = false;
         self.ctx.visit_spans(|_, span| {
             if seen {
@@ -311,7 +313,7 @@ impl<'a, N> fmt::Display for FmtCtx<'a, N> {
     }
 }
 
-struct FullCtx<'a, N: 'a> {
+struct FullCtx<'a, N> {
     ctx: &'a span::Context<'a, N>,
     ansi: bool,
 }
@@ -327,7 +329,7 @@ impl<'a, N> fmt::Display for FullCtx<'a, N>
 where
     N: crate::NewVisitor<'a>,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut seen = false;
         let style = if self.ansi {
             Style::new().bold()
@@ -399,7 +401,7 @@ impl<'a> fmt::Display for FmtLevel<'a> {
 
 #[cfg(feature = "ansi")]
 impl<'a> fmt::Display for FmtLevel<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.ansi {
             match *self.level {
                 Level::TRACE => write!(f, "{}", Colour::Purple.paint("TRACE")),

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -10,6 +10,8 @@
 //!
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [`Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
+#![doc(html_root_url = "https://docs.rs/tracing-f,t/0.0.1-alpha.3")]
+#![cfg_attr(test, deny(warnings))]
 use tracing_core::{field, subscriber::Interest, Event, Metadata};
 
 use std::{any::TypeId, cell::RefCell, fmt, io};

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -1,22 +1,3 @@
-extern crate tracing_core;
-#[cfg(test)]
-#[macro_use]
-extern crate tracing;
-
-#[cfg(feature = "ansi")]
-extern crate ansi_term;
-#[cfg(feature = "chrono")]
-extern crate chrono;
-extern crate lock_api;
-extern crate owning_ref;
-extern crate parking_lot;
-#[cfg(feature = "tracing-log")]
-extern crate tracing_log;
-
-#[macro_use]
-extern crate lazy_static;
-extern crate regex;
-
 use tracing_core::{field, subscriber::Interest, Event, Metadata};
 
 use std::{any::TypeId, cell::RefCell, fmt, io};
@@ -78,7 +59,7 @@ where
     N: for<'a> NewVisitor<'a>,
 {
     #[inline]
-    fn ctx(&self) -> span::Context<N> {
+    fn ctx(&self) -> span::Context<'_, N> {
         span::Context::new(&self.spans, &self.new_visitor)
     }
 }
@@ -104,17 +85,17 @@ where
         self.filter.callsite_enabled(metadata, &self.ctx())
     }
 
-    fn enabled(&self, metadata: &Metadata) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
         self.filter.enabled(metadata, &self.ctx())
     }
 
     #[inline]
-    fn new_span(&self, attrs: &span::Attributes) -> span::Id {
+    fn new_span(&self, attrs: &span::Attributes<'_>) -> span::Id {
         self.spans.new_span(attrs, &self.new_visitor)
     }
 
     #[inline]
-    fn record(&self, span: &span::Id, values: &span::Record) {
+    fn record(&self, span: &span::Id, values: &span::Record<'_>) {
         self.spans.record(span, values, &self.new_visitor)
     }
 
@@ -122,7 +103,7 @@ where
         // TODO: implement this please
     }
 
-    fn event(&self, event: &Event) {
+    fn event(&self, event: &Event<'_>) {
         thread_local! {
             static BUF: RefCell<String> = RefCell::new(String::new());
         }

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -1,3 +1,15 @@
+//! A `Subscriber` for formatting and logging `tracing` data.
+//!
+//! ## Overview
+//!
+//! [`tracing`] is a framework for instrumenting Rust programs with context-aware,
+//! structured, event-based diagnostic information. This crate provides an
+//! implementation of the [`Subscriber`] trait that records `tracing`'s `Event`s
+//! and `Span`s by formatting them as text and logging them to stdout.
+//!
+//!
+//! [`tracing`]: https://crates.io/crates/tracing
+//! [`Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
 use tracing_core::{field, subscriber::Interest, Event, Metadata};
 
 use std::{any::TypeId, cell::RefCell, fmt, io};
@@ -7,10 +19,10 @@ pub mod format;
 mod span;
 pub mod time;
 
-pub use crate::filter::Filter;
-pub use crate::format::FormatEvent;
-pub use crate::span::Context;
+#[doc(inline)]
+pub use crate::{filter::Filter, format::FormatEvent, span::Context};
 
+/// A `Subscriber` that logs formatted representations of `tracing` events.
 #[derive(Debug)]
 pub struct FmtSubscriber<
     N = format::NewRecorder,
@@ -24,6 +36,7 @@ pub struct FmtSubscriber<
     settings: Settings,
 }
 
+/// Configures and constructs `FmtSubscriber`s.
 #[derive(Debug, Default)]
 pub struct Builder<N = format::NewRecorder, E = format::Format<format::Full>, F = filter::EnvFilter>
 {

--- a/tracing-fmt/src/span.rs
+++ b/tracing-fmt/src/span.rs
@@ -14,6 +14,8 @@ pub struct Span<'a> {
     lock: OwningHandle<RwLockReadGuard<'a, Slab>, RwLockReadGuard<'a, Slot>>,
 }
 
+/// Represents the `Subscriber`'s view of the current span context to a
+/// formatter.
 pub struct Context<'a, N> {
     store: &'a Store,
     new_visitor: &'a N,

--- a/tracing-fmt/src/time.rs
+++ b/tracing-fmt/src/time.rs
@@ -1,3 +1,5 @@
+//! Formatters for event timestamps.
+
 #[cfg(feature = "chrono")]
 use chrono;
 


### PR DESCRIPTION
This PR prepares a new alpha of `tracing-fmt` with the improved
support for log events added in PR #249.

I've also tried to add some more rudimentary docs & done some
minor cleanup like fixing Rust 2018 edition idioms.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>