### PR TITLE
examples: make use of tracing APIs more idiomatic

### DIFF
--- a/nightly-examples/Cargo.toml
+++ b/nightly-examples/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dev-dependencies]
 tracing = "0.1"
-tracing-fmt = "0.0.1-alpha.2"
+tracing-fmt = "0.0.1-alpha.3"
 tracing-futures = { path = "../tracing-futures", default-features = false, features = ["std-future"] }
 tokio = { git = "https://github.com/tokio-rs/tokio.git" }
 tracing-attributes = { path = "../tracing-attributes" }

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -46,7 +46,7 @@ proc-macro2 = "0.4"
 [dev-dependencies]
 tracing = "0.1"
 tracing-core = "0.1.4"
-tracing-fmt = "0.0.1-alpha.2"
+tracing-fmt = "0.0.1-alpha.3"
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-env-logger/Cargo.toml
+++ b/tracing-env-logger/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-tracing-log = { path = "../tracing-log" }
+tracing-log = "0.0.1-alpha.1"
 env_logger = "0.5"
 log = "0.4"
 

--- a/tracing-env-logger/src/lib.rs
+++ b/tracing-env-logger/src/lib.rs
@@ -2,10 +2,15 @@ use env_logger;
 use log;
 use tracing_log;
 
-pub fn try_init() -> Result<(), log::SetLoggerError> {
-    env_logger::Builder::from_default_env()
+pub fn try_init_from_builder(mut builder: env_logger::Builder) -> Result<(), log::SetLoggerError> {
+    // TODO: make this an extension trait method
+    builder
         .format(|_, record| tracing_log::format_trace(record))
         .try_init()
+}
+
+pub fn try_init() -> Result<(), log::SetLoggerError> {
+    try_init_from_builder(env_logger::Builder::from_default_env())
 }
 
 pub fn init() {

--- a/tracing-fmt/examples/yak_shave.rs
+++ b/tracing-fmt/examples/yak_shave.rs
@@ -1,9 +1,8 @@
 #![deny(rust_2018_idioms)]
 use tracing::{debug, error, info, span, trace, warn, Level};
 
+#[tracing::instrument]
 fn shave(yak: usize) -> bool {
-    let span = span!(Level::TRACE, "shave", yak = yak);
-    let _e = span.enter();
     debug!(
         message = "hello! I'm gonna shave a yak.",
         excitement = "yay!"
@@ -17,30 +16,37 @@ fn shave(yak: usize) -> bool {
     }
 }
 
+fn shave_all(yaks: usize) -> usize {
+    let span = span!(Level::TRACE, "shaving_yaks", yaks_to_shave = yaks);
+    let _enter = span.enter();
+
+    info!("shaving yaks");
+
+    let mut num_shaved = 0;
+    for yak in 1..=yaks {
+        let shaved = shave(yak);
+        trace!(target: "yak_events", yak, shaved);
+
+        if !shaved {
+            error!(message = "failed to shave yak!", yak);
+        } else {
+            num_shaved += 1;
+        }
+
+        trace!(target: "yak_events", yaks_shaved = num_shaved);
+    }
+
+    num_shaved
+}
+
 fn main() {
     let subscriber = tracing_fmt::FmtSubscriber::builder().finish();
 
     tracing::subscriber::with_default(subscriber, || {
         let number_of_yaks = 3;
-        let mut number_shaved = 0;
         debug!("preparing to shave {} yaks", number_of_yaks);
 
-        span!(Level::TRACE, "shaving_yaks", yaks_to_shave = number_of_yaks).in_scope(|| {
-            info!("shaving yaks");
-
-            for yak in 1..=number_of_yaks {
-                let shaved = shave(yak);
-                trace!(target: "yak_events", yak = yak, shaved = shaved);
-
-                if !shaved {
-                    error!(message = "failed to shave yak!", yak = yak);
-                } else {
-                    number_shaved += 1;
-                }
-
-                trace!(target: "yak_events", yaks_shaved = number_shaved);
-            }
-        });
+        let number_shaved = shave_all(number_of_yaks);
 
         debug!(
             message = "yak shaving completed.",

--- a/tracing-fmt/src/filter/env.rs
+++ b/tracing-fmt/src/filter/env.rs
@@ -803,5 +803,4 @@ mod tests {
                 .unwrap();
         let _: EnvFilter = format!("{}", f1).parse().unwrap();
     }
-
 }

--- a/tracing-fmt/src/filter/reload.rs
+++ b/tracing-fmt/src/filter/reload.rs
@@ -219,5 +219,4 @@ mod test {
             .reload(EnvFilter::from_default_env())
             .expect("should reload");
     }
-
 }

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -32,7 +32,7 @@ tokio-executor = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tokio = "0.1.22"
-tracing-fmt = "0.0.1-alpha.2"
+tracing-fmt = "0.0.1-alpha.3"
 tracing-core = "0.1.2"
 
 [badges]

--- a/tracing-futures/examples/proxy_server.rs
+++ b/tracing-futures/examples/proxy_server.rs
@@ -4,7 +4,7 @@ https://raw.githubusercontent.com/tokio-rs/tokio/master/tokio/examples/proxy.rs
 */
 #![deny(rust_2018_idioms)]
 
-use tracing::{debug, field, info, span, Level};
+use tracing::{debug, error, info, span, warn, Level};
 use tracing_futures::Instrument;
 
 use std::env;
@@ -17,6 +17,9 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let subscriber = tracing_fmt::FmtSubscriber::builder().finish();
+    tracing::subscriber::set_global_default(subscriber)?;
+
     let listen_addr = env::args()
         .nth(1)
         .unwrap_or_else(|| "127.0.0.1:8081".to_string());
@@ -29,23 +32,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create a TCP listener which will listen for incoming connections.
     let socket = TcpListener::bind(&listen_addr)?;
-    info!("Listening on: {}", listen_addr);
-    info!("Proxying to: {}", server_addr);
+    println!("Listening on: {}", listen_addr);
+    println!("Proxying to: {}", server_addr);
 
     let done = socket
         .incoming()
-        .map_err(|e| debug!(msg = "error accepting socket", error = field::display(&e)))
+        .map_err(|error| error!(msg = "error accepting socket", %error))
         .for_each(move |client| {
             let server = TcpStream::connect(&server_addr);
             let mut client_addr = None;
             match client.peer_addr() {
-                Ok(x) => {
-                    client_addr = Some(x);
-                    info!(message = "client connected", client_addr = field::debug(x))
+                Ok(addr) => {
+                    client_addr = Some(addr);
+                    info!(message = "client connected", client_addr = %addr);
                 }
-                Err(e) => debug!(
+                Err(error) => warn!(
                     message = "Could not get client information",
-                    error = field::display(&e)
+                    %error
                 ),
             }
 
@@ -68,52 +71,41 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // After the copy is done we indicate to the remote side that we've
                 // finished by shutting down the connection.
                 let client_to_server = copy(client_reader, server_writer)
-                    .and_then(|(n, _, server_writer)| {
-                        info!(size = n);
-                        shutdown(server_writer).map(move |_| n)
+                    .and_then(|(size, _, server_writer)| {
+                        info!(size);
+                        shutdown(server_writer).map(move |_| size)
                     })
-                    .instrument(span!(Level::TRACE, "client_to_server"));
+                    .instrument(span!(Level::INFO, "client_to_server"));
 
                 let server_to_client = copy(server_reader, client_writer)
-                    .and_then(|(n, _, client_writer)| {
-                        info!(size = n);
-                        shutdown(client_writer).map(move |_| n)
+                    .and_then(|(size, _, client_writer)| {
+                        info!(size);
+                        shutdown(client_writer).map(move |_| size)
                     })
-                    .instrument(span!(Level::TRACE, "server_to_client"));
+                    .instrument(span!(Level::INFO, "server_to_client"));
 
                 client_to_server.join(server_to_client)
             });
 
             let msg = amounts
-                .map(move |(from_client, from_server)| {
+                .map(move |(client_to_server, server_to_client)| {
                     info!(
-                        client_to_server = from_client,
-                        server_to_client = from_server
+                        message = "transfer completed",
+                        client_to_server, server_to_client,
                     );
                 })
-                .map_err(|e| {
+                .map_err(|error| {
                     // Don't panic. Maybe the client just disconnected too soon.
-                    debug!(error = field::display(&e));
+                    debug!(%error);
                 })
-                .instrument(span!(
-                    Level::TRACE,
-                    "transfer completed",
-                    client_address = field::debug(&client_addr),
-                    server_address = field::debug(&server_addr)
-                ));
+                .instrument(span!(Level::TRACE, "transfer", ?client_addr, ?server_addr));
 
             tokio::spawn(msg);
 
             Ok(())
         });
 
-    let subscriber = tracing_fmt::FmtSubscriber::builder().finish();
-    let _ = tracing::subscriber::set_global_default(subscriber);
-    let done = done.instrument(span!(
-        Level::TRACE,
-        "proxy",
-        listen_addr = field::debug(&listen_addr)
-    ));
+    let done = done.instrument(span!(Level::TRACE, "proxy", %listen_addr));
     tokio::run(done);
 
     Ok(())
@@ -145,7 +137,7 @@ impl AsyncRead for MyTcpStream {}
 
 impl AsyncWrite for MyTcpStream {
     fn shutdown(&mut self) -> Poll<(), io::Error> {
-        r#try!(self.0.lock().unwrap().shutdown(Shutdown::Write));
+        self.0.lock().unwrap().shutdown(Shutdown::Write)?;
         Ok(().into())
     }
 }

--- a/tracing-futures/examples/proxy_server.rs
+++ b/tracing-futures/examples/proxy_server.rs
@@ -32,8 +32,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create a TCP listener which will listen for incoming connections.
     let socket = TcpListener::bind(&listen_addr)?;
-    println!("Listening on: {}", listen_addr);
-    println!("Proxying to: {}", server_addr);
+    info!("Listening on: {}", listen_addr);
+    info!("Proxying to: {}", server_addr);
 
     let done = socket
         .incoming()

--- a/tracing-serde/examples/serde_shaved_yak.rs
+++ b/tracing-serde/examples/serde_shaved_yak.rs
@@ -78,9 +78,8 @@ impl Subscriber for JsonSubscriber {
     }
 }
 
+#[tracing::instrument]
 fn shave(yak: usize) -> bool {
-    let span = span!(Level::TRACE, "shave", yak = yak);
-    let _e = span.enter();
     debug!(
         message = "hello! I'm gonna shave a yak.",
         excitement = "yay!"
@@ -94,6 +93,29 @@ fn shave(yak: usize) -> bool {
     }
 }
 
+fn shave_all(yaks: usize) -> usize {
+    let span = span!(Level::TRACE, "shaving_yaks", yaks_to_shave = yaks);
+    let _enter = span.enter();
+
+    info!("shaving yaks");
+
+    let mut num_shaved = 0;
+    for yak in 1..=yaks {
+        let shaved = shave(yak);
+        trace!(target: "yak_events", yak, shaved);
+
+        if !shaved {
+            error!(message = "failed to shave yak!", yak);
+        } else {
+            num_shaved += 1;
+        }
+
+        trace!(target: "yak_events", yaks_shaved = num_shaved);
+    }
+
+    num_shaved
+}
+
 fn main() {
     let subscriber = JsonSubscriber {
         next_id: AtomicUsize::new(1),
@@ -101,25 +123,9 @@ fn main() {
 
     tracing::subscriber::with_default(subscriber, || {
         let number_of_yaks = 3;
-        let mut number_shaved = 0;
         debug!("preparing to shave {} yaks", number_of_yaks);
 
-        span!(Level::TRACE, "shaving_yaks", yaks_to_shave = number_of_yaks).in_scope(|| {
-            info!("shaving yaks");
-
-            for yak in 1..=number_of_yaks {
-                let shaved = shave(yak);
-                trace!(target: "yak_events", yak = yak, shaved = shaved);
-
-                if !shaved {
-                    error!(message = "failed to shave yak!", yak = yak);
-                } else {
-                    number_shaved += 1;
-                }
-
-                trace!(target: "yak_events", yaks_shaved = number_shaved);
-            }
-        });
+        let number_shaved = shave_all(number_of_yaks);
 
         debug!(
             message = "yak shaving completed.",

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -33,7 +33,7 @@ smallvec = { optional = true, version = "0.6.10"}
 lazy_static = { optional = true, version = "1" }
 
 [dev-dependencies]
-tracing-fmt = "0.0.1-alpha.2"
+tracing-fmt = "0.0.1-alpha.3"
 tracing = "0.1"
 
 [badges]

--- a/tracing-tower-http/Cargo.toml
+++ b/tracing-tower-http/Cargo.toml
@@ -34,7 +34,7 @@ tokio = "0.1"
 tokio-current-thread = "0.1.1"
 tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
 tracing-subscriber = { path = "../tracing-subscriber" }
-tracing-fmt = { path = "../tracing-fmt" }
+tracing-fmt = "0.0.1-alpha.3"
 tokio-io = "0.1"
 ansi_term = "0.11"
 humantime = "1.1.1"

--- a/tracing-tower-http/examples/tower-h2-server.rs
+++ b/tracing-tower-http/examples/tower-h2-server.rs
@@ -7,7 +7,7 @@ use tokio::net::TcpListener;
 use tokio::runtime::Runtime;
 use tower_h2::{Body, RecvBody, Server};
 use tower_service::Service;
-use tracing::{debug, error, field, info, span, warn, Level};
+use tracing::{debug, error, info, span, warn, Level};
 use tracing_futures::Instrument;
 
 type Response = http::Response<RspBody>;
@@ -136,7 +136,7 @@ fn main() {
 
             let serve = h2
                 .serve(sock)
-                .map_err(|e| error!(serve_error = ?e))
+                .map_err(|serve_error| error!(%serve_error))
                 .and_then(|_| {
                     debug!("response finished");
                     future::ok(())
@@ -146,8 +146,8 @@ fn main() {
 
             Ok((h2, reactor))
         })
-        .map_err(|e| {
-            error!(accept_error = ?error);
+        .map_err(|accept_error| {
+            error!(%accept_error);
         })
         .map(|_| {})
         .instrument(serve_span.clone());

--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -46,7 +46,7 @@ tokio-buf = "0.1"
 tower = "0.1"
 tower-hyper = "0.1"
 tower-http-util = "0.1"
-tracing-fmt = "0.0.1-alpha.2"
+tracing-fmt = "0.0.1-alpha.3"
 rand = "0.7"
 
 [badges]

--- a/tracing-tower/src/request_span.rs
+++ b/tracing-tower/src/request_span.rs
@@ -207,7 +207,6 @@ pub mod make {
             }))
         }
     }
-
 }
 
 // === impl Service ===

--- a/tracing/examples/sloggish/main.rs
+++ b/tracing/examples/sloggish/main.rs
@@ -12,7 +12,7 @@
 //! [`slog` README]: https://github.com/slog-rs/slog#terminal-output-example
 #![deny(rust_2018_idioms)]
 
-use tracing::{debug, field, info, span, warn, Level};
+use tracing::{debug, info, span, warn, Level};
 
 mod sloggish_subscriber;
 use self::sloggish_subscriber::SloggishSubscriber;
@@ -22,7 +22,7 @@ fn main() {
     tracing::subscriber::set_global_default(subscriber).unwrap();
 
     let app_span = span!(Level::TRACE, "", version = %5.0);
-    let _e = span.enter();
+    let _e = app_span.enter();
 
     let server_span = span!(Level::TRACE, "server", host = "localhost", port = 8080);
     let _e2 = server_span.enter();

--- a/tracing/examples/sloggish/main.rs
+++ b/tracing/examples/sloggish/main.rs
@@ -21,31 +21,32 @@ fn main() {
     let subscriber = SloggishSubscriber::new(2);
     tracing::subscriber::set_global_default(subscriber).unwrap();
 
-    span!(Level::TRACE, "", version = &field::display(5.0)).in_scope(|| {
-        span!(Level::TRACE, "server", host = "localhost", port = 8080).in_scope(|| {
-            info!("starting");
-            info!("listening");
-            let peer1 = span!(Level::TRACE, "conn", peer_addr = "82.9.9.9", port = 42381);
-            peer1.in_scope(|| {
-                debug!("connected");
-                debug!({ length = 2 }, "message received");
-            });
-            let peer2 = span!(Level::TRACE, "conn", peer_addr = "8.8.8.8", port = 18230);
-            peer2.in_scope(|| {
-                debug!("connected");
-            });
-            peer1.in_scope(|| {
-                warn!({ algo = "xor" }, "weak encryption requested");
-                debug!({ length = 8 }, "response sent");
-                debug!("disconnected");
-            });
-            peer2.in_scope(|| {
-                debug!({ length = 5 }, "message received");
-                debug!({ length = 8 }, "response sent");
-                debug!("disconnected");
-            });
-            warn!("internal error");
-            info!("exit");
-        })
+    let app_span = span!(Level::TRACE, "", version = %5.0);
+    let _e = span.enter();
+
+    let server_span = span!(Level::TRACE, "server", host = "localhost", port = 8080);
+    let _e2 = server_span.enter();
+    info!("starting");
+    info!("listening");
+    let peer1 = span!(Level::TRACE, "conn", peer_addr = "82.9.9.9", port = 42381);
+    peer1.in_scope(|| {
+        debug!("connected");
+        debug!({ length = 2 }, "message received");
     });
+    let peer2 = span!(Level::TRACE, "conn", peer_addr = "8.8.8.8", port = 18230);
+    peer2.in_scope(|| {
+        debug!("connected");
+    });
+    peer1.in_scope(|| {
+        warn!({ algo = "xor" }, "weak encryption requested");
+        debug!({ length = 8 }, "response sent");
+        debug!("disconnected");
+    });
+    peer2.in_scope(|| {
+        debug!({ length = 5 }, "message received");
+        debug!({ length = 8 }, "response sent");
+        debug!("disconnected");
+    });
+    warn!("internal error");
+    info!("exit");
 }


### PR DESCRIPTION

## Motivation

Some Tracing examples, especially in unstable crates, were written
against earlier versions of `tracing`. They don't always demonstrate
the most idiomatic use of Tracing APIs.

## Solution

This updates the examples to use newer Tracing APIs and syntax. Now, the
examples will demonstrate the preferred idioms.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>