### PR TITLE
log: fix cyclic dependency

### DIFF
--- a/tracing-env-logger/Cargo.toml
+++ b/tracing-env-logger/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-tracing-log = "0.0.1-alpha.1"
+tracing-log = { version = "0.0.1-alpha.2", path = "../tracing-log" }
 env_logger = "0.5"
 log = "0.4"
 

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-log"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"
@@ -19,7 +19,6 @@ readme = "README.md"
 
 [dependencies]
 tracing-core = "0.1.2"
-tracing-subscriber = "0.0.1-alpha.2"
 log = { version = "0.4", features = ["std"] }
 lazy_static = "1.3.0"
 

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -36,7 +36,7 @@ smallvec = { optional = true, version = "0.6.10"}
 lazy_static = { optional = true, version = "1" }
 
 # fmt
-tracing-log = { version = "0.0.1-alpha.1", optional = true }
+tracing-log = { version = "0.0.1-alpha.2", path = "../tracing-log", optional = true }
 ansi_term = { version = "0.11", optional = true }
 owning_ref = { version = "0.4.0", optional = true }
 parking_lot = { version = ">= 0.7, < 0.10", features = ["owning_ref"], optional = true }


### PR DESCRIPTION
## Motivation

Currently, the `tracing-log` crate uses the `CurrentSpan` utility in
`tracing-subscriber`. However, now that `tracing-fmt` has been moved
into `tracing-subscriber`, its `log` feature (which depends on
`tracing-log`) creates a cyclic dependency between these two crates.

## Solution

This branch solves the cyclic dependency by removing the
`tracing-subscriber` dependency from `tracing-log`. Instead, the
current span is tracked manually.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
