### PR TITLE
Port examples from `tracing-futures` to use async await

### DIFF
--- a/nightly-examples/Cargo.toml
+++ b/nightly-examples/Cargo.toml
@@ -17,3 +17,4 @@ tracing-fmt = "0.0.1-alpha.3"
 tracing-futures = { path = "../tracing-futures", default-features = false, features = ["std-future"] }
 tokio = { git = "https://github.com/tokio-rs/tokio.git" }
 tracing-attributes = { path = "../tracing-attributes" }
+futures-preview = "0.3.0-alpha.18"

--- a/nightly-examples/examples/async_fn.rs
+++ b/nightly-examples/examples/async_fn.rs
@@ -24,7 +24,7 @@ use tokio::net::TcpStream;
 use tracing::info;
 use tracing_attributes::instrument;
 
-use std::{io, error::Error, net::SocketAddr};
+use std::{error::Error, io, net::SocketAddr};
 
 #[instrument]
 async fn connect(addr: &SocketAddr) -> io::Result<TcpStream> {

--- a/nightly-examples/examples/async_fn.rs
+++ b/nightly-examples/examples/async_fn.rs
@@ -15,7 +15,6 @@
 //!
 //! [`hello_world`]: https://github.com/tokio-rs/tokio/blob/132e9f1da5965530b63554d7a1c59824c3de4e30/tokio/examples/hello_world.rs
 #![deny(rust_2018_idioms)]
-#![feature(async_await)]
 
 use tokio;
 use tokio::io::AsyncWriteExt;

--- a/nightly-examples/examples/echo.rs
+++ b/nightly-examples/examples/echo.rs
@@ -21,7 +21,6 @@
 //!
 //! [echo-example]: https://github.com/tokio-rs/tokio/blob/master/tokio/examples/echo.rs
 
-#![feature(async_await)]
 #![warn(rust_2018_idioms)]
 
 use futures::future::{FutureExt, TryFutureExt};
@@ -33,7 +32,7 @@ use std::env;
 use std::error::Error;
 use std::net::SocketAddr;
 
-use tracing::{debug, error, info, info_span, instrument, trace, trace_span, warn};
+use tracing::{debug, info, info_span, trace_span, warn};
 use tracing_futures::Instrument;
 
 #[tokio::main]

--- a/nightly-examples/examples/echo.rs
+++ b/nightly-examples/examples/echo.rs
@@ -13,11 +13,11 @@
 //!
 //! and in another terminal you can run:
 //!
-//!     cargo +nightly run --example proxy_server 127.0.0.1:8081
+//!     nc localhost 3000
 //!
-//! Each line you type in to the `connect` terminal should be echo'd back to
-//! you! If you open up multiple terminals running the `connect` example you
-//! should be able to see them all make progress simultaneously.
+//! Each line you type in to the `netcat` terminal should be echo'd back to
+//! you! If you open up multiple terminals with `netcat` instances connected 
+//! to the same address you should be able to see them all make progress simultaneously.
 //!
 //! [echo-example]: https://github.com/tokio-rs/tokio/blob/master/tokio/examples/echo.rs
 
@@ -52,6 +52,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // connections. This TCP listener is bound to the address we determined
     // above and must be associated with an event loop.
     let mut listener = TcpListener::bind(&addr)?;
+    // Use `fmt::Debug` impl for `addr` using the `%` sybmol
     info!(message = "Listening on", %addr);
 
     loop {
@@ -77,7 +78,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     .read(&mut buf)
                     .map(|bytes| {
                         if let Ok(n) = bytes {
-                            debug!(message = "read bytes", n);
+                            debug!(bytes_read = n);
                         }
 
                         bytes
@@ -98,7 +99,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     .write_all(&buf[0..n])
                     .map(|bytes| {
                         if let Ok(()) = bytes {
-                            debug!(message = "wrote bytes", n);
+                            debug!(bytes_written = n);
                         }
 
                         bytes
@@ -111,7 +112,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     .await
                     .expect("failed to write data to socket");
 
-                info!(message = "echo'd data", ?peer_addr, size = n);
+
+                info!(message = "echo'd data", %peer_addr, size = n);
             }
         })
         .instrument(info_span!("echo", %peer_addr));

--- a/nightly-examples/examples/echo.rs
+++ b/nightly-examples/examples/echo.rs
@@ -81,7 +81,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     .write_all(&buf[0..n])
                     .await
                     .expect("failed to write data to socket");
-                
+
                 info!(message = "echo'd data", peer_addr = ?peer_addr, size = n);
             }
         });

