### PR TITLE
examples: update to use Rust 2018 idioms

### DIFF
--- a/nightly-examples/examples/async_fn.rs
+++ b/nightly-examples/examples/async_fn.rs
@@ -14,7 +14,9 @@
 //!     cargo +nightly run --example async_fn
 //!
 //! [`hello_world`]: https://github.com/tokio-rs/tokio/blob/132e9f1da5965530b63554d7a1c59824c3de4e30/tokio/examples/hello_world.rs
+#![deny(rust_2018_idioms)]
 #![feature(async_await)]
+
 use tokio;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;

--- a/tracing-attributes/examples/args.rs
+++ b/tracing-attributes/examples/args.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use tracing::{debug, info};
 use tracing_attributes::instrument;
 

--- a/tracing-attributes/examples/basic.rs
+++ b/tracing-attributes/examples/basic.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use tracing::{debug, info, span, Level};
 use tracing_attributes::instrument;
 

--- a/tracing-env-logger/Cargo.toml
+++ b/tracing-env-logger/Cargo.toml
@@ -14,6 +14,7 @@ categories = [
 ]
 keywords = ["logging", "tracing"]
 license = "MIT"
+edition = "2018"
 
 [dependencies]
 tracing-log = { path = "../tracing-log" }

--- a/tracing-env-logger/examples/hyper-echo.rs
+++ b/tracing-env-logger/examples/hyper-echo.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 extern crate futures;
 extern crate hyper;
 #[macro_use]

--- a/tracing-env-logger/examples/hyper-echo.rs
+++ b/tracing-env-logger/examples/hyper-echo.rs
@@ -1,14 +1,5 @@
 #![deny(rust_2018_idioms)]
 
-extern crate futures;
-extern crate hyper;
-#[macro_use]
-extern crate tracing;
-extern crate tokio;
-extern crate tracing_env_logger;
-extern crate tracing_fmt;
-extern crate tracing_futures;
-
 use futures::future;
 use hyper::rt::{Future, Stream};
 use hyper::server::conn::Http;
@@ -17,7 +8,7 @@ use hyper::{Body, Method, Request, Response, StatusCode};
 
 use std::str;
 
-use tracing::{field, Level};
+use tracing::{debug, error, field, info, span, Level};
 use tracing_futures::{Instrument, Instrumented};
 
 type BoxFut = Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send>;

