### PR TITLE
docs: add links to external resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,26 @@ The crates included as part of Tracing are:
 [sub-crates]: https://crates.io/crates/tracing-subscriber
 [sub-docs]: https://docs.rs/tracing-subscriber
 
+## External Resources
+
+This is a list of links to blog posts, conference talks, and tutorials about
+Tracing.
+
+#### Blog Posts
+
+* [Diagnostics with Tracing][tokio-blog-2019-08] on the Tokio blog, August 2019
+
+[tokio-blog-2019-08]: https://tokio.rs/blog/2019-08-tracing/
+
+#### Talks
+
+* [Bay Area Rust Meetup talk and Q&A][bay-rust-2018-03], March 2018
+
+[bay-rust-2018-03]: https://www.youtube.com/watch?v=j_kXRg3zlec
+
+Help us expand this list! If you've written or spoken about Tracing, or
+know of resources that aren't listed, please open a pull request adding them.
+
 ## License
 
 This project is licensed under the [MIT license](LICENSE).
@@ -120,5 +140,3 @@ This project is licensed under the [MIT license](LICENSE).
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in Tracing by you, shall be licensed as MIT, without any additional
 terms or conditions.
-
-[`tokio-trace`]: https://github.com/tokio-rs/tokio/tree/master/tokio-trace


### PR DESCRIPTION
## Motivation

There is now a handful of blog posts and conference talks about Tracing.
These external resources may be very helpful, especially for new users
or contributors learning how to use Tracing. However, they aren't
currently linked anywhere in this repository, so they can be hard to
discover.

## Solution

This PR adds an "External Resources" section to README.md.

I also considered adding a new document (maybe RESOURCES.md or
something?), instead of putting them in the README, but I thought that
it was easier to find the references in the README. Since the section is
currently quite short, I'm not concerned about making the README too
long. If, in the future, there are a lot of talks & posts listed here,
we could consider moving the list to a separate document and linking to
it in the README.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
