### PR TITLE
attributes: support overriding name of the span

### DIFF
--- a/tracing-attributes/tests/names.rs
+++ b/tracing-attributes/tests/names.rs
@@ -1,0 +1,43 @@
+mod support;
+use support::*;
+
+use tracing::subscriber::with_default;
+use tracing_attributes::instrument;
+
+#[instrument]
+fn default_name() {}
+
+#[instrument(name = "my_name")]
+fn custom_name() {}
+
+#[test]
+fn default_name_test() {
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(span::mock().named("default_name"))
+        .enter(span::mock().named("default_name"))
+        .exit(span::mock().named("default_name"))
+        .done()
+        .run_with_handle();
+
+    with_default(subscriber, || {
+        default_name();
+    });
+
+    handle.assert_finished();
+}
+
+#[test]
+fn custom_name_test() {
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(span::mock().named("my_name"))
+        .enter(span::mock().named("my_name"))
+        .exit(span::mock().named("my_name"))
+        .done()
+        .run_with_handle();
+
+    with_default(subscriber, || {
+        custom_name();
+    });
+
+    handle.assert_finished();
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

PR for the issue #298 

## Solution

Add a new function to either parse the name from the macro's attribute or return the default name (instrumented method's name). Do you want to have the previous function's name as a field? In that case, that would require a bit of change (maybe return an option of something from `name`).

I added some tests, please tell me if you need more (in the nightly async/await test for example)