### PR TITLE
chore: port CI to GitHub Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
     - uses: hecrj/setup-rust-action@v1
       with:
-        rust-version: ${{ matrix.rust }}
+        rust-version: stable
     - uses: actions/checkout@master
     - name: Build
       run: cargo build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
         rust-version: ${{ matrix.rust }}
     - uses: actions/checkout@master
     - name: Check
-      run: cargo check --all
+      run: cargo check --all --bins --examples --tests
 
   test-versions:
     # Test against the stable, beta, and nightly Rust toolchains on ubuntu-latest.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,24 +1,85 @@
 name: CI
 
-on: [push]
+on:
+- push:
+  paths:
+  - '*.rs'
+  - 'Cargo.toml'
 
 jobs:
-  check: 
-  
+  check:
     runs-on: ubuntu-latest
-    
+    strategy:
+      matrix:
+        rust: [stable, 1.34.0]
     steps:
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: ${{ matrix.rust }}
     - uses: actions/checkout@master
     - name: Check
       run: cargo check --all
 
-  build:
+  test:
     needs: check
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        rust: [stable, beta, nightly, 1.34.0]
     steps:
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: ${{ matrix.rust }}
     - uses: actions/checkout@master
     - name: Build
-      run: cargo build --verbose
+      run: cargo build
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --all
+
+  features-stable:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: stable
+    - uses: actions/checkout@master
+    - name: "Test log support"
+      run: (cd tracing/test-log-support && cargo test)
+    - name: "Test static max level"
+      run: (cd tracing/test_static_max_level_features && cargo test)
+    - name: "Test tracing-core no-std support"
+      run: (cd tracing-core && cargo test --no-default-features)
+    - name: "Test tracing no-std support"
+      run: (cd tracing && cargo test --no-default-features)
+    - name: "Test tracing all features"
+      run: cargo test -p tracing --all-features
+
+  features-nightly:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: nightly
+    - uses: actions/checkout@master
+    - name: "Test tracing-futures std::future support"
+      run: (cd tracing-futures/test_std_future && cargo test)
+    - name: "Test tracing-attributes async/await support"
+      run: (cd tracing/test_static_max_level_features && cargo test)
+    - name: "Test tracing-core no-std support"
+      run: (cd tracing-attributes/test_async_await && cargo test)
+    - name: "Test nightly-only examples"
+      run: (cd nightly-examples && cargo test)
+
+  style:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: stable
+    - uses: actions/checkout@master
+    - name: rustfmt
+      run: cargo fmt --all -- --check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,7 @@ on:
   paths:
   - '*.rs'
   - 'Cargo.toml'
+  - '.github/workflows/CI.yml'
 
 jobs:
   check:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,11 +1,11 @@
 name: CI
 
 on:
-- push:
-  paths:
-  - '*.rs'
-  - 'Cargo.toml'
-  - '.github/workflows/CI.yml'
+  push:
+    paths:
+    - '*.rs'
+    - 'Cargo.toml'
+    - '.github/workflows/CI.yml'
 
 jobs:
   check:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
         rust-version: ${{ matrix.rust }}
     - uses: actions/checkout@master
     - name: Check
-      run: cargo check --all --bins --examples --tests
+      run: cargo check --all --bins --examples --tests --benches
 
   test-versions:
     # Test against the stable, beta, and nightly Rust toolchains on ubuntu-latest.
@@ -105,3 +105,15 @@ jobs:
     - uses: actions/checkout@master
     - name: rustfmt
       run: cargo fmt --all -- --check
+
+  warnings:
+    # Check for any warnings. This is informational and thus is allowed to fail.
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: stable
+    - uses: actions/checkout@master
+    - name: warnings
+      run: RUSTFLAGS="-Dwarnings" cargo check --all

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   check:
+    # Run `cargo check` first to ensure that the pushed code at least compiles.
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -21,12 +22,12 @@ jobs:
     - name: Check
       run: cargo check --all
 
-  test:
+  test-versions:
+    # Test against the stable, beta, and nightly Rust toolchains on ubuntu-latest.
     needs: check
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable, beta, nightly, 1.34.0]
     steps:
     - uses: hecrj/setup-rust-action@v1
@@ -38,7 +39,25 @@ jobs:
     - name: Run tests
       run: cargo test --all
 
+  test-os:
+    # Test against stable Rust across macOS, Windows, and Linux.
+    needs: check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: ${{ matrix.rust }}
+    - uses: actions/checkout@master
+    - name: Build
+      run: cargo build
+    - name: Run tests
+      run: cargo test --all
+
   features-stable:
+    # Feature flag tests that run on stable Rust.
     needs: check
     runs-on: ubuntu-latest
     steps:
@@ -58,6 +77,7 @@ jobs:
       run: cargo test -p tracing --all-features
 
   features-nightly:
+    # Feature flag tests for features that require nightly Rust.
     needs: check
     runs-on: ubuntu-latest
     steps:
@@ -75,6 +95,7 @@ jobs:
       run: (cd nightly-examples && cargo test)
 
   style:
+    # Check style.
     needs: check
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Motivation

The `tokio` org is in the Github actions beta. Running our CI jobs on Actions
rather than Azure Pipelines has a few potential advantages: 

- GitHub Actions allows us to conditionally run workflows based on what
  files were modified. This lets us configure the Rust CI tests/checks
  to only run when actual Rust source code was modified. This will let 
  us merge PRs that change READMEs, CI configs, etc. but don't actually
  modify any source code more quickly, since they won't have to wait
  for all the tests to run.
- GitHub Actions has slightly nicer integration with the GitHub UI 
  (IMO), and it takes fewer clicks to see the logs from a failed build
  than on Azure.
- Finally, I've (anecdotally) observed GitHub Actions workflows to
  start much sooner than the corresponding Azure Pipelines workflows.
  Although the stages seem to take similar amounts of time to run, it
  seems like there's sometimes a delay between an event that triggers
  Azure Pipelines and the job actually starting. My guess is that 
  GitHub Actions recieves the triggering webhook a bit sooner because
  it's running on the same infrastructure that actually hosts the repo?

## Solution

This branch ports the Azure Pipelines CI configs to run on GitHub 
Actions. I've tried to port the config relatively faithfully, with a
few tweaks.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
