### PR TITLE
subscriber: prepare to release 0.1.1

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.1 (September 4, 2019)
+
+### Fixed
+
+- Potential double panic in `CurrentSpan` (#325)
+
 # 0.1.0 (September 3, 2019)
 
 - Initial release

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "tracing-subscriber"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-subscriber/0.1.0/tracing-subscriber"
+documentation = "https://docs.rs/tracing-subscriber/0.1.1/tracing-subscriber"
 description = """
 Utilities for implementing and composing `tracing` subscribers.
 """

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! [`tracing`]: https://docs.rs/tracing/latest/tracing/
 //! [`Subscriber`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/trait.Subscriber.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.1.1")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
Fixed:

- Potential double panic in `CurrentSpan` (#325)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>