### PR TITLE
tracing: reorganize & clarify documentation

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -293,7 +293,7 @@
 //! The `%` sigil operates similarly, but indicates that the value should be
 //! recorded using its [`fmt::Display`] implementation:
 //! ```
-//! # use tracing::{span, Level};
+//! # use tracing::{event, Level};
 //! # fn main() {
 //! # #[derive(Debug)]
 //! # struct MyStruct {
@@ -313,7 +313,7 @@
 //! The `%` and `?` sigils may also be used with local variable shorthand:
 //!
 //! ```
-//! # use tracing::{span, Level};
+//! # use tracing::{event, Level};
 //! # fn main() {
 //! # #[derive(Debug)]
 //! # struct MyStruct {

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -604,9 +604,9 @@
 //! [`set_global_default`]: subscriber/fn.set_global_default.html
 //! [`with_default`]: subscriber/fn.with_default.html
 //! [`tokio-rs/tracing`]: https://github.com/tokio-rs/tracing
-//! [`tracing-futures`]: https://github.com/tokio-rs/tracing/tree/master/tracing-futures
+//! [`tracing-futures`]: https://crates.io/crates/tracing-futures
 //! [`tracing-subscriber`]: https://crates.io/crates/tracing-subscriber
-//! [`tracing-log`]: https://github.com/tokio-rs/tracing/tree/master/tracing-log
+//! [`tracing-log`]: https://crates.io/crates/tracing-log
 //! [`tracing-timing`]: https://crates.io/crates/tracing-timing
 //! [static verbosity level]: level_filters/index.html#compile-time-filters
 //! [instrument]: https://docs.rs/tracing-attributes/latest/tracing_attributes/attr.instrument.html

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -195,14 +195,14 @@
 //! For example:
 //!
 //! ```
-//! # use tracing::{span, Level};
+//! # use tracing::{span, event, Level};
 //! # fn main() {
 //! span!(target: "app_spans", Level::TRACE, "my span");
 //! event!(target: "app_events", Level::INFO, "something has happened!");
 //! # }
 //! ```
 //! ```
-//! # use tracing::{span, Level};
+//! # use tracing::{span, event, Level};
 //! # fn main() {
 //! let span = span!(Level::TRACE, "my span");
 //! event!(parent: &span, Level::INFO, "something has happened!");

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -148,7 +148,7 @@
 //!
 //! For example:
 //! ```
-//! use tracing::{info, instrument};
+//! use tracing::{Level, event, instrument};
 //!
 //! #[instrument]
 //! pub fn my_function(my_arg: usize) {
@@ -206,6 +206,7 @@
 //! # fn main() {
 //! let span = span!(Level::TRACE, "my span");
 //! event!(parent: &span, Level::INFO, "something has happened!");
+//! # }
 //! ```
 //!
 //! The span macros also take a string literal after the level, to set the name
@@ -320,11 +321,11 @@
 //! #     field: &'static str,
 //! # }
 //! #
-//! # let greeting = MyStruct {
+//! # let my_struct = MyStruct {
 //! #     field: "Hello world!"
 //! # };
 //! // `my_struct.field` will be recorded using its `fmt::Display` implementation.
-//! event!(Level::TRACE, "my span", %greeting.field);
+//! event!(Level::TRACE,  %my_struct.field);
 //! # }
 //! ```
 //!

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -554,9 +554,8 @@
 //!
 //!  - [`tracing-futures`] provides a compatibility layer with the `futures`
 //!    crate, allowing spans to be attached to `Future`s, `Stream`s, and `Executor`s.
-//!  - [`tracing-fmt`] provides a `Subscriber` implementation for
-//!    logging formatted trace data to stdout, with similar filtering and
-//!    formatting to the `env-logger` crate.
+//!  - [`tracing-subscriber`] provides `Subscriber` implementations and
+//!    utilities for working with `Subscriber`s.
 //!  - [`tracing-log`] provides a compatibility layer with the `log` crate,
 //!    allowing log messages to be recorded as `tracing` `Event`s within the
 //!    trace tree. This is useful when a project using `tracing` have
