### PR TITLE
fmt: support customizing output stream

### DIFF
--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -37,18 +37,22 @@ pub struct FmtSubscriber<
     filter: F,
     spans: span::Store,
     settings: Settings,
-    new_writer: W
+    new_writer: W,
 }
 
 /// Configures and constructs `FmtSubscriber`s.
 #[derive(Debug, Default)]
-pub struct Builder<N = format::NewRecorder, E = format::Format<format::Full>, F = filter::EnvFilter, W = fn() -> io::Stdout>
-{
+pub struct Builder<
+    N = format::NewRecorder,
+    E = format::Format<format::Full>,
+    F = filter::EnvFilter,
+    W = fn() -> io::Stdout,
+> {
     new_visitor: N,
     fmt_event: E,
     filter: F,
     settings: Settings,
-    new_writer: W
+    new_writer: W,
 }
 
 #[derive(Debug, Default)]
@@ -98,7 +102,7 @@ where
     N: for<'a> NewVisitor<'a> + 'static,
     E: FormatEvent<N> + 'static,
     F: Filter<N> + 'static,
-    W: NewWriter + 'static
+    W: NewWriter + 'static,
 {
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         self.filter.callsite_enabled(metadata, &self.ctx())
@@ -217,7 +221,11 @@ pub trait NewWriter {
     fn new_writer(&self) -> Self::Writer;
 }
 
-impl<F, W> NewWriter for F where F: Fn() -> W, W: io::Write {
+impl<F, W> NewWriter for F
+where
+    F: Fn() -> W,
+    W: io::Write,
+{
     type Writer = W;
 
     fn new_writer(&self) -> Self::Writer {
@@ -234,7 +242,7 @@ impl Default for Builder {
             new_visitor: format::NewRecorder,
             fmt_event: format::Format::default(),
             settings: Settings::default(),
-            new_writer: io::stdout
+            new_writer: io::stdout,
         }
     }
 }
@@ -244,7 +252,7 @@ where
     N: for<'a> NewVisitor<'a> + 'static,
     E: FormatEvent<N> + 'static,
     F: Filter<N> + 'static,
-    W: NewWriter + 'static
+    W: NewWriter + 'static,
 {
     pub fn finish(self) -> FmtSubscriber<N, E, F, W> {
         FmtSubscriber {
@@ -253,7 +261,7 @@ where
             filter: self.filter,
             spans: span::Store::with_capacity(32),
             settings: self.settings,
-            new_writer: self.new_writer
+            new_writer: self.new_writer,
         }
     }
 }
@@ -270,7 +278,7 @@ where
             fmt_event: self.fmt_event.with_timer(timer),
             filter: self.filter,
             settings: self.settings,
-            new_writer: self.new_writer
+            new_writer: self.new_writer,
         }
     }
 
@@ -281,7 +289,7 @@ where
             fmt_event: self.fmt_event.without_time(),
             filter: self.filter,
             settings: self.settings,
-            new_writer: self.new_writer
+            new_writer: self.new_writer,
         }
     }
 
@@ -315,7 +323,7 @@ where
             fmt_event: self.fmt_event,
             filter: filter::ReloadFilter::new(self.filter),
             settings: self.settings,
-            new_writer: self.new_writer
+            new_writer: self.new_writer,
         }
     }
 }
@@ -343,7 +351,7 @@ impl<N, E, F, W> Builder<N, E, F, W> {
             fmt_event: self.fmt_event,
             filter: self.filter,
             settings: self.settings,
-            new_writer: self.new_writer
+            new_writer: self.new_writer,
         }
     }
 
@@ -358,7 +366,7 @@ impl<N, E, F, W> Builder<N, E, F, W> {
             fmt_event: self.fmt_event,
             filter,
             settings: self.settings,
-            new_writer: self.new_writer
+            new_writer: self.new_writer,
         }
     }
 
@@ -374,7 +382,7 @@ impl<N, E, F, W> Builder<N, E, F, W> {
             filter: self.filter,
             new_visitor: self.new_visitor,
             settings: self.settings,
-            new_writer: self.new_writer
+            new_writer: self.new_writer,
         }
     }
 
