### PR TITLE
subscriber: add `fmt::Display` impl for `Filter`

### DIFF
--- a/tracing-subscriber/src/filter/level.rs
+++ b/tracing-subscriber/src/filter/level.rs
@@ -65,12 +65,12 @@ impl PartialOrd<Level> for LevelFilter {
 impl fmt::Display for LevelFilter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
-            Inner::Off => f.pad("OFF"),
-            Inner::Level(Level::ERROR) => f.pad("ERROR"),
-            Inner::Level(Level::WARN) => f.pad("WARN"),
-            Inner::Level(Level::INFO) => f.pad("INFO"),
-            Inner::Level(Level::DEBUG) => f.pad("DEBUG"),
-            Inner::Level(Level::TRACE) => f.pad("TRACE"),
+            Inner::Off => f.pad("off"),
+            Inner::Level(Level::ERROR) => f.pad("error"),
+            Inner::Level(Level::WARN) => f.pad("warn"),
+            Inner::Level(Level::INFO) => f.pad("info"),
+            Inner::Level(Level::DEBUG) => f.pad("debug"),
+            Inner::Level(Level::TRACE) => f.pad("trace"),
         }
     }
 }


### PR DESCRIPTION
## Motivation

The `tracing-fmt::filter::EnvFilter` type implemented `fmt::Display`,
but `tracing-subscriber::filter::Filter` does not. A `fmt::Display` impl
for filters can be useful, in order to show users the currently active
filter (e.g. linkerd/linkerd2-proxy#342).

## Solution

This branch adds a `fmt::Display` implementation to `Filter`.

Since the `matchers::Pattern` type used internally for pattern matching
does not implement `fmt::Display` nor expose the string from which the
pattern was constructed, it was necessary to add a new internal type
which holds both a `matchers::Pattern` and the string representation of
that pattern. This has the side benefit of fixing a _technically_
incorrect `cmp::PartialEq` implementation for `ValueMatch`, although
this was never a problem in practice.

I've also added a test asserting that we can parse a filter string,
format the parsed filter, and parse the formatted representation to a
filter with the same directives.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
