### PR TITLE
 chore: add PR labeler action 

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,7 @@
+crate/tracing: tracing/**
+crate/core: tracing-core/**
+crate/proc-macros: tracing-attributes/**
+crate/fmt: tracing-fmt/**
+crate/futures: tracing-futures/**
+crate/log: tracing-log/**
+crate/subscriber: tracing-subscriber/**

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,12 @@
+name: Labeler
+on: [pull-request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
The `tokio` org is now part of the github actions beta.

This branch dips our feet in the metaphorical water by
setting up a simple action that adds crate labels to PRs.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>