### PR TITLE
tracing: prepare to release 0.1.6

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.1.6 (August 20, 2019)
+
+### Added
+
+- `std::error::Error` as a new primitive type (#277)
+- Support for mixing key-value fields and `format_args` messages without curly
+  braces as delimiters (#288)
+
+### Changed
+
+- `tracing-core` dependency to 0.1.5 (#294)
+- `tracing-attributes` dependency to 0.1.2 (#297)
+
 # 0.1.5 (August 9, 2019)
 
 ### Added

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -30,7 +30,7 @@ edition = "2018"
 [dependencies]
 tracing-core = { version = "0.1.5", default-features = false }
 log = { version = "0.4", optional = true }
-tracing-attributes = "0.1.1"
+tracing-attributes = "0.1.2"
 cfg-if = "0.1.9"
 
 [dev-dependencies]

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,15 +8,15 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing/0.1.5/tracing"
+documentation = "https://docs.rs/tracing/0.1.6/tracing"
 description = """
-A scoped, structured logging and diagnostics system.
+Application-level tracing for Rust.
 """
 categories = [
     "development-tools::debugging",
@@ -24,7 +24,7 @@ categories = [
     "asynchronous",
     "no-std",
 ]
-keywords = ["logging", "tracing"]
+keywords = ["logging", "tracing", "metrics", "async"]
 edition = "2018"
 
 [dependencies]

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -12,9 +12,9 @@ Application-level tracing for Rust.
 [Chat][gitter-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing
+[crates-url]: https://crates.io/crates/tracing/0.1.6
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing
+[docs-url]: https://docs.rs/tracing/0.1.6
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master
@@ -47,7 +47,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing = "0.1.5"
+tracing = "0.1.6"
 ```
 
 This crate provides macros for creating `Span`s and `Event`s, which represent

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.5")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.6")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
Added:

- `std::error::Error` as a new primitive type (#277)
- Support for mixing key-value fields and `format_args` messages without
  curly braces as delimiters (#288)

Changed:

- `tracing-core` dependency to 0.1.5 (#294)
- `tracing-attributes` dependency to 0.1.2 (#297)