--- a/tracing-env-logger/src/lib.rs
+++ b/tracing-env-logger/src/lib.rs
@@ -1,6 +1,6 @@
-extern crate env_logger;
-extern crate log;
-extern crate tracing_log;
+use env_logger;
+use log;
+use tracing_log;
 
 pub fn try_init() -> Result<(), log::SetLoggerError> {
     env_logger::Builder::from_default_env()

--- a/tracing-fmt/examples/yak_shave.rs
+++ b/tracing-fmt/examples/yak_shave.rs
@@ -1,3 +1,4 @@
+#![deny(rust_2018_idioms)]
 use tracing::{debug, error, info, span, trace, warn, Level};
 
 fn shave(yak: usize) -> bool {

--- a/tracing-futures/examples/proxy_server.rs
+++ b/tracing-futures/examples/proxy_server.rs
@@ -4,13 +4,7 @@ https://raw.githubusercontent.com/tokio-rs/tokio/master/tokio/examples/proxy.rs
 */
 #![deny(rust_2018_idioms)]
 
-use tokio;
-#[macro_use]
-extern crate tracing;
-use tracing_fmt;
-
-
-use tracing::{field, Level};
+use tracing::{debug, field, info, span, Level};
 use tracing_futures::Instrument;
 
 use std::env;
@@ -35,8 +29,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create a TCP listener which will listen for incoming connections.
     let socket = TcpListener::bind(&listen_addr)?;
-    println!("Listening on: {}", listen_addr);
-    println!("Proxying to: {}", server_addr);
+    info!("Listening on: {}", listen_addr);
+    info!("Proxying to: {}", server_addr);
 
     let done = socket
         .incoming()

--- a/tracing-futures/examples/proxy_server.rs
+++ b/tracing-futures/examples/proxy_server.rs
@@ -2,7 +2,7 @@
 This example has been taken and modified from here :
 https://raw.githubusercontent.com/tokio-rs/tokio/master/tokio/examples/proxy.rs
 */
-
+#![deny(rust_2018_idioms)]
 extern crate futures;
 extern crate tokio;
 #[macro_use]

--- a/tracing-futures/examples/proxy_server.rs
+++ b/tracing-futures/examples/proxy_server.rs
@@ -3,12 +3,12 @@ This example has been taken and modified from here :
 https://raw.githubusercontent.com/tokio-rs/tokio/master/tokio/examples/proxy.rs
 */
 #![deny(rust_2018_idioms)]
-extern crate futures;
-extern crate tokio;
+
+use tokio;
 #[macro_use]
 extern crate tracing;
-extern crate tracing_fmt;
-extern crate tracing_futures;
+use tracing_fmt;
+
 
 use tracing::{field, Level};
 use tracing_futures::Instrument;

--- a/tracing-futures/examples/spawny-thing.rs
+++ b/tracing-futures/examples/spawny-thing.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 extern crate futures;
 extern crate tokio;
 #[macro_use]

--- a/tracing-futures/examples/spawny-thing.rs
+++ b/tracing-futures/examples/spawny-thing.rs
@@ -1,14 +1,7 @@
 #![deny(rust_2018_idioms)]
 
-extern crate futures;
-extern crate tokio;
-#[macro_use]
-extern crate tracing;
-extern crate tracing_fmt;
-extern crate tracing_futures;
-
 use futures::future::{self, Future};
-use tracing::Level;
+use tracing::{debug, info, span, Level};
 use tracing_futures::Instrument;
 
 fn parent_task(how_many: usize) -> impl Future<Item = (), Error = ()> {

--- a/tracing-macros/examples/factorial.rs
+++ b/tracing-macros/examples/factorial.rs
@@ -5,8 +5,8 @@
 extern crate tracing;
 #[macro_use]
 extern crate tracing_macros;
-extern crate env_logger;
-extern crate tracing_log;
+use env_logger;
+use tracing_log;
 
 fn factorial(n: u32) -> u32 {
     if dbg!(n <= 1) {

--- a/tracing-macros/examples/factorial.rs
+++ b/tracing-macros/examples/factorial.rs
@@ -1,4 +1,6 @@
 //! Compare to the example given in the documentation for the `std::dbg` macro.
+#![deny(rust_2018_idioms)]
+
 #[macro_use]
 extern crate tracing;
 #[macro_use]

--- a/tracing-serde/examples/serde_shaved_yak.rs
+++ b/tracing-serde/examples/serde_shaved_yak.rs
@@ -1,22 +1,16 @@
-#[macro_use]
-extern crate serde_json;
-
-#[macro_use]
-extern crate tracing;
-
-
-
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
+use tracing::{debug, error, info, span, trace, warn};
 use tracing_core::{
     event::Event,
     metadata::{Level, Metadata},
     span::{Attributes, Id, Record},
     subscriber::Subscriber,
 };
-
 use tracing_serde::AsSerde;
+
+use serde_json::json;
 
 pub struct JsonSubscriber {
     next_id: AtomicUsize, // you need to assign span IDs, so you need a counter

--- a/tracing-serde/examples/serde_shaved_yak.rs
+++ b/tracing-serde/examples/serde_shaved_yak.rs
@@ -3,8 +3,8 @@ extern crate serde_json;
 
 #[macro_use]
 extern crate tracing;
-extern crate tracing_core;
-extern crate tracing_serde;
+
+
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
@@ -23,7 +23,7 @@ pub struct JsonSubscriber {
 }
 
 impl Subscriber for JsonSubscriber {
-    fn enabled(&self, metadata: &Metadata) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
         let json = json!({
         "enabled": {
             "metadata": metadata.as_serde(),
@@ -32,7 +32,7 @@ impl Subscriber for JsonSubscriber {
         true
     }
 
-    fn new_span(&self, attrs: &Attributes) -> Id {
+    fn new_span(&self, attrs: &Attributes<'_>) -> Id {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let id = Id::from_u64(id as u64);
         let json = json!({
@@ -44,7 +44,7 @@ impl Subscriber for JsonSubscriber {
         id
     }
 
-    fn record(&self, span: &Id, values: &Record) {
+    fn record(&self, span: &Id, values: &Record<'_>) {
         let json = json!({
         "record": {
             "span": span.as_serde(),
@@ -62,7 +62,7 @@ impl Subscriber for JsonSubscriber {
         println!("{}", json);
     }
 
-    fn event(&self, event: &Event) {
+    fn event(&self, event: &Event<'_>) {
         let json = json!({
             "event": event.as_serde(),
         });

--- a/tracing-subscriber/examples/filter_yakshave.rs
+++ b/tracing-subscriber/examples/filter_yakshave.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use tracing::Level;
 use tracing_subscriber::prelude::*;
 

--- a/tracing-tower-http/examples/tower-h2-server.rs
+++ b/tracing-tower-http/examples/tower-h2-server.rs
@@ -1,19 +1,5 @@
 #![deny(rust_2018_idioms)]
 
-extern crate bytes;
-extern crate futures;
-extern crate h2;
-extern crate http;
-extern crate tokio;
-#[macro_use]
-extern crate tracing;
-extern crate env_logger;
-extern crate tower_h2;
-extern crate tower_service;
-extern crate tracing_fmt;
-extern crate tracing_futures;
-extern crate tracing_tower_http;
-
 use bytes::{Bytes, IntoBuf};
 use futures::*;
 use http::Request;
@@ -21,7 +7,7 @@ use tokio::net::TcpListener;
 use tokio::runtime::Runtime;
 use tower_h2::{Body, RecvBody, Server};
 use tower_service::Service;
-use tracing::{field, Level};
+use tracing::{debug, error, field, info, span, warn, Level};
 use tracing_futures::Instrument;
 
 type Response = http::Response<RspBody>;

--- a/tracing-tower-http/examples/tower-h2-server.rs
+++ b/tracing-tower-http/examples/tower-h2-server.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 extern crate bytes;
 extern crate futures;
 extern crate h2;

--- a/tracing-tower/examples/h2-client.rs
+++ b/tracing-tower/examples/h2-client.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use bytes::Bytes;
 use futures::*;
 use h2::Reason;

--- a/tracing-tower/examples/h2-client.rs
+++ b/tracing-tower/examples/h2-client.rs
@@ -12,7 +12,6 @@ use tower_h2::client::Connect;
 use tower_h2::{Body, RecvBody};
 use tower_service::Service;
 use tower_util::MakeService;
-use tracing;
 use tracing_futures::Instrument;
 use tracing_tower::InstrumentableService;
 
@@ -36,7 +35,7 @@ fn main() {
     impl Service<()> for Conn {
         type Response = TcpStream;
         type Error = ::std::io::Error;
-        type Future = Box<Future<Item = TcpStream, Error = ::std::io::Error> + Send>;
+        type Future = Box<dyn Future<Item = TcpStream, Error = ::std::io::Error> + Send>;
 
         fn poll_ready(&mut self) -> Poll<(), Self::Error> {
             Ok(().into())
@@ -102,7 +101,7 @@ struct Serial {
         tower_h2::client::Connection<TcpStream, TaskExecutor, tower_h2::NoBody>,
         http::Request<tower_h2::NoBody>,
     >,
-    pending: Option<Box<Future<Item = (), Error = tower_h2::client::Error> + Send>>,
+    pending: Option<Box<dyn Future<Item = (), Error = tower_h2::client::Error> + Send>>,
 }
 
 impl Future for Serial {

--- a/tracing-tower/examples/h2-server.rs
+++ b/tracing-tower/examples/h2-server.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use bytes::{Bytes, IntoBuf};
 use futures::*;
 use http::Request;

--- a/tracing-tower/examples/load.rs
+++ b/tracing-tower/examples/load.rs
@@ -260,7 +260,7 @@ where
 {
     type Response = Response<Body>;
     type Error = hyper::Error;
-    type Future = Box<Future<Item = Self::Response, Error = Self::Error> + Send + 'static>;
+    type Future = Box<dyn Future<Item = Self::Response, Error = Self::Error> + Send + 'static>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         Ok(().into())
@@ -318,7 +318,7 @@ impl HandleError {
 }
 
 impl fmt::Display for HandleError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             HandleError::BadPath => f.pad("path must be a single ASCII character"),
             HandleError::NoContentLength => f.pad("request must have Content-Length header"),
@@ -331,7 +331,7 @@ impl fmt::Display for HandleError {
 impl std::error::Error for HandleError {}
 
 impl fmt::Display for WrongMethod {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "unsupported method: please use one of {:?}", self.0)
     }
 }

--- a/tracing-tower/examples/load.rs
+++ b/tracing-tower/examples/load.rs
@@ -20,7 +20,8 @@
 //! By dynamically changing the filter we can try to track down the cause of the
 //! error.
 //!
-//! As a hint: all spans and events from the load generator have the "gen" target.
+//! As a hint: all spans and events from the load generator have the "gen" target
+#![deny(rust_2018_idioms)]
 use futures::{future, Future, Poll, Stream};
 use hyper::{header, Method, Request, Response, StatusCode};
 use tokio_tcp::TcpListener;

--- a/tracing/examples/counters.rs
+++ b/tracing/examples/counters.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 #[macro_use]
 extern crate tracing;
 

--- a/tracing/examples/counters.rs
+++ b/tracing/examples/counters.rs
@@ -1,13 +1,10 @@
 #![deny(rust_2018_idioms)]
 
-#[macro_use]
-extern crate tracing;
-
 use tracing::{
     field::{Field, Visit},
-    span,
+    info, span,
     subscriber::{self, Subscriber},
-    Event, Id, Level, Metadata,
+    warn, Event, Id, Level, Metadata,
 };
 
 use std::{

--- a/tracing/examples/sloggish/main.rs
+++ b/tracing/examples/sloggish/main.rs
@@ -11,10 +11,8 @@
 //! [`slog-term`]: https://docs.rs/slog-term/2.4.0/slog_term/
 //! [`slog` README]: https://github.com/slog-rs/slog#terminal-output-example
 #![deny(rust_2018_idioms)]
-#[macro_use]
-extern crate tracing;
 
-use tracing::{field, Level};
+use tracing::{debug, field, info, span, warn, Level};
 
 mod sloggish_subscriber;
 use self::sloggish_subscriber::SloggishSubscriber;

--- a/tracing/examples/sloggish/main.rs
+++ b/tracing/examples/sloggish/main.rs
@@ -10,6 +10,7 @@
 //!
 //! [`slog-term`]: https://docs.rs/slog-term/2.4.0/slog_term/
 //! [`slog` README]: https://github.com/slog-rs/slog#terminal-output-example
+#![deny(rust_2018_idioms)]
 #[macro_use]
 extern crate tracing;
 

--- a/tracing/examples/sloggish/sloggish_subscriber.rs
+++ b/tracing/examples/sloggish/sloggish_subscriber.rs
@@ -11,13 +11,13 @@
 //! [`slog-term`]: https://docs.rs/slog-term/2.4.0/slog_term/
 //! [`slog` README]: https://github.com/slog-rs/slog#terminal-output-example
 use self::ansi_term::{Color, Style};
-use super::tracing::{
+use ansi_term;
+use humantime;
+use tracing::{
     self,
     field::{Field, Visit},
     Id, Level, Subscriber,
 };
-use ansi_term;
-use humantime;
 
 use std::{
     cell::RefCell,


### PR DESCRIPTION

## Motivation

`tracing` is built with Rust's 2018 edition, but some examples use
outdated idioms. Ideally, examples would show code using the currently
preferred idioms. This improves clarity, especially for newer Rust
programmers who may not be familiar with the idioms of earlier editions.
 
## Solution

This branch updates all the examples to use Rust 2018 edition idioms,
and adds `deny` attributes to prevent the use of outdated idioms.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>