### PR TITLE
chore: rm unused dev deps

### DIFF
--- a/tracing-tower-http/Cargo.toml
+++ b/tracing-tower-http/Cargo.toml
@@ -25,20 +25,6 @@ tower-service = "0.2"
 tower = { git = "https://github.com/tower-rs/tower.git" }
 http = "0.1"
 
-[dev-dependencies]
-bytes = "0.4"
-h2 = "0.1.11"
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2.git" }
-string = { git = "https://github.com/carllerche/string" }
-tokio = "0.1"
-tokio-current-thread = "0.1.1"
-tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
-tracing-subscriber = { version = "0.0.1-alpha.3", path = "../tracing-subscriber" }
-tokio-io = "0.1"
-ansi_term = "0.11"
-humantime = "1.1.1"
-env_logger = "0.5"
-
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
 maintenance = { status = "experimental" }

--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -29,25 +29,6 @@ tower-layer = { version = "0.1", optional = true }
 tower-util = { version = "0.1", optional = true }
 http = { version = "0.1", optional = true }
 
-[dev-dependencies]
-bytes = "0.4"
-h2 = "0.1.11"
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2.git" }
-string = { git = "https://github.com/carllerche/string" }
-hyper = "0.12"
-futures = "0.1"
-tokio = "0.1"
-tokio-current-thread = "0.1.1"
-tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
-tokio-io = "0.1"
-tokio-tcp = "0.1"
-tokio-buf = "0.1"
-tower = "0.1"
-tower-hyper = "0.1"
-tower-http-util = "0.1"
-tracing-subscriber = { version = "0.0.1-alpha.3", path = "../tracing-subscriber" }
-rand = "0.7"
-
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
 maintenance = { status = "experimental" }


### PR DESCRIPTION
These examples were moved in #316, but apparently I forgot to delete
the dev dependencies in some Cargo.tomls.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>