### PR TITLE
tracing: new syntax puts messages first

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -2222,7 +2222,7 @@ macro_rules! valueset {
     };
     // Remainder is unparseable, but exists --- must be format args!
     (@ { $(,)* $($out:expr),* }, $next:expr, $($rest:tt)+) => {
-        $crate::valueset!(@ { $($out),*, (&$next, Some(&format_args!($($rest)+) as &Value)) }, $next, )
+        $crate::valueset!(@ { (&$next, Some(&format_args!($($rest)+) as &Value)), $($out),* }, $next, )
     };
 
     // === entry ===
@@ -2280,7 +2280,7 @@ macro_rules! fieldset {
 
     // Remainder is unparseable, but exists --- must be format args!
     (@ { $(,)* $($out:expr),* } $($rest:tt)+) => {
-        $crate::fieldset!(@ { $($out),*, "message" })
+        $crate::fieldset!(@ { "message", $($out),*, })
     };
 
     // == entry ==


### PR DESCRIPTION
## Motivation

The old syntax for macros with messages would put the message field
first, followed by all the other fields. The new (no curly braces)
syntax (added in #288) puts messages last, inconsistently with 
everything else. Since message field ordering currently matters for 
how some subscribers (e.g. `tracing-fmt`) display events, we should 
make this somewhat more consistent.

## Solution

This branch changes the new macro syntax to put the `message` 
field first, rather than last.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>