@@ -389,7 +397,7 @@ impl<N, E, F, W> Builder<N, E, F, W> {
             fmt_event,
             filter: self.filter,
             settings: self.settings,
-            new_writer: self.new_writer
+            new_writer: self.new_writer,
         }
     }
 

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -30,22 +30,25 @@ pub struct FmtSubscriber<
     N = format::NewRecorder,
     E = format::Format<format::Full>,
     F = filter::EnvFilter,
+    W = NewStdout
 > {
     new_visitor: N,
     fmt_event: E,
     filter: F,
     spans: span::Store,
     settings: Settings,
+    new_writer: W
 }
 
 /// Configures and constructs `FmtSubscriber`s.
 #[derive(Debug, Default)]
-pub struct Builder<N = format::NewRecorder, E = format::Format<format::Full>, F = filter::EnvFilter>
+pub struct Builder<N = format::NewRecorder, E = format::Format<format::Full>, F = filter::EnvFilter, W = NewStdout>
 {
     new_visitor: N,
     fmt_event: E,
     filter: F,
     settings: Settings,
+    new_writer: W
 }
 
 #[derive(Debug, Default)]
@@ -69,7 +72,7 @@ impl Default for FmtSubscriber {
     }
 }
 
-impl<N, E, F> FmtSubscriber<N, E, F>
+impl<N, E, F, W> FmtSubscriber<N, E, F, W>
 where
     N: for<'a> NewVisitor<'a>,
 {
@@ -79,7 +82,7 @@ where
     }
 }
 
-impl<N, E, F> FmtSubscriber<N, E, filter::ReloadFilter<F, N>>
+impl<N, E, F, W> FmtSubscriber<N, E, filter::ReloadFilter<F, N>, W>
 where
     F: Filter<N> + 'static,
 {
@@ -90,11 +93,12 @@ where
     }
 }
 
-impl<N, E, F> tracing_core::Subscriber for FmtSubscriber<N, E, F>
+impl<N, E, F, W> tracing_core::Subscriber for FmtSubscriber<N, E, F, W>
 where
     N: for<'a> NewVisitor<'a> + 'static,
     E: FormatEvent<N> + 'static,
     F: Filter<N> + 'static,
+    W: NewWriter + 'static
 {
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         self.filter.callsite_enabled(metadata, &self.ctx())
@@ -141,7 +145,8 @@ where
 
             if self.fmt_event.format_event(&ctx, buf, event).is_ok() {
                 // TODO: make the io object configurable
-                let _ = io::Write::write_all(&mut io::stdout(), buf.as_bytes());
+                let mut writer = self.new_writer.new_writer();
+                let _ = io::Write::write_all(&mut writer, buf.as_bytes());
             }
 
             buf.clear();
@@ -206,6 +211,22 @@ where
     }
 }
 
+pub trait NewWriter {
+    type Writer: io::Write;
+
+    fn new_writer(&self) -> Self::Writer;
+}
+
+pub struct NewStdout;
+
+impl NewWriter for NewStdout {
+    type Writer = io::Stdout;
+
+    fn new_writer(&self) -> Self::Writer {
+        io::stdout()
+    }
+}
+
 // ===== impl Builder =====
 
 impl Default for Builder {
@@ -215,55 +236,60 @@ impl Default for Builder {
             new_visitor: format::NewRecorder,
             fmt_event: format::Format::default(),
             settings: Settings::default(),
+            new_writer: NewStdout
         }
     }
 }
 
-impl<N, E, F> Builder<N, E, F>
+impl<N, E, F, W> Builder<N, E, F, W>
 where
     N: for<'a> NewVisitor<'a> + 'static,
     E: FormatEvent<N> + 'static,
     F: Filter<N> + 'static,
