### PR TITLE
tracing: fix macro log support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,9 @@ stages:
          - template: azure/install-rust.yml@templates
            parameters:
             rust: stable
-         - bash: cd tracing/test-log-support && cargo test
+         - bash: |
+             (cd tracing/test-log-support && cargo test) &&
+             cargo test -p tracing --features log
            displayName: "Test log support"
          - bash: cd tracing/test_static_max_level_features && cargo test
            displayName: "Test static max level features"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,9 +30,7 @@ stages:
          - template: azure/install-rust.yml@templates
            parameters:
             rust: stable
-         - bash: |
-             (cd tracing/test-log-support && cargo test) &&
-             cargo test -p tracing --features log
+         - bash: cd tracing/test-log-support && cargo test
            displayName: "Test log support"
          - bash: cd tracing/test_static_max_level_features && cargo test
            displayName: "Test static max level features"
@@ -40,6 +38,8 @@ stages:
            displayName: "Test tracing-core no-std support"
          - bash: cd tracing && cargo test --no-default-features
            displayName: "Test tracing no-std support"
+         - bash: cargo test -p tracing --all-features
+           displayName: "Test tracing all features"
      - job: custom_nightly
        pool:
          vmImage: ubuntu-16.04

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -2135,139 +2135,93 @@ macro_rules! valueset {
         &[ $($val),* ]
     };
 
-    // === recursive case (more tts), non-empty out set ===
+    // === recursive case (more tts) ===
 
     // TODO(#1138): determine a new syntax for uninitialized span fields, and
     // re-enable this.
-    // (@{ $($out:expr),+ }, $next:expr, $($k:ident).+ = _, $($rest:tt)*) => {
-    //     $crate::valueset!(@ { $($out),+, (&$next, None) }, $next, $($rest)*)
+    // (@{ $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = _, $($rest:tt)*) => {
+    //     $crate::valueset!(@ { $($out),*, (&$next, None) }, $next, $($rest)*)
     // };
-    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),+, (&$next, Some(&debug(&$val) as &Value)) },
+            @ { $($out),*, (&$next, Some(&debug(&$val) as &Value)) },
             $next,
             $($rest)*
         )
     };
-    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),+, (&$next, Some(&display(&$val) as &Value)) },
+            @ { $($out),*, (&$next, Some(&display(&$val) as &Value)) },
             $next,
             $($rest)*
         )
     };
-    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+ = $val:expr, $($rest:tt)*) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = $val:expr, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),+, (&$next, Some(&$val as &Value)) },
+            @ { $($out),*, (&$next, Some(&$val as &Value)) },
             $next,
             $($rest)*
         )
     };
-    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+, $($rest:tt)*) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),+, (&$next, Some(&$($k).+ as &Value)) },
+            @ { $($out),*, (&$next, Some(&$($k).+ as &Value)) },
             $next,
             $($rest)*
         )
     };
-    (@ { $($out:expr),+ }, $next:expr, ?$($k:ident).+, $($rest:tt)*) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, ?$($k:ident).+, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),+, (&$next, Some(&debug(&$($k).+) as &Value)) },
+            @ { $($out),*, (&$next, Some(&debug(&$($k).+) as &Value)) },
             $next,
             $($rest)*
         )
     };
-    (@ { $($out:expr),+ }, $next:expr, %$($k:ident).+, $($rest:tt)*) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, %$($k:ident).+, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),+, (&$next, Some(&display(&$($k).+) as &Value)) },
+            @ { $($out),*, (&$next, Some(&display(&$($k).+) as &Value)) },
             $next,
             $($rest)*
         )
     };
-    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+ = ?$val:expr) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = ?$val:expr) => {
         $crate::valueset!(
-            @ { $($out),+, (&$next, Some(&debug(&$val) as &Value)) },
+            @ { $($out),*, (&$next, Some(&debug(&$val) as &Value)) },
             $next,
         )
     };
-    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+ = %$val:expr) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = %$val:expr) => {
         $crate::valueset!(
-            @ { $($out),+, (&$next, Some(&display(&$val) as &Value)) },
+            @ { $($out),*, (&$next, Some(&display(&$val) as &Value)) },
             $next,
         )
     };
