### PR TITLE
tracing(test): rename subscriber mock to test

### DIFF
--- a/tracing-attributes/test_async_await/tests/async_fn.rs
+++ b/tracing-attributes/test_async_await/tests/async_fn.rs
@@ -18,7 +18,7 @@ async fn test_async_fn(polls: usize) -> Result<(), ()> {
 
 #[test]
 fn async_fn_only_enters_for_polls() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(span::mock().named("test_async_fn"))
         .enter(span::mock().named("test_async_fn"))
         .event(event::mock().with_fields(field::mock("awaiting").with_value(&true)))

--- a/tracing-attributes/test_async_await/tests/async_fn.rs
+++ b/tracing-attributes/test_async_await/tests/async_fn.rs
@@ -18,7 +18,7 @@ async fn test_async_fn(polls: usize) -> Result<(), ()> {
 
 #[test]
 fn async_fn_only_enters_for_polls() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(span::mock().named("test_async_fn"))
         .enter(span::mock().named("test_async_fn"))
         .event(event::mock().with_fields(field::mock("awaiting").with_value(&true)))

--- a/tracing-attributes/test_async_await/tests/async_fn.rs
+++ b/tracing-attributes/test_async_await/tests/async_fn.rs
@@ -18,7 +18,7 @@ async fn test_async_fn(polls: usize) -> Result<(), ()> {
 
 #[test]
 fn async_fn_only_enters_for_polls() {
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .new_span(span::mock().named("test_async_fn"))
         .enter(span::mock().named("test_async_fn"))
         .event(event::mock().with_fields(field::mock("awaiting").with_value(&true)))

--- a/tracing-attributes/tests/instrument.rs
+++ b/tracing-attributes/tests/instrument.rs
@@ -21,7 +21,7 @@ fn override_everything() {
         .named("my_other_fn")
         .at_level(Level::DEBUG)
         .with_target("my_target");
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .new_span(span.clone())
         .enter(span.clone())
         .exit(span.clone())
@@ -55,7 +55,7 @@ fn fields() {
         .named("my_fn")
         .at_level(Level::DEBUG)
         .with_target("my_target");
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .new_span(
             span.clone().with_field(
                 field::mock("arg1")
@@ -101,7 +101,7 @@ fn generics() {
 
     let span = span::mock().named("my_fn");
 
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .new_span(
             span.clone().with_field(
                 field::mock("arg1")

--- a/tracing-attributes/tests/instrument.rs
+++ b/tracing-attributes/tests/instrument.rs
@@ -1,4 +1,5 @@
 mod support;
+use support::subscriber::SubscriberTest;
 use support::*;
 
 use tracing::subscriber::with_default;
@@ -21,7 +22,7 @@ fn override_everything() {
         .named("my_other_fn")
         .at_level(Level::DEBUG)
         .with_target("my_target");
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(span.clone())
         .enter(span.clone())
         .exit(span.clone())
@@ -55,7 +56,7 @@ fn fields() {
         .named("my_fn")
         .at_level(Level::DEBUG)
         .with_target("my_target");
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(
             span.clone().with_field(
                 field::mock("arg1")
@@ -101,7 +102,7 @@ fn generics() {
 
     let span = span::mock().named("my_fn");
 
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(
             span.clone().with_field(
                 field::mock("arg1")

--- a/tracing-attributes/tests/instrument.rs
+++ b/tracing-attributes/tests/instrument.rs
@@ -21,7 +21,7 @@ fn override_everything() {
         .named("my_other_fn")
         .at_level(Level::DEBUG)
         .with_target("my_target");
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(span.clone())
         .enter(span.clone())
         .exit(span.clone())
@@ -55,7 +55,7 @@ fn fields() {
         .named("my_fn")
         .at_level(Level::DEBUG)
         .with_target("my_target");
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(
             span.clone().with_field(
                 field::mock("arg1")
@@ -101,7 +101,7 @@ fn generics() {
 
     let span = span::mock().named("my_fn");
 
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(
             span.clone().with_field(
                 field::mock("arg1")

--- a/tracing-attributes/tests/levels.rs
+++ b/tracing-attributes/tests/levels.rs
@@ -21,7 +21,7 @@ fn named_levels() {
 
     #[instrument(level = "eRrOr")]
     fn error() {}
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .new_span(span::mock().named("trace").at_level(Level::TRACE))
         .enter(span::mock().named("trace").at_level(Level::TRACE))
         .exit(span::mock().named("trace").at_level(Level::TRACE))
@@ -67,7 +67,7 @@ fn numeric_levels() {
 
     #[instrument(level = 5)]
     fn error() {}
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .new_span(span::mock().named("trace").at_level(Level::TRACE))
         .enter(span::mock().named("trace").at_level(Level::TRACE))
         .exit(span::mock().named("trace").at_level(Level::TRACE))

--- a/tracing-attributes/tests/levels.rs
+++ b/tracing-attributes/tests/levels.rs
@@ -21,7 +21,7 @@ fn named_levels() {
 
     #[instrument(level = "eRrOr")]
     fn error() {}
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(span::mock().named("trace").at_level(Level::TRACE))
         .enter(span::mock().named("trace").at_level(Level::TRACE))
         .exit(span::mock().named("trace").at_level(Level::TRACE))
@@ -67,7 +67,7 @@ fn numeric_levels() {
 
     #[instrument(level = 5)]
     fn error() {}
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(span::mock().named("trace").at_level(Level::TRACE))
         .enter(span::mock().named("trace").at_level(Level::TRACE))
         .exit(span::mock().named("trace").at_level(Level::TRACE))

--- a/tracing-attributes/tests/levels.rs
+++ b/tracing-attributes/tests/levels.rs
@@ -1,4 +1,5 @@
 mod support;
+use support::subscriber::SubscriberTest;
 use support::*;
 
 use tracing::subscriber::with_default;
@@ -21,7 +22,7 @@ fn named_levels() {
 
     #[instrument(level = "eRrOr")]
     fn error() {}
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(span::mock().named("trace").at_level(Level::TRACE))
         .enter(span::mock().named("trace").at_level(Level::TRACE))
         .exit(span::mock().named("trace").at_level(Level::TRACE))
@@ -67,7 +68,7 @@ fn numeric_levels() {
 
     #[instrument(level = 5)]
     fn error() {}
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(span::mock().named("trace").at_level(Level::TRACE))
         .enter(span::mock().named("trace").at_level(Level::TRACE))
         .exit(span::mock().named("trace").at_level(Level::TRACE))

--- a/tracing-attributes/tests/targets.rs
+++ b/tracing-attributes/tests/targets.rs
@@ -24,7 +24,7 @@ mod my_mod {
 
 #[test]
 fn default_targets() {
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .new_span(
             span::mock()
                 .named("default_target")
@@ -68,7 +68,7 @@ fn default_targets() {
 
 #[test]
 fn custom_targets() {
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .new_span(span::mock().named("custom_target").with_target("my_target"))
         .enter(span::mock().named("custom_target").with_target("my_target"))
         .exit(span::mock().named("custom_target").with_target("my_target"))

--- a/tracing-attributes/tests/targets.rs
+++ b/tracing-attributes/tests/targets.rs
@@ -1,4 +1,5 @@
 mod support;
+use support::subscriber::SubscriberTest;
 use support::*;
 
 use tracing::subscriber::with_default;
@@ -24,7 +25,7 @@ mod my_mod {
 
 #[test]
 fn default_targets() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(
             span::mock()
                 .named("default_target")
@@ -68,7 +69,7 @@ fn default_targets() {
 
 #[test]
 fn custom_targets() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(span::mock().named("custom_target").with_target("my_target"))
         .enter(span::mock().named("custom_target").with_target("my_target"))
         .exit(span::mock().named("custom_target").with_target("my_target"))

--- a/tracing-attributes/tests/targets.rs
+++ b/tracing-attributes/tests/targets.rs
@@ -24,7 +24,7 @@ mod my_mod {
 
 #[test]
 fn default_targets() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(
             span::mock()
                 .named("default_target")
@@ -68,7 +68,7 @@ fn default_targets() {
 
 #[test]
 fn custom_targets() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(span::mock().named("custom_target").with_target("my_target"))
         .enter(span::mock().named("custom_target").with_target("my_target"))
         .exit(span::mock().named("custom_target").with_target("my_target"))

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -226,7 +226,7 @@ pub mod support;
 
 #[cfg(test)]
 mod tests {
-    use super::{test_support::*, *};
+    use super::{test_support::subscriber::SubscriberTest, test_support::*, *};
 
     struct PollN<T, E> {
         and_return: Option<Result<T, E>>,
@@ -280,7 +280,7 @@ mod tests {
 
         #[test]
         fn future_enter_exit_is_reasonable() {
-            let (subscriber, handle) = subscriber::SubscriberTest::new()
+            let (subscriber, handle) = SubscriberTest::new()
                 .enter(span::mock().named("foo"))
                 .exit(span::mock().named("foo"))
                 .enter(span::mock().named("foo"))
@@ -300,7 +300,7 @@ mod tests {
         #[cfg(feature = "futures-01")]
         #[test]
         fn future_error_ends_span() {
-            let (subscriber, handle) = subscriber::SubscriberTest::new()
+            let (subscriber, handle) = SubscriberTest::new()
                 .enter(span::mock().named("foo"))
                 .exit(span::mock().named("foo"))
                 .enter(span::mock().named("foo"))
@@ -320,7 +320,7 @@ mod tests {
 
         #[test]
         fn stream_enter_exit_is_reasonable() {
-            let (subscriber, handle) = subscriber::SubscriberTest::new()
+            let (subscriber, handle) = SubscriberTest::new()
                 .enter(span::mock().named("foo"))
                 .exit(span::mock().named("foo"))
                 .enter(span::mock().named("foo"))
@@ -343,7 +343,7 @@ mod tests {
 
         #[test]
         fn span_follows_future_onto_threadpool() {
-            let (subscriber, handle) = subscriber::SubscriberTest::new()
+            let (subscriber, handle) = SubscriberTest::new()
                 .enter(span::mock().named("a"))
                 .enter(span::mock().named("b"))
                 .exit(span::mock().named("b"))

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -280,7 +280,7 @@ mod tests {
 
         #[test]
         fn future_enter_exit_is_reasonable() {
-            let (subscriber, handle) = subscriber::mock()
+            let (subscriber, handle) = subscriber::test()
                 .enter(span::mock().named("foo"))
                 .exit(span::mock().named("foo"))
                 .enter(span::mock().named("foo"))
@@ -300,7 +300,7 @@ mod tests {
         #[cfg(feature = "futures-01")]
         #[test]
         fn future_error_ends_span() {
-            let (subscriber, handle) = subscriber::mock()
+            let (subscriber, handle) = subscriber::test()
                 .enter(span::mock().named("foo"))
                 .exit(span::mock().named("foo"))
                 .enter(span::mock().named("foo"))
@@ -320,7 +320,7 @@ mod tests {
 
         #[test]
         fn stream_enter_exit_is_reasonable() {
-            let (subscriber, handle) = subscriber::mock()
+            let (subscriber, handle) = subscriber::test()
                 .enter(span::mock().named("foo"))
                 .exit(span::mock().named("foo"))
                 .enter(span::mock().named("foo"))
@@ -343,7 +343,7 @@ mod tests {
 
         #[test]
         fn span_follows_future_onto_threadpool() {
-            let (subscriber, handle) = subscriber::mock()
+            let (subscriber, handle) = subscriber::test()
                 .enter(span::mock().named("a"))
                 .enter(span::mock().named("b"))
                 .exit(span::mock().named("b"))

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -280,7 +280,7 @@ mod tests {
 
         #[test]
         fn future_enter_exit_is_reasonable() {
-            let (subscriber, handle) = subscriber::test()
+            let (subscriber, handle) = subscriber::SubscriberTest::new()
                 .enter(span::mock().named("foo"))
                 .exit(span::mock().named("foo"))
                 .enter(span::mock().named("foo"))
@@ -300,7 +300,7 @@ mod tests {
         #[cfg(feature = "futures-01")]
         #[test]
         fn future_error_ends_span() {
-            let (subscriber, handle) = subscriber::test()
+            let (subscriber, handle) = subscriber::SubscriberTest::new()
                 .enter(span::mock().named("foo"))
                 .exit(span::mock().named("foo"))
                 .enter(span::mock().named("foo"))
@@ -320,7 +320,7 @@ mod tests {
 
         #[test]
         fn stream_enter_exit_is_reasonable() {
-            let (subscriber, handle) = subscriber::test()
+            let (subscriber, handle) = subscriber::SubscriberTest::new()
                 .enter(span::mock().named("foo"))
                 .exit(span::mock().named("foo"))
                 .enter(span::mock().named("foo"))
@@ -343,7 +343,7 @@ mod tests {
 
         #[test]
         fn span_follows_future_onto_threadpool() {
-            let (subscriber, handle) = subscriber::test()
+            let (subscriber, handle) = subscriber::SubscriberTest::new()
                 .enter(span::mock().named("a"))
                 .enter(span::mock().named("b"))
                 .exit(span::mock().named("b"))

--- a/tracing-futures/test_std_future/tests/test.rs
+++ b/tracing-futures/test_std_future/tests/test.rs
@@ -10,7 +10,7 @@ use tracing_futures::Instrument;
 
 #[test]
 fn enter_exit_is_reasonable() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
         .enter(span::mock().named("foo"))
@@ -28,7 +28,7 @@ fn enter_exit_is_reasonable() {
 
 #[test]
 fn error_ends_span() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
         .enter(span::mock().named("foo"))

--- a/tracing-futures/test_std_future/tests/test.rs
+++ b/tracing-futures/test_std_future/tests/test.rs
@@ -10,7 +10,7 @@ use tracing_futures::Instrument;
 
 #[test]
 fn enter_exit_is_reasonable() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
         .enter(span::mock().named("foo"))
@@ -28,7 +28,7 @@ fn enter_exit_is_reasonable() {
 
 #[test]
 fn error_ends_span() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
         .enter(span::mock().named("foo"))

--- a/tracing-futures/test_std_future/tests/test.rs
+++ b/tracing-futures/test_std_future/tests/test.rs
@@ -10,7 +10,7 @@ use tracing_futures::Instrument;
 
 #[test]
 fn enter_exit_is_reasonable() {
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
         .enter(span::mock().named("foo"))
@@ -28,7 +28,7 @@ fn enter_exit_is_reasonable() {
 
 #[test]
 fn error_ends_span() {
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
         .enter(span::mock().named("foo"))

--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -24,7 +24,7 @@ tracing-core = "0.1.2"
 
 [dev-dependencies]
 serde_json = "1.0"
-tracing = "0.1.3"
+tracing = "0.1"
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -24,7 +24,7 @@ tracing-core = "0.1.2"
 
 [dev-dependencies]
 serde_json = "1.0"
-tracing = "0.1"
+tracing = "0.1.3"
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-subscriber/tests/field_filter.rs
+++ b/tracing-subscriber/tests/field_filter.rs
@@ -6,7 +6,7 @@ use tracing_subscriber::{filter::Filter, prelude::*};
 #[test]
 fn field_filter_events() {
     let filter: Filter = "[{thing}]=debug".parse().expect("filter should parse");
-    let (subscriber, finished) = subscriber::mock()
+    let (subscriber, finished) = subscriber::test()
         .event(
             event::mock()
                 .at_level(Level::INFO)
@@ -37,7 +37,7 @@ fn field_filter_spans() {
     let filter: Filter = "[{enabled=true}]=debug"
         .parse()
         .expect("filter should parse");
-    let (subscriber, finished) = subscriber::mock()
+    let (subscriber, finished) = subscriber::test()
         .enter(span::mock().named("span1"))
         .event(
             event::mock()
@@ -80,7 +80,7 @@ fn record_after_created() {
     let filter: Filter = "[{enabled=true}]=debug"
         .parse()
         .expect("filter should parse");
-    let (subscriber, finished) = subscriber::mock()
+    let (subscriber, finished) = subscriber::test()
         .enter(span::mock().named("span"))
         .exit(span::mock().named("span"))
         .record(

--- a/tracing-subscriber/tests/field_filter.rs
+++ b/tracing-subscriber/tests/field_filter.rs
@@ -6,7 +6,7 @@ use tracing_subscriber::{filter::Filter, prelude::*};
 #[test]
 fn field_filter_events() {
     let filter: Filter = "[{thing}]=debug".parse().expect("filter should parse");
-    let (subscriber, finished) = subscriber::test()
+    let (subscriber, finished) = subscriber::SubscriberTest::new()
         .event(
             event::mock()
                 .at_level(Level::INFO)
@@ -37,7 +37,7 @@ fn field_filter_spans() {
     let filter: Filter = "[{enabled=true}]=debug"
         .parse()
         .expect("filter should parse");
-    let (subscriber, finished) = subscriber::test()
+    let (subscriber, finished) = subscriber::SubscriberTest::new()
         .enter(span::mock().named("span1"))
         .event(
             event::mock()
@@ -80,7 +80,7 @@ fn record_after_created() {
     let filter: Filter = "[{enabled=true}]=debug"
         .parse()
         .expect("filter should parse");
-    let (subscriber, finished) = subscriber::test()
+    let (subscriber, finished) = subscriber::SubscriberTest::new()
         .enter(span::mock().named("span"))
         .exit(span::mock().named("span"))
         .record(

--- a/tracing-subscriber/tests/field_filter.rs
+++ b/tracing-subscriber/tests/field_filter.rs
@@ -1,4 +1,5 @@
 mod support;
+use self::support::subscriber::SubscriberTest;
 use self::support::*;
 use tracing::{self, subscriber::with_default, Level};
 use tracing_subscriber::{filter::Filter, prelude::*};
@@ -6,7 +7,7 @@ use tracing_subscriber::{filter::Filter, prelude::*};
 #[test]
 fn field_filter_events() {
     let filter: Filter = "[{thing}]=debug".parse().expect("filter should parse");
-    let (subscriber, finished) = subscriber::SubscriberTest::new()
+    let (subscriber, finished) = SubscriberTest::new()
         .event(
             event::mock()
                 .at_level(Level::INFO)
@@ -37,7 +38,7 @@ fn field_filter_spans() {
     let filter: Filter = "[{enabled=true}]=debug"
         .parse()
         .expect("filter should parse");
-    let (subscriber, finished) = subscriber::SubscriberTest::new()
+    let (subscriber, finished) = SubscriberTest::new()
         .enter(span::mock().named("span1"))
         .event(
             event::mock()
@@ -80,7 +81,7 @@ fn record_after_created() {
     let filter: Filter = "[{enabled=true}]=debug"
         .parse()
         .expect("filter should parse");
-    let (subscriber, finished) = subscriber::SubscriberTest::new()
+    let (subscriber, finished) = SubscriberTest::new()
         .enter(span::mock().named("span"))
         .exit(span::mock().named("span"))
         .record(

--- a/tracing-subscriber/tests/filter.rs
+++ b/tracing-subscriber/tests/filter.rs
@@ -6,7 +6,7 @@ use tracing_subscriber::{filter::Filter, prelude::*};
 #[test]
 fn level_filter_event() {
     let filter: Filter = "info".parse().expect("filter should parse");
-    let (subscriber, finished) = subscriber::mock()
+    let (subscriber, finished) = subscriber::test()
         .event(event::mock().at_level(Level::INFO))
         .event(event::mock().at_level(Level::WARN))
         .event(event::mock().at_level(Level::ERROR))
@@ -28,7 +28,7 @@ fn level_filter_event() {
 #[test]
 fn level_filter_event_with_target() {
     let filter: Filter = "info,stuff=debug".parse().expect("filter should parse");
-    let (subscriber, finished) = subscriber::mock()
+    let (subscriber, finished) = subscriber::test()
         .event(event::mock().at_level(Level::INFO))
         .event(event::mock().at_level(Level::DEBUG).with_target("stuff"))
         .event(event::mock().at_level(Level::WARN).with_target("stuff"))
@@ -57,7 +57,7 @@ fn span_name_filter_is_dynamic() {
     let filter: Filter = "info,[cool_span]=debug"
         .parse()
         .expect("filter should parse");
-    let (subscriber, finished) = subscriber::mock()
+    let (subscriber, finished) = subscriber::test()
         .event(event::mock().at_level(Level::INFO))
         .enter(span::mock().named("cool_span"))
         .event(event::mock().at_level(Level::DEBUG))
@@ -101,7 +101,7 @@ fn span_name_filter_is_dynamic() {
 #[test]
 fn field_filter_events() {
     let filter: Filter = "[{thing}]=debug".parse().expect("filter should parse");
-    let (subscriber, finished) = subscriber::mock()
+    let (subscriber, finished) = subscriber::test()
         .event(
             event::mock()
                 .at_level(Level::INFO)

--- a/tracing-subscriber/tests/filter.rs
+++ b/tracing-subscriber/tests/filter.rs
@@ -1,4 +1,5 @@
 mod support;
+use self::support::subscriber::SubscriberTest;
 use self::support::*;
 use tracing::{self, subscriber::with_default, Level};
 use tracing_subscriber::{filter::Filter, prelude::*};
@@ -6,7 +7,7 @@ use tracing_subscriber::{filter::Filter, prelude::*};
 #[test]
 fn level_filter_event() {
     let filter: Filter = "info".parse().expect("filter should parse");
-    let (subscriber, finished) = subscriber::SubscriberTest::new()
+    let (subscriber, finished) = SubscriberTest::new()
         .event(event::mock().at_level(Level::INFO))
         .event(event::mock().at_level(Level::WARN))
         .event(event::mock().at_level(Level::ERROR))
@@ -28,7 +29,7 @@ fn level_filter_event() {
 #[test]
 fn level_filter_event_with_target() {
     let filter: Filter = "info,stuff=debug".parse().expect("filter should parse");
-    let (subscriber, finished) = subscriber::SubscriberTest::new()
+    let (subscriber, finished) = SubscriberTest::new()
         .event(event::mock().at_level(Level::INFO))
         .event(event::mock().at_level(Level::DEBUG).with_target("stuff"))
         .event(event::mock().at_level(Level::WARN).with_target("stuff"))
@@ -57,7 +58,7 @@ fn span_name_filter_is_dynamic() {
     let filter: Filter = "info,[cool_span]=debug"
         .parse()
         .expect("filter should parse");
-    let (subscriber, finished) = subscriber::SubscriberTest::new()
+    let (subscriber, finished) = SubscriberTest::new()
         .event(event::mock().at_level(Level::INFO))
         .enter(span::mock().named("cool_span"))
         .event(event::mock().at_level(Level::DEBUG))
@@ -101,7 +102,7 @@ fn span_name_filter_is_dynamic() {
 #[test]
 fn field_filter_events() {
     let filter: Filter = "[{thing}]=debug".parse().expect("filter should parse");
-    let (subscriber, finished) = subscriber::SubscriberTest::new()
+    let (subscriber, finished) = SubscriberTest::new()
         .event(
             event::mock()
                 .at_level(Level::INFO)

--- a/tracing-subscriber/tests/filter.rs
+++ b/tracing-subscriber/tests/filter.rs
@@ -6,7 +6,7 @@ use tracing_subscriber::{filter::Filter, prelude::*};
 #[test]
 fn level_filter_event() {
     let filter: Filter = "info".parse().expect("filter should parse");
-    let (subscriber, finished) = subscriber::test()
+    let (subscriber, finished) = subscriber::SubscriberTest::new()
         .event(event::mock().at_level(Level::INFO))
         .event(event::mock().at_level(Level::WARN))
         .event(event::mock().at_level(Level::ERROR))
@@ -28,7 +28,7 @@ fn level_filter_event() {
 #[test]
 fn level_filter_event_with_target() {
     let filter: Filter = "info,stuff=debug".parse().expect("filter should parse");
-    let (subscriber, finished) = subscriber::test()
+    let (subscriber, finished) = subscriber::SubscriberTest::new()
         .event(event::mock().at_level(Level::INFO))
         .event(event::mock().at_level(Level::DEBUG).with_target("stuff"))
         .event(event::mock().at_level(Level::WARN).with_target("stuff"))
@@ -57,7 +57,7 @@ fn span_name_filter_is_dynamic() {
     let filter: Filter = "info,[cool_span]=debug"
         .parse()
         .expect("filter should parse");
-    let (subscriber, finished) = subscriber::test()
+    let (subscriber, finished) = subscriber::SubscriberTest::new()
         .event(event::mock().at_level(Level::INFO))
         .enter(span::mock().named("cool_span"))
         .event(event::mock().at_level(Level::DEBUG))
@@ -101,7 +101,7 @@ fn span_name_filter_is_dynamic() {
 #[test]
 fn field_filter_events() {
     let filter: Filter = "[{thing}]=debug".parse().expect("filter should parse");
-    let (subscriber, finished) = subscriber::test()
+    let (subscriber, finished) = subscriber::SubscriberTest::new()
         .event(
             event::mock()
                 .at_level(Level::INFO)

--- a/tracing/tests/event.rs
+++ b/tracing/tests/event.rs
@@ -20,7 +20,7 @@ use tracing::{
 
 #[test]
 fn event_without_message() {
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .event(
             event::mock().with_fields(
                 field::mock("answer")
@@ -47,7 +47,7 @@ fn event_without_message() {
 
 #[test]
 fn event_with_message() {
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .event(event::mock().with_fields(field::mock("message").with_value(
             &tracing::field::debug(format_args!("hello from my event! yak shaved = {:?}", true)),
         )))
@@ -118,7 +118,7 @@ fn string_message_without_delims() {
 
 #[test]
 fn one_with_everything() {
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .event(
             event::mock()
                 .with_fields(
@@ -152,7 +152,7 @@ fn one_with_everything() {
 
 #[test]
 fn moved_field() {
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .event(
             event::mock().with_fields(
                 field::mock("foo")
@@ -172,7 +172,7 @@ fn moved_field() {
 
 #[test]
 fn dotted_field_name() {
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .event(
             event::mock().with_fields(
                 field::mock("foo.bar")
@@ -192,7 +192,7 @@ fn dotted_field_name() {
 
 #[test]
 fn borrowed_field() {
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .event(
             event::mock().with_fields(
                 field::mock("foo")
@@ -228,7 +228,7 @@ fn move_field_out_of_struct() {
         x: 3.234,
         y: -1.223,
     };
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .event(
             event::mock().with_fields(
                 field::mock("x")
@@ -254,7 +254,7 @@ fn move_field_out_of_struct() {
 
 #[test]
 fn display_shorthand() {
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .event(
             event::mock().with_fields(
                 field::mock("my_field")
@@ -273,7 +273,7 @@ fn display_shorthand() {
 
 #[test]
 fn debug_shorthand() {
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .event(
             event::mock().with_fields(
                 field::mock("my_field")
@@ -292,7 +292,7 @@ fn debug_shorthand() {
 
 #[test]
 fn both_shorthands() {
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .event(
             event::mock().with_fields(
                 field::mock("display_field")
@@ -312,7 +312,7 @@ fn both_shorthands() {
 
 #[test]
 fn explicit_child() {
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .new_span(span::mock().named("foo"))
         .event(event::mock().with_explicit_parent(Some("foo")))
         .done()
@@ -328,7 +328,7 @@ fn explicit_child() {
 
 #[test]
 fn explicit_child_at_levels() {
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .new_span(span::mock().named("foo"))
         .event(event::mock().with_explicit_parent(Some("foo")))
         .event(event::mock().with_explicit_parent(Some("foo")))

--- a/tracing/tests/event.rs
+++ b/tracing/tests/event.rs
@@ -10,6 +10,7 @@
 extern crate tracing;
 mod support;
 
+use self::support::subscriber::SubscriberTest;
 use self::support::*;
 
 use tracing::{
@@ -20,7 +21,7 @@ use tracing::{
 
 #[test]
 fn event_without_message() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .event(
             event::mock().with_fields(
                 field::mock("answer")
@@ -47,7 +48,7 @@ fn event_without_message() {
 
 #[test]
 fn event_with_message() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .event(event::mock().with_fields(field::mock("message").with_value(
             &tracing::field::debug(format_args!("hello from my event! yak shaved = {:?}", true)),
         )))
@@ -118,7 +119,7 @@ fn string_message_without_delims() {
 
 #[test]
 fn one_with_everything() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .event(
             event::mock()
                 .with_fields(
@@ -152,7 +153,7 @@ fn one_with_everything() {
 
 #[test]
 fn moved_field() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .event(
             event::mock().with_fields(
                 field::mock("foo")
@@ -172,7 +173,7 @@ fn moved_field() {
 
 #[test]
 fn dotted_field_name() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .event(
             event::mock().with_fields(
                 field::mock("foo.bar")
@@ -192,7 +193,7 @@ fn dotted_field_name() {
 
 #[test]
 fn borrowed_field() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .event(
             event::mock().with_fields(
                 field::mock("foo")
@@ -228,7 +229,7 @@ fn move_field_out_of_struct() {
         x: 3.234,
         y: -1.223,
     };
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .event(
             event::mock().with_fields(
                 field::mock("x")
@@ -254,7 +255,7 @@ fn move_field_out_of_struct() {
 
 #[test]
 fn display_shorthand() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .event(
             event::mock().with_fields(
                 field::mock("my_field")
@@ -273,7 +274,7 @@ fn display_shorthand() {
 
 #[test]
 fn debug_shorthand() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .event(
             event::mock().with_fields(
                 field::mock("my_field")
@@ -292,7 +293,7 @@ fn debug_shorthand() {
 
 #[test]
 fn both_shorthands() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .event(
             event::mock().with_fields(
                 field::mock("display_field")
@@ -312,7 +313,7 @@ fn both_shorthands() {
 
 #[test]
 fn explicit_child() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(span::mock().named("foo"))
         .event(event::mock().with_explicit_parent(Some("foo")))
         .done()
@@ -328,7 +329,7 @@ fn explicit_child() {
 
 #[test]
 fn explicit_child_at_levels() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(span::mock().named("foo"))
         .event(event::mock().with_explicit_parent(Some("foo")))
         .event(event::mock().with_explicit_parent(Some("foo")))

--- a/tracing/tests/event.rs
+++ b/tracing/tests/event.rs
@@ -20,7 +20,7 @@ use tracing::{
 
 #[test]
 fn event_without_message() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .event(
             event::mock().with_fields(
                 field::mock("answer")
@@ -47,7 +47,7 @@ fn event_without_message() {
 
 #[test]
 fn event_with_message() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .event(event::mock().with_fields(field::mock("message").with_value(
             &tracing::field::debug(format_args!("hello from my event! yak shaved = {:?}", true)),
         )))
@@ -118,7 +118,7 @@ fn string_message_without_delims() {
 
 #[test]
 fn one_with_everything() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .event(
             event::mock()
                 .with_fields(
@@ -152,7 +152,7 @@ fn one_with_everything() {
 
 #[test]
 fn moved_field() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .event(
             event::mock().with_fields(
                 field::mock("foo")
@@ -172,7 +172,7 @@ fn moved_field() {
 
 #[test]
 fn dotted_field_name() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .event(
             event::mock().with_fields(
                 field::mock("foo.bar")
@@ -192,7 +192,7 @@ fn dotted_field_name() {
 
 #[test]
 fn borrowed_field() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .event(
             event::mock().with_fields(
                 field::mock("foo")
@@ -228,7 +228,7 @@ fn move_field_out_of_struct() {
         x: 3.234,
         y: -1.223,
     };
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .event(
             event::mock().with_fields(
                 field::mock("x")
@@ -254,7 +254,7 @@ fn move_field_out_of_struct() {
 
 #[test]
 fn display_shorthand() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .event(
             event::mock().with_fields(
                 field::mock("my_field")
@@ -273,7 +273,7 @@ fn display_shorthand() {
 
 #[test]
 fn debug_shorthand() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .event(
             event::mock().with_fields(
                 field::mock("my_field")
@@ -292,7 +292,7 @@ fn debug_shorthand() {
 
 #[test]
 fn both_shorthands() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .event(
             event::mock().with_fields(
                 field::mock("display_field")
@@ -312,7 +312,7 @@ fn both_shorthands() {
 
 #[test]
 fn explicit_child() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(span::mock().named("foo"))
         .event(event::mock().with_explicit_parent(Some("foo")))
         .done()
@@ -328,7 +328,7 @@ fn explicit_child() {
 
 #[test]
 fn explicit_child_at_levels() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(span::mock().named("foo"))
         .event(event::mock().with_explicit_parent(Some("foo")))
         .event(event::mock().with_explicit_parent(Some("foo")))

--- a/tracing/tests/filter_caching_is_lexically_scoped.rs
+++ b/tracing/tests/filter_caching_is_lexically_scoped.rs
@@ -32,7 +32,7 @@ fn filter_caching_is_lexically_scoped() {
     let count = Arc::new(AtomicUsize::new(0));
     let count2 = count.clone();
 
-    let subscriber = subscriber::test()
+    let subscriber = subscriber::SubscriberTest::new()
         .with_filter(move |meta| match meta.name() {
             "emily" | "frank" => {
                 count2.fetch_add(1, Ordering::Relaxed);

--- a/tracing/tests/filter_caching_is_lexically_scoped.rs
+++ b/tracing/tests/filter_caching_is_lexically_scoped.rs
@@ -32,7 +32,7 @@ fn filter_caching_is_lexically_scoped() {
     let count = Arc::new(AtomicUsize::new(0));
     let count2 = count.clone();
 
-    let subscriber = subscriber::mock()
+    let subscriber = subscriber::test()
         .with_filter(move |meta| match meta.name() {
             "emily" | "frank" => {
                 count2.fetch_add(1, Ordering::Relaxed);

--- a/tracing/tests/filter_caching_is_lexically_scoped.rs
+++ b/tracing/tests/filter_caching_is_lexically_scoped.rs
@@ -11,7 +11,7 @@ extern crate std;
 extern crate tracing;
 mod support;
 
-use self::support::*;
+use self::support::subscriber::SubscriberTest;
 use tracing::Level;
 
 use std::sync::{
@@ -32,7 +32,7 @@ fn filter_caching_is_lexically_scoped() {
     let count = Arc::new(AtomicUsize::new(0));
     let count2 = count.clone();
 
-    let subscriber = subscriber::SubscriberTest::new()
+    let subscriber = SubscriberTest::new()
         .with_filter(move |meta| match meta.name() {
             "emily" | "frank" => {
                 count2.fetch_add(1, Ordering::Relaxed);

--- a/tracing/tests/filters_are_not_reevaluated_for_the_same_span.rs
+++ b/tracing/tests/filters_are_not_reevaluated_for_the_same_span.rs
@@ -27,7 +27,7 @@ fn filters_are_not_reevaluated_for_the_same_span() {
     let alice_count2 = alice_count.clone();
     let bob_count2 = bob_count.clone();
 
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .with_filter(move |meta| match meta.name() {
             "alice" => {
                 alice_count2.fetch_add(1, Ordering::Relaxed);

--- a/tracing/tests/filters_are_not_reevaluated_for_the_same_span.rs
+++ b/tracing/tests/filters_are_not_reevaluated_for_the_same_span.rs
@@ -10,7 +10,7 @@ extern crate std;
 extern crate tracing;
 mod support;
 
-use self::support::*;
+use self::support::subscriber::SubscriberTest;
 use tracing::Level;
 
 use std::sync::{
@@ -27,7 +27,7 @@ fn filters_are_not_reevaluated_for_the_same_span() {
     let alice_count2 = alice_count.clone();
     let bob_count2 = bob_count.clone();
 
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .with_filter(move |meta| match meta.name() {
             "alice" => {
                 alice_count2.fetch_add(1, Ordering::Relaxed);

--- a/tracing/tests/filters_are_not_reevaluated_for_the_same_span.rs
+++ b/tracing/tests/filters_are_not_reevaluated_for_the_same_span.rs
@@ -27,7 +27,7 @@ fn filters_are_not_reevaluated_for_the_same_span() {
     let alice_count2 = alice_count.clone();
     let bob_count2 = bob_count.clone();
 
-    let (subscriber, handle) = subscriber::test()
+    let (subscriber, handle) = subscriber::SubscriberTest::new()
         .with_filter(move |meta| match meta.name() {
             "alice" => {
                 alice_count2.fetch_add(1, Ordering::Relaxed);

--- a/tracing/tests/filters_are_reevaluated_for_different_call_sites.rs
+++ b/tracing/tests/filters_are_reevaluated_for_different_call_sites.rs
@@ -27,7 +27,7 @@ fn filters_are_reevaluated_for_different_call_sites() {
     let charlie_count2 = charlie_count.clone();
     let dave_count2 = dave_count.clone();
 
-    let subscriber = subscriber::mock()
+    let subscriber = subscriber::test()
         .with_filter(move |meta| {
             println!("Filter: {:?}", meta.name());
             match meta.name() {

--- a/tracing/tests/filters_are_reevaluated_for_different_call_sites.rs
+++ b/tracing/tests/filters_are_reevaluated_for_different_call_sites.rs
@@ -27,7 +27,7 @@ fn filters_are_reevaluated_for_different_call_sites() {
     let charlie_count2 = charlie_count.clone();
     let dave_count2 = dave_count.clone();
 
-    let subscriber = subscriber::test()
+    let subscriber = subscriber::SubscriberTest::new()
         .with_filter(move |meta| {
             println!("Filter: {:?}", meta.name());
             match meta.name() {

--- a/tracing/tests/filters_are_reevaluated_for_different_call_sites.rs
+++ b/tracing/tests/filters_are_reevaluated_for_different_call_sites.rs
@@ -10,7 +10,7 @@ extern crate std;
 extern crate tracing;
 mod support;
 
-use self::support::*;
+use self::support::subscriber::SubscriberTest;
 use tracing::Level;
 
 use std::sync::{
@@ -27,7 +27,7 @@ fn filters_are_reevaluated_for_different_call_sites() {
     let charlie_count2 = charlie_count.clone();
     let dave_count2 = dave_count.clone();
 
-    let subscriber = subscriber::SubscriberTest::new()
+    let subscriber = SubscriberTest::new()
         .with_filter(move |meta| {
             println!("Filter: {:?}", meta.name());
             match meta.name() {

--- a/tracing/tests/span.rs
+++ b/tracing/tests/span.rs
@@ -7,6 +7,7 @@
 extern crate tracing;
 mod support;
 
+use self::support::subscriber::SubscriberTest;
 use self::support::*;
 use std::thread;
 use tracing::{
@@ -21,7 +22,7 @@ fn handles_to_the_same_span_are_equal() {
     // `Subscriber::enabled`, so that the spans will be constructed. We
     // won't enter any spans in this test, so the subscriber won't actually
     // expect to see any spans.
-    with_default(subscriber::SubscriberTest::new().run(), || {
+    with_default(SubscriberTest::new().run(), || {
         let foo1 = span!(Level::TRACE, "foo");
         let foo2 = foo1.clone();
         // Two handles that point to the same span are equal.
@@ -31,7 +32,7 @@ fn handles_to_the_same_span_are_equal() {
 
 #[test]
 fn handles_to_different_spans_are_not_equal() {
-    with_default(subscriber::SubscriberTest::new().run(), || {
+    with_default(SubscriberTest::new().run(), || {
         // Even though these spans have the same name and fields, they will have
         // differing metadata, since they were created on different lines.
         let foo1 = span!(Level::TRACE, "foo", bar = 1u64, baz = false);
@@ -49,7 +50,7 @@ fn handles_to_different_spans_with_the_same_metadata_are_not_equal() {
         span!(Level::TRACE, "foo", bar = 1u64, baz = false)
     }
 
-    with_default(subscriber::SubscriberTest::new().run(), || {
+    with_default(SubscriberTest::new().run(), || {
         let foo1 = make_span();
         let foo2 = make_span();
 
@@ -60,7 +61,7 @@ fn handles_to_different_spans_with_the_same_metadata_are_not_equal() {
 
 #[test]
 fn spans_always_go_to_the_subscriber_that_tagged_them() {
-    let subscriber1 = subscriber::SubscriberTest::new()
+    let subscriber1 = SubscriberTest::new()
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
         .enter(span::mock().named("foo"))
@@ -68,7 +69,7 @@ fn spans_always_go_to_the_subscriber_that_tagged_them() {
         .drop_span(span::mock().named("foo"))
         .done()
         .run();
-    let subscriber2 = subscriber::SubscriberTest::new().run();
+    let subscriber2 = SubscriberTest::new().run();
 
     let foo = with_default(subscriber1, || {
         let foo = span!(Level::TRACE, "foo");
@@ -82,7 +83,7 @@ fn spans_always_go_to_the_subscriber_that_tagged_them() {
 
 #[test]
 fn spans_always_go_to_the_subscriber_that_tagged_them_even_across_threads() {
-    let subscriber1 = subscriber::SubscriberTest::new()
+    let subscriber1 = SubscriberTest::new()
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
         .enter(span::mock().named("foo"))
@@ -99,7 +100,7 @@ fn spans_always_go_to_the_subscriber_that_tagged_them_even_across_threads() {
     // Even though we enter subscriber 2's context, the subscriber that
     // tagged the span should see the enter/exit.
     thread::spawn(move || {
-        with_default(subscriber::SubscriberTest::new().run(), || {
+        with_default(SubscriberTest::new().run(), || {
             foo.in_scope(|| {});
         })
     })
@@ -109,7 +110,7 @@ fn spans_always_go_to_the_subscriber_that_tagged_them_even_across_threads() {
 
 #[test]
 fn dropping_a_span_calls_drop_span() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
         .drop_span(span::mock().named("foo"))
@@ -126,7 +127,7 @@ fn dropping_a_span_calls_drop_span() {
 
 #[test]
 fn span_closes_after_event() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .enter(span::mock().named("foo"))
         .event(event::mock())
         .exit(span::mock().named("foo"))
@@ -144,7 +145,7 @@ fn span_closes_after_event() {
 
 #[test]
 fn new_span_after_event() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .enter(span::mock().named("foo"))
         .event(event::mock())
         .exit(span::mock().named("foo"))
@@ -166,7 +167,7 @@ fn new_span_after_event() {
 
 #[test]
 fn event_outside_of_span() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .event(event::mock())
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
@@ -183,7 +184,7 @@ fn event_outside_of_span() {
 
 #[test]
 fn cloning_a_span_calls_clone_span() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .clone_span(span::mock().named("foo"))
         .run_with_handle();
     with_default(subscriber, || {
@@ -196,7 +197,7 @@ fn cloning_a_span_calls_clone_span() {
 
 #[test]
 fn drop_span_when_exiting_dispatchers_context() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .clone_span(span::mock().named("foo"))
         .drop_span(span::mock().named("foo"))
         .drop_span(span::mock().named("foo"))
@@ -212,7 +213,7 @@ fn drop_span_when_exiting_dispatchers_context() {
 
 #[test]
 fn clone_and_drop_span_always_go_to_the_subscriber_that_tagged_the_span() {
-    let (subscriber1, handle1) = subscriber::SubscriberTest::new()
+    let (subscriber1, handle1) = SubscriberTest::new()
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
         .clone_span(span::mock().named("foo"))
@@ -221,7 +222,7 @@ fn clone_and_drop_span_always_go_to_the_subscriber_that_tagged_the_span() {
         .drop_span(span::mock().named("foo"))
         .drop_span(span::mock().named("foo"))
         .run_with_handle();
-    let subscriber2 = subscriber::SubscriberTest::new().done().run();
+    let subscriber2 = SubscriberTest::new().done().run();
 
     let foo = with_default(subscriber1, || {
         let foo = span!(Level::TRACE, "foo");
@@ -242,7 +243,7 @@ fn clone_and_drop_span_always_go_to_the_subscriber_that_tagged_the_span() {
 
 #[test]
 fn span_closes_when_exited() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
         .drop_span(span::mock().named("foo"))
@@ -261,7 +262,7 @@ fn span_closes_when_exited() {
 
 #[test]
 fn enter() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .enter(span::mock().named("foo"))
         .event(event::mock())
         .exit(span::mock().named("foo"))
@@ -279,7 +280,7 @@ fn enter() {
 
 #[test]
 fn moved_field() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(
             span::mock().named("foo").with_field(
                 field::mock("bar")
@@ -307,7 +308,7 @@ fn moved_field() {
 
 #[test]
 fn dotted_field_name() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(
             span::mock()
                 .named("foo")
@@ -324,7 +325,7 @@ fn dotted_field_name() {
 
 #[test]
 fn borrowed_field() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(
             span::mock().named("foo").with_field(
                 field::mock("bar")
@@ -366,7 +367,7 @@ fn move_field_out_of_struct() {
         x: 3.234,
         y: -1.223,
     };
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(
             span::mock().named("foo").with_field(
                 field::mock("x")
@@ -401,7 +402,7 @@ fn move_field_out_of_struct() {
 /*
 #[test]
 fn add_field_after_new_span() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(
             span::mock()
                 .named("foo")
@@ -429,7 +430,7 @@ fn add_field_after_new_span() {
 
 #[test]
 fn add_fields_only_after_new_span() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(span::mock().named("foo"))
         .record(
             span::mock().named("foo"),
@@ -458,7 +459,7 @@ fn add_fields_only_after_new_span() {
 
 #[test]
 fn record_new_value_for_field() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(
             span::mock().named("foo").with_field(
                 field::mock("bar")
@@ -488,7 +489,7 @@ fn record_new_value_for_field() {
 
 #[test]
 fn record_new_values_for_fields() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(
             span::mock().named("foo").with_field(
                 field::mock("bar")
@@ -523,7 +524,7 @@ fn record_new_values_for_fields() {
 
 #[test]
 fn new_span_with_target_and_log_level() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(
             span::mock()
                 .named("foo")
@@ -542,7 +543,7 @@ fn new_span_with_target_and_log_level() {
 
 #[test]
 fn explicit_root_span_is_root() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(span::mock().named("foo").with_explicit_parent(None))
         .done()
         .run_with_handle();
@@ -556,7 +557,7 @@ fn explicit_root_span_is_root() {
 
 #[test]
 fn explicit_root_span_is_root_regardless_of_ctx() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(span::mock().named("foo"))
         .enter(span::mock().named("foo"))
         .new_span(span::mock().named("bar").with_explicit_parent(None))
@@ -575,7 +576,7 @@ fn explicit_root_span_is_root_regardless_of_ctx() {
 
 #[test]
 fn explicit_child() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(span::mock().named("foo"))
         .new_span(span::mock().named("bar").with_explicit_parent(Some("foo")))
         .done()
@@ -591,7 +592,7 @@ fn explicit_child() {
 
 #[test]
 fn explicit_child_at_levels() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(span::mock().named("foo"))
         .new_span(span::mock().named("a").with_explicit_parent(Some("foo")))
         .new_span(span::mock().named("b").with_explicit_parent(Some("foo")))
@@ -615,7 +616,7 @@ fn explicit_child_at_levels() {
 
 #[test]
 fn explicit_child_regardless_of_ctx() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(span::mock().named("foo"))
         .new_span(span::mock().named("bar"))
         .enter(span::mock().named("bar"))
@@ -634,7 +635,7 @@ fn explicit_child_regardless_of_ctx() {
 
 #[test]
 fn contextual_root() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(span::mock().named("foo").with_contextual_parent(None))
         .done()
         .run_with_handle();
@@ -648,7 +649,7 @@ fn contextual_root() {
 
 #[test]
 fn contextual_child() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(span::mock().named("foo"))
         .enter(span::mock().named("foo"))
         .new_span(
@@ -671,7 +672,7 @@ fn contextual_child() {
 
 #[test]
 fn display_shorthand() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(
             span::mock().named("my_span").with_field(
                 field::mock("my_field")
@@ -690,7 +691,7 @@ fn display_shorthand() {
 
 #[test]
 fn debug_shorthand() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(
             span::mock().named("my_span").with_field(
                 field::mock("my_field")
@@ -709,7 +710,7 @@ fn debug_shorthand() {
 
 #[test]
 fn both_shorthands() {
-    let (subscriber, handle) = subscriber::SubscriberTest::new()
+    let (subscriber, handle) = SubscriberTest::new()
         .new_span(
             span::mock().named("my_span").with_field(
                 field::mock("display_field")

--- a/tracing/tests/span.rs
+++ b/tracing/tests/span.rs
@@ -21,7 +21,7 @@ fn handles_to_the_same_span_are_equal() {
     // `Subscriber::enabled`, so that the spans will be constructed. We
     // won't enter any spans in this test, so the subscriber won't actually
     // expect to see any spans.
-    with_default(subscriber::mock().run(), || {
+    with_default(subscriber::test().run(), || {
         let foo1 = span!(Level::TRACE, "foo");
         let foo2 = foo1.clone();
         // Two handles that point to the same span are equal.
@@ -31,7 +31,7 @@ fn handles_to_the_same_span_are_equal() {
 
 #[test]
 fn handles_to_different_spans_are_not_equal() {
-    with_default(subscriber::mock().run(), || {
+    with_default(subscriber::test().run(), || {
         // Even though these spans have the same name and fields, they will have
         // differing metadata, since they were created on different lines.
         let foo1 = span!(Level::TRACE, "foo", bar = 1u64, baz = false);
@@ -49,7 +49,7 @@ fn handles_to_different_spans_with_the_same_metadata_are_not_equal() {
         span!(Level::TRACE, "foo", bar = 1u64, baz = false)
     }
 
-    with_default(subscriber::mock().run(), || {
+    with_default(subscriber::test().run(), || {
         let foo1 = make_span();
         let foo2 = make_span();
 
@@ -60,7 +60,7 @@ fn handles_to_different_spans_with_the_same_metadata_are_not_equal() {
 
 #[test]
 fn spans_always_go_to_the_subscriber_that_tagged_them() {
-    let subscriber1 = subscriber::mock()
+    let subscriber1 = subscriber::test()
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
         .enter(span::mock().named("foo"))
@@ -68,7 +68,7 @@ fn spans_always_go_to_the_subscriber_that_tagged_them() {
         .drop_span(span::mock().named("foo"))
         .done()
         .run();
-    let subscriber2 = subscriber::mock().run();
+    let subscriber2 = subscriber::test().run();
 
     let foo = with_default(subscriber1, || {
         let foo = span!(Level::TRACE, "foo");
@@ -82,7 +82,7 @@ fn spans_always_go_to_the_subscriber_that_tagged_them() {
 
 #[test]
 fn spans_always_go_to_the_subscriber_that_tagged_them_even_across_threads() {
-    let subscriber1 = subscriber::mock()
+    let subscriber1 = subscriber::test()
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
         .enter(span::mock().named("foo"))
@@ -99,7 +99,7 @@ fn spans_always_go_to_the_subscriber_that_tagged_them_even_across_threads() {
     // Even though we enter subscriber 2's context, the subscriber that
     // tagged the span should see the enter/exit.
     thread::spawn(move || {
-        with_default(subscriber::mock().run(), || {
+        with_default(subscriber::test().run(), || {
             foo.in_scope(|| {});
         })
     })
@@ -109,7 +109,7 @@ fn spans_always_go_to_the_subscriber_that_tagged_them_even_across_threads() {
 
 #[test]
 fn dropping_a_span_calls_drop_span() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
         .drop_span(span::mock().named("foo"))
@@ -126,7 +126,7 @@ fn dropping_a_span_calls_drop_span() {
 
 #[test]
 fn span_closes_after_event() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .enter(span::mock().named("foo"))
         .event(event::mock())
         .exit(span::mock().named("foo"))
@@ -144,7 +144,7 @@ fn span_closes_after_event() {
 
 #[test]
 fn new_span_after_event() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .enter(span::mock().named("foo"))
         .event(event::mock())
         .exit(span::mock().named("foo"))
@@ -166,7 +166,7 @@ fn new_span_after_event() {
 
 #[test]
 fn event_outside_of_span() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .event(event::mock())
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
@@ -183,7 +183,7 @@ fn event_outside_of_span() {
 
 #[test]
 fn cloning_a_span_calls_clone_span() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .clone_span(span::mock().named("foo"))
         .run_with_handle();
     with_default(subscriber, || {
@@ -196,7 +196,7 @@ fn cloning_a_span_calls_clone_span() {
 
 #[test]
 fn drop_span_when_exiting_dispatchers_context() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .clone_span(span::mock().named("foo"))
         .drop_span(span::mock().named("foo"))
         .drop_span(span::mock().named("foo"))
@@ -212,7 +212,7 @@ fn drop_span_when_exiting_dispatchers_context() {
 
 #[test]
 fn clone_and_drop_span_always_go_to_the_subscriber_that_tagged_the_span() {
-    let (subscriber1, handle1) = subscriber::mock()
+    let (subscriber1, handle1) = subscriber::test()
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
         .clone_span(span::mock().named("foo"))
@@ -221,7 +221,7 @@ fn clone_and_drop_span_always_go_to_the_subscriber_that_tagged_the_span() {
         .drop_span(span::mock().named("foo"))
         .drop_span(span::mock().named("foo"))
         .run_with_handle();
-    let subscriber2 = subscriber::mock().done().run();
+    let subscriber2 = subscriber::test().done().run();
 
     let foo = with_default(subscriber1, || {
         let foo = span!(Level::TRACE, "foo");
@@ -242,7 +242,7 @@ fn clone_and_drop_span_always_go_to_the_subscriber_that_tagged_the_span() {
 
 #[test]
 fn span_closes_when_exited() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .enter(span::mock().named("foo"))
         .exit(span::mock().named("foo"))
         .drop_span(span::mock().named("foo"))
@@ -261,7 +261,7 @@ fn span_closes_when_exited() {
 
 #[test]
 fn enter() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .enter(span::mock().named("foo"))
         .event(event::mock())
         .exit(span::mock().named("foo"))
@@ -279,7 +279,7 @@ fn enter() {
 
 #[test]
 fn moved_field() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(
             span::mock().named("foo").with_field(
                 field::mock("bar")
@@ -307,7 +307,7 @@ fn moved_field() {
 
 #[test]
 fn dotted_field_name() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(
             span::mock()
                 .named("foo")
@@ -324,7 +324,7 @@ fn dotted_field_name() {
 
 #[test]
 fn borrowed_field() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(
             span::mock().named("foo").with_field(
                 field::mock("bar")
@@ -366,7 +366,7 @@ fn move_field_out_of_struct() {
         x: 3.234,
         y: -1.223,
     };
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(
             span::mock().named("foo").with_field(
                 field::mock("x")
@@ -401,7 +401,7 @@ fn move_field_out_of_struct() {
 /*
 #[test]
 fn add_field_after_new_span() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(
             span::mock()
                 .named("foo")
@@ -429,7 +429,7 @@ fn add_field_after_new_span() {
 
 #[test]
 fn add_fields_only_after_new_span() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(span::mock().named("foo"))
         .record(
             span::mock().named("foo"),
@@ -458,7 +458,7 @@ fn add_fields_only_after_new_span() {
 
 #[test]
 fn record_new_value_for_field() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(
             span::mock().named("foo").with_field(
                 field::mock("bar")
@@ -488,7 +488,7 @@ fn record_new_value_for_field() {
 
 #[test]
 fn record_new_values_for_fields() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(
             span::mock().named("foo").with_field(
                 field::mock("bar")
@@ -523,7 +523,7 @@ fn record_new_values_for_fields() {
 
 #[test]
 fn new_span_with_target_and_log_level() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(
             span::mock()
                 .named("foo")
@@ -542,7 +542,7 @@ fn new_span_with_target_and_log_level() {
 
 #[test]
 fn explicit_root_span_is_root() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(span::mock().named("foo").with_explicit_parent(None))
         .done()
         .run_with_handle();
@@ -556,7 +556,7 @@ fn explicit_root_span_is_root() {
 
 #[test]
 fn explicit_root_span_is_root_regardless_of_ctx() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(span::mock().named("foo"))
         .enter(span::mock().named("foo"))
         .new_span(span::mock().named("bar").with_explicit_parent(None))
@@ -575,7 +575,7 @@ fn explicit_root_span_is_root_regardless_of_ctx() {
 
 #[test]
 fn explicit_child() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(span::mock().named("foo"))
         .new_span(span::mock().named("bar").with_explicit_parent(Some("foo")))
         .done()
@@ -591,7 +591,7 @@ fn explicit_child() {
 
 #[test]
 fn explicit_child_at_levels() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(span::mock().named("foo"))
         .new_span(span::mock().named("a").with_explicit_parent(Some("foo")))
         .new_span(span::mock().named("b").with_explicit_parent(Some("foo")))
@@ -615,7 +615,7 @@ fn explicit_child_at_levels() {
 
 #[test]
 fn explicit_child_regardless_of_ctx() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(span::mock().named("foo"))
         .new_span(span::mock().named("bar"))
         .enter(span::mock().named("bar"))
@@ -634,7 +634,7 @@ fn explicit_child_regardless_of_ctx() {
 
 #[test]
 fn contextual_root() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(span::mock().named("foo").with_contextual_parent(None))
         .done()
         .run_with_handle();
@@ -648,7 +648,7 @@ fn contextual_root() {
 
 #[test]
 fn contextual_child() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(span::mock().named("foo"))
         .enter(span::mock().named("foo"))
         .new_span(
@@ -671,7 +671,7 @@ fn contextual_child() {
 
 #[test]
 fn display_shorthand() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(
             span::mock().named("my_span").with_field(
                 field::mock("my_field")
@@ -690,7 +690,7 @@ fn display_shorthand() {
 
 #[test]
 fn debug_shorthand() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(
             span::mock().named("my_span").with_field(
                 field::mock("my_field")
@@ -709,7 +709,7 @@ fn debug_shorthand() {
 
 #[test]
 fn both_shorthands() {
-    let (subscriber, handle) = subscriber::mock()
+    let (subscriber, handle) = subscriber::test()
         .new_span(
             span::mock().named("my_span").with_field(
                 field::mock("display_field")

--- a/tracing/tests/support/subscriber.rs
+++ b/tracing/tests/support/subscriber.rs
@@ -43,21 +43,21 @@ struct Running<F: Fn(&Metadata<'_>) -> bool> {
     filter: F,
 }
 
-pub struct MockSubscriber<F: Fn(&Metadata<'_>) -> bool> {
+pub struct SubscriberTest<F: Fn(&Metadata<'_>) -> bool> {
     expected: VecDeque<Expect>,
     filter: F,
 }
 
 pub struct MockHandle(Arc<Mutex<VecDeque<Expect>>>);
 
-pub fn mock() -> MockSubscriber<fn(&Metadata<'_>) -> bool> {
-    MockSubscriber {
+pub fn test() -> SubscriberTest<fn(&Metadata<'_>) -> bool> {
+    SubscriberTest {
         expected: VecDeque::new(),
         filter: (|_: &Metadata<'_>| true) as for<'r, 's> fn(&'r Metadata<'s>) -> _,
     }
 }
 
-impl<F> MockSubscriber<F>
+impl<F> SubscriberTest<F>
 where
     F: Fn(&Metadata<'_>) -> bool + 'static,
 {
@@ -108,11 +108,11 @@ where
         self
     }
 
-    pub fn with_filter<G>(self, filter: G) -> MockSubscriber<G>
+    pub fn with_filter<G>(self, filter: G) -> SubscriberTest<G>
     where
         G: Fn(&Metadata<'_>) -> bool + 'static,
     {
-        MockSubscriber {
+        SubscriberTest {
             filter,
             expected: self.expected,
         }

--- a/tracing/tests/support/subscriber.rs
+++ b/tracing/tests/support/subscriber.rs
@@ -50,17 +50,17 @@ pub struct SubscriberTest<F: Fn(&Metadata<'_>) -> bool> {
 
 pub struct MockHandle(Arc<Mutex<VecDeque<Expect>>>);
 
-pub fn test() -> SubscriberTest<fn(&Metadata<'_>) -> bool> {
-    SubscriberTest {
-        expected: VecDeque::new(),
-        filter: (|_: &Metadata<'_>| true) as for<'r, 's> fn(&'r Metadata<'s>) -> _,
-    }
-}
-
 impl<F> SubscriberTest<F>
 where
     F: Fn(&Metadata<'_>) -> bool + 'static,
 {
+    pub fn new() -> SubscriberTest<fn(&Metadata<'_>) -> bool> {
+        SubscriberTest {
+            expected: VecDeque::new(),
+            filter: (|_: &Metadata<'_>| true) as for<'r, 's> fn(&'r Metadata<'s>) -> _,
+        }
+    }
+
     pub fn enter(mut self, span: MockSpan) -> Self {
         self.expected.push_back(Expect::Enter(span));
         self

--- a/tracing/tests/support/subscriber.rs
+++ b/tracing/tests/support/subscriber.rs
@@ -50,17 +50,19 @@ pub struct SubscriberTest<F: Fn(&Metadata<'_>) -> bool> {
 
 pub struct MockHandle(Arc<Mutex<VecDeque<Expect>>>);
 
-impl<F> SubscriberTest<F>
-where
-    F: Fn(&Metadata<'_>) -> bool + 'static,
-{
-    pub fn new() -> SubscriberTest<fn(&Metadata<'_>) -> bool> {
+impl SubscriberTest<fn(&Metadata<'_>) -> bool> {
+    pub fn new() -> Self {
         SubscriberTest {
             expected: VecDeque::new(),
             filter: (|_: &Metadata<'_>| true) as for<'r, 's> fn(&'r Metadata<'s>) -> _,
         }
     }
+}
 
+impl<F> SubscriberTest<F>
+where
+    F: Fn(&Metadata<'_>) -> bool + 'static,
+{
     pub fn enter(mut self, span: MockSpan) -> Self {
         self.expected.push_back(Expect::Enter(span));
         self


### PR DESCRIPTION
Prior to this change, the test plans for unit tests used
`subscriber::mock()` to construct a set of expectations for what the
actual subscriber will do. This object was not acting like a mock
object, and so the name is confusing

This change renames this class to make it more clear that it is setting
up a test, not a mock subscriber.

GitHub issue #272