### PR TITLE
futures: fix broken builds with tokio alpha support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,6 +82,8 @@ jobs:
     - uses: actions/checkout@master
     - name: "Test tracing-futures std::future support"
       run: (cd tracing-futures/test_std_future && cargo test)
+    - name: "Test tracing-futures tokio alpha support"
+      run: (cd tracing-futures && cargo check --no-default-features --features "tokio-alpha")
     - name: "Test tracing-attributes async/await support"
       run: (cd tracing/test_static_max_level_features && cargo test)
     - name: "Test tracing-core no-std support"

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-futures"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"
@@ -27,12 +27,12 @@ tokio-alpha = ["std-future", "tokio_02"]
 
 [dependencies]
 futures = { version = "0.1", optional = true }
-futures-core-preview = { version = "0.3.0-alpha.17", optional = true }
+futures-core-preview = { version = "0.3.0-alpha.18", optional = true }
 pin-utils = { version = "0.1.0-alpha.4", optional = true }
 tracing = "0.1"
 tokio-executor = { version = "0.1", optional = true }
 tokio = { version = "0.1", optional = true }
-tokio_02 = { package = "tokio", version = "0.2.0-alpha.1", optional = true }
+tokio_02 = { package = "tokio", version = "0.2.0-alpha.4", optional = true }
 
 [dev-dependencies]
 tokio = "0.1.22"


### PR DESCRIPTION
## Motivation

This branch fixes broken builds of `tracing-futures` with the
`tokio-alpha` feature.

## Solution

I've added the missing `WithDispatch` impl for 
`std::future::Future` that was breaking the build. I've also
updated the `tokio` alpha dependency, and added a CI check
that the tokio-alpha feature flag compiles.

Fixes #337 