### PR TITLE
chore: publish docs `tracing` for master + PR branches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,6 +205,8 @@ example would explicitly use `Timeout::new`. For example:
 /// # }
 ```
 
+To reduce the effort required to review documentation-related changes, `tracing`'s CI system generates preview websites containing the `rustdoc` output for the entire repository for each PR.
+
 ### Commits
 
 It is a recommended best practice to keep your changes as logically grouped as

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,7 +205,11 @@ example would explicitly use `Timeout::new`. For example:
 /// # }
 ```
 
-To reduce the effort required to review documentation-related changes, `tracing`'s CI system generates preview websites containing the `rustdoc` output for the entire repository for each PR.
+To reduce the effort required to review documentation-related changes,
+`tracing`'s CI system generates preview websites containing the
+`rustdoc` output for the entire repository for each PR. The preview can
+be viewed by clicking the `details` link on the
+`netlify/tracing-rs/deploy-preview check` on all pull requests.
 
 ### Commits
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Application-level tracing for Rust.
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
+[![Documentation (master)][docs-master-badge]][docs-master-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
@@ -12,6 +13,8 @@ Application-level tracing for Rust.
 [crates-url]: https://crates.io/crates/tracing
 [docs-badge]: https://docs.rs/tracing/badge.svg
 [docs-url]: https://docs.rs/tracing
+[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
+[docs-master-url]: https://tracing-rs.netlify.com
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Application-level tracing for Rust.
 [gitter-url]: https://gitter.im/tokio-rs/tracing
 
 [Website](https://tokio.rs) |
-[Chat](https://gitter.im/tracing-rs/tracing)
+[Chat](https://gitter.im/tracing-rs/tracing) | [Documentation (master branch)](https://tracing-rs.netlify.com/)
 
 ## Overview
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  command = "curl https://sh.rustup.rs -sSf | sh -s -- -y && source $HOME/.cargo/env && cargo doc --no-deps"
+  publish = "target/doc"
+
+[[redirects]]
+  from = "/"
+  to = "/tracing"

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -4,6 +4,7 @@ Macro attributes for application-level tracing.
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
+[![Documentation (master)][docs-master-badge]][docs-master-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
@@ -15,6 +16,8 @@ Macro attributes for application-level tracing.
 [crates-url]: https://crates.io/crates/tracing-attributes
 [docs-badge]: https://docs.rs/tracing-attributes/badge.svg
 [docs-url]: https://docs.rs/tracing-attributes/0.1.2
+[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
+[docs-master-url]: https://tracing-rs.netlify.com/tracing_attributes
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -4,6 +4,7 @@ Core primitives for application-level tracing.
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
+[![Documentation (master)][docs-master-badge]][docs-master-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
@@ -15,6 +16,8 @@ Core primitives for application-level tracing.
 [crates-url]: https://crates.io/crates/tracing-core/0.1.5
 [docs-badge]: https://docs.rs/tracing-core/badge.svg
 [docs-url]: https://docs.rs/tracing-core/0.1.5
+[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
+[docs-master-url]: https://tracing-rs.netlify.com/tracing_core
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master

--- a/tracing-fmt/README.md
+++ b/tracing-fmt/README.md
@@ -7,6 +7,7 @@ this library from their new home in `tracing-subscriber::fmt`.
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
+[![Documentation (master)][docs-master-badge]][docs-master-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
@@ -22,6 +23,8 @@ this library from their new home in `tracing-subscriber::fmt`.
 [crates-url]: https://crates.io/crates/tracing-fmt
 [docs-badge]: https://docs.rs/tracing-fmt/badge.svg
 [docs-url]: https://docs.rs/tracing-fmt
+[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
+[docs-master-url]: https://tracing-rs.netlify.com/tracing_fmt
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master

--- a/tracing-futures/README.md
+++ b/tracing-futures/README.md
@@ -6,6 +6,7 @@ Utilities for instrumenting futures-based code with [`tracing`].
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
+[![Documentation (master)][docs-master-badge]][docs-master-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
@@ -18,6 +19,8 @@ Utilities for instrumenting futures-based code with [`tracing`].
 [crates-url]: https://crates.io/crates/tracing-futures
 [docs-badge]: https://docs.rs/tracing-futures/badge.svg
 [docs-url]: https://docs.rs/tracing-futures
+[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
+[docs-master-url]: https://tracing-rs.netlify.com/tracing_futures
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master

--- a/tracing-log/README.md
+++ b/tracing-log/README.md
@@ -4,6 +4,7 @@
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
+[![Documentation (master)][docs-master-badge]][docs-master-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
@@ -16,6 +17,8 @@
 [crates-url]: https://crates.io/crates/tracing-log
 [docs-badge]: https://docs.rs/tracing-log/badge.svg
 [docs-url]: https://docs.rs/tracing-log
+[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
+[docs-master-url]: https://tracing-rs.netlify.com/tracing_log
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master

--- a/tracing-serde/README.md
+++ b/tracing-serde/README.md
@@ -2,7 +2,14 @@
 
 An adapter for serializing `tracing` types using `serde`.
 
-[Documentation](https://docs.rs/tracing-serde/0.1.0/tracing_serde/index.html)
+
+[![Documentation][docs-badge]][docs-url]
+[![Documentation (master)][docs-master-badge]][docs-master-url]
+
+[docs-badge]: https://docs.rs/tracing-serde/badge.svg
+[docs-url]: https://docs.rs/tracing-serde
+[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
+[docs-master-url]: https://tracing-rs.netlify.com/tracing_serde
 
 ## Overview
 

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -4,6 +4,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
+[![Documentation (master)][docs-master-badge]][docs-master-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
@@ -18,6 +19,8 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
 [docs-url]: https://docs.rs/tracing-subscriber
+[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
+[docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -4,6 +4,7 @@ Application-level tracing for Rust.
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
+[![Documentation (master)][docs-master-badge]][docs-master-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
@@ -15,6 +16,8 @@ Application-level tracing for Rust.
 [crates-url]: https://crates.io/crates/tracing/0.1.8
 [docs-badge]: https://docs.rs/tracing/badge.svg
 [docs-url]: https://docs.rs/tracing/0.1.8
+[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
+[docs-master-url]: https://tracing-rs.netlify.com/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [azure-badge]: https://dev.azure.com/tracing/tracing/_apis/build/status/tokio-rs.tracing?branchName=master


### PR DESCRIPTION
chore: build and publish documentation for each branch.

This commit introduces support for:
- building and deploying documentation for the master branch
- building and deploying (preview) documentation for each pull request and for each PR
- adds a link in `README.md` pointing to the generated documentation for the master branch
- notes the per-PR documentation previews in `CONTRIBUTING.md`

Closes #210