### PR TITLE
attributes: prepare to release 0.1.2

### DIFF
--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Changed
 
 - Updated `syn` and `quote` dependencies to 1.0 (#292)
+- Removed direct dependency on `proc-macro2` to avoid potential version
+  conflicts (#296)
 
 ### Fixed
 

--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.1.2 (August 19, 2019)
+
+### Changed
+
+- Updated `syn` and `quote` dependencies to 1.0 (#292)
+
+### Fixed
+
+- Outdated idioms in examples (#271, #273)
+
 # 0.1.1 (August 9, 2019)
 
 ### Changed

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-attributes"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     "Tokio Contributors <team@tokio.rs>",
     "Eliza Weisman <eliza@buoyant.io>",

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -14,7 +14,7 @@ Macro attributes for application-level tracing.
 [crates-badge]: https://img.shields.io/crates/v/tracing-attributes.svg
 [crates-url]: https://crates.io/crates/tracing-attributes
 [docs-badge]: https://docs.rs/tracing-attributes/badge.svg
-[docs-url]: https://docs.rs/tracing-attributes
+[docs-url]: https://docs.rs/tracing-attributes/0.1.2
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master
@@ -37,7 +37,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing-attributes = "0.1.0"
+tracing-attributes = "0.1.2"
 ```
 
 This crate provides the `#[instrument]` attribute for instrumenting a function
@@ -54,7 +54,7 @@ pub fn my_function(my_arg: usize) {
 
 
 [`tracing`]: https://crates.io/crates/tracing
-[span]: https://docs.rs/tracing/0.1.3/tracing/span/index.html
+[span]: https://docs.rs/tracing/0.1.5/tracing/span/index.html
 
 ## License
 

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.2")]
 #![deny(missing_debug_implementations, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 
@@ -35,7 +35,7 @@
 //! ```
 //!
 //! [`tracing`]: https://crates.io/crates/tracing
-//! [span]: https://docs.rs/tracing/0.1.3/tracing/span/index.html
+//! [span]: https://docs.rs/tracing/0.1.5/tracing/span/index.html
 //! [instrument]: attr.instrument.html
 extern crate proc_macro;
 
@@ -105,7 +105,7 @@ use syn::{
 /// - When using `#[instrument]` on an `async fn`, the `tracing_futures` must
 ///   also be specified as a dependency in `Cargo.toml`.
 ///
-/// [span]: https://docs.rs/tracing/0.1.3/tracing/span/index.html
+/// [span]: https://docs.rs/tracing/0.1.5/tracing/span/index.html
 /// [`tracing`]: https://github.com/tokio-rs/tracing
 #[proc_macro_attribute]
 pub fn instrument(args: TokenStream, item: TokenStream) -> TokenStream {


### PR DESCRIPTION
Changed:

- Updated `syn` and `quote` dependencies to 1.0 (#292)
- Removed direct dependency on `proc-macro2` to avoid potential version
  conflicts (#296)

Fixed:

- Outdated idioms in examples (#271, #273)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>