### PR TITLE
subscriber: allow adding directives to filters

### DIFF
--- a/tracing-subscriber/src/filter/directive.rs
+++ b/tracing-subscriber/src/filter/directive.rs
@@ -316,8 +316,16 @@ impl PartialOrd for Directive {
         {
             if ordering == Ordering::Equal {
                 debug_assert_eq!(
-                    self, other,
-                    "invariant violated: Ordering::Equal must imply a == b"
+                    self.target, other.target,
+                    "invariant violated: Ordering::Equal must imply a.target == b.target"
+                );
+                debug_assert_eq!(
+                    self.in_span, other.in_span,
+                    "invariant violated: Ordering::Equal must imply a.in_span == b.in_span"
+                );
+                debug_assert_eq!(
+                    self.fields, other.fields,
+                    "invariant violated: Ordering::Equal must imply a.fields == b.fields"
                 );
             }
         }
@@ -514,8 +522,12 @@ impl PartialOrd for StaticDirective {
         {
             if ordering == Ordering::Equal {
                 debug_assert_eq!(
-                    self, other,
-                    "invariant violated: Ordering::Equal must imply a == b"
+                    self.target, other.target,
+                    "invariant violated: Ordering::Equal must imply a.target == b.target"
+                );
+                debug_assert_eq!(
+                    self.field_names, other.field_names,
+                    "invariant violated: Ordering::Equal must imply a.field_names == b.field_names"
                 );
             }
         }

--- a/tracing-subscriber/src/filter/directive.rs
+++ b/tracing-subscriber/src/filter/directive.rs
@@ -414,7 +414,7 @@ impl<T: Match + Ord> DirectiveSet<T> {
         if level > &self.max_level {
             self.max_level = level.clone();
         }
-        self.directives.insert(directive);
+        let _ = self.directives.replace(directive);
     }
 }
 

--- a/tracing-subscriber/src/filter/mod.rs
+++ b/tracing-subscriber/src/filter/mod.rs
@@ -127,6 +127,10 @@ impl Filter {
     /// below a certain verbosity level, or parsed from a string specifying a
     /// directive.
     ///
+    /// If a filter directive is inserted that matches exactly the same spans
+    /// and events as a previous filter, but sets a different level for those
+    /// spans and events, the previous directive is overwritten.
+    ///
     /// [`LevelFilter`]: struct.LevelFilter.html
     ///
     /// # Examples

--- a/tracing-subscriber/src/filter/mod.rs
+++ b/tracing-subscriber/src/filter/mod.rs
@@ -119,24 +119,36 @@ impl Filter {
 
     /// Add a filtering directive to this `Filter`.
     ///
+    /// The added directive will be used in addition to any previously set
+    /// directives, either added using this method or provided when the filter
+    /// is constructed.
+    ///
+    /// Directives may be [`LevelFilter`]s, which will enable all traces at or
+    /// below a certain verbosity level, or parsed from a string specifying a
+    /// directive.
+    ///
+    /// [`LevelFilter`]: struct.LevelFilter.html
+    ///
     /// # Examples
     /// ```rust
     /// use tracing_subscriber::filter::{Filter, LevelFilter};
     /// # fn main() {
     /// let mut filter = Filter::from_default_env()
-    ///     .with_directive(LevelFilter::INFO);
+    ///     .add_directive(LevelFilter::INFO);
     /// # }
     /// ```
     /// ```rust
     /// use tracing_subscriber::filter::{Filter, Directive};
+    ///
     /// # fn try_mk_filter() -> Result<(), Box<dyn ::std::error::Error>> {
     /// let mut filter = Filter::try_from_default_env()?
-    ///     .with_directive("my_crate::module=trace".parse::<Directive>()?);
+    ///     .add_directive("my_crate::module=trace".parse::<Directive>()?)
+    ///     .add_directive("my_crate::my_other_module::something=info".parse::<Directive>()?);
     /// # Ok(())
     /// # }
     /// # fn main() {}
     /// ```
-    pub fn with_directive(mut self, directive: impl Into<Directive>) -> Self {
+    pub fn add_directive(mut self, directive: impl Into<Directive>) -> Self {
         let directive = directive.into();
         if let Some(stat) = directive.to_static() {
             self.statics.add(stat)

--- a/tracing-subscriber/src/filter/mod.rs
+++ b/tracing-subscriber/src/filter/mod.rs
@@ -3,7 +3,7 @@
 mod level;
 #[doc(inline)]
 pub use self::{
-    directive::{ParseError, Directive},
+    directive::{Directive, ParseError},
     field::BadName as BadFieldName,
     level::{LevelFilter, ParseError as LevelParseError},
 };


### PR DESCRIPTION
## Motivation

Currently, the `tracing-subscriber::Filter` type can be constructed from
an environment variable or string containing filter directives. However,
once it has been constructed, new directives may not be added.

## Solution

This commit adds an API for adding directives to a filter after it has
been constructed. Directives can be constructed either from
`LevelFilter`s or by parsing a string. Eventually, this API will also
allow us to add a programmatic builder API for directives.

This is a prerequisite for future work such as https://github.com/tokio-rs/tracing/issues/332#issuecomment-529138912

Signed-off-by: Eliza Weisman <eliza@buoyant.io>