--- a/nightly-examples/examples/echo.rs
+++ b/nightly-examples/examples/echo.rs
@@ -1,0 +1,89 @@
+//! A "hello world" echo server with Tokio
+//!
+//! This server will create a TCP listener, accept connections in a loop, and
+//! write back everything that's read off of each TCP connection.
+//!
+//! Because the Tokio runtime uses a thread pool, each TCP connection is
+//! processed concurrently with all other TCP connections across multiple
+//! threads.
+//!
+//! To see this server in action, you can run this in one terminal:
+//!
+//!     cargo run --example echo
+//!
+//! and in another terminal you can run:
+//!
+//!     cargo run --example connect 127.0.0.1:8080
+//!
+//! Each line you type in to the `connect` terminal should be echo'd back to
+//! you! If you open up multiple terminals running the `connect` example you
+//! should be able to see them all make progress simultaneously.
+
+#![feature(async_await)]
+#![warn(rust_2018_idioms)]
+
+use tokio;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+use std::env;
+use std::error::Error;
+use std::net::SocketAddr;
+
+use tracing::{debug, error, info, warn};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let subscriber = tracing_fmt::FmtSubscriber::builder().finish();
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    // Allow passing an address to listen on as the first argument of this
+    // program, but otherwise we'll just set up our TCP listener on
+    // 127.0.0.1:8080 for connections.
+    let addr = env::args().nth(1).unwrap_or("127.0.0.1:3000".to_string());
+    let addr = addr.parse::<SocketAddr>()?;
+
+    // Next up we create a TCP listener which will listen for incoming
+    // connections. This TCP listener is bound to the address we determined
+    // above and must be associated with an event loop.
+    let mut listener = TcpListener::bind(&addr)?;
+    info!("Listening on: {}", addr);
+
+    loop {
+        // Asynchronously wait for an inbound socket.
+        let (mut socket, peer_addr) = listener.accept().await?;
+
+        info!("Got connection from: {}", peer_addr);
+
+        // And this is where much of the magic of this server happens. We
+        // crucially want all clients to make progress concurrently, rather than
+        // blocking one on completion of another. To achieve this we use the
+        // `tokio::spawn` function to execute the work in the background.
+        //
+        // Essentially here we're executing a new task to run concurrently,
+        // which will allow all of our clients to be processed concurrently.
+
+        tokio::spawn(async move {
+            let mut buf = [0; 1024];
+
+            // In a loop, read data from the socket and write the data back.
+            loop {
+                let n = socket
+                    .read(&mut buf)
+                    .await
+                    .expect("failed to read data from socket");
+
+                if n == 0 {
+                    return;
+                }
+
+                socket
+                    .write_all(&buf[0..n])
+                    .await
+                    .expect("failed to write data to socket");
+                
+                info!(message = "echo'd data", peer_addr = ?peer_addr, size = n);
+            }
+        });
+    }
+}

--- a/nightly-examples/examples/proxy_server.rs
+++ b/nightly-examples/examples/proxy_server.rs
@@ -1,7 +1,6 @@
 #![feature(async_await)]
 #![deny(rust_2018_idioms)]
 
-
 //! A proxy that forwards data to another server and forwards that server's
 //! responses back to clients.
 //!

