### PR TITLE
futures: use current span and dispatcher context

### DIFF
--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -64,6 +64,10 @@ pub trait Instrument: Sized {
     fn instrument(self, span: Span) -> Instrumented<Self> {
         Instrumented { inner: self, span }
     }
+    #[inline]
+    fn in_current_span(self) -> Instrumented<Self> {
+        self.instrument(Span::current())
+    }
 }
 
 /// Extension trait allowing futures, streams, and skins to be instrumented with
@@ -83,6 +87,13 @@ pub trait WithSubscriber: Sized {
         WithDispatch {
             inner: self,
             dispatch: subscriber.into(),
+        }
+    }
+    #[inline]
+    fn with_current_subscriber(self) -> WithDispatch<Self> {
+        WithDispatch {
+            inner: self,
+            dispatch: dispatcher::get_default(|default| default.clone()),
         }
     }
 }


### PR DESCRIPTION
### Crate
`tracing-futures`

### Motivation
Previously, both traits expose a single method (Instrument::instrument and WithSubscriber::with_subscriber, respectively) which accepts the span or dispatcher to attach to the future.

### Solution
This PR adds convenience methods to `Instrument` and `WithSubscriber` that instrument the future in the current span/dispatcher context. I'm expecting the method names to change and
would very much appreciate your input.

Fixes: #231 