### PR TITLE
subscriber: avoid double panics in `CurrentSpan`

### DIFF
--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -98,17 +98,19 @@ impl CurrentSpan {
     /// Returns the [`Id`](::Id) of the span in which the current thread is
     /// executing, or `None` if it is not inside of a span.
     pub fn id(&self) -> Option<Id> {
-        self.current.get().last().cloned()
+        self.current.with(|current| current.last().cloned())?
     }
 
     /// Records that the current thread has entered the span with the provided ID.
     pub fn enter(&self, span: Id) {
-        self.current.get().push(span)
+        self.current.with(|current| current.push(span));
     }
 
     /// Records that the current thread has exited a span.
     pub fn exit(&self) {
-        self.current.get().pop();
+        self.current.with(|current| {
+            let _ = current.pop();
+        });
     }
 }
 


### PR DESCRIPTION
## Motivation

The `ThreadLocal` struct used by `CurrentSpan` currently can cause a
double panic, since it is unclear why the current thread's slot is
unset. The `try_get` function may return `None` because that thread has
not yet been created, _or_ it may return `None` because we are
panicking. However, the code that calls this function doesn't correctly
handle this --- it assumes `None` is returned because the thread has not
yet had its local slot created, and `expect`s that it will exist after
inserting the local slot.

## Solution

I've updated this code to present a more `LocalKey`-like API, and avoid
potential double panics here. Now, when the thread is panicking, the
closure passed into `with` is not invoked.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>