### PR TITLE
chore: make CI filters less restrictive

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,11 +1,6 @@
 name: CI
 
-on:
-  push:
-    paths:
-    - '*.rs'
-    - 'Cargo.toml'
-    - '.github/workflows/CI.yml'
+on: [push]
 
 jobs:
   check:


### PR DESCRIPTION
## Motivation

Apparently, the GitHub Actions `paths:` filtering for events uses [an
API][1] from the standard library of a known bad programming language,
which [doesn't behave the way normal unix globs do][2] and [cannot match
arbitrarily nested files][3].

This means that the filter was running the CI action only on PRs that
changed a `Cargo.toml` or `*.rs` _in the root of the repository_, rather
than _any_ `Cargo.toml` or `*.rs`, as a reasonable person might assume
it would. 

## Solution

This branch removes path filtering from the CI workflow, since 
apparently it is *impossible* to get the relatively simple behavior we
would want using this thing.

Since almost all `tracing` pull requests touch a `*.rs` or `Cargo.toml`
anyway, this path filtering wasn't really getting us a whole lot.
Removing it shouldn't make a huge difference. It's a shame that we have
to do a full Rust build & test run on PRs that only touch READMEs etc,
but \_(ツ)_/¯.

[1]: https://help.github.com/en/articles/workflow-syntax-for-github-actions#onpushpull_requestpaths
[2]: https://golang.org/pkg/path/#Match
[3]: https://github.com/golang/go/issues/11862

Signed-off-by: Eliza Weisman <eliza@buoyant.io>