@@ -606,7 +605,7 @@
 //! [`with_default`]: subscriber/fn.with_default.html
 //! [`tokio-rs/tracing`]: https://github.com/tokio-rs/tracing
 //! [`tracing-futures`]: https://github.com/tokio-rs/tracing/tree/master/tracing-futures
-//! [`tracing-fmt`]: https://github.com/tokio-rs/tracing/tree/master/tracing-fmt
+//! [`tracing-subscriber`]: https://crates.io/crates/tracing-subscriber
 //! [`tracing-log`]: https://github.com/tokio-rs/tracing/tree/master/tracing-log
 //! [`tracing-timing`]: https://crates.io/crates/tracing-timing
 //! [static verbosity level]: level_filters/index.html#compile-time-filters

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -89,7 +89,8 @@
 //! implementations of the [`Subscriber`] trait. `Subscriber`s are notified
 //! when an `Event` takes place and when a `Span` is entered or exited. These
 //! notifications are represented by the following `Subscriber` trait methods:
-//! + [`observe_event`], called when an `Event` takes place,
+//!
+//! + [`event`][Subscriber::event], called when an `Event` takes place,
 //! + [`enter`], called when execution enters a `Span`,
 //! + [`exit`], called when execution exits a `Span`
 //!
@@ -594,7 +595,7 @@
 //! [`in_scope`]: span/struct.Span.html#method.in_scope
 //! [`Event`]: struct.Event.html
 //! [`Subscriber`]: subscriber/trait.Subscriber.html
-//! [`observe_event`]: subscriber/trait.Subscriber.html#tymethod.observe_event
+//! [Subscriber::event]: subscriber/trait.Subscriber.html#tymethod.event
 //! [`enter`]: subscriber/trait.Subscriber.html#tymethod.enter
 //! [`exit`]: subscriber/trait.Subscriber.html#tymethod.exit
 //! [`enabled`]: subscriber/trait.Subscriber.html#tymethod.enabled

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -1,5 +1,10 @@
 /// Constructs a new span.
 ///
+/// See [the top-level documentation][lib] for details on the syntax accepted by
+/// this macro.
+///
+/// [lib]: index.html#using-the-macros
+///
 /// # Examples
 ///
 /// Creating a new span:
@@ -11,225 +16,6 @@
 /// // do work inside the span...
 /// # }
 /// ```