+    W: NewWriter + 'static
 {
-    pub fn finish(self) -> FmtSubscriber<N, E, F> {
+    pub fn finish(self) -> FmtSubscriber<N, E, F, W> {
         FmtSubscriber {
             new_visitor: self.new_visitor,
             fmt_event: self.fmt_event,
             filter: self.filter,
             spans: span::Store::with_capacity(32),
             settings: self.settings,
+            new_writer: self.new_writer
         }
     }
 }
 
-impl<N, L, T, F> Builder<N, format::Format<L, T>, F>
+impl<N, L, T, F, W> Builder<N, format::Format<L, T>, F, W>
 where
     N: for<'a> NewVisitor<'a> + 'static,
     F: Filter<N> + 'static,
 {
     /// Use the given `timer` for log message timestamps.
-    pub fn with_timer<T2>(self, timer: T2) -> Builder<N, format::Format<L, T2>, F> {
+    pub fn with_timer<T2>(self, timer: T2) -> Builder<N, format::Format<L, T2>, F, W> {
         Builder {
             new_visitor: self.new_visitor,
             fmt_event: self.fmt_event.with_timer(timer),
             filter: self.filter,
             settings: self.settings,
+            new_writer: self.new_writer
         }
     }
 
     /// Do not emit timestamps with log messages.
-    pub fn without_time(self) -> Builder<N, format::Format<L, ()>, F> {
+    pub fn without_time(self) -> Builder<N, format::Format<L, ()>, F, W> {
         Builder {
             new_visitor: self.new_visitor,
             fmt_event: self.fmt_event.without_time(),
             filter: self.filter,
             settings: self.settings,
+            new_writer: self.new_writer
         }
     }
 
     /// Enable ANSI encoding for formatted events.
     #[cfg(feature = "ansi")]
-    pub fn with_ansi(self, ansi: bool) -> Builder<N, format::Format<L, T>, F> {
+    pub fn with_ansi(self, ansi: bool) -> Builder<N, format::Format<L, T>, F, W> {
         Builder {
             fmt_event: self.fmt_event.with_ansi(ansi),
             ..self
@@ -271,7 +297,7 @@ where
     }
 
     /// Sets whether or not an event's target is displayed.
-    pub fn with_target(self, display_target: bool) -> Builder<N, format::Format<L, T>, F> {
+    pub fn with_target(self, display_target: bool) -> Builder<N, format::Format<L, T>, F, W> {
         Builder {
             fmt_event: self.fmt_event.with_target(display_target),
             ..self
@@ -279,23 +305,24 @@ where
     }
 }
 
-impl<N, E, F> Builder<N, E, F>
+impl<N, E, F, W> Builder<N, E, F, W>
 where
     F: Filter<N> + 'static,
 {
     /// Configures the subscriber being built to allow filter reloading at
     /// runtime.
-    pub fn with_filter_reloading(self) -> Builder<N, E, filter::ReloadFilter<F, N>> {
+    pub fn with_filter_reloading(self) -> Builder<N, E, filter::ReloadFilter<F, N>, W> {
         Builder {
             new_visitor: self.new_visitor,
             fmt_event: self.fmt_event,
             filter: filter::ReloadFilter::new(self.filter),
             settings: self.settings,
+            new_writer: self.new_writer
         }
     }
 }
 
-impl<N, E, F> Builder<N, E, filter::ReloadFilter<F, N>>
+impl<N, E, F, W> Builder<N, E, filter::ReloadFilter<F, N>, W>
 where
     F: Filter<N> + 'static,
 {
@@ -306,10 +333,10 @@ where
     }
 }
 
-impl<N, E, F> Builder<N, E, F> {
+impl<N, E, F, W> Builder<N, E, F, W> {
     /// Sets the Visitor that the subscriber being built will use to record
     /// fields.
-    pub fn with_visitor<N2>(self, new_visitor: N2) -> Builder<N2, E, F>
+    pub fn with_visitor<N2>(self, new_visitor: N2) -> Builder<N2, E, F, W>
     where
         N2: for<'a> NewVisitor<'a> + 'static,
     {
@@ -318,12 +345,13 @@ impl<N, E, F> Builder<N, E, F> {
             fmt_event: self.fmt_event,
             filter: self.filter,
             settings: self.settings,
+            new_writer: self.new_writer
         }
     }
 
     /// Sets the filter that the subscriber being built will use to determine if
     /// a span or event is enabled.
-    pub fn with_filter<F2>(self, filter: F2) -> Builder<N, E, F2>
+    pub fn with_filter<F2>(self, filter: F2) -> Builder<N, E, F2, W>
     where
         F2: Filter<N> + 'static,
     {
@@ -332,13 +360,14 @@ impl<N, E, F> Builder<N, E, F> {
             fmt_event: self.fmt_event,
             filter,
             settings: self.settings,
+            new_writer: self.new_writer
         }
     }
 
     /// Sets the subscriber being built to use a less verbose formatter.
     ///
     /// See [`format::Compact`].
-    pub fn compact(self) -> Builder<N, format::Format<format::Compact>, F>
+    pub fn compact(self) -> Builder<N, format::Format<format::Compact>, F, W>
     where
         N: for<'a> NewVisitor<'a> + 'static,
     {
@@ -347,12 +376,13 @@ impl<N, E, F> Builder<N, E, F> {
             filter: self.filter,
             new_visitor: self.new_visitor,
             settings: self.settings,
+            new_writer: self.new_writer
         }
     }
 
     /// Sets the function that the subscriber being built should use to format
     /// events that occur.
-    pub fn on_event<E2>(self, fmt_event: E2) -> Builder<N, E2, F>
+    pub fn on_event<E2>(self, fmt_event: E2) -> Builder<N, E2, F, W>
     where
         E2: FormatEvent<N> + 'static,
     {
@@ -361,6 +391,7 @@ impl<N, E, F> Builder<N, E, F> {
             fmt_event,
             filter: self.filter,
             settings: self.settings,
+            new_writer: self.new_writer
         }
     }
 

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -30,7 +30,7 @@ pub struct FmtSubscriber<
     N = format::NewRecorder,
     E = format::Format<format::Full>,
     F = filter::EnvFilter,
-    W = NewStdout
+    W = fn() -> io::Stdout,
 > {
     new_visitor: N,
     fmt_event: E,
@@ -42,7 +42,7 @@ pub struct FmtSubscriber<
 
 /// Configures and constructs `FmtSubscriber`s.
 #[derive(Debug, Default)]
-pub struct Builder<N = format::NewRecorder, E = format::Format<format::Full>, F = filter::EnvFilter, W = NewStdout>
+pub struct Builder<N = format::NewRecorder, E = format::Format<format::Full>, F = filter::EnvFilter, W = fn() -> io::Stdout>
 {
     new_visitor: N,
     fmt_event: E,
@@ -217,13 +217,11 @@ pub trait NewWriter {
     fn new_writer(&self) -> Self::Writer;
 }
 
-pub struct NewStdout;
-
-impl NewWriter for NewStdout {
-    type Writer = io::Stdout;
+impl<F, W> NewWriter for F where F: Fn() -> W, W: io::Write {
+    type Writer = W;
 
     fn new_writer(&self) -> Self::Writer {
-        io::stdout()
+        (self)()
     }
 }
 
@@ -236,7 +234,7 @@ impl Default for Builder {
             new_visitor: format::NewRecorder,
             fmt_event: format::Format::default(),
             settings: Settings::default(),
-            new_writer: NewStdout
+            new_writer: io::stdout
         }
     }
 }

--- a/tracing-fmt/src/lib.rs
+++ b/tracing-fmt/src/lib.rs
@@ -411,6 +411,22 @@ impl<N, E, F, W> Builder<N, E, F, W> {
     }
 }
 
+impl<N, E, F, W> Builder<N, E, F, W> {
+    /// Sets the Writer that the subscriber being built will use to log events.
+    pub fn with_writer<W2>(self, new_writer: W2) -> Builder<N, E, F, W2>
+    where
+        W2: NewWriter + 'static,
+    {
+        Builder {
+            new_visitor: self.new_visitor,
+            fmt_event: self.fmt_event,
+            filter: self.filter,
+            settings: self.settings,
+            new_writer,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
## Motivation

Closes #225

> When logging trace data, users may wish to write to a number of output streams, such as to stdout, to stderr, or to a file, depending on their use-case. Currently, however, the IO stream that tracing-fmt writes to is hard-coded to `stdout`

## Solution

- [x] Add a new trait, `NewWriter`, to abstract over the action of creating a new object that implements `std::io::Write`
- [x] Add a new type parameter to `FmtSubscriber` and its `Builder` for that trait
- [x] Default that type parameter to `std::io::stdout`
- [ ] Add tests for the new functionality
- [ ] Add example(s) to demonstrate the new functionality?