### PR TITLE
tracing: prepare to release 0.1.7

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.1.7 (August 30, 2019)
+
+### Changed
+
+- New (curly-brace free) event message syntax to place the message in the first
+  field rather than the last (#309)
+
+### Fixed
+
+- Fixed a regression causing macro stack exhaustion when the `log` feature flag
+  is enabled (#304)
+
 # 0.1.6 (August 20, 2019)
 
 ### Added

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,13 +8,13 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing/0.1.6/tracing"
+documentation = "https://docs.rs/tracing/0.1.7/tracing"
 description = """
 Application-level tracing for Rust.
 """

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -12,9 +12,9 @@ Application-level tracing for Rust.
 [Chat][gitter-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.6
+[crates-url]: https://crates.io/crates/tracing/0.1.7
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.6
+[docs-url]: https://docs.rs/tracing/0.1.7
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master
@@ -47,7 +47,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing = "0.1.6"
+tracing = "0.1.7"
 ```
 
 This crate provides macros for creating `Span`s and `Event`s, which represent

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.6")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.7")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
Changed:

- New (curly-brace free) event message syntax to place the message in
  the first field rather than the last (#309)

Fixed:

- Fixed a regression causing macro stack exhaustion when the `log`
  feature flag is enabled (#304)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>