### PR TITLE
core: prepare to release 0.1.5

### DIFF
--- a/tracing-core/CHANGELOG.md
+++ b/tracing-core/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.5 (August 16, 2019)
+
+### Added
+
+- `std::error::Error` as a new primitive `Value` type (#277)
+- `Event::new` and `Event::new_child_of` to manually construct `Event`s (#281)
+
 # 0.1.4 (August 9, 2019)
 
 ### Added

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -8,13 +8,13 @@ name = "tracing-core"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-core/0.1.4/tracing_core"
+documentation = "https://docs.rs/tracing-core/0.1.5/tracing_core"
 description = """
 Core primitives for application-level tracing.
 """

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -12,9 +12,9 @@ Core primitives for application-level tracing.
 [Chat][gitter-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-core.svg
-[crates-url]: https://crates.io/crates/tracing-core
+[crates-url]: https://crates.io/crates/tracing-core/0.1.5
 [docs-badge]: https://docs.rs/tracing-core/badge.svg
-[docs-url]: https://docs.rs/tracing-core
+[docs-url]: https://docs.rs/tracing-core/0.1.5
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master
@@ -68,22 +68,22 @@ The following crate feature flags are available:
 
   ```toml
   [dependencies]
-  tracing-core = { version = "0.1.4", default-features = false }
+  tracing-core = { version = "0.1.5", default-features = false }
   ```
 
   **Note**:`tracing-core`'s `no_std` support requires `liballoc`.
 
 [`tracing`]: ../tracing
-[`Span`]: https://docs.rs/tracing-core/0.1.4/tracing_core/span/struct.Span.html
-[`Event`]: https://docs.rs/tracing-core/0.1.4/tracing_core/event/struct.Event.html
-[`Subscriber`]: https://docs.rs/tracing-core/0.1.4/tracing_core/subscriber/trait.Subscriber.html
-[`Metadata`]: https://docs.rs/tracing-core/0.1.4/tracing_core/metadata/struct.Metadata.html
-[`Callsite`]: https://docs.rs/tracing-core/0.1.4/tracing_core/callsite/trait.Callsite.html
-[`Field`]: https://docs.rs/tracing-core/0.1.4/tracing_core/field/struct.Field.html
-[`FieldSet`]: https://docs.rs/tracing-core/0.1.4/tracing_core/field/struct.FieldSet.html
-[`Value`]: https://docs.rs/tracing-core/0.1.4/tracing_core/field/trait.Value.html
-[`ValueSet`]: https://docs.rs/tracing-core/0.1.4/tracing_core/field/struct.ValueSet.html
-[`Dispatch`]: https://docs.rs/tracing-core/0.1.4/tracing_core/dispatcher/struct.Dispatch.html
+[`Span`]: https://docs.rs/tracing-core/0.1.5/tracing_core/span/struct.Span.html
+[`Event`]: https://docs.rs/tracing-core/0.1.5/tracing_core/event/struct.Event.html
+[`Subscriber`]: https://docs.rs/tracing-core/0.1.5/tracing_core/subscriber/trait.Subscriber.html
+[`Metadata`]: https://docs.rs/tracing-core/0.1.5/tracing_core/metadata/struct.Metadata.html
+[`Callsite`]: https://docs.rs/tracing-core/0.1.5/tracing_core/callsite/trait.Callsite.html
+[`Field`]: https://docs.rs/tracing-core/0.1.5/tracing_core/field/struct.Field.html
+[`FieldSet`]: https://docs.rs/tracing-core/0.1.5/tracing_core/field/struct.FieldSet.html
+[`Value`]: https://docs.rs/tracing-core/0.1.5/tracing_core/field/trait.Value.html
+[`ValueSet`]: https://docs.rs/tracing-core/0.1.5/tracing_core/field/struct.ValueSet.html
+[`Dispatch`]: https://docs.rs/tracing-core/0.1.5/tracing_core/dispatcher/struct.Dispatch.html
 
 ## License
 

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -147,7 +147,7 @@ macro_rules! identify_callsite {
 ///
 /// [metadata]: metadata/struct.Metadata.html
 /// [`Metadata::new`]: metadata/struct.Metadata.html#method.new
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! metadata {
     (
         name: $name:expr,
@@ -178,36 +178,12 @@ macro_rules! metadata {
             $name,
             $target,
             $level,
-            Some(__tracing_core_file!()),
-            Some(__tracing_core_line!()),
-            Some(__tracing_core_module_path!()),
-            $crate::field::FieldSet::new($fields, identify_callsite!($callsite)),
+            Some(file!()),
+            Some(line!()),
+            Some(module_path!()),
+            $crate::field::FieldSet::new($fields, $crate::identify_callsite!($callsite)),
             $kind,
         )
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __tracing_core_module_path {
-    () => {
-        module_path!()
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __tracing_core_file {
-    () => {
-        file!()
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __tracing_core_line {
-    () => {
-        line!()
     };
 }
 

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tracing-core/0.1.4")]
+#![doc(html_root_url = "https://docs.rs/tracing-core/0.1.5")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 
@@ -52,7 +52,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing-core = { version = "0.1.4", default-features = false }
+//!   tracing-core = { version = "0.1.5", default-features = false }
 //!   ```
 //!   **Note**:`tracing-core`'s `no_std` support requires `liballoc`.
 //!


### PR DESCRIPTION
Added:

- `std::error::Error` as a new primitive `Value` type (#277)
- `Event::new` and `Event::new_child_of` to manually construct `Event`s (#281)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>