### PR TITLE
log: fix log callsites sometimes now having stable addresses

### DIFF
--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -184,6 +184,7 @@ impl Fields {
 macro_rules! log_cs {
     ($level:expr) => {{
         struct Callsite;
+        static CALLSITE: Callsite = Callsite;
         static META: Metadata = Metadata::new(
             "log event",
             "log",
@@ -191,7 +192,7 @@ macro_rules! log_cs {
             None,
             None,
             None,
-            field::FieldSet::new(FIELD_NAMES, identify_callsite!(&Callsite)),
+            field::FieldSet::new(FIELD_NAMES, identify_callsite!(&CALLSITE)),
             Kind::EVENT,
         );
 
@@ -202,7 +203,7 @@ macro_rules! log_cs {
             }
         }
 
-        &Callsite
+        &CALLSITE
     }};
 }
 
@@ -407,16 +408,38 @@ mod test {
         let meta = record.as_trace();
         let (cs, _keys) = loglevel_to_cs(record.level());
         let cs_meta = cs.metadata();
-        assert_eq!(meta.callsite(), cs_meta.callsite());
+        assert_eq!(
+            meta.callsite(),
+            cs_meta.callsite(),
+            "actual: {:#?}\nexpected: {:#?}",
+            meta,
+            cs_meta
+        );
         assert_eq!(meta.level(), &level.as_trace());
     }
 
     #[test]
-    fn log_callsite_is_correct() {
+    fn error_callsite_is_correct() {
         test_callsite(log::Level::Error);
+    }
+
+    #[test]
+    fn warn_callsite_is_correct() {
         test_callsite(log::Level::Warn);
+    }
+
+    #[test]
+    fn info_callsite_is_correct() {
         test_callsite(log::Level::Info);
+    }
+
+    #[test]
+    fn debug_callsite_is_correct() {
         test_callsite(log::Level::Debug);
+    }
+
+    #[test]
+    fn trace_callsite_is_correct() {
         test_callsite(log::Level::Trace);
     }
 }


### PR DESCRIPTION
## Motivation:

The upgrade from Rust 1.36.0 to Rust 1.37.0 introduced a regression in
`tracing-log` on macOS, where callsite identifiers for generated `log`
callsites that were previously considered equal are no longer equal.

## Solution:

Previously, the generated callsite was represented as a zero-sized
struct with no fields:

```rust
struct Callsite;
```

The metadata for the generated callsite was constructed by invoking the
`identifiy_callsite!` macro with `&Callsite`, like this:

```rust
    field::FieldSet::new(FIELD_NAMES, identify_callsite!(&Callsite)),
```

and the block generated by the macro ended with `&Callsite`, which would
be assigned to a static.

Previously, this resulted with the callsite identifier and the static
being pointers to the _same_ address, and everything worked correctly.
However, the compiler behaviour appears to have changed in Rust
1.37.0, and two &-references to the same zero-sized struct are, at least
on macOS, no longer pointers to the same memory address.

This commit fixes the regression by changing the `log_cs!` macro to
create a `static` and assign the zero-sized struct to it, like this:

```rust
static CALLSITE: Callsite = Callsite;
```

and use references to the _static_ rather than to the type constructor.
Now, references to `&CALLSITE` point to the same memory address, even on
macOS.

I've also made some minor tweaks to the tests that caught this to make
debugging future log callsite bugs easier. Now, rather than one test
function that tests all log levels, we create a separate test for each
level, to make it easier to determine whether there's a bug for all log
callsites or only a particular one. Also, I've added more information
to the assertion failure messages in these tests.

## Notes:

This may have been our fault. I'm not sure if the behaviour of
references to a new instance of a zero-sized struct (i.e. `&Callsite`)
were ever _guaranteed_ to point to the same memory location or not, so
it may be totally fine of the compiler to change this on us without
warning. However, if this is guaranteed, this is a compiler bug.

I think that by switching to using a static, however, we are making the
guarantee more explicit in either case: if the compiler were ever to
compile two references to the same static as references to different
addresses, that would be a violation of the guarantees of the `static`
keyword. Note that [The Rust Reference][1] states that:

> All references to the static refer to the same memory location.

[1]: https://doc.rust-lang.org/reference/items/static-items.html#static-items

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
