### PR TITLE
subscriber: pre-0.1 polish pass

### DIFF
--- a/tracing-subscriber/src/filter/field.rs
+++ b/tracing-subscriber/src/filter/field.rs
@@ -10,30 +10,30 @@ use super::{FieldMap, LevelFilter};
 use tracing_core::field::{Field, Visit};
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct Match {
-    pub name: String, // TODO: allow match patterns for names?
-    pub value: Option<ValueMatch>,
+pub(crate) struct Match {
+    pub(crate) name: String, // TODO: allow match patterns for names?
+    pub(crate) value: Option<ValueMatch>,
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct CallsiteMatch {
-    pub fields: FieldMap<ValueMatch>,
-    pub level: LevelFilter,
+pub(crate) struct CallsiteMatch {
+    pub(crate) fields: FieldMap<ValueMatch>,
+    pub(crate) level: LevelFilter,
 }
 
 #[derive(Debug)]
-pub struct SpanMatch {
+pub(crate) struct SpanMatch {
     fields: FieldMap<(ValueMatch, AtomicBool)>,
     level: LevelFilter,
     has_matched: AtomicBool,
 }
 
-pub struct MatchVisitor<'a> {
+pub(crate) struct MatchVisitor<'a> {
     inner: &'a SpanMatch,
 }
 
 #[derive(Debug, Clone)]
-pub enum ValueMatch {
+pub(crate) enum ValueMatch {
     Bool(bool),
     U64(u64),
     I64(i64),
@@ -65,12 +65,12 @@ impl FromStr for Match {
 }
 
 impl Match {
-    pub fn has_value(&self) -> bool {
+    pub(crate) fn has_value(&self) -> bool {
         self.value.is_some()
     }
 
     // TODO: reference count these strings?
-    pub fn name(&self) -> String {
+    pub(crate) fn name(&self) -> String {
         self.name.clone()
     }
 }
@@ -110,13 +110,13 @@ impl Eq for ValueMatch {}
 impl Error for BadName {}
 
 impl fmt::Display for BadName {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "invalid field name `{}`", self.name)
     }
 }
 
 impl CallsiteMatch {
-    pub fn to_span_match(&self) -> SpanMatch {
+    pub(crate) fn to_span_match(&self) -> SpanMatch {
         let fields = self
             .fields
             .iter()
@@ -131,12 +131,12 @@ impl CallsiteMatch {
 }
 
 impl SpanMatch {
-    pub fn visitor<'a>(&'a self) -> MatchVisitor<'a> {
+    pub(crate) fn visitor<'a>(&'a self) -> MatchVisitor<'a> {
         MatchVisitor { inner: self }
     }
 
     #[inline]
-    pub fn is_matched(&self) -> bool {
+    pub(crate) fn is_matched(&self) -> bool {
         if self.has_matched.load(Ordering::Acquire) {
             return true;
         }
@@ -156,7 +156,7 @@ impl SpanMatch {
     }
 
     #[inline]
-    pub fn filter(&self) -> Option<LevelFilter> {
+    pub(crate) fn filter(&self) -> Option<LevelFilter> {
         if self.is_matched() {
             Some(self.level.clone())
         } else {

--- a/tracing-subscriber/src/filter/level.rs
+++ b/tracing-subscriber/src/filter/level.rs
@@ -1,6 +1,7 @@
 use std::{cmp::Ordering, fmt, str::FromStr};
 use tracing_core::Level;
 
+/// A filter which is enabled for a given verbosity level and below.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct LevelFilter(Inner);
 

--- a/tracing-subscriber/src/filter/level.rs
+++ b/tracing-subscriber/src/filter/level.rs
@@ -62,7 +62,7 @@ impl PartialOrd<Level> for LevelFilter {
 }
 
 impl fmt::Display for LevelFilter {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             Inner::Off => f.pad("OFF"),
             Inner::Level(Level::ERROR) => f.pad("ERROR"),
@@ -75,7 +75,7 @@ impl fmt::Display for LevelFilter {
 }
 
 impl fmt::Debug for LevelFilter {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             Inner::Off => f.pad("LevelFilter::OFF"),
             Inner::Level(Level::ERROR) => f.pad("LevelFilter::ERROR"),
@@ -142,7 +142,7 @@ impl From<Level> for LevelFilter {
 // === impl ParseError ===
 
 impl fmt::Display for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "invalid level`")
     }
 }

--- a/tracing-subscriber/src/filter/mod.rs
+++ b/tracing-subscriber/src/filter/mod.rs
@@ -1,9 +1,12 @@
 //! A `Layer` that enables or disables spans and events based on a set of
 //! filtering directives.
-pub mod level;
-pub use self::directive::ParseError;
-pub use self::field::BadName;
-pub use self::level::LevelFilter;
+mod level;
+#[doc(inline)]
+pub use self::{
+    directive::ParseError,
+    field::BadName as BadFieldName,
+    level::{LevelFilter, ParseError as LevelParseError},
+};
 mod directive;
 mod field;
 use self::directive::Directive;
@@ -58,6 +61,11 @@ enum ErrorKind {
 }
 
 impl Filter {
+    /// The default environment variable used by [`Filter::from_default_env`]
+    /// and [`Filter::try_from_default_env`].
+    ///
+    /// [`Filter::from_default_env`]: #method.from_default_env
+    /// [`Filter::try_from_default_env`]: #method.try_from_default_env
     pub const DEFAULT_ENV: &'static str = "RUST_LOG";
 
     /// Returns a new `Filter` from the value of the `RUST_LOG` environment
@@ -292,15 +300,15 @@ mod tests {
         fn register_callsite(&self, _: &'static Metadata<'static>) -> subscriber::Interest {
             subscriber::Interest::always()
         }
-        fn new_span(&self, _: &span::Attributes) -> span::Id {
+        fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
             span::Id::from_u64(0xDEAD)
         }
-        fn event(&self, _event: &Event) {}
-        fn record(&self, _span: &span::Id, _values: &span::Record) {}
+        fn event(&self, _event: &Event<'_>) {}
+        fn record(&self, _span: &span::Id, _values: &span::Record<'_>) {}
         fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
 
         #[inline]
-        fn enabled(&self, _metadata: &Metadata) -> bool {
+        fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
             true
         }
         fn enter(&self, _span: &span::Id) {}
@@ -310,7 +318,7 @@ mod tests {
     struct Cs;
     impl Callsite for Cs {
         fn set_interest(&self, _interest: Interest) {}
-        fn metadata(&self) -> &Metadata {
+        fn metadata(&self) -> &Metadata<'_> {
             unimplemented!()
         }
     }

--- a/tracing-subscriber/src/filter/mod.rs
+++ b/tracing-subscriber/src/filter/mod.rs
@@ -161,7 +161,7 @@ impl<S: Subscriber> Layer<S> for Filter {
         }
     }
 
-    fn enabled(&self, metadata: &Metadata, _: Context<S>) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>, _: Context<'_, S>) -> bool {
         let level = metadata.level();
         for filter in self.scope.get().iter() {
             if filter >= level {
@@ -174,7 +174,7 @@ impl<S: Subscriber> Layer<S> for Filter {
         false
     }
 
-    fn new_span(&self, attrs: &span::Attributes, id: &span::Id, _: Context<S>) {
+    fn new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, _: Context<'_, S>) {
         let by_cs = try_lock!(self.by_cs.read());
         if let Some(cs) = by_cs.get(&attrs.metadata().callsite()) {
             let span = cs.to_span_match(attrs);
@@ -182,13 +182,13 @@ impl<S: Subscriber> Layer<S> for Filter {
         }
     }
 
-    fn on_record(&self, id: &span::Id, values: &span::Record, _: Context<S>) {
+    fn on_record(&self, id: &span::Id, values: &span::Record<'_>, _: Context<'_, S>) {
         if let Some(span) = try_lock!(self.by_id.read()).get(id) {
             span.record_update(values);
         }
     }
 
-    fn on_enter(&self, id: &span::Id, _: Context<S>) {
+    fn on_enter(&self, id: &span::Id, _: Context<'_, S>) {
         // XXX: This is where _we_ could push IDs to the stack instead, and use
         // that to allow changing the filter while a span is already entered.
         // But that might be much less efficient...
@@ -197,13 +197,13 @@ impl<S: Subscriber> Layer<S> for Filter {
         }
     }
 
-    fn on_exit(&self, id: &span::Id, _: Context<S>) {
+    fn on_exit(&self, id: &span::Id, _: Context<'_, S>) {
         if self.cares_about_span(id) {
             self.scope.get().pop();
         }
     }
 
-    fn on_close(&self, id: span::Id, _: Context<S>) {
+    fn on_close(&self, id: span::Id, _: Context<'_, S>) {
         // If we don't need to acquire a write lock, avoid doing so.
         if !self.cares_about_span(&id) {
             return;
@@ -256,7 +256,7 @@ impl From<env::VarError> for FromEnvError {
 }
 
 impl fmt::Display for FromEnvError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
             ErrorKind::Parse(ref p) => p.fmt(f),
             ErrorKind::Env(ref e) => e.fmt(f),

--- a/tracing-subscriber/src/fmt/format.rs
+++ b/tracing-subscriber/src/fmt/format.rs
@@ -277,6 +277,16 @@ impl<'a> field::Visit for Recorder<'a> {
     }
 }
 
+// This has to be a manual impl, as `&mut dyn Writer` doesn't implement `Debug`.
+impl<'a> fmt::Debug for Recorder<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Recorder")
+            .field("writer", &format_args!("<dyn fmt::Write>"))
+            .field("is_empty", &self.is_empty)
+            .finish()
+    }
+}
+
 struct FmtCtx<'a, N> {
     ctx: &'a span::Context<'a, N>,
     ansi: bool,

--- a/tracing-subscriber/src/fmt/format.rs
+++ b/tracing-subscriber/src/fmt/format.rs
@@ -205,7 +205,16 @@ where
     }
 }
 
-pub struct NewRecorder;
+#[derive(Debug)]
+pub struct NewRecorder {
+    _p: (),
+}
+
+impl NewRecorder {
+    pub(crate) fn new() -> Self {
+        Self { _p: () }
+    }
+}
 
 pub struct Recorder<'a> {
     writer: &'a mut dyn Write,
@@ -213,7 +222,7 @@ pub struct Recorder<'a> {
 }
 
 impl<'a> Recorder<'a> {
-    pub fn new(writer: &'a mut dyn Write, is_empty: bool) -> Self {
+    pub(crate) fn new(writer: &'a mut dyn Write, is_empty: bool) -> Self {
         Self { writer, is_empty }
     }
 

--- a/tracing-subscriber/src/fmt/format.rs
+++ b/tracing-subscriber/src/fmt/format.rs
@@ -205,6 +205,8 @@ where
     }
 }
 
+/// The default implementation of `NewVisitor` that records fields using the
+/// default format.
 #[derive(Debug)]
 pub struct NewRecorder {
     _p: (),
@@ -216,6 +218,7 @@ impl NewRecorder {
     }
 }
 
+/// A visitor that records fields using the default format.
 pub struct Recorder<'a> {
     writer: &'a mut dyn Write,
     is_empty: bool,

--- a/tracing-subscriber/src/fmt/format.rs
+++ b/tracing-subscriber/src/fmt/format.rs
@@ -274,7 +274,7 @@ struct FmtCtx<'a, N> {
 }
 
 impl<'a, N: 'a> FmtCtx<'a, N> {
-    pub fn new(ctx: &'a span::Context<'a, N>, ansi: bool) -> Self {
+    pub(crate) fn new(ctx: &'a span::Context<'a, N>, ansi: bool) -> Self {
         Self { ctx, ansi }
     }
 }
@@ -329,7 +329,7 @@ struct FullCtx<'a, N> {
 }
 
 impl<'a, N: 'a> FullCtx<'a, N> {
-    pub fn new(ctx: &'a span::Context<'a, N>, ansi: bool) -> Self {
+    pub(crate) fn new(ctx: &'a span::Context<'a, N>, ansi: bool) -> Self {
         Self { ctx, ansi }
     }
 }
@@ -391,7 +391,7 @@ struct FmtLevel<'a> {
 }
 
 impl<'a> FmtLevel<'a> {
-    pub fn new(level: &'a Level, ansi: bool) -> Self {
+    pub(crate) fn new(level: &'a Level, ansi: bool) -> Self {
         Self { level, ansi }
     }
 }

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -230,7 +230,7 @@ impl Default for Builder {
     fn default() -> Self {
         Builder {
             filter: layer::identity(),
-            new_visitor: format::NewRecorder,
+            new_visitor: format::NewRecorder::new(),
             fmt_event: format::Format::default(),
             settings: Settings::default(),
             make_writer: io::stdout,

--- a/tracing-subscriber/src/fmt/span.rs
+++ b/tracing-subscriber/src/fmt/span.rs
@@ -16,6 +16,7 @@ pub struct Span<'a> {
 
 /// Represents the `Subscriber`'s view of the current span context to a
 /// formatter.
+#[derive(Debug)]
 pub struct Context<'a, N> {
     store: &'a Store,
     new_visitor: &'a N,
@@ -124,6 +125,17 @@ impl<'a> Span<'a> {
             }
         }
         f(my_id, self)
+    }
+}
+
+impl<'a> fmt::Debug for Span<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Span")
+            .field("name", &self.name())
+            .field("parent", &self.parent())
+            .field("metadata", self.metadata())
+            .field("fields", &self.fields())
+            .finish()
     }
 }
 

--- a/tracing-subscriber/src/fmt/span.rs
+++ b/tracing-subscriber/src/fmt/span.rs
@@ -209,7 +209,7 @@ fn id_to_idx(id: &Id) -> usize {
 }
 
 impl Store {
-    pub fn with_capacity(capacity: usize) -> Self {
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
         Store {
             inner: RwLock::new(Slab {
                 slab: Vec::with_capacity(capacity),
@@ -219,13 +219,13 @@ impl Store {
     }
 
     #[inline]
-    pub fn current(&self) -> Option<Id> {
+    pub(crate) fn current(&self) -> Option<Id> {
         CONTEXT
             .try_with(|current| current.borrow().last().map(|span| self.clone_span(span)))
             .ok()?
     }
 
-    pub fn push(&self, id: &Id) {
+    pub(crate) fn push(&self, id: &Id) {
         let _ = CONTEXT.try_with(|current| {
             let mut current = current.borrow_mut();
             if current.contains(id) {
@@ -236,7 +236,7 @@ impl Store {
         });
     }
 
-    pub fn pop(&self, expected_id: &Id) {
+    pub(crate) fn pop(&self, expected_id: &Id) {
         let id = CONTEXT
             .try_with(|current| {
                 let mut current = current.borrow_mut();
@@ -261,7 +261,7 @@ impl Store {
     /// recently emptied span will be reused. Otherwise, a new allocation will
     /// be added to the slab.
     #[inline]
-    pub fn new_span<N>(&self, attrs: &Attributes<'_>, new_visitor: &N) -> Id
+    pub(crate) fn new_span<N>(&self, attrs: &Attributes<'_>, new_visitor: &N) -> Id
     where
         N: for<'a> super::NewVisitor<'a>,
     {
@@ -327,7 +327,7 @@ impl Store {
     /// Returns a `Span` to the span with the specified `id`, if one
     /// currently exists.
     #[inline]
-    pub fn get(&self, id: &Id) -> Option<Span<'_>> {
+    pub(crate) fn get(&self, id: &Id) -> Option<Span<'_>> {
         let lock = OwningHandle::try_new(self.inner.read(), |slab| {
             unsafe { &*slab }.read_slot(id_to_idx(id)).ok_or(())
         })
@@ -337,7 +337,7 @@ impl Store {
 
     /// Records that the span with the given `id` has the given `fields`.
     #[inline]
-    pub fn record<N>(&self, id: &Id, fields: &Record<'_>, new_recorder: &N)
+    pub(crate) fn record<N>(&self, id: &Id, fields: &Record<'_>, new_recorder: &N)
     where
         N: for<'a> super::NewVisitor<'a>,
     {
@@ -352,7 +352,7 @@ impl Store {
     /// removes the span if it is zero.
     ///
     /// The allocated span slot will be reused when a new span is created.
-    pub fn drop_span(&self, id: Id) -> bool {
+    pub(crate) fn drop_span(&self, id: Id) -> bool {
         let this = self.inner.read();
         let idx = id_to_idx(&id);
 
@@ -376,7 +376,7 @@ impl Store {
         true
     }
 
-    pub fn clone_span(&self, id: &Id) -> Id {
+    pub(crate) fn clone_span(&self, id: &Id) -> Id {
         let this = self.inner.read();
         let idx = id_to_idx(id);
 

--- a/tracing-subscriber/src/fmt/span.rs
+++ b/tracing-subscriber/src/fmt/span.rs
@@ -173,6 +173,7 @@ impl<'a, N> Context<'a, N> {
             .unwrap_or(Ok(()))
     }
 
+    /// Executes a closure with the reference to the current span.
     pub fn with_current<F, R>(&self, f: F) -> Option<R>
     where
         F: FnOnce((&Id, Span<'_>)) -> R,
@@ -198,6 +199,8 @@ impl<'a, N> Context<'a, N> {
         Self { store, new_visitor }
     }
 
+    /// Returns a new visitor that formats span fields to the provided writer.
+    /// The visitor configuration is provided by the subscriber.
     pub fn new_visitor<'writer>(
         &self,
         writer: &'writer mut dyn fmt::Write,

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -367,6 +367,7 @@ where
     }
 }
 
+/// Extension trait adding a `with(Layer)` combinator to `Subscriber`s.
 pub trait SubscriberExt: Subscriber + crate::sealed::Sealed {
     fn with<L>(self, layer: L) -> Layered<L, Self>
     where
@@ -716,17 +717,17 @@ pub(crate) mod tests {
             Interest::never()
         }
 
-        fn enabled(&self, _: &Metadata) -> bool {
+        fn enabled(&self, _: &Metadata<'_>) -> bool {
             false
         }
 
-        fn new_span(&self, _: &span::Attributes) -> span::Id {
+        fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
             span::Id::from_u64(1)
         }
 
-        fn record(&self, _: &span::Id, _: &span::Record) {}
+        fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
         fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
-        fn event(&self, _: &Event) {}
+        fn event(&self, _: &Event<'_>) {}
         fn enter(&self, _: &span::Id) {}
         fn exit(&self, _: &span::Id) {}
     }

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -369,6 +369,7 @@ where
 
 /// Extension trait adding a `with(Layer)` combinator to `Subscriber`s.
 pub trait SubscriberExt: Subscriber + crate::sealed::Sealed {
+    /// Wraps `self` with the provided `layer`.
     fn with<L>(self, layer: L) -> Layered<L, Self>
     where
         L: Layer<Self>,
@@ -697,13 +698,10 @@ impl<'a, S> Clone for Context<'a, S> {
 impl<S: Subscriber> Layer<S> for Identity {}
 
 impl Identity {
+    /// Returns a new `Identity` layer.
     pub fn new() -> Self {
         Self { _p: () }
     }
-}
-
-pub fn identity() -> Identity {
-    Identity::new()
 }
 
 #[cfg(test)]

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -86,6 +86,7 @@ use std::default::Default;
 pub type CurrentSpanPerThread = CurrentSpan;
 
 /// Tracks the currently executing span on a per-thread basis.
+#[derive(Debug)]
 pub struct CurrentSpan {
     current: thread::Local<Vec<Id>>,
 }
@@ -119,8 +120,6 @@ impl Default for CurrentSpan {
 }
 
 mod sealed {
-    pub struct SealedTy {
-        _p: (),
-    }
-    pub trait Sealed<A = SealedTy> {}
+
+    pub trait Sealed<A = ()> {}
 }

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -12,6 +12,43 @@
 //!
 //! [`tracing`]: https://docs.rs/tracing/latest/tracing/
 //! [`Subscriber`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/trait.Subscriber.html
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.1.0")]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
+#![cfg_attr(test, deny(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub,
+    bad-style,
+    const-err,
+    dead-code,
+    extra-requirement-in-impl,
+    improper-ctypes,
+    legacy-directory-ownership,
+    non-shorthand-field-patterns,
+    no-mangle-generic-items,
+    overflowing-literals,
+    path-statements ,
+    patterns-in-fns-without-body,
+    plugin-as-library,
+    private-in-public,
+    private-no-mangle-fns,
+    private-no-mangle-statics,
+    raw-pointer-derive,
+    safe-extern-statics,
+    unconditional-recursion,
+    unions-with-drop-fields,
+    unused,
+    unused-allocation,
+    unused-comparisons,
+    unused-parens,
+    while-true
+))]
 use tracing_core::span::Id;
 
 #[macro_use]

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -19,36 +19,35 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(test, deny(
-    missing_debug_implementations,
-    missing_docs,
-    rust_2018_idioms,
-    unreachable_pub,
-    bad-style,
-    const-err,
-    dead-code,
-    extra-requirement-in-impl,
-    improper-ctypes,
-    legacy-directory-ownership,
-    non-shorthand-field-patterns,
-    no-mangle-generic-items,
-    overflowing-literals,
-    path-statements ,
-    patterns-in-fns-without-body,
-    plugin-as-library,
-    private-in-public,
-    private-no-mangle-fns,
-    private-no-mangle-statics,
-    raw-pointer-derive,
-    safe-extern-statics,
-    unconditional-recursion,
-    unions-with-drop-fields,
-    unused,
-    unused-allocation,
-    unused-comparisons,
-    unused-parens,
-    while-true
-))]
+#![cfg_attr(
+    test,
+    deny(
+        missing_debug_implementations,
+        missing_docs,
+        rust_2018_idioms,
+        unreachable_pub,
+        bad_style,
+        const_err,
+        dead_code,
+        improper_ctypes,
+        legacy_directory_ownership,
+        non_shorthand_field_patterns,
+        no_mangle_generic_items,
+        overflowing_literals,
+        path_statements,
+        patterns_in_fns_without_body,
+        plugin_as_library,
+        private_in_public,
+        safe_extern_statics,
+        unconditional_recursion,
+        unions_with_drop_fields,
+        unused,
+        unused_allocation,
+        unused_comparisons,
+        unused_parens,
+        while_true
+    )
+)]
 use tracing_core::span::Id;
 
 #[macro_use]

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -82,6 +82,7 @@ pub use fmt::Subscriber as FmtSubscriber;
 
 use std::default::Default;
 
+/// Tracks the currently executing span on a per-thread basis.
 #[deprecated(since = "0.0.1-alpha.2", note = "renamed to `CurrentSpan`")]
 pub type CurrentSpanPerThread = CurrentSpan;
 
@@ -92,6 +93,7 @@ pub struct CurrentSpan {
 }
 
 impl CurrentSpan {
+    /// Returns a new `CurrentSpan`.
     pub fn new() -> Self {
         Self {
             current: thread::Local::new(),
@@ -104,10 +106,12 @@ impl CurrentSpan {
         self.current.get().last().cloned()
     }
 
+    /// Records that the current thread has entered the span with the provided ID.
     pub fn enter(&self, span: Id) {
         self.current.get().push(span)
     }
 
+    /// Records that the current thread has exited a span.
     pub fn exit(&self) {
         self.current.get().pop();
     }

--- a/tracing-subscriber/src/prelude.rs
+++ b/tracing-subscriber/src/prelude.rs
@@ -1,3 +1,8 @@
+//! The `tracing-subscriber` prelude.
+//!
+//! This brings into scope a number of extension traits that define methods on
+//! types defined here and in other crates.
+
 pub use crate::layer::{
     Layer as __tracing_subscriber_Layer, SubscriberExt as __tracing_subscriber_SubscriberExt,
 };

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -252,11 +252,11 @@ mod test {
             Two,
         }
         impl<S: Subscriber> crate::Layer<S> for Filter {
-            fn register_callsite(&self, _: &Metadata) -> Interest {
+            fn register_callsite(&self, _: &Metadata<'_>) -> Interest {
                 Interest::sometimes()
             }
 
-            fn enabled(&self, _: &Metadata, _: layer::Context<S>) -> bool {
+            fn enabled(&self, _: &Metadata<'_>, _: layer::Context<'_, S>) -> bool {
                 match self {
                     Filter::One => FILTER1_CALLS.fetch_add(1, Ordering::Relaxed),
                     Filter::Two => FILTER2_CALLS.fetch_add(1, Ordering::Relaxed),

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -125,6 +125,7 @@ where
         (this, handle)
     }
 
+    /// Returns a `Handle` that can be used to reload the wrapped `Layer`.
     pub fn handle(&self) -> Handle<L, S> {
         Handle {
             inner: Arc::downgrade(&self.inner),

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -64,47 +64,47 @@ where
     }
 
     #[inline]
-    fn enabled(&self, metadata: &Metadata, ctx: layer::Context<S>) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>, ctx: layer::Context<'_, S>) -> bool {
         try_lock!(self.inner.read(), else return false).enabled(metadata, ctx)
     }
 
     #[inline]
-    fn new_span(&self, attrs: &span::Attributes, id: &span::Id, ctx: layer::Context<S>) {
+    fn new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: layer::Context<'_, S>) {
         try_lock!(self.inner.read()).new_span(attrs, id, ctx)
     }
 
     #[inline]
-    fn on_record(&self, span: &span::Id, values: &span::Record, ctx: layer::Context<S>) {
+    fn on_record(&self, span: &span::Id, values: &span::Record<'_>, ctx: layer::Context<'_, S>) {
         try_lock!(self.inner.read()).on_record(span, values, ctx)
     }
 
     #[inline]
-    fn on_follows_from(&self, span: &span::Id, follows: &span::Id, ctx: layer::Context<S>) {
+    fn on_follows_from(&self, span: &span::Id, follows: &span::Id, ctx: layer::Context<'_, S>) {
         try_lock!(self.inner.read()).on_follows_from(span, follows, ctx)
     }
 
     #[inline]
-    fn on_event(&self, event: &Event, ctx: layer::Context<S>) {
+    fn on_event(&self, event: &Event<'_>, ctx: layer::Context<'_, S>) {
         try_lock!(self.inner.read()).on_event(event, ctx)
     }
 
     #[inline]
-    fn on_enter(&self, id: &span::Id, ctx: layer::Context<S>) {
+    fn on_enter(&self, id: &span::Id, ctx: layer::Context<'_, S>) {
         try_lock!(self.inner.read()).on_enter(id, ctx)
     }
 
     #[inline]
-    fn on_exit(&self, id: &span::Id, ctx: layer::Context<S>) {
+    fn on_exit(&self, id: &span::Id, ctx: layer::Context<'_, S>) {
         try_lock!(self.inner.read()).on_exit(id, ctx)
     }
 
     #[inline]
-    fn on_close(&self, id: span::Id, ctx: layer::Context<S>) {
+    fn on_close(&self, id: span::Id, ctx: layer::Context<'_, S>) {
         try_lock!(self.inner.read()).on_close(id, ctx)
     }
 
     #[inline]
-    fn on_id_change(&self, old: &span::Id, new: &span::Id, ctx: layer::Context<S>) {
+    fn on_id_change(&self, old: &span::Id, new: &span::Id, ctx: layer::Context<'_, S>) {
         try_lock!(self.inner.read()).on_id_change(old, new, ctx)
     }
 }
@@ -222,7 +222,7 @@ impl Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         error::Error::description(self).fmt(f)
     }
 }

--- a/tracing-tower/examples/load.rs
+++ b/tracing-tower/examples/load.rs
@@ -32,7 +32,6 @@ use tower_hyper::server::Server;
 use std::{error::Error, fmt, net::SocketAddr};
 use tracing;
 use tracing_futures::Instrument;
-use tracing_subscriber::prelude::*;
 use tracing_subscriber::FmtSubscriber;
 
 fn main() {


### PR DESCRIPTION

In the near future, the `tracing-subscriber` crate should be ready for a
stable 0.1 release. Before we can do that, we should do some pre-release
polish, such as denying warnings, updating idioms, and adding missing
documentation.

This branch performs most of the necessary polish for
`tracing-subscriber`. Please note the following:

* The next release will not be version 0.1, as PR #241 would be a 
  breaking change, and I'd like to land that first. We'll probably do
  an alpha.4 first.
* I didn't add `deny(warnings)`, as that will also deny deprecation 
  warnings, and I've had bad experiences with deprecations breaking
  CI in the past. Instead, I've denied most other warnings explicitly.
  The downside to this is a *very* long list of deny attributes.
* The docs added in this branch are pretty rough. It would be good to
  expand them some more in the future, hopefully before 0.1.