-///
-/// ## Recording Fields
-///
-/// Span fields are written using the syntax `key = value`.
-/// ```
-/// # use tracing::{span, Level};
-/// # fn main() {
-/// // construct a new span with two fields:
-/// //  - "foo", with a value of 42,
-/// //  - "bar", with the value "false"
-/// let my_span = span!(Level::INFO, "my_span", foo = 42, bar = false);
-/// # }
-/// ```
-/// Note that a trailing comma on the final field is valid:
-/// ```
-/// # use tracing::{span, Level};
-/// # fn main() {
-/// span!(
-///     Level::INFO,
-///     "my_span",
-///     foo = 42,
-///     bar = false,
-/// );
-/// # }
-/// ```
-///
-/// As shorthand, local variables may be used as field values without an
-/// assignment, similar to [struct initializers]. For example:
-/// ```
-/// # use tracing::{span, Level};
-/// # fn main() {
-/// let user = "ferris";
-///
-/// span!(Level::TRACE, "login", user);
-/// // is equivalent to:
-/// span!(Level::TRACE, "login", user = user);
-/// # }
-///```
-///
-/// Field names can include dots, but should not be terminated by them:
-/// ```
-/// # use tracing::{span, Level};
-/// # fn main() {
-/// let user = "ferris";
-/// let email = "ferris@rust-lang.org";
-/// span!(Level::TRACE, "login", user, user.email = email);
-/// # }
-///```
-///
-/// Since field names can include dots, fields on local structs can be used
-/// using the local variable shorthand:
-/// ```
-/// # use tracing::{span, Level};
-/// # fn main() {
-/// # struct User {
-/// #    name: &'static str,
-/// #    email: &'static str,
-/// # }
-/// let user = User {
-///     name: "ferris",
-///     email: "ferris@rust-lang.org",
-/// };
-/// // the span will have the fields `user.name = "ferris"` and
-/// // `user.email = "ferris@rust-lang.org"`.
-/// span!(Level::TRACE, "login", user.name, user.email);
-/// # }
-///```
-///
-// TODO(#1138): determine a new syntax for uninitialized span fields, and
-// re-enable this.
-// /// Field values may be recorded after the span is created. The `_` character is
-// /// used to represent a field whose value has yet to be recorded:
-// /// ```
-// /// # #[macro_use]
-// /// # extern crate tracing;
-// /// # use tracing::Level;
-// /// # fn main() {
-// /// let my_span = span!(Level::TRACE, "my span", foo = 2, bar = _);
-// /// my_span.record("bar", &7);
-// /// # }
-// /// ```
-// ///
-/// The `?` sigil is shorthand for [`field::debug`]:
-/// ```
-/// # use tracing::{span, Level};
-/// # fn main() {
-/// #[derive(Debug)]
-/// struct MyStruct {
-///     field: &'static str,
-/// }
-///
-/// let my_struct = MyStruct {
-///     field: "Hello world!"
-/// };
-///
-/// // `my_struct` will be recorded using its `fmt::Debug` implementation.
-/// span!(Level::TRACE, "my span", foo = ?my_struct);
-/// // is equivalent to:
-/// span!(Level::TRACE, "my span", foo = tracing::field::debug(&my_struct));
-/// # }
-/// ```
-///
-/// The `%` character is shorthand for [`field::display`]:
-/// ```
-/// # use tracing::{span, Level};
-/// # fn main() {
-/// # #[derive(Debug)]
-/// # struct MyStruct {
-/// #     field: &'static str,
-/// # }
-/// #
-/// # let my_struct = MyStruct {
-/// #     field: "Hello world!"
-/// # };
-/// // `my_struct.field` will be recorded using its `fmt::Display` implementation.
-/// span!(Level::TRACE, "my span", foo = %my_struct.field);
-/// // is equivalent to:
-/// span!(Level::TRACE, "my span", foo = tracing::field::display(&my_struct.field));
-/// # }
-/// ```
-///
-/// The `%` and `?` sigils may also be used with local variable shorthand:
-/// ```
-/// # use tracing::{span, Level};
-/// # fn main() {
-/// # #[derive(Debug)]
-/// # struct MyStruct {
-/// #     field: &'static str,
-/// # }
-/// #
-/// # let my_struct = MyStruct {
-/// #     field: "Hello world!"
-/// # };
-/// // `my_struct.field` will be recorded using its `fmt::Display` implementation.
-/// let my_span = span!(Level::TRACE, "my span", %my_struct.field);
-/// # }
-/// ```
-///
-/// Note that a span may have up to 32 fields. The following will not compile:
-/// ```rust,compile_fail
-///  # #[macro_use]
-/// # extern crate tracing;
-/// # use tracing::Level;
-/// # fn main() {
-/// span!(
-///     Level::TRACE,
-///     "too many fields!",
-///     a = 1, b = 2, c = 3, d = 4, e = 5, f = 6, g = 7, h = 8, i = 9,
-///     j = 10, k = 11, l = 12, m = 13, n = 14, o = 15, p = 16, q = 17,
-///     r = 18, s = 19, t = 20, u = 21, v = 22, w = 23, x = 24, y = 25,
-///     z = 26, aa = 27, bb = 28, cc = 29, dd = 30, ee = 31, ff = 32, gg = 33
-/// );
-/// # }
-/// ```
-///
-/// ## Setting Span Attributes
-///
-/// In addition to the level and name of the span, which are required, the
-/// [target] and [parent span] may be overridden. For example:
-///
-/// Creating a span with custom target:
-/// ```
-/// # use tracing::{span, Level};
-/// # fn main() {
-/// span!(target: "app_span", Level::TRACE, "my span");
-/// # }
-/// ```
-///
-/// Creating a span with an explicit parent:
-/// ```rust
-/// # use tracing::{span, Level};
-/// # fn main() {
-/// // Create, but do not enter, a span called "foo".
-/// let foo = span!(Level::INFO, "foo");
-///
-/// // Create and enter a span called "bar".
-/// let bar = span!(Level::INFO, "bar");
-/// let _enter = bar.enter();
-///
-/// // Although we have currently entered "bar", "baz"'s parent span
-/// // will be "foo".
-/// let baz = span!(parent: &foo, Level::INFO, "baz");
-/// # }
-/// ```
-///
-/// Creating a span _without_ a parent:
-///
-///```rust
-/// # use tracing::{span, Level};
-/// # fn main() {
-/// let foo = span!(Level::INFO, "foo");
-/// let _enter = foo.enter();
-///
-/// // Although we have currently entered "foo", "bar" will be created
-/// // as the root of its own trace tree:
-/// let bar = span!(parent: None, Level::INFO, "bar");
-/// # }
-/// ```
-///
-/// Both the parent and target may be overridden simultaenously:
-///
-///```rust
-/// # use tracing::{span, Level};
-/// # fn main() {
-/// let foo = span!(Level::INFO, "foo");
-//
-/// let bar = span!(target: "bar_events", parent: &foo, Level::INFO, "bar");
-/// # }
-/// ```
-///
-/// By default, the module path to the current Rust module will be used
-/// as the target, and the parent will be [determined contextually].
-///
-/// [struct initializers]: https://doc.rust-lang.org/book/ch05-01-defining-structs.html#using-the-field-init-shorthand-when-variables-and-fields-have-the-same-name
-/// [target]: struct.Metadata.html#method.target
-/// [parent span]: span/struct.Attributes.html#method.parent
-/// [determined contextually]: span/struct.Attributes.html#method.is_contextual
-/// [`field::debug`]: field/fn.display.html
-/// [`field::display`]: field/fn.display.html
 #[macro_export]
 macro_rules! span {
     (target: $target:expr, parent: $parent:expr, $lvl:expr, $name:expr) => {
@@ -342,8 +128,12 @@ macro_rules! span {
 /// [Fields] and [attributes] are set using the same syntax as the [`span!`]
 /// macro.
 ///
-/// [attributes]: macro.span.html#setting-span-attributes
-/// [Fields]: macro.span.html#recording-fields
+/// See [the top-level documentation][lib] for details on the syntax accepted by
+/// this macro.
+///
+/// [lib]: index.html#using-the-macros
+/// [attributes]: index.html#configuring-attributes
+/// [Fields]: index.html#recording-fields
 /// [`span!`]: macro.span.html
 ///
 /// # Examples
@@ -419,8 +209,12 @@ macro_rules! trace_span {
 /// [Fields] and [attributes] are set using the same syntax as the [`span!`]
 /// macro.
 ///
-/// [attributes]: macro.span.html#setting-span-attributes
-/// [Fields]: macro.span.html#recording-fields
+/// See [the top-level documentation][lib] for details on the syntax accepted by
+/// this macro.
+///
+/// [lib]: index.html#using-the-macros
+/// [attributes]: index.html#configuring-attributes
+/// [Fields]: index.html#recording-fields
 /// [`span!`]: macro.span.html
 ///
 /// # Examples
@@ -496,8 +290,12 @@ macro_rules! debug_span {
 /// [Fields] and [attributes] are set using the same syntax as the [`span!`]
 /// macro.
 ///
-/// [attributes]: macro.span.html#setting-span-attributes
-/// [Fields]: macro.span.html#recording-fields
+/// See [the top-level documentation][lib] for details on the syntax accepted by
+/// this macro.
+///
+/// [lib]: index.html#using-the-macros
+/// [attributes]: index.html#configuring-attributes
+/// [Fields]: index.html#recording-fields
 /// [`span!`]: macro.span.html
 ///
 /// # Examples
@@ -573,8 +371,12 @@ macro_rules! info_span {
 /// [Fields] and [attributes] are set using the same syntax as the [`span!`]
 /// macro.
 ///
-/// [attributes]: macro.span.html#setting-span-attributes
-/// [Fields]: macro.span.html#recording-fields
+/// See [the top-level documentation][lib] for details on the syntax accepted by
+/// this macro.
+///
+/// [lib]: index.html#using-the-macros
+/// [attributes]: index.html#configuring-attributes
+/// [Fields]: index.html#recording-fields
 /// [`span!`]: macro.span.html
 ///
 /// # Examples
@@ -649,8 +451,12 @@ macro_rules! warn_span {
 /// [Fields] and [attributes] are set using the same syntax as the [`span!`]
 /// macro.
 ///
-/// [attributes]: macro.span.html#setting-span-attributes
-/// [Fields]: macro.span.html#recording-fields
+/// See [the top-level documentation][lib] for details on the syntax accepted by
+/// this macro.
+///
+/// [lib]: index.html#using-the-macros
+/// [attributes]: index.html#configuring-attributes
+/// [Fields]: index.html#recording-fields
 /// [`span!`]: macro.span.html
 ///
 /// # Examples
@@ -727,6 +533,11 @@ macro_rules! error_span {
 /// Optionally, a format string and arguments may follow the fields; this will
 /// be used to construct an implicit field named "message".
 ///
+/// See [the top-level documentation][lib] for details on the syntax accepted by
+/// this macro.
+///
+/// [lib]: index.html#using-the-macros
+///
 /// # Examples
 ///
 /// ```rust
@@ -750,67 +561,20 @@ macro_rules! error_span {
 /// # }
 /// ```
 ///
-/// Note that *unlike `span!`*, `event!` requires a value for all fields. As
-/// events are recorded immediately when the macro is invoked, there is no
-/// opportunity for fields to be recorded later. A trailing comma on the final
-/// field is valid.
-///
-/// For example, the following does not compile:
-/// ```rust,compile_fail
-/// # #[macro_use]
-/// # extern crate tracing;
-/// # use tracing::Level;
-/// # fn main() {
-/// event!(Level::INFO, foo = 5, bad_field, bar = "hello")
-/// #}
-/// ```
-/// Shorthand for `field::debug`:
-/// ```
-/// # use tracing::{event, Level};
-/// # fn main() {
-/// #[derive(Debug)]
-/// struct MyStruct {
-///     field: &'static str,
-/// }
-///
-/// let my_struct = MyStruct {
-///     field: "Hello world!"
-/// };
-///
-/// // `my_struct` will be recorded using its `fmt::Debug` implementation.
-/// event!(Level::TRACE, ?my_struct);
-/// # }
-/// ```
-/// Shorthand for `field::display`:
-/// ```
-/// # use tracing::{event, Level};
-/// # fn main() {
-/// # #[derive(Debug)]
-/// # struct MyStruct {
-/// #     field: &'static str,
-/// # }
-/// #
-/// # let my_struct = MyStruct {
-/// #     field: "Hello world!"
-/// # };
-/// // `my_struct.field` will be recorded using its `fmt::Display` implementation.
-/// event!(Level::TRACE, %my_struct.field);
-/// # }
-/// ```
-/// Events may have up to 32 fields. The following will not compile:
-/// ```rust,compile_fail
-///  # #[macro_use]
-/// # extern crate tracing;
-/// # use tracing::Level;
-/// # fn main() {
-/// event!(Level::INFO,
-///     a = 1, b = 2, c = 3, d = 4, e = 5, f = 6, g = 7, h = 8, i = 9,
-///     j = 10, k = 11, l = 12, m = 13, n = 14, o = 15, p = 16, q = 17,
-///     r = 18, s = 19, t = 20, u = 21, v = 22, w = 23, x = 24, y = 25,
-///     z = 26, aa = 27, bb = 28, cc = 29, dd = 30, ee = 31, ff = 32, gg = 33
-/// );
-/// # }
-/// ```
+// /// Note that *unlike `span!`*, `event!` requires a value for all fields. As
+// /// events are recorded immediately when the macro is invoked, there is no
+// /// opportunity for fields to be recorded later. A trailing comma on the final
+// /// field is valid.
+// ///
+// /// For example, the following does not compile:
+// /// ```rust,compile_fail
+// /// # #[macro_use]
+// /// # extern crate tracing;
+// /// # use tracing::Level;
+// /// # fn main() {
+// /// event!(Level::INFO, foo = 5, bad_field, bar = "hello")
+// /// #}
+// /// ```
 #[macro_export]
 macro_rules! event {
     (target: $target:expr, parent: $parent:expr, $lvl:expr, { $($fields:tt)* } )=> ({
@@ -1028,9 +792,12 @@ macro_rules! event {
 
 /// Constructs an event at the trace level.
 ///
-/// When both a message and fields are included, curly braces (`{` and `}`) are
-/// used to delimit the list of fields from the format string for the message.
-/// A trailing comma on the final field is valid.
+/// This functions similarly to the [`event!`] macro. See [the top-level
+/// documentation][lib] for details on the syntax accepted by
+/// this macro.
+///
+/// [`event!`]: macro.event.html
+/// [lib]: index.html#using-the-macros
 ///
 /// # Examples
 ///
@@ -1225,9 +992,12 @@ macro_rules! trace {
 
 /// Constructs an event at the debug level.
 ///
-/// When both a message and fields are included, curly braces (`{` and `}`) are
-/// used to delimit the list of fields from the format string for the message.
-/// A trailing comma on the final field is valid.
+/// This functions similarly to the [`event!`] macro. See [the top-level
+/// documentation][lib] for details on the syntax accepted by
+/// this macro.
+///
+/// [`event!`]: macro.event.html
+/// [lib]: index.html#using-the-macros
 ///
 /// # Examples
 ///
@@ -1423,9 +1193,12 @@ macro_rules! debug {
 
 /// Constructs an event at the info level.
 ///
-/// When both a message and fields are included, curly braces (`{` and `}`) are
-/// used to delimit the list of fields from the format string for the message.
-/// A trailing comma on the final field is valid.
+/// This functions similarly to the [`event!`] macro. See [the top-level
+/// documentation][lib] for details on the syntax accepted by
+/// this macro.
+///
+/// [`event!`]: macro.event.html
+/// [lib]: index.html#using-the-macros
 ///
 /// # Examples
 ///
@@ -1632,9 +1405,12 @@ macro_rules! info {
 
 /// Constructs an event at the warn level.
 ///
-/// When both a message and fields are included, curly braces (`{` and `}`) are
-/// used to delimit the list of fields from the format string for the message.
-/// A trailing comma on the final field is valid.
+/// This functions similarly to the [`event!`] macro. See [the top-level
+/// documentation][lib] for details on the syntax accepted by
+/// this macro.
+///
+/// [`event!`]: macro.event.html
+/// [lib]: index.html#using-the-macros
 ///
 /// # Examples
 ///
@@ -1834,9 +1610,12 @@ macro_rules! warn {
 
 /// Constructs an event at the error level.
 ///
-/// When both a message and fields are included, curly braces (`{` and `}`) are
-/// used to delimit the list of fields from the format string for the message.
-/// A trailing comma on the final field is valid.
+/// This functions similarly to the [`event!`] macro. See [the top-level
+/// documentation][lib] for details on the syntax accepted by
+/// this macro.
+///
+/// [`event!`]: macro.event.html
+/// [lib]: index.html#using-the-macros
 ///
 /// # Examples
 ///


### PR DESCRIPTION
This branch updates and reorganizes the crate-level docs in `tracing`. In
particular, I've:

- moved the documentation on `span!` and `event!` macro syntax to a
  single place that the macros link to, and made the differences 
  between the span and event macros clearer.
- added more section headers to make linking into the docs easier
- fixed some typos, broken links, and markdown errors
- simplified the "Core Concepts" section a little
- made it clearer that the `tracing` crate does not provide 
  subscriber impls
- added more documentation describing how to use the 
  instrumentation APIs
- replaced the link to `tracing-fmt` with `tracing-subscriber`

Signed-off-by: Eliza Weisman <eliza@buoyant.io>