### PR TITLE
log: prepare to release 0.1

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,7 +13,7 @@ tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
 tracing-subscriber = { version = "0.0.1-alpha.4", path = "../tracing-subscriber" }
 tracing-futures = { version = "0.0.1-alpha.1", path = "../tracing-futures" }
 tracing-attributes =  "0.1.2"
-tracing-log = { path = "../tracing-log", version = "0.0.1-alpha.1" }
+tracing-log = { path = "../tracing-log", version = "0.1" }
 tracing-env-logger = { path = "../tracing-env-logger" }
 tracing-serde = { path = "../tracing-serde" }
 

--- a/tracing-env-logger/Cargo.toml
+++ b/tracing-env-logger/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-tracing-log = { version = "0.0.1-alpha.2", path = "../tracing-log" }
+tracing-log = { version = "0.1", path = "../tracing-log" }
 env_logger = "0.5"
 log = "0.4"
 

--- a/tracing-log/CHANGELOG.md
+++ b/tracing-log/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0 (September 3, 2019)
+
+- Initial release

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tracing-log"
-version = "0.0.1-alpha.2"
+version = "0.1.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-log/0.0.1-alpha.1/tracing_log"
+documentation = "https://docs.rs/tracing-log/0.1.0/tracing_log"
 description = """
 Provides compatibility between `tracing` and the `log` crate.
 """
@@ -32,4 +32,4 @@ tracing = "0.1"
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
-maintenance = { status = "experimental" }
+maintenance = { status = "actively-maintained" }

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -17,6 +17,11 @@ keywords = ["logging", "tracing", "log"]
 license = "MIT"
 readme = "README.md"
 
+[features]
+default = ["log-tracer", "trace-logger"]
+log-tracer = []
+trace-logger = []
+
 [dependencies]
 tracing-core = "0.1.2"
 log = { version = "0.4", features = ["std"] }

--- a/tracing-log/README.md
+++ b/tracing-log/README.md
@@ -1,7 +1,5 @@
 # tracing-log
 
-**Warning: Until `tracing-log` has a 0.1.0 release on crates.io, please treat every release as potentially breaking.**
-
 [`log`] compatibility for [`tracing`].
 
 [![Crates.io][crates-badge]][crates-url]

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -160,15 +160,25 @@ pub fn format_trace(record: &log::Record<'_>) -> io::Result<()> {
     Ok(())
 }
 
+/// Trait implemented for `tracing` types that can be converted to a `log`
+/// equivalent.
 pub trait AsLog: crate::sealed::Sealed {
+    /// The `log` type that this type can be converted into.
     type Log;
+    /// Returns the `log` equivalent of `self`.
     fn as_log(&self) -> Self::Log;
 }
 
-pub trait AsTrace {
+/// Trait implemented for `log` types that can be converted to a `tracing`
+/// equivalent.
+pub trait AsTrace: crate::sealed::Sealed {
+    /// The `tracing` type that this type can be converted into.
     type Trace;
+    /// Returns the `tracing` equivalent of `self`.
     fn as_trace(&self) -> Self::Trace;
 }
+
+impl<'a> crate::sealed::Sealed for Metadata<'a> {}
 
 impl<'a> AsLog for Metadata<'a> {
     type Log = log::Metadata<'a>;
@@ -274,6 +284,8 @@ fn loglevel_to_cs(level: log::Level) -> (&'static dyn Callsite, &'static Fields)
     }
 }
 