--- a/nightly-examples/examples/proxy_server.rs
+++ b/nightly-examples/examples/proxy_server.rs
@@ -1,0 +1,103 @@
+#![feature(async_await)]
+#![deny(rust_2018_idioms)]
+
+
+//! A proxy that forwards data to another server and forwards that server's
+//! responses back to clients.
+//!
+//! Because the Tokio runtime uses a thread pool, each TCP connection is
+//! processed concurrently with all other TCP connections across multiple
+//! threads.
+//!
+//! You can showcase this by running this in one terminal:
+//!
+//!     cargo +nightly run --example proxy_server
+//!
+//! This in another terminal
+//!
+//!     cargo run --example echo
+//!
+//! And finally this in another terminal
+//!
+//!     nc localhost 8081
+//!
+//! This final terminal will connect to our proxy, which will in turn connect to
+//! the echo server, and you'll be able to see data flowing between them.
+
+use futures::{future::try_join, FutureExt};
+use tokio::{
+    self,
+    io::AsyncReadExt,
+    net::{TcpListener, TcpStream},
+    prelude::*,
+};
+
+use tracing::{debug, info, warn};
+use tracing_attributes::instrument;
+
+use std::{env, net::SocketAddr};
+
+#[instrument]
+async fn transfer(
+    inbound: TcpStream,
+    proxy_addr: SocketAddr,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let outbound = TcpStream::connect(&proxy_addr).await?;
+
+    let (mut ri, mut wi) = inbound.split();
+    let (mut ro, mut wo) = outbound.split();
+
+    let client_to_server = ri.copy(&mut wo);
+    let server_to_client = ro.copy(&mut wi);
+
+    let (client_to_server, server_to_client) = try_join(client_to_server, server_to_client).await?;
+    info!(
+        message = "transfer completed",
+        client_to_server, server_to_client
+    );
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let subscriber = tracing_fmt::FmtSubscriber::builder().finish();
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    let listen_addr = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "127.0.0.1:8081".to_string());
+    let listen_addr = listen_addr.parse::<SocketAddr>()?;
+
+    let server_addr = env::args()
+        .nth(2)
+        .unwrap_or_else(|| "127.0.0.1:3000".to_string());
+    let server_addr = server_addr.parse::<SocketAddr>()?;
+
+    let mut listener = TcpListener::bind(&listen_addr)?.incoming();
+    info!("Listening on: {}", listen_addr);
+    info!("Proxying to: {}", server_addr);
+
+    while let Some(Ok(inbound)) = listener.next().await {
+        match inbound.peer_addr() {
+            Ok(addr) => {
+                info!(message = "client connected", client_addr = %addr);
+            }
+            Err(error) => warn!(
+                message = "Could not get client information",
+                %error
+            ),
+        }
+
+        let transfer = transfer(inbound, server_addr).map(|r| {
+            if let Err(err) = r {
+                // Don't panic, maybe the client just disconnected too soon
+                debug!(%err);
+            }
+        });
+
+        tokio::spawn(transfer);
+    }
+
+    Ok(())
+}

--- a/nightly-examples/examples/proxy_server.rs
+++ b/nightly-examples/examples/proxy_server.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![deny(rust_2018_idioms)]
 
 //! A proxy that forwards data to another server and forwards that server's
@@ -23,7 +22,7 @@
 //! This final terminal will connect to our proxy, which will in turn connect to
 //! the echo server, and you'll be able to see data flowing between them.
 
