### PR TITLE
tracing: prepare to release 0.1.8

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dev-dependencies]
 
 # tracing crates
-tracing = "0.1.8"
+tracing = "0.1"
 tracing-core = "0.1"
 tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
 tracing-subscriber = { version = "0.0.1-alpha.4", path = "../tracing-subscriber" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dev-dependencies]
 
 # tracing crates
-tracing = "0.1.7"
+tracing = "0.1.8"
 tracing-core = "0.1"
 tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
 tracing-subscriber = { version = "0.0.1-alpha.4", path = "../tracing-subscriber" }

--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.1.8 (September 3, 2019)
+
+### Changed
+
+- Reorganized and improved API documentation (#317)
+
+### Removed
+
+- Dev-dependencies on `ansi_term` and `humantime` crates, which were used only
+  for examples (#316)
+
 # 0.1.7 (August 30, 2019)
 
 ### Changed

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,13 +8,13 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing/0.1.7/tracing"
+documentation = "https://docs.rs/tracing/0.1.8/tracing"
 description = """
 Application-level tracing for Rust.
 """

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -12,9 +12,9 @@ Application-level tracing for Rust.
 [Chat][gitter-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.7
+[crates-url]: https://crates.io/crates/tracing/0.1.8
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.7
+[docs-url]: https://docs.rs/tracing/0.1.8
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master
@@ -47,7 +47,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing = "0.1.7"
+tracing = "0.1.8"
 ```
 
 This crate provides macros for creating `Span`s and `Event`s, which represent

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.7")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.8")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 
@@ -585,7 +585,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing = { version = "0.1.5", default-features = false }
+//!   tracing = { version = "0.1.8", default-features = false }
 //!   ```
 //!   **Note**:`tracing`'s `no_std` support requires `liballoc`.
 //!


### PR DESCRIPTION
Changed

- Reorganized and improved API documentation (#317)

Removed

- Dev-dependencies on `ansi_term` and `humantime` crates, which were
  used only for examples (#316)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>