### PR TITLE
tracing, fmt: update to use core std::error::Error support

### DIFF
--- a/tracing-fmt/Cargo.toml
+++ b/tracing-fmt/Cargo.toml
@@ -26,7 +26,7 @@ default = ["ansi", "chrono", "tracing-log"]
 ansi = ["ansi_term"]
 
 [dependencies]
-tracing-core = "0.1.2"
+tracing-core = "0.1.5"
 tracing-log = { version = "0.0.1-alpha.1", optional = true }
 ansi_term = { version = "0.11", optional = true }
 regex = "1"

--- a/tracing-fmt/examples/yak_shave.rs
+++ b/tracing-fmt/examples/yak_shave.rs
@@ -1,19 +1,21 @@
 #![deny(rust_2018_idioms)]
 use tracing::{debug, error, info, span, trace, warn, Level};
 
+use std::{error::Error, fmt};
+
 #[tracing::instrument]
-fn shave(yak: usize) -> bool {
+fn shave(yak: usize) -> Result<(), Box<dyn Error + 'static>> {
     debug!(
         message = "hello! I'm gonna shave a yak.",
         excitement = "yay!"
     );
     if yak == 3 {
         warn!(target: "yak_events", "could not locate yak!");
-        false
+        Err(ShaveError::new(yak, YakError::new("could not locate yak")))?;
     } else {
         trace!(target: "yak_events", "yak shaved successfully");
-        true
     }
+    Ok(())
 }
 
 fn shave_all(yaks: usize) -> usize {
@@ -24,11 +26,15 @@ fn shave_all(yaks: usize) -> usize {
 
     let mut num_shaved = 0;
     for yak in 1..=yaks {
-        let shaved = shave(yak);
-        trace!(target: "yak_events", yak, shaved);
+        let res = shave(yak);
+        trace!(target: "yak_events", yak, shaved = res.is_ok());
 
-        if !shaved {
-            error!(message = "failed to shave yak!", yak);
+        if let Err(ref error) = res {
+            error!(
+                message = "failed to shave yak!",
+                yak,
+                error = error.as_ref()
+            );
         } else {
             num_shaved += 1;
         }
@@ -53,4 +59,50 @@ fn main() {
             all_yaks_shaved = number_shaved == number_of_yaks,
         );
     });
+}
+
+#[derive(Debug)]
+struct ShaveError {
+    source: Box<dyn Error + 'static>,
+    yak: usize,
+}
+
+impl fmt::Display for ShaveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "shaving yak #{} failed!", self.yak)
+    }
+}
+
+impl Error for ShaveError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
+impl ShaveError {
+    fn new(yak: usize, source: impl Into<Box<dyn Error + 'static>>) -> Self {
+        Self {
+            source: source.into(),
+            yak,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct YakError {
+    description: &'static str,
+}
+
+impl fmt::Display for YakError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.description)
+    }
+}
+
+impl Error for YakError {}
+
+impl YakError {
+    fn new(description: &'static str) -> Self {
+        Self { description }
+    }
 }

--- a/tracing-fmt/src/format.rs
+++ b/tracing-fmt/src/format.rs
@@ -244,6 +244,17 @@ impl<'a> field::Visit for Recorder<'a> {
         }
     }
 
+    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+        if let Some(source) = value.source() {
+            self.record_debug(
+                field,
+                &format_args!("{} {}.source={}", value, field, source),
+            )
+        } else {
+            self.record_debug(field, &format_args!("{}", value))
+        }
+    }
+
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
         self.maybe_pad();
         let _ = match field.name() {

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -28,7 +28,7 @@ keywords = ["logging", "tracing"]
 edition = "2018"
 
 [dependencies]
-tracing-core = { version = "0.1.4", default-features = false }
+tracing-core = { version = "0.1.5", default-features = false }
 log = { version = "0.4", optional = true }
 tracing-attributes = "0.1.1"
 cfg-if = "0.1.9"


### PR DESCRIPTION
This branch updates `tracing-core` and `tracing-fmt` to use the suppport for `std::error::Error` added in #277.

I'd like to update the examples in other crates as well, but I'm holding off on that until after the next `tracing` release, to avoid adding path deps in unpublished crates.