### PR TITLE
attributes: remove direct dependency on proc-macro2

### DIFF
--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -41,7 +41,6 @@ async-await = []
 [dependencies]
 syn = { version = "1", features = ["full", "extra-traits"] }
 quote = "1"
-proc-macro2 = "1"
 
 [dev-dependencies]
 tracing = "0.1"


### PR DESCRIPTION
## Motivation

As discussed in #292:

> A follow-up to remove an explicit dependency on `proc-macro2` would be great, though, as it would make it easier to avoid pulling duplicate versions of that crate.

## Solution

Remove `proc-macro2` as a direct dependency and replace usages of types from it accordingly.