### PR TITLE
meta: add pages publish action on master commits

### DIFF
--- a/.github/workflows/publish_pages.yml
+++ b/.github/workflows/publish_pages.yml
@@ -1,0 +1,24 @@
+name: Publish Pages
+on:
+  push:
+    branches:
+    - master
+    # # only rebuild RustDoc when source code has changed
+    # paths:
+    #   - /**/src/**
+
+jobs:
+  publish_doc:
+    runs-on: ubuntu-latest
+    steps:
+    # check out the repo
+    - uses: actions/checkout@v1
+    # This step references the directory that contains the action.
+    - name: build docs
+      run: cargo doc --all
+    - name: publish
+      uses: maxheld83/ghpages@v0.2.1
+      env:
+        BUILD_DIR=target/doc
+
+

--- a/.github/workflows/publish_pages.yml
+++ b/.github/workflows/publish_pages.yml
@@ -3,9 +3,10 @@ on:
   push:
     branches:
     - master
-    # # only rebuild RustDoc when source code has changed
-    # paths:
-    #   - /**/src/**
+    # only rebuild RustDoc when source code has changed, or the workflow is modified
+    paths:
+    - /**/src/**
+    - .github/workflows
 
 jobs:
   publish_doc:


### PR DESCRIPTION
## Motivation

Currently, we link to RustDoc on docs.rs. This is built when a crate is
published to crates.io. In some cases, it is also valuable to publish
the documentation for the latest `master` branch, so that users using
git dependencies can see up to date docs.

## Solution

This branch adds a GitHub action that will build docs & publish them to
the `gh-pages` branch when source files change.

Closes: #210

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