-    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+ = $val:expr) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = $val:expr) => {
         $crate::valueset!(
-            @ { $($out),+, (&$next, Some(&$val as &Value)) },
+            @ { $($out),*, (&$next, Some(&$val as &Value)) },
             $next,
         )
     };
-    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+) => {
         $crate::valueset!(
-            @ { $($out),+, (&$next, Some(&$($k).+ as &Value)) },
+            @ { $($out),*, (&$next, Some(&$($k).+ as &Value)) },
             $next,
         )
     };
-    (@ { $($out:expr),+ }, $next:expr, ?$($k:ident).+) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, ?$($k:ident).+) => {
         $crate::valueset!(
-            @ { $($out),+, (&$next, Some(&debug(&$($k).+) as &Value)) },
+            @ { $($out),*, (&$next, Some(&debug(&$($k).+) as &Value)) },
             $next,
         )
     };
-    (@ { $($out:expr),+ }, $next:expr, %$($k:ident).+) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, %$($k:ident).+) => {
         $crate::valueset!(
-            @ { $($out),+, (&$next, Some(&display(&$($k).+) as &Value)) },
+            @ { $($out),*, (&$next, Some(&display(&$($k).+) as &Value)) },
             $next,
         )
     };
-
-    // == recursive case (more tts), empty out set ===
-
-    // TODO(#1138): determine a new syntax for uninitialized span fields, and
-    // re-enable this.
-    // (@ { }, $next:expr, $($k:ident).+ = _, $($rest:tt)* ) => {
-    //     $crate::valueset!(@ { (&$next, None) }, $next, $($rest)* )
-    // };
-    (@ { }, $next:expr, $($k:ident).+ = ?$val:expr, $($rest:tt)* ) => {
-        $crate::valueset!(@ { (&$next, Some(&debug(&$val) as &Value)) }, $next, $($rest)* )
-    };
-    (@ { }, $next:expr, $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
-        $crate::valueset!(@ { (&$next, Some(&display(&$val) as &Value)) }, $next, $($rest)*)
-    };
-    (@ { }, $next:expr, $($k:ident).+ = $val:expr, $($rest:tt)*) => {
-        $crate::valueset!(@ { (&$next, Some(&$val as &Value)) }, $next, $($rest)*)
-    };
-    (@ { }, $next:expr, $($k:ident).+, $($rest:tt)*) => {
-        $crate::valueset!(@ { (&$next, Some(&$($k).+ as &Value)) }, $next, $($rest)* )
-    };
-    (@ { }, $next:expr, ?$($k:ident).+, $($rest:tt)*) => {
-        $crate::valueset!(@ { (&$next, Some(&debug(&$($k).+) as &Value)) }, $next, $($rest)* )
-    };
-    (@ { }, $next:expr, %$($k:ident).+, $($rest:tt)*) => {
-        $crate::valueset!(@ { (&$next, Some(&display(&$($k).+) as &Value)) }, $next, $($rest)* )
-    };
-    // no trailing comma
-    (@ { }, $next:expr, $($k:ident).+ = ?$val:expr) => {
-        $crate::valueset!(@ { (&$next, Some(&debug(&$val) as &Value)) }, $next )
-    };
-    (@ { }, $next:expr, $($k:ident).+ = %$val:expr) => {
-        $crate::valueset!(@ { (&$next, Some(&display(&$val) as &Value)) }, $next)
-    };
-    (@ { }, $next:expr, $($k:ident).+ = $val:expr) => {
-        $crate::valueset!(@ { (&$next, Some(&$val as &Value)) }, $next)
-    };
-    (@ { }, $next:expr, $($k:ident).+) => {
-        $crate::valueset!(@ { (&$next, Some(&$($k).+ as &Value)) }, $next)
-    };
-    (@ { }, $next:expr, ?$($k:ident).+) => {
-        $crate::valueset!(@ { (&$next, Some(&debug(&$($k).+) as &Value)) }, $next)
-    };
-    (@ { }, $next:expr, %$($k:ident).+) => {
-        $crate::valueset!(@ { (&$next, Some(&display(&$($k).+) as &Value)) }, $next)
-    };
-
     // Remainder is unparseable, but exists --- must be format args!
-    (@ { $($out:expr),* }, $next:expr, $($rest:tt)+) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, $($rest:tt)+) => {
         $crate::valueset!(@ { $($out),*, (&$next, Some(&format_args!($($rest)+) as &Value)) }, $next, )
     };
 
