### PR TITLE
nightly-examples: track upstream

### DIFF
--- a/nightly-examples/examples/echo.rs
+++ b/nightly-examples/examples/echo.rs
@@ -16,7 +16,7 @@
 //!     nc localhost 3000
 //!
 //! Each line you type in to the `netcat` terminal should be echo'd back to
-//! you! If you open up multiple terminals with `netcat` instances connected 
+//! you! If you open up multiple terminals with `netcat` instances connected
 //! to the same address you should be able to see them all make progress simultaneously.
 //!
 //! [echo-example]: https://github.com/tokio-rs/tokio/blob/master/tokio/examples/echo.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Next up we create a TCP listener which will listen for incoming
     // connections. This TCP listener is bound to the address we determined
     // above and must be associated with an event loop.
-    let mut listener = TcpListener::bind(&addr)?;
+    let mut listener = TcpListener::bind(&addr).await?;
     // Use `fmt::Debug` impl for `addr` using the `%` sybmol
     info!(message = "Listening on", %addr);
 
@@ -111,7 +111,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     .instrument(trace_span!("write"))
                     .await
                     .expect("failed to write data to socket");
-
 
                 info!(message = "echo'd data", %peer_addr, size = n);
             }

--- a/nightly-examples/examples/proxy_server.rs
+++ b/nightly-examples/examples/proxy_server.rs
@@ -101,7 +101,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or_else(|| "127.0.0.1:3000".to_string());
     let server_addr = server_addr.parse::<SocketAddr>()?;
 
-    let mut listener = TcpListener::bind(&listen_addr)?.incoming();
+    let mut listener = TcpListener::bind(&listen_addr).await?.incoming();
+
     info!("Listening on: {}", listen_addr);
     info!("Proxying to: {}", server_addr);
 


### PR DESCRIPTION
Apparently `TcpListener::bind` is async now.

This fixes CI.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>