### PR TITLE
chore: rm tracing-subscriber path deps

### DIFF
--- a/nightly-examples/Cargo.toml
+++ b/nightly-examples/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dev-dependencies]
 tracing = "0.1"
-tracing-subscriber = { version = "0.0.1-alpha.3", path = "../tracing-subscriber" }
+tracing-subscriber =  "0.0.1-alpha.4"
 tracing-futures = { path = "../tracing-futures", default-features = false, features = ["std-future"] }
 tokio = { git = "https://github.com/tokio-rs/tokio.git" }
 tracing-attributes = { path = "../tracing-attributes" }

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -45,7 +45,7 @@ quote = "1"
 [dev-dependencies]
 tracing = "0.1"
 tracing-core = "0.1.4"
-tracing-subscriber = { version = "0.0.1-alpha.3", path = "../tracing-subscriber" }
+tracing-subscriber = "0.0.1-alpha.4"
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-env-logger/Cargo.toml
+++ b/tracing-env-logger/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4"
 [dev-dependencies]
 tracing = "0.1"
 tracing-futures = { path = "../tracing-futures" }
-tracing-subscriber = { version = "0.0.1-alpha.3", path = "../tracing-subscriber" }
+tracing-subscriber = "0.0.1-alpha.4"
 hyper = "0.12.25"
 futures = "0.1"
 tokio = "0.1.22"

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -36,7 +36,7 @@ tokio_02 = { package = "tokio", version = "0.2.0-alpha.1", optional = true }
 
 [dev-dependencies]
 tokio = "0.1.22"
-tracing-subscriber = { version = "0.0.1-alpha.3", path = "../tracing-subscriber" }
+tracing-subscriber =  "0.0.1-alpha.4"
 tracing-core = "0.1.2"
 
 [badges]

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -19,7 +19,7 @@ readme = "README.md"
 
 [dependencies]
 tracing-core = "0.1.2"
-tracing-subscriber = "0.0.1-alpha.2"
+tracing-subscriber = "0.0.1-alpha.4"
 log = { version = "0.4", features = ["std"] }
 lazy_static = "1.3.0"
 

--- a/tracing-tower-http/Cargo.toml
+++ b/tracing-tower-http/Cargo.toml
@@ -33,7 +33,7 @@ string = { git = "https://github.com/carllerche/string" }
 tokio = "0.1"
 tokio-current-thread = "0.1.1"
 tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
-tracing-subscriber = { version = "0.0.1-alpha.3", path = "../tracing-subscriber" }
+tracing-subscriber = "0.0.1-alpha.4"
 tokio-io = "0.1"
 ansi_term = "0.11"
 humantime = "1.1.1"

--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -45,7 +45,7 @@ tokio-buf = "0.1"
 tower = "0.1"
 tower-hyper = "0.1"
 tower-http-util = "0.1"
-tracing-subscriber = { version = "0.0.1-alpha.3", path = "../tracing-subscriber" }
+tracing-subscriber = "0.0.1-alpha.4"
 rand = "0.7"
 
 [badges]


### PR DESCRIPTION

## Motivation

Now that `tracing-subscriber` 0.0.1-alpha.4 has been published, we can
remove path dependencies on it from other crates.

## Solution

This branch does that.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>