+impl<'a> crate::sealed::Sealed for log::Record<'a> {}
+
 impl<'a> AsTrace for log::Record<'a> {
     type Trace = Metadata<'a>;
     fn as_trace(&self) -> Self::Trace {
@@ -291,6 +303,8 @@ impl<'a> AsTrace for log::Record<'a> {
     }
 }
 
+impl crate::sealed::Sealed for tracing_core::Level {}
+
 impl AsLog for tracing_core::Level {
     type Log = log::Level;
     fn as_log(&self) -> log::Level {
@@ -303,6 +317,8 @@ impl AsLog for tracing_core::Level {
         }
     }
 }
+
+impl crate::sealed::Sealed for log::Level {}
 
 impl AsTrace for log::Level {
     type Trace = tracing_core::Level;
@@ -346,6 +362,8 @@ pub trait NormalizeEvent<'a>: crate::sealed::Sealed {
     /// Returns wether this `Event` represents a log (from the `log` crate)
     fn is_log(&self) -> bool;
 }
+
+impl<'a> crate::sealed::Sealed for Event<'a> {}
 
 impl<'a> NormalizeEvent<'a> for Event<'a> {
     fn normalized_metadata(&'a self) -> Option<Metadata<'a>> {

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -160,7 +160,7 @@ pub fn format_trace(record: &log::Record<'_>) -> io::Result<()> {
     Ok(())
 }
 
-pub trait AsLog {
+pub trait AsLog: crate::sealed::Sealed {
     type Log;
     fn as_log(&self) -> Self::Log;
 }
@@ -336,7 +336,7 @@ impl AsTrace for log::Level {
 /// [`normalized_metadata`]: trait.NormalizeEvent.html#normalized_metadata
 /// [`AsTrace`]: trait.AsTrace.html
 /// [`log::Record`]: https://docs.rs/log/0.4.7/log/struct.Record.html
-pub trait NormalizeEvent<'a> {
+pub trait NormalizeEvent<'a>: crate::sealed::Sealed {
     /// If this `Event` comes from a `log`, this method provides a new
     /// normalized `Metadata` which has all available attributes
     /// from the original log, including `file`, `line`, `module_path`
@@ -422,6 +422,10 @@ impl<'a> Visit for LogVisitor<'a> {
             }
         }
     }
+}
+
+mod sealed {
+    pub trait Sealed {}
 }
 
 #[cfg(test)]

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -1,6 +1,3 @@
-#![doc(html_root_url = "https://docs.rs/tracing-log/0.0.1-alpha.1")]
-#![deny(missing_debug_implementations, unreachable_pub)]
-#![cfg_attr(test, deny(warnings))]
 //! Adapters for connecting unstructured log records from the `log` crate into
 //! the `tracing` ecosystem.
 //!
@@ -77,6 +74,42 @@
 //! [`tracing::Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
 //! [`Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
 //! [`tracing::Event`]: https://docs.rs/tracing/latest/tracing/struct.Event.html
+#![doc(html_root_url = "https://docs.rs/tracing-log/0.0.1-alpha.1")]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
+#![cfg_attr(
+    test,
+    deny(
+        missing_debug_implementations,
+        missing_docs,
+        rust_2018_idioms,
+        unreachable_pub,
+        bad_style,
+        const_err,
+        dead_code,
+        improper_ctypes,
+        legacy_directory_ownership,
+        non_shorthand_field_patterns,
+        no_mangle_generic_items,
+        overflowing_literals,
+        path_statements,
+        patterns_in_fns_without_body,
+        plugin_as_library,
+        private_in_public,
+        safe_extern_statics,
+        unconditional_recursion,
+        unions_with_drop_fields,
+        unused,
+        unused_allocation,
+        unused_comparisons,
+        unused_parens,
+        while_true
+    )
+)]
 use lazy_static::lazy_static;
 
 use std::{fmt, io};

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -63,6 +63,11 @@
 //! implement this logging, or an additional layer of filtering will be
 //! required to avoid infinitely converting between `Event` and `log::Record`.
 //!
+//! # Feature Flags
+//!
+//! * `trace-logger`: enables the `TraceLogger` type (on by default)
+//! * `log-tracer`: enables the `LogTracer` type (on by default)
+//!
 //! [`init`]: struct.LogTracer.html#method.init
 //! [`init_with_filter`]: struct.LogTracer.html#method.init_with_filter
 //! [`LogTracer`]: struct.LogTracer.html
@@ -123,11 +128,19 @@ use tracing_core::{
     subscriber, Event, Metadata,
 };
 
+#[cfg(feature = "log-tracer")]
 pub mod log_tracer;
+
+#[cfg(feature = "trace-logger")]
 pub mod trace_logger;
 
+#[cfg(feature = "log-tracer")]
 #[doc(inline)]