-use futures::{future::try_join, FutureExt, TryFutureExt};
+use futures::{future::try_join, TryFutureExt};
 use tokio::{
     self,
     io::AsyncReadExt,

--- a/nightly-examples/examples/proxy_server.rs
+++ b/nightly-examples/examples/proxy_server.rs
@@ -50,7 +50,7 @@ async fn transfer(
         .copy(&mut wo)
         .map(|bytes| {
             if let Ok(n) = bytes {
-                debug!(message = "copy finished", n);
+                debug!(bytes_copied = n);
             }
 
             bytes
@@ -64,7 +64,7 @@ async fn transfer(
         .copy(&mut wi)
         .map(|bytes| {
             if let Ok(n) = bytes {
-                debug!(message = "copy finished", n);
+                debug!(bytes_copied = n);
             }
 
             bytes
@@ -119,7 +119,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let transfer = transfer(inbound, server_addr).map(|r| {
             if let Err(err) = r {
                 // Don't panic, maybe the client just disconnected too soon
-                debug!(%err);
+                debug!(error = %err);
             }
         });
 

--- a/nightly-examples/examples/spawny_thing.rs
+++ b/nightly-examples/examples/spawny_thing.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![deny(rust_2018_idioms)]
 
 /// This is a example showing how information is scoped.
@@ -27,7 +26,7 @@ async fn parent_task(subtasks: usize) {
     let result = join_all(subtasks).await;
 
     debug!("all subtasks completed");
-    let sum = result.into_iter().sum();
+    let sum: usize = result.into_iter().sum();
     info!(sum);
 }
 
@@ -42,7 +41,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let subscriber = tracing_fmt::FmtSubscriber::builder()
         .with_filter("trace".parse::<tracing_fmt::filter::EnvFilter>()?)
         .finish();
-    tracing::subscriber::set_global_default(subscriber);
+    tracing::subscriber::set_global_default(subscriber)?;
     parent_task(10).await;
     Ok(())
 }

--- a/nightly-examples/examples/spawny_thing.rs
+++ b/nightly-examples/examples/spawny_thing.rs
@@ -1,0 +1,48 @@
+#![feature(async_await)]
+#![deny(rust_2018_idioms)]
+
+/// This is a example showing how information is scoped.
+///
+/// You can run this example by running the following command in a terminal
+///
+/// ```
+/// RUST_LOG=spawny_thing=trace cargo +nightly run --example spawny_thing
+/// ```
+
+use tokio;
+
+use futures::future::join_all;
+use tracing::{debug, info};
+use tracing_attributes::instrument;
+
+#[instrument]
+async fn parent_task(subtasks: usize) {
+    info!("spawning subtasks...");
+    let subtasks = (1..=subtasks)
+        .map(|number| {
+            debug!(message = "creating subtask;", number);
+            subtask(number)
+        })
+        .collect::<Vec<_>>();
+
+    let result = join_all(subtasks).await;
+
+    debug!("all subtasks completed");
+    let sum: usize = result.into_iter().sum();
+    info!(sum = sum);
+}
+
+#[instrument]
+async fn subtask(number: usize) -> usize {
+    info!("polling subtask... {}", number);
+    number
+}
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let subscriber = tracing_fmt::FmtSubscriber::builder()
+        .with_filter("trace".parse::<tracing_fmt::filter::EnvFilter>().unwrap())
+        .finish();
+    let _ = tracing::subscriber::set_global_default(subscriber);
+    parent_task(10).await;
+    Ok(())
+}

--- a/nightly-examples/examples/spawny_thing.rs
+++ b/nightly-examples/examples/spawny_thing.rs
@@ -32,7 +32,7 @@ async fn parent_task(subtasks: usize) {
 
 #[instrument]
 async fn subtask(number: usize) -> usize {
-    info!("polling subtask... {}", number);
+    info!("polling subtask...");
     number
 }
 

--- a/nightly-examples/examples/spawny_thing.rs
+++ b/nightly-examples/examples/spawny_thing.rs
@@ -6,9 +6,8 @@
 /// You can run this example by running the following command in a terminal
 ///
 /// ```
-/// RUST_LOG=spawny_thing=trace cargo +nightly run --example spawny_thing
+/// cargo +nightly run --example spawny_thing
 /// ```
-
 use tokio;
 
 use futures::future::join_all;
@@ -28,8 +27,8 @@ async fn parent_task(subtasks: usize) {
     let result = join_all(subtasks).await;
 
     debug!("all subtasks completed");
-    let sum: usize = result.into_iter().sum();
-    info!(sum = sum);
+    let sum = result.into_iter().sum();
+    info!(sum);
 }
 
 #[instrument]
@@ -37,12 +36,13 @@ async fn subtask(number: usize) -> usize {
     info!("polling subtask... {}", number);
     number
 }
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let subscriber = tracing_fmt::FmtSubscriber::builder()
-        .with_filter("trace".parse::<tracing_fmt::filter::EnvFilter>().unwrap())
+        .with_filter("trace".parse::<tracing_fmt::filter::EnvFilter>()?)
         .finish();
-    let _ = tracing::subscriber::set_global_default(subscriber);
+    tracing::subscriber::set_global_default(subscriber);
     parent_task(10).await;
     Ok(())
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

Knocking off a couple of items from #269 by porting over the examples under `tracing-future`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Ported over the example from Tokio's [`proxy_server`][proxy] example and updated it with trace information similar to what is currently present. In order to show case the example, I also added the [`echo` server][echo] example, as the server being proxied needs to be concurrent as well.

Finally I ported over the `spawny_thing` example to use async await.

[proxy]: https://github.com/tokio-rs/tokio/blob/master/tokio/examples/proxy.rs
[echo]: https://github.com/tokio-rs/tokio/blob/master/tokio/examples/proxy.rs