### PR TITLE
attributes: update dependencies

### DIFF
--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -39,9 +39,9 @@ proc-macro = true
 async-await = []
 
 [dependencies]
-syn = { version = "0.15", features = ["full", "extra-traits"] }
-quote = "0.6"
-proc-macro2 = "0.4"
+syn = { version = "1", features = ["full", "extra-traits"] }
+quote = "1"
+proc-macro2 = "1"
 
 [dev-dependencies]
 tracing = "0.1"


### PR DESCRIPTION
- update `quote`, `syn`, and `proc-macro2` all to version 1
- react to breaking changes in `syn`


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

`tokio` 0.2 introduced a `tokio-macros` crate that uses macro-related dependencies similar to `tracing-attributes`. Recently, [those dependencies were updated], incorporating breaking changes from those dependencies. This means that users of `tokio` 0.2 and `tracing-attributes` will have duplicate dependencies.

## Solution

Update `proc-macro2`, `syn`, and `quote` to version 1, and react to the breaking changes (mostly in `syn`).

Note that this is currently a naive, compiler-error-driven refactoring of `tracing-attributes`. Everything appears to be working, but I'm not sure if there's a better (e.g. more performant) way to use the new dependencies. Additionally, I noticed that `tokio-macros` dropped having a direct dependency on `proc-macro2`, and I don't know if `tracing-attributes` should do the same.

Fixes: #270

[those dependencies were updated]: https://github.com/tokio-rs/tokio/pull/1432