-pub use self::{log_tracer::LogTracer, trace_logger::TraceLogger};
+pub use self::log_tracer::LogTracer;
+
+#[cfg(feature = "trace-logger")]
+#[doc(inline)]
+pub use self::trace_logger::TraceLogger;
 
 /// Format a log record as a trace event in the current span.
 pub fn format_trace(record: &log::Record<'_>) -> io::Result<()> {

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -130,7 +130,7 @@ pub mod trace_logger;
 pub use self::{log_tracer::LogTracer, trace_logger::TraceLogger};
 
 /// Format a log record as a trace event in the current span.
-pub fn format_trace(record: &log::Record) -> io::Result<()> {
+pub fn format_trace(record: &log::Record<'_>) -> io::Result<()> {
     let filter_meta = record.as_trace();
     if !dispatcher::get_default(|dispatch| dispatch.enabled(&filter_meta)) {
         return Ok(());

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -218,7 +218,7 @@ macro_rules! log_cs {
     ($level:expr) => {{
         struct Callsite;
         static CALLSITE: Callsite = Callsite;
-        static META: Metadata = Metadata::new(
+        static META: Metadata<'static> = Metadata::new(
             "log event",
             "log",
             $level,

--- a/tracing-log/src/log_tracer.rs
+++ b/tracing-log/src/log_tracer.rs
@@ -1,21 +1,42 @@
+//! An adapter for converting [`log`] records into `tracing` `Event`s.
+//!
+//! This module provides the [`LogTracer`] type which implements `log`'s [logger
+//! interface] by recording log records as `tracing` `Event`s. This is intended for
+//! use in conjunction with a `tracing` `Subscriber` to consume events from
+//! dependencies that emit [`log`] records within a trace context.
+//!
+//! # Usage
+//!
+//! To create and initialize a `LogTracer` with the default configurations, use:
+//!
+//! * [`init`] if you want to convert all logs, regardless of log level,
+//!   allowing the tracing `Subscriber` to perform any filtering
+//! * [`init_with_filter`] to convert all logs up to a specified log level
+//!
+//! In addition, a [builder] is available for cases where more advanced
+//! configuration is required. In particular, the builder can be used to [ignore
+//! log records][ignore] emitted by particular crates. This is useful in cases
+//! such as when a crate emits both `tracing` diagnostics _and_ log records by
+//! default.
+//!
+//! [`LogTracer`]: struct.LogTracer.html
+//! [`log`]: https://docs.rs/log/0.4.8/log/
+//! [logger interface]: https://docs.rs/log/0.4.8/log/trait.Log.html
+//! [`init`]: struct.LogTracer.html#method.init.html
+//! [`init_with_filter`]: struct.LogTracer.html#method.init_with_filter.html
+//! [builder]: struct.LogTracer.html#method.builder
+//! [ignore]: struct.Builder.html#method.ignore_crate
 use crate::{format_trace, AsTrace};
 use log;
 use tracing_core::dispatcher;
 
 /// A simple "logger" that converts all log records into `tracing` `Event`s.
-///
-/// Can be initialized with:
-///
-/// * [`init`] if you want to convert all logs and do the filtering in a subscriber
-/// * [`init_with_filter`] if you know in advance a log level you want to filter
-///
-/// [`init`]: ../fn.init.html
-/// [`init_with_filter`]: ../fn.init_with_filter.html
 #[derive(Debug)]
 pub struct LogTracer {
     ignore_crates: Box<[String]>,
 }
 
+/// Configures a new `LogTracer`.
 #[derive(Debug)]
 pub struct Builder {
     ignore_crates: Vec<String>,
@@ -170,6 +191,9 @@ impl log::Log for LogTracer {
 // ===== impl Builder =====
 
 impl Builder {
+    /// Returns a new `Builder` to construct a [`LogTracer`].
+    ///
+    /// [`LogTracer`]: struct.LogTracer.html
     pub fn new() -> Self {
         Self::default()
     }

--- a/tracing-log/src/log_tracer.rs
+++ b/tracing-log/src/log_tracer.rs
@@ -134,7 +134,7 @@ impl Default for LogTracer {
 }
 
 impl log::Log for LogTracer {
-    fn enabled(&self, metadata: &log::Metadata) -> bool {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
         if self.ignore_crates.is_empty() {
             return true;
         }
@@ -148,7 +148,7 @@ impl log::Log for LogTracer {
             .any(|ignored| target.starts_with(ignored))
     }
 
-    fn log(&self, record: &log::Record) {
+    fn log(&self, record: &log::Record<'_>) {
         let enabled = dispatcher::get_default(|dispatch| {
             // TODO: can we cache this for each log record, so we can get
             // similar to the callsite cache?

--- a/tracing-log/src/trace_logger.rs
+++ b/tracing-log/src/trace_logger.rs
@@ -134,7 +134,7 @@ struct SpanLineBuilder {
 }
 
 impl SpanLineBuilder {
-    fn new(parent: Option<Id>, meta: &Metadata, fields: String) -> Self {
+    fn new(parent: Option<Id>, meta: &Metadata<'_>, fields: String) -> Self {
         Self {
             parent,
             ref_count: 1,
@@ -148,7 +148,7 @@ impl SpanLineBuilder {
         }
     }
 
-    fn log_meta(&self) -> log::Metadata {
+    fn log_meta(&self) -> log::Metadata<'_> {
         log::MetadataBuilder::new()
             .level(self.level)
             .target(self.target.as_ref())
@@ -181,11 +181,11 @@ impl field::Visit for SpanLineBuilder {
 }
 
 impl Subscriber for TraceLogger {
-    fn enabled(&self, metadata: &Metadata) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
         log::logger().enabled(&metadata.as_log())
     }
 
-    fn new_span(&self, attrs: &span::Attributes) -> Id {
+    fn new_span(&self, attrs: &span::Attributes<'_>) -> Id {
         let id = self.next_id();
         let mut spans = self.spans.lock().unwrap();
         let mut fields = String::new();
@@ -203,7 +203,7 @@ impl Subscriber for TraceLogger {
         id
     }
 
-    fn record(&self, span: &Id, values: &span::Record) {
+    fn record(&self, span: &Id, values: &span::Record<'_>) {
         let mut spans = self.spans.lock().unwrap();
         if let Some(span) = spans.get_mut(span) {
             values.record(span);
@@ -302,7 +302,7 @@ impl Subscriber for TraceLogger {
         }
     }
 
-    fn event(&self, event: &Event) {
+    fn event(&self, event: &Event<'_>) {
         let meta = event.metadata();
         let log_meta = meta.as_log();
         let logger = log::logger();
@@ -376,7 +376,7 @@ impl TraceLogger {
 struct LogEvent<'a>(&'a Event<'a>);
 
 impl<'a> fmt::Display for LogEvent<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut has_logged = false;
         let mut format_fields = |field: &field::Field, value: &dyn fmt::Debug| {
             let name = field.name();
@@ -396,7 +396,7 @@ impl<'a> fmt::Display for LogEvent<'a> {
 }
 
 impl fmt::Debug for TraceLogger {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TraceLogger")
             .field("settings", &self.settings)
             .field("spans", &self.spans)

--- a/tracing-log/src/trace_logger.rs
+++ b/tracing-log/src/trace_logger.rs
@@ -1,3 +1,13 @@
+//! A `tracing` [`Subscriber`] that uses the [`log`] crate as a backend for
+//! formatting `tracing` spans and events.
+//!
+//! When a [`TraceLogger`] is set as the current subscriber, it will record
+//! traces by emitting [`log::Record`]s that can be collected by a logger.
+//!
+//! [`log`]: https://docs.rs/log/0.4.8/log/index.html
+//! [`Subscriber`]: https://docs.rs/tracing/0.1.7/tracing/subscriber/trait.Subscriber.html
+//! [`TraceLogger`]: struct.TraceLogger.html
+//! [`log::Record`]: https://docs.rs/log/0.4.8/log/struct.Record.html
 use crate::AsLog;
 use std::{
     cell::RefCell,
@@ -14,8 +24,10 @@ use tracing_core::{
     Event, Metadata, Subscriber,
 };
 
-/// A `tracing_core::Subscriber` implementation that logs all recorded
+/// A `tracing` [`Subscriber`] implementation that logs all recorded
 /// trace events.
+///
+//. [`Subscriber`]: https://docs.rs/tracing/0.1.7/tracing/subscriber/trait.Subscriber.html
 pub struct TraceLogger {
     settings: Builder,
     spans: Mutex<HashMap<Id, SpanLineBuilder>>,
@@ -25,7 +37,9 @@ pub struct TraceLogger {
 thread_local! {
     static CURRENT: RefCell<Vec<Id>> = RefCell::new(Vec::new());
 }
-
+/// Configures and constructs a [`TraceLogger`].
+///
+/// [`TraceLogger`]: struct.TraceLogger.html
 #[derive(Debug)]
 pub struct Builder {
     log_span_closes: bool,
@@ -39,10 +53,12 @@ pub struct Builder {
 // ===== impl TraceLogger =====
 
 impl TraceLogger {
+    /// Returns a new `TraceLogger` with the default configuration.
     pub fn new() -> Self {
         Self::builder().finish()
     }
 
+    /// Returns a `Builder` for configuring a `TraceLogger`.
     pub fn builder() -> Builder {
         Default::default()
     }
@@ -62,6 +78,10 @@ impl TraceLogger {
 // ===== impl Builder =====
 
 impl Builder {
+    /// Configures whether or not the [`TraceLogger`] being constructed will log
+    /// when a span closes.
+    ///
+    /// [`TraceLogger`]: struct.TraceLogger.html
     pub fn with_span_closes(self, log_span_closes: bool) -> Self {
         Self {
             log_span_closes,
@@ -69,6 +89,10 @@ impl Builder {
         }
     }
 
+    /// Configures whether or not the [`TraceLogger`] being constructed will
+    /// include the fields of parent spans when formatting events.
+    ///
+    /// [`TraceLogger`]: struct.TraceLogger.html
     pub fn with_parent_fields(self, parent_fields: bool) -> Self {
         Self {
             parent_fields,
@@ -76,22 +100,44 @@ impl Builder {
         }
     }
 
+    /// Configures whether or not the [`TraceLogger`] being constructed will log
+    /// when a span is entered.
+    ///
+    /// If this is set to false, fields from the current span will still be
+    /// recorded as context, but the actual entry will not create a log record.
+    ///
+    /// [`TraceLogger`]: struct.TraceLogger.html
     pub fn with_span_entry(self, log_enters: bool) -> Self {
         Self { log_enters, ..self }
     }
 
+    /// Configures whether or not the [`TraceLogger`] being constructed will log
+    /// when a span is exited.
+    ///
+    /// [`TraceLogger`]: struct.TraceLogger.html
     pub fn with_span_exits(self, log_exits: bool) -> Self {
         Self { log_exits, ..self }
     }
 
+    /// Configures whether or not the [`TraceLogger`] being constructed will
+    /// include span IDs when formatting log output.
+    ///
+    /// [`TraceLogger`]: struct.TraceLogger.html
     pub fn with_ids(self, log_ids: bool) -> Self {
         Self { log_ids, ..self }
     }
 
+    /// Configures whether or not the [`TraceLogger`] being constructed will
+    /// include the names of parent spans as context when formatting events.
+    ///
+    /// [`TraceLogger`]: struct.TraceLogger.html
     pub fn with_parent_names(self, log_parent: bool) -> Self {
         Self { log_parent, ..self }
     }
 
+    /// Complete the builder, returning a configured [`TraceLogger`].
+    ///
+    /// [`TraceLogger`]: struct.TraceLogger.html
     pub fn finish(self) -> TraceLogger {
         TraceLogger::from_builder(self)
     }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -36,7 +36,7 @@ smallvec = { optional = true, version = "0.6.10"}
 lazy_static = { optional = true, version = "1" }
 
 # fmt
-tracing-log = { version = "0.0.1-alpha.2", path = "../tracing-log", optional = true }
+tracing-log = { version = "0.1", path = "../tracing-log", optional = true, default-features = false }
 ansi_term = { version = "0.11", optional = true }
 owning_ref = { version = "0.4.0", optional = true }
 parking_lot = { version = ">= 0.7, < 0.10", features = ["owning_ref"], optional = true }


### PR DESCRIPTION
This branch prepares `tracing-log` for an 0.1 release.

Taking this crate out of alpha will allow us to publish
`tracing-subscriber` 0.1, as that crate depends on `tracing-log` & I
don't want to publish an 0.1 that depends on an alpha crate.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>