### PR TITLE
core, tracing: make disabled events way faster

### DIFF
--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -252,9 +252,13 @@ pub fn set_global_default(dispatcher: Dispatch) -> Result<(), SetGlobalDefaultEr
     }
 }
 
+/// Returns true if a `tracing` dispatcher has ever been set.
+///
+/// This may be used to completely elide trace points if tracing is not in use
+/// at all or has yet to be initialized.
 #[doc(hidden)]
 #[inline(always)]
-pub fn exists() -> bool {
+pub fn has_been_set() -> bool {
     EXISTS.load(Ordering::Relaxed)
 }
 

--- a/tracing-macros/Cargo.toml
+++ b/tracing-macros/Cargo.toml
@@ -18,10 +18,10 @@ keywords = ["logging", "tracing"]
 license = "MIT"
 
 [dependencies]
-tracing = { version = "0.1", path = "../tracing" }
+tracing = "0.1"
 
 [dev-dependencies]
-tracing-log = { path = "../tracing-log" }
+tracing-log = "0.1"
 env_logger = "0.5"
 
 [badges]

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -35,7 +35,7 @@ cfg-if = "0.1.9"
 
 [dev-dependencies]
 futures = "0.1"
-criterion = { version = "0.2", default_features = false }
+criterion = { version = "0.3", default_features = false }
 log = "0.4"
 
 [features]

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -28,7 +28,7 @@ keywords = ["logging", "tracing", "metrics", "async"]
 edition = "2018"
 
 [dependencies]
-tracing-core = { version = "0.1.5", default-features = false }
+tracing-core = { version = "0.1.5", path = "../tracing-core", default-features = false }
 log = { version = "0.4", optional = true }
 tracing-attributes = "0.1.2"
 cfg-if = "0.1.9"

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -669,6 +669,8 @@ pub mod subscriber;
 pub mod __macro_support {
     pub use crate::stdlib::sync::atomic::{AtomicUsize, Ordering};
 
+    pub const LOG_ENABLED: bool = cfg!(feature = "log");
+
     #[cfg(feature = "std")]
     pub use crate::stdlib::sync::Once;
 

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -1844,7 +1844,7 @@ macro_rules! callsite {
 #[doc(hidden)]
 macro_rules! level_enabled {
     ($lvl:expr) => {
-        $crate::dispatcher::exists() && $lvl <= $crate::level_filters::STATIC_MAX_LEVEL
+        $crate::dispatcher::has_been_set() && $lvl <= $crate::level_filters::STATIC_MAX_LEVEL
     };
 }
 

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -33,15 +33,14 @@ macro_rules! span {
                 fields: $($fields)*
             };
             let meta = callsite.metadata();
-
-            if $lvl <= $crate::level_filters::STATIC_MAX_LEVEL && $crate::is_enabled!(callsite) {
+            if $crate::level_enabled!($lvl) && $crate::is_enabled!(callsite) {
                 $crate::Span::child_of(
                     $parent,
                     meta,
                     &$crate::valueset!(meta.fields(), $($fields)*),
                 )
             } else {
-                 $crate::__tracing_disabled_span!(
+                $crate::__tracing_disabled_span!(
                     meta,
                     &$crate::valueset!(meta.fields(), $($fields)*)
                 )
@@ -60,11 +59,10 @@ macro_rules! span {
                 fields: $($fields)*
             };
             let meta = callsite.metadata();
-
-            if $lvl <= $crate::level_filters::STATIC_MAX_LEVEL && $crate::is_enabled!(callsite) {
+            if $crate::level_enabled!($lvl) && $crate::is_enabled!(callsite) {
                 $crate::Span::new(
                     meta,
-                    &$crate::valueset!(meta.fields(), $($fields)*)
+                    &$crate::valueset!(meta.fields(), $($fields)*),
                 )
             } else {
                 $crate::__tracing_disabled_span!(
@@ -73,7 +71,6 @@ macro_rules! span {
                 )
             }
         }
-
     };
     (target: $target:expr, parent: $parent:expr, $lvl:expr, $name:expr) => {
         $crate::span!(target: $target, parent: $parent, $lvl, $name,)
@@ -585,7 +582,7 @@ macro_rules! event {
                 $($fields)*
             );
 
-            if $lvl <= $crate::level_filters::STATIC_MAX_LEVEL {
+            if $crate::level_enabled!($lvl) {
                 #[allow(unused_imports)]
                 use $crate::{callsite, dispatcher, Event, field::{Value, ValueSet}};
                 use $crate::callsite::Callsite;
@@ -630,8 +627,7 @@ macro_rules! event {
                 $lvl,
                 $($fields)*
             );
-
-            if $lvl <= $crate::level_filters::STATIC_MAX_LEVEL {
+            if $crate::level_enabled!($lvl) {
                 #[allow(unused_imports)]
                 use $crate::{callsite, dispatcher, Event, field::{Value, ValueSet}};
                 use $crate::callsite::Callsite;
@@ -1886,6 +1882,15 @@ macro_rules! callsite {
         });
         &MyCallsite
     }};
+}
+
+#[macro_export]
+// TODO: determine if this ought to be public API?
+#[doc(hidden)]
+macro_rules! level_enabled {
+    ($lvl:expr) => {
+        $crate::dispatcher::exists() && $lvl <= $crate::level_filters::STATIC_MAX_LEVEL
+    };
 }
 
 #[macro_export]

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -2141,10 +2141,9 @@ macro_rules! __tracing_mk_span {
                     &$crate::valueset!(meta.fields(), $($fields)*),
                 )
             } else {
-                $crate::__tracing_disabled_span!(
-                    meta,
-                    &$crate::valueset!(meta.fields(), $($fields)*)
-                )
+                let span = $crate::Span::new_disabled(meta);
+                span.record_all(&$crate::valueset!(meta.fields(), $($fields)*));
+                span
             }
         }
     };
@@ -2166,7 +2165,7 @@ macro_rules! __tracing_mk_span {
                     &$crate::valueset!(meta.fields(), $($fields)*),
                 )
             } else {
-                let span = $crate::Span::new_disabled($meta);
+                let span = $crate::Span::new_disabled(meta);
                 span.record_all(&$crate::valueset!(meta.fields(), $($fields)*));
                 span
             }

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -463,6 +463,7 @@ impl Span {
     /// span is not present.
     ///
     /// Entering, exiting, and recording values on this span will do nothing.
+    #[inline(always)]
     pub const fn none() -> Span {
         Self {
             inner: None,


### PR DESCRIPTION

## Motivation

When `tracing` is not in use, no default subscriber will be set, and
tracing instrumentation points can be skipped. Currently, the
instrumentation macros detect this by testing if the callsite's
`Interest` is `never`. However, this is significantly slower than how
the `log` crate detects that there is no logger: we must call a function
through a trait object, do a relaxed load, construct an `Interest` from
an integer, and then test on the value of the `Interest`. Furthermore,
we must construct the callsite _at all_ in order to do this. Meanwhile, 
when no logger is set, `log` can skip log records with only a single 
relaxed atomic load.

## Solution

This branch adds a new private-API method in `tracing_core::dispatcher`
that allows us to check if a dispatcher has ever been set. If this is
false, then `tracing` has not yet been initialized and the callsite can
be elided entirely. Representing this as an atomic bool lets us perform
a single relaxed load and branch, without having to mess around with
`Interest`s and callsite vtables and so on. In cases where `tracing`
will never be used, this will always be false.

This the event macro performance with no subscriber set on par with the
`log` crate's performance when no logger is set. Spans are a bit slower
because they must still construct a disabled span object, but the span
macros are somewhat faster in this case than they were previously.

## Benchmark results

Before:

![Screen Shot 2019-09-04 at 2 59 06 PM](https://user-images.githubusercontent.com/2796466/64294816-965d9b00-cf24-11e9-9e90-b6d3ee337da8.png)

After:

![Screen Shot 2019-09-04 at 2 58 34 PM](https://user-images.githubusercontent.com/2796466/64294827-9d84a900-cf24-11e9-9223-fa39dfcef46b.png)

Note that when no subscriber is set, skipping an event previously
took an average of around 2 ns, and skipping a span took around 
5 ns. Now, skipping an event takes around 850 ps (about the
same as skipping a `log` macro when there's no logger), while 
skipping a span macro takes around 2 ns.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>