@@ -2299,59 +2253,33 @@ macro_rules! fieldset {
         &[ $($out),* ]
     };
 
-    // == empty out set, remaining tts ==
-    (@ { } $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
-        $crate::fieldset!(@ { $crate::__tracing_stringify!($($k).+) } $($rest)*)
+    // == recursive cases (more tts) ==
+    (@ { $(,)* $($out:expr),* } $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
+        $crate::fieldset!(@ { $($out),*, $crate::__tracing_stringify!($($k).+) } $($rest)*)
     };
-    (@ { } $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
-        $crate::fieldset!(@ { $crate::__tracing_stringify!($($k).+) } $($rest)*)
+    (@ { $(,)* $($out:expr),* } $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
+        $crate::fieldset!(@ { $($out),*, $crate::__tracing_stringify!($($k).+) } $($rest)*)
     };
-    (@ { } $($k:ident).+ = $val:expr, $($rest:tt)*) => {
-        $crate::fieldset!(@ { $crate::__tracing_stringify!($($k).+) } $($rest)*)
-    };
-    // TODO(#1138): determine a new syntax for uninitialized span fields, and
-    // re-enable this.
-    // (@ { } $($k:ident).+ = _, $($rest:tt)*) => {
-    //     $crate::fieldset!(@ { $crate::__tracing_stringify!($($k).+) } $($rest)*)
-    // };
-    (@ { } ?$($k:ident).+, $($rest:tt)*) => {
-        $crate::fieldset!(@ { $crate::__tracing_stringify!($($k).+) } $($rest)*)
-    };
-    (@ { } %$($k:ident).+, $($rest:tt)*) => {
-        $crate::fieldset!(@ { $crate::__tracing_stringify!($($k).+) } $($rest)*)
-    };
-    (@ { } $($k:ident).+, $($rest:tt)*) => {
-        $crate::fieldset!(@ { $crate::__tracing_stringify!($($k).+) } $($rest)*)
-    };
-
-
-    // == non-empty out set, remaining tts ==
-    (@ { $($out:expr),+ } $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
-        $crate::fieldset!(@ { $($out),+,$crate::__tracing_stringify!($($k).+) } $($rest)*)
-    };
-    (@ { $($out:expr),+ } $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
-        $crate::fieldset!(@ { $($out),+, $crate::__tracing_stringify!($($k).+) } $($rest)*)
-    };
-    (@ { $($out:expr),+ } $($k:ident).+ = $val:expr, $($rest:tt)*) => {
-        $crate::fieldset!(@ { $($out),+, $crate::__tracing_stringify!($($k).+) } $($rest)*)
+    (@ { $(,)* $($out:expr),* } $($k:ident).+ = $val:expr, $($rest:tt)*) => {
+        $crate::fieldset!(@ { $($out),*, $crate::__tracing_stringify!($($k).+) } $($rest)*)
     };
     // TODO(#1138): determine a new syntax for uninitialized span fields, and
     // re-enable this.
-    // (@ { $($out:expr),+ } $($k:ident).+ = _, $($rest:tt)*) => {
-    //     $crate::fieldset!(@ { $($out),+, $crate::__tracing_stringify!($($k).+) } $($rest)*)
+    // (@ { $($out:expr),* } $($k:ident).+ = _, $($rest:tt)*) => {
+    //     $crate::fieldset!(@ { $($out),*, $crate::__tracing_stringify!($($k).+) } $($rest)*)
     // };
-    (@ { $($out:expr),+ } ?$($k:ident).+, $($rest:tt)*) => {
-        $crate::fieldset!(@ { $($out),+, $crate::__tracing_stringify!($($k).+) } $($rest)*)
+    (@ { $(,)* $($out:expr),* } ?$($k:ident).+, $($rest:tt)*) => {
+        $crate::fieldset!(@ { $($out),*, $crate::__tracing_stringify!($($k).+) } $($rest)*)
     };
-    (@ { $($out:expr),+ } %$($k:ident).+, $($rest:tt)*) => {
-        $crate::fieldset!(@ { $($out),+, $crate::__tracing_stringify!($($k).+) } $($rest)*)
+    (@ { $(,)* $($out:expr),* } %$($k:ident).+, $($rest:tt)*) => {
+        $crate::fieldset!(@ { $($out),*, $crate::__tracing_stringify!($($k).+) } $($rest)*)
     };
-    (@ { $($out:expr),+ } $($k:ident).+, $($rest:tt)*) => {
-        $crate::fieldset!(@ { $($out),+, $crate::__tracing_stringify!($($k).+) } $($rest)*)
+    (@ { $(,)* $($out:expr),* } $($k:ident).+, $($rest:tt)*) => {
+        $crate::fieldset!(@ { $($out),*, $crate::__tracing_stringify!($($k).+) } $($rest)*)
     };
 
     // Remainder is unparseable, but exists --- must be format args!
-    (@ { $($out:expr),* } $($rest:tt)+) => {
+    (@ { $(,)* $($out:expr),* } $($rest:tt)+) => {
         $crate::fieldset!(@ { $($out),*, "message" })
     };
 

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -2494,103 +2494,55 @@ macro_rules! __mk_format_string {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __mk_format_args {
-    // == base case ==
+    // === finished --- called into by base cases ===
     (@ { $(,)* $($out:expr),* $(,)* }, $fmt:expr, fields: $(,)*) => {
         format_args!($fmt, $($out),*)
     };
 
-    // === terminating case (more tts), non-empty out set ===
-    (@ { $($out:expr),+ }, $fmt:expr, fields: $($k:ident).+ = ?$val:expr $(,)*) => {
-        $crate::__mk_format_args!(@ { $($out),+, $val }, $fmt, fields: )
+    // === base case (no more tts) ===
+    (@ { $(,)* $($out:expr),* }, $fmt:expr, fields: $($k:ident).+ = ?$val:expr $(,)*) => {
+        $crate::__mk_format_args!(@ { $($out),*, $val }, $fmt, fields: )
     };
-    (@ { $($out:expr),+ }, $fmt:expr, fields: $($k:ident).+ = %$val:expr $(,)*) => {
-        $crate::__mk_format_args!(@ { $($out),+, $val }, $fmt, fields: )
+    (@ { $(,)* $($out:expr),* }, $fmt:expr, fields: $($k:ident).+ = %$val:expr $(,)*) => {
+        $crate::__mk_format_args!(@ { $($out),*, $val }, $fmt, fields: )
     };
-    (@ { $($out:expr),+ }, $fmt:expr, fields: $($k:ident).+ = $val:expr $(,)*) => {
-        $crate::__mk_format_args!(@ { $($out),+, $val }, $fmt, fields: )
-    };
-    // ====== shorthand field syntax ===
-    (@ { $($out:expr),+ }, $fmt:expr, fields: ?$($k:ident).+ $(,)*) => {
-        $crate::__mk_format_args!(@ { $($out),+, &$($k).+ }, $fmt, fields:)
-    };
-    (@ { $($out:expr),+ }, $fmt:expr, fields: %$($k:ident).+ $(,)*) => {
-        $crate::__mk_format_args!(@ { $($out),+, &$($k).+ }, $fmt, fields: )
-    };
-    (@ { $($out:expr),+ }, $fmt:expr, fields: $($k:ident).+ $(,)*) => {
-        $crate::__mk_format_args!(@ { $($out),+, &$($k).+ }, $fmt, fields: )
-    };
-
-    // == terminating case (more tts), empty out set ===
-    (@ { }, $fmt:expr, fields: message = $val:expr $(,)*) => {
-        $crate::__mk_format_args!(@ { $val }, $fmt, fields: )
-    };
-    (@ { }, $fmt:expr, fields: $($k:ident).+ = ?$val:expr $(,)*) => {
-        $crate::__mk_format_args!(@ { $val }, $fmt, fields: )
-    };
-    (@ { }, $fmt:expr, fields: $($k:ident).+ = %$val:expr $(,)*) => {
-        $crate::__mk_format_args!(@ { $val }, $fmt, fields: )
-    };
-    (@ { }, $fmt:expr, fields: $($k:ident).+ = $val:expr $(,)*) => {
-        $crate::__mk_format_args!(@ { $val }, $fmt, fields: )
+    (@ { $(,)* $($out:expr),* }, $fmt:expr, fields: $($k:ident).+ = $val:expr $(,)*) => {
+        $crate::__mk_format_args!(@ { $($out),*, $val }, $fmt, fields: )
     };
     // ====== shorthand field syntax ===
-    (@ { }, $fmt:expr, fields: ?$($k:ident).+ $(,)*) => {
-        $crate::__mk_format_args!(@ { &$($k).+ }, $fmt, fields: )
+    (@ { $(,)* $($out:expr),* }, $fmt:expr, fields: ?$($k:ident).+ $(,)*) => {
+        $crate::__mk_format_args!(@ { $($out),*, &$($k).+ }, $fmt, fields:)
     };
-    (@ { }, $fmt:expr, fields: %$($k:ident).+ $(,)*) => {
-        $crate::__mk_format_args!(@ { &$($k).+ }, $fmt, fields: )
+    (@ { $(,)* $($out:expr),* }, $fmt:expr, fields: %$($k:ident).+ $(,)*) => {
+        $crate::__mk_format_args!(@ { $($out),*, &$($k).+ }, $fmt, fields: )
     };
-    (@ { }, $fmt:expr, fields: $($k:ident).+ $(,)*) => {
-        $crate::__mk_format_args!(@ { &$($k).+ }, $fmt, fields: )
+    (@ { $(,)* $($out:expr),* }, $fmt:expr, fields: $($k:ident).+ $(,)*) => {
+        $crate::__mk_format_args!(@ { $($out),*, &$($k).+ }, $fmt, fields: )
     };
 
-    // === recursive case (more tts), non-empty out set ===
-    (@ { $($out:expr),+ }, $fmt:expr, fields: $($k:ident).+ = ?$val:expr, $($rest:tt)+) => {
-        $crate::__mk_format_args!(@ { $($out),+, $val }, $fmt, fields: $($rest)+)
+    // === recursive case (more tts) ===
+    (@ { $(,)* $($out:expr),* }, $fmt:expr, fields: $($k:ident).+ = ?$val:expr, $($rest:tt)+) => {
+        $crate::__mk_format_args!(@ { $($out),*, $val }, $fmt, fields: $($rest)+)
     };
-    (@ { $($out:expr),+ }, $fmt:expr, fields: $($k:ident).+ = %$val:expr, $($rest:tt)+) => {
-        $crate::__mk_format_args!(@ { $($out),+, $val }, $fmt, fields: $($rest)+)
+    (@ { $(,)* $($out:expr),* }, $fmt:expr, fields: $($k:ident).+ = %$val:expr, $($rest:tt)+) => {
+        $crate::__mk_format_args!(@ { $($out),*, $val }, $fmt, fields: $($rest)+)
     };
-    (@ { $($out:expr),+ }, $fmt:expr, fields: $($k:ident).+ = $val:expr, $($rest:tt)+) => {
-        $crate::__mk_format_args!(@ { $($out),+, $val }, $fmt, fields: $($rest)+)
+    (@ { $(,)* $($out:expr),* }, $fmt:expr, fields: $($k:ident).+ = $val:expr, $($rest:tt)+) => {
+        $crate::__mk_format_args!(@ { $($out),*, $val }, $fmt, fields: $($rest)+)
     };
     // ====== shorthand field syntax ===
-    (@ { $($out:expr),+ }, $fmt:expr, fields: ?$($k:ident).+, $($rest:tt)+) => {
-        $crate::__mk_format_args!(@ { $($out),+, &$($k).+ }, $fmt, fields: $($rest)+)
+    (@ { $(,)* $($out:expr),* }, $fmt:expr, fields: ?$($k:ident).+, $($rest:tt)+) => {
+        $crate::__mk_format_args!(@ { $($out),*, &$($k).+ }, $fmt, fields: $($rest)+)
     };
-    (@ { $($out:expr),+ }, $fmt:expr, fields: %$($k:ident).+, $($rest:tt)+) => {
-        $crate::__mk_format_args!(@ { $($out),+, &$($k).+ }, $fmt, fields: $($rest)+)
+    (@ { $(,)* $($out:expr),* }, $fmt:expr, fields: %$($k:ident).+, $($rest:tt)+) => {
+        $crate::__mk_format_args!(@ { $($out),*, &$($k).+ }, $fmt, fields: $($rest)+)
     };
-    (@ { $($out:expr),+ }, $fmt:expr, fields: $($k:ident).+, $($rest:tt)+) => {
-        $crate::__mk_format_args!(@ { $($out),+, &$($k).+ }, $fmt, fields: $($rest)+)
-    };
-
-    // == recursive case (more tts), empty out set ===
-    (@ { }, $fmt:expr, fields: message = $val:expr, $($rest:tt)+) => {
-        $crate::__mk_format_args!(@ { $val }, $fmt, fields: $($rest)+)
-    };
-    (@ { }, $fmt:expr, fields: $($k:ident).+ = ?$val:expr, $($rest:tt)+) => {
-        $crate::__mk_format_args!(@ { $val }, $fmt, fields: $($rest)+)
-    };
-    (@ { }, $fmt:expr, fields: $($k:ident).+ = %$val:expr, $($rest:tt)+) => {
-        $crate::__mk_format_args!(@ { $val }, $fmt, fields: $($rest)+)
-    };
-    (@ { }, $fmt:expr, fields: $($k:ident).+ = $val:expr, $($rest:tt)+) => {
-        $crate::__mk_format_args!(@ { $val }, $fmt, fields: $($rest)+)
-    };
-    // ====== shorthand field syntax ===
-    (@ { }, $fmt:expr, fields: ?$($k:ident).+, $($rest:tt)+) => {
-        $crate::__mk_format_args!(@ { &$($k).+ }, $fmt, fields: $($rest)+)
-    };
-    (@ { }, $fmt:expr, fields: %$($k:ident).+, $($rest:tt)+) => {
-        $crate::__mk_format_args!(@ { &$($k).+ }, $fmt, fields: $($rest)+)
-    };
-    (@ { }, $fmt:expr, fields: $($k:ident).+, $($rest:tt)+) => {
-        $crate::__mk_format_args!(@ { &$($k).+ }, $fmt, fields: $($rest)+)
+    (@ { $(,)* $($out:expr),* }, $fmt:expr, fields: $($k:ident).+, $($rest:tt)+) => {
+        $crate::__mk_format_args!(@ { $($out),*, &$($k).+ }, $fmt, fields: $($rest)+)
     };
 
-    // -=== rest is unparseable ===
-    (@ { $($out:expr),* }, $fmt:expr, fields: $($rest:tt)+) => {
+    // === rest is unparseable --- must be fmt args ===
+    (@ { $(,)* $($out:expr),* }, $fmt:expr, fields: $($rest:tt)+) => {
         $crate::__mk_format_args!(@ { format_args!($($rest)+), $($out),* }, $fmt, fields: )
     };
 

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -2417,68 +2417,38 @@ macro_rules! __tracing_disabled_span {
 #[macro_export]
 macro_rules! __mk_format_string {
     // === base case ===
-    (@ { $($out:expr),+ $(,)* } $(,)*) => {
-        concat!( $($out),+)
+    (@ { $(,)* $($out:expr),* $(,)* } $(,)*) => {
+        concat!( $($out),*)
     };
 
-    // === recursive case (more tts), non-empty out set ===
-
+    // === recursive case (more tts), ===
     // ====== shorthand field syntax ===
-    (@ { $($out:expr),+ }, ?$($k:ident).+, $($rest:tt)*) => {
-        tracing::__mk_format_string!(@ { $($out),+, tracing::__tracing_stringify!($($k).+), "={:?} " }, $($rest)*)
+    (@ { $(,)* $($out:expr),* }, ?$($k:ident).+, $($rest:tt)*) => {
+        tracing::__mk_format_string!(@ { $($out),*, tracing::__tracing_stringify!($($k).+), "={:?} " }, $($rest)*)
     };
-    (@ { $($out:expr),+ }, %$($k:ident).+, $($rest:tt)*) => {
-        tracing::__mk_format_string!(@ { $($out),+, tracing::__tracing_stringify!($($k).+), "={} " }, $($rest)*)
+    (@ { $(,)* $($out:expr),* }, %$($k:ident).+, $($rest:tt)*) => {
+        tracing::__mk_format_string!(@ { $($out),*, tracing::__tracing_stringify!($($k).+), "={} " }, $($rest)*)
     };
-    (@ { $($out:expr),+ }, $($k:ident).+, $($rest:tt)*) => {
-        tracing::__mk_format_string!(@ { $($out),+, tracing::__tracing_stringify!($($k).+), "={:?} " }, $($rest)*)
+    (@ { $(,)* $($out:expr),* }, $($k:ident).+, $($rest:tt)*) => {
+        tracing::__mk_format_string!(@ { $($out),*, tracing::__tracing_stringify!($($k).+), "={:?} " }, $($rest)*)
     };
-
-    (@ { $($out:expr),+ }, message = $val:expr, $($rest:tt)*) => {
-        tracing::__mk_format_string!(@ { $($out),+, "{} " }, $($rest)*)
+    // ====== kv field syntax ===
+    (@ { $(,)* $($out:expr),* }, message = $val:expr, $($rest:tt)*) => {
+        tracing::__mk_format_string!(@ { $($out),*, "{} " }, $($rest)*)
     };
-    (@ { $($out:expr),+ }, $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
-        tracing::__mk_format_string!(@ { $($out),+, tracing::__tracing_stringify!($($k).+), "={:?} " }, $($rest)*)
+    (@ { $(,)* $($out:expr),* }, $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
+        tracing::__mk_format_string!(@ { $($out),*, tracing::__tracing_stringify!($($k).+), "={:?} " }, $($rest)*)
     };
-    (@ { $($out:expr),+ }, $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
-        tracing::__mk_format_string!(@ { $($out),+, tracing::__tracing_stringify!($($k).+), "={} " }, $($rest)*)
+    (@ { $(,)* $($out:expr),* }, $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
+        tracing::__mk_format_string!(@ { $($out),*, tracing::__tracing_stringify!($($k).+), "={} " }, $($rest)*)
     };
-    (@ { $($out:expr),+ }, $($k:ident).+ = $val:expr, $($rest:tt)*) => {
-        tracing::__mk_format_string!(@ { $($out),+, tracing::__tracing_stringify!($($k).+), "={:?} " }, $($rest)*)
-    };
-
-
-
-    // === recursive case (more tts), empty out set ===
-    // ====== shorthand field syntax ===
-    (@ { }, ?$($k:ident).+, $($rest:tt)*) => {
-        tracing::__mk_format_string!(@ { tracing::__tracing_stringify!($($k).+), "={:?} " }, $($rest)*)
-    };
-    (@ { }, %$($k:ident).+, $($rest:tt)*) => {
-        tracing::__mk_format_string!(@ { tracing::__tracing_stringify!($($k).+), "={} " }, $($rest)*)
-    };
-    (@ { }, $($k:ident).+, $($rest:tt)*) => {
-        tracing::__mk_format_string!(@ { tracing::__tracing_stringify!($($k).+), "={:?} " }, $($rest)*)
-    };
-    (@ { }, message = $val:expr, $($rest:tt)*) => {
-        tracing::__mk_format_string!(@ { "{} " }, $($rest)*)
-    };
-    (@ { }, $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
-        tracing::__mk_format_string!(@ { tracing::__tracing_stringify!($($k).+), "={:?} " }, $($rest)*)
-    };
-    (@ { }, $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
-        tracing::__mk_format_string!(@ {  tracing::__tracing_stringify!($($k).+), "={} " }, $($rest)*)
-    };
-    (@ { }, $($k:ident).+ = $val:expr, $($rest:tt)*) => {
-        tracing::__mk_format_string!(@ { tracing::__tracing_stringify!($($k).+), "={:?} " }, $($rest)*)
+    (@ { $(,)* $($out:expr),* }, $($k:ident).+ = $val:expr, $($rest:tt)*) => {
+        tracing::__mk_format_string!(@ { $($out),*, tracing::__tracing_stringify!($($k).+), "={:?} " }, $($rest)*)
     };
 
-    // === rest is unparseable ===
-    (@ { $($out:expr),* }, $($rest:tt)+) => {
+    // === rest is unparseable --- must be fmt args ===
+    (@ { $(,)* $($out:expr),* }, $($rest:tt)+) => {
         tracing::__mk_format_string!(@ { "{}", $($out),* }, )
-    };
-    (@ { }, $($rest:tt)+) => {
-        tracing::__mk_format_string!(@ { "{}" }, )
     };
 
     // === entry ===


### PR DESCRIPTION
#288 introduced a regression that causes infinite macro recursion when
the `log` feature is enabled. This PR fixes it (by making the macros 
significantly worse).

I've also added a new test step that runs with `--all-features`, since
apparently CI doesn't already do this.

Fixes #303