### PR TITLE
subscriber: rename `Filter` to `EnvFilter`

### DIFF
--- a/examples/examples/futures-proxy-server.rs
+++ b/examples/examples/futures-proxy-server.rs
@@ -17,10 +17,10 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use tracing_subscriber::{fmt, Filter};
+    use tracing_subscriber::{fmt, EnvFilter};
 
     let subscriber = fmt::Subscriber::builder()
-        .with_filter(Filter::from_default_env())
+        .with_filter(EnvFilter::from_default_env())
         .finish();
     tracing::subscriber::set_global_default(subscriber)?;
 

--- a/examples/examples/subscriber-filter.rs
+++ b/examples/examples/subscriber-filter.rs
@@ -3,10 +3,10 @@
 mod yak_shave;
 
 fn main() {
-    use tracing_subscriber::{fmt, Filter};
+    use tracing_subscriber::{fmt, EnvFilter};
 
     let subscriber = fmt::Subscriber::builder()
-        .with_filter(Filter::from_default_env())
+        .with_filter(EnvFilter::from_default_env())
         .finish();
 
     tracing::subscriber::with_default(subscriber, || {

--- a/examples/examples/tower-h2-client.rs
+++ b/examples/examples/tower-h2-client.rs
@@ -18,10 +18,10 @@ use tracing_tower::InstrumentableService;
 pub struct Conn(SocketAddr);
 
 fn main() {
-    use tracing_subscriber::filter::Filter;
+    use tracing_subscriber::filter::EnvFilter;
     // Set the default subscriber to record all traces emitted by this example
     // and by the `tracing_tower` library's helpers.
-    let filter = Filter::from_default_env()
+    let filter = EnvFilter::from_default_env()
         .add_directive("tower_h2_client=trace".parse().unwrap())
         .add_directive("tracing_tower=trace".parse().unwrap());
     let subscriber = tracing_subscriber::FmtSubscriber::builder()

--- a/examples/examples/tower-h2-server.rs
+++ b/examples/examples/tower-h2-server.rs
@@ -95,8 +95,8 @@ impl tower_service::Service<()> for NewSvc {
 fn main() {
     // Set the default subscriber to record all traces emitted by this example
     // and by the `tracing_tower` library's helpers.
-    use tracing_subscriber::filter::Filter;
-    let filter = Filter::from_default_env()
+    use tracing_subscriber::filter::EnvFilter;
+    let filter = EnvFilter::from_default_env()
         .add_directive("tower_h2_server=trace".parse().unwrap())
         .add_directive("tracing_tower=trace".parse().unwrap());
     let subscriber = tracing_subscriber::FmtSubscriber::builder()

--- a/examples/examples/tower-load.rs
+++ b/examples/examples/tower-load.rs
@@ -224,7 +224,7 @@ impl Service<()> for MakeSvc {
 }
 
 struct AdminSvc<S> {
-    handle: tracing_subscriber::reload::Handle<tracing_subscriber::filter::Filter, S>,
+    handle: tracing_subscriber::reload::Handle<tracing_subscriber::filter::EnvFilter, S>,
 }
 
 impl<S> Clone for AdminSvc<S> {
@@ -296,7 +296,7 @@ where
         let body = str::from_utf8(&bytes.as_ref()).map_err(|e| format!("{}", e))?;
         tracing::trace!(request.body = ?body);
         let new_filter = body
-            .parse::<tracing_subscriber::filter::Filter>()
+            .parse::<tracing_subscriber::filter::EnvFilter>()
             .map_err(|e| format!("{}", e))?;
         self.handle.reload(new_filter).map_err(|e| format!("{}", e))
     }

--- a/nightly-examples/examples/echo.rs
+++ b/nightly-examples/examples/echo.rs
@@ -37,10 +37,10 @@ use tracing_futures::Instrument;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    use tracing_subscriber::{Filter, FmtSubscriber};
+    use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
     let subscriber = FmtSubscriber::builder()
-        .with_filter(Filter::from_default_env().add_directive("echo=trace".parse()?))
+        .with_filter(EnvFilter::from_default_env().add_directive("echo=trace".parse()?))
         .finish();
     tracing::subscriber::set_global_default(subscriber)?;
 

--- a/nightly-examples/examples/proxy_server.rs
+++ b/nightly-examples/examples/proxy_server.rs
@@ -86,10 +86,10 @@ async fn transfer(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use tracing_subscriber::{Filter, FmtSubscriber};
+    use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
     let subscriber = FmtSubscriber::builder()
-        .with_filter(Filter::from_default_env().add_directive("proxy_server=trace".parse()?))
+        .with_filter(EnvFilter::from_default_env().add_directive("proxy_server=trace".parse()?))
         .finish();
     tracing::subscriber::set_global_default(subscriber)?;
 

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 license = "MIT"

--- a/tracing-subscriber/src/filter/mod.rs
+++ b/tracing-subscriber/src/filter/mod.rs
@@ -10,3 +10,11 @@ pub use self::level::{LevelFilter, ParseError as LevelParseError};
 
 #[cfg(feature = "filter")]
 pub use self::env::*;
+
+/// A `Layer` which filters spans and events based on a set of filter
+/// directives.
+///
+/// **Note**: renamed to `EnvFilter` in 0.1.2; use that instead.
+#[cfg(feature = "filter")]
+#[deprecated(since = "0.1.2", note = "renamed to `EnvFilter`")]
+pub type Filter = EnvFilter;

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -384,7 +384,7 @@ where
 }
 
 #[cfg(feature = "filter")]
-impl<N, E, W> Builder<N, E, crate::Filter, W>
+impl<N, E, W> Builder<N, E, crate::EnvFilter, W>
 where
     Formatter<N, E, W>: tracing_core::Subscriber + 'static,
 {
@@ -392,7 +392,7 @@ where
     /// runtime.
     pub fn with_filter_reloading(
         self,
-    ) -> Builder<N, E, crate::reload::Layer<crate::Filter, Formatter<N, E, W>>, W> {
+    ) -> Builder<N, E, crate::reload::Layer<crate::EnvFilter, Formatter<N, E, W>>, W> {
         let (filter, _) = crate::reload::Layer::new(self.filter);
         Builder {
             new_visitor: self.new_visitor,
@@ -405,13 +405,13 @@ where
 }
 
 #[cfg(feature = "filter")]
-impl<N, E, W> Builder<N, E, crate::reload::Layer<crate::Filter, Formatter<N, E, W>>, W>
+impl<N, E, W> Builder<N, E, crate::reload::Layer<crate::EnvFilter, Formatter<N, E, W>>, W>
 where
     Formatter<N, E, W>: tracing_core::Subscriber + 'static,
 {
     /// Returns a `Handle` that may be used to reload the constructed subscriber's
     /// filter.
-    pub fn reload_handle(&self) -> crate::reload::Handle<crate::Filter, Formatter<N, E, W>> {
+    pub fn reload_handle(&self) -> crate::reload::Handle<crate::EnvFilter, Formatter<N, E, W>> {
         self.filter.handle()
     }
 }
@@ -432,7 +432,7 @@ impl<N, E, F, W> Builder<N, E, F, W> {
         }
     }
 
-    /// Sets the [`Filter`] that the subscriber will use to determine if
+    /// Sets the [`EnvFilter`] that the subscriber will use to determine if
     /// a span or event is enabled.
     ///
     /// Note that this method requires the "filter" feature flag to be enabled.
@@ -445,10 +445,10 @@ impl<N, E, F, W> Builder<N, E, F, W> {
     /// Setting a filter based on the value of the `RUST_LOG` environment
     /// variable:
     /// ```rust
-    /// use tracing_subscriber::{FmtSubscriber, Filter};
+    /// use tracing_subscriber::{FmtSubscriber, EnvFilter};
     ///
     /// let subscriber = FmtSubscriber::builder()
-    ///     .with_filter(Filter::from_default_env())
+    ///     .with_filter(EnvFilter::from_default_env())
     ///     .finish();
     /// ```
     ///
@@ -467,11 +467,11 @@ impl<N, E, F, W> Builder<N, E, F, W> {
     /// ```rust
     /// use tracing_subscriber::{
     ///     FmtSubscriber,
-    ///     filter::{Filter, LevelFilter},
+    ///     filter::{EnvFilter, LevelFilter},
     /// };
     ///
     /// # fn filter() -> Result<(), Box<dyn std::error::Error>> {
-    /// let filter = Filter::try_from_env("MY_CUSTOM_FILTER_ENV_VAR")?
+    /// let filter = EnvFilter::try_from_env("MY_CUSTOM_FILTER_ENV_VAR")?
     ///     // Set the base level when not matched by other directives to WARN.
     ///     .add_directive(LevelFilter::WARN.into())
     ///     // Set the max level for `my_crate::my_mod` to DEBUG, overriding
@@ -483,10 +483,10 @@ impl<N, E, F, W> Builder<N, E, F, W> {
     ///     .finish();
     /// # Ok(())}
     /// ```
-    /// [`Filter`]: ../filter/struct.Filter.html
+    /// [`EnvFilter`]: ../filter/struct.EnvFilter.html
     /// [`with_max_level`]: #method.with_max_level
     #[cfg(feature = "filter")]
-    pub fn with_filter(self, filter: impl Into<crate::Filter>) -> Builder<N, E, crate::Filter, W>
+    pub fn with_filter(self, filter: impl Into<crate::EnvFilter>) -> Builder<N, E, crate::EnvFilter, W>
     where
         Formatter<N, E, W>: tracing_core::Subscriber + 'static,
     {
@@ -503,7 +503,7 @@ impl<N, E, F, W> Builder<N, E, F, W> {
     /// Sets the maximum [verbosity level] that will be enabled by the
     /// subscriber.
     ///
-    /// If the max level has already been set, or a [`Filter`] was added by
+    /// If the max level has already been set, or a [`EnvFilter`] was added by
     /// [`with_filter`], this replaces that configuration with the new
     /// maximum level.
     ///
@@ -530,7 +530,7 @@ impl<N, E, F, W> Builder<N, E, F, W> {
     ///     .finish();
     /// ```
     /// [verbosity level]: https://docs.rs/tracing-core/0.1.5/tracing_core/struct.Level.html
-    /// [`Filter`]: ../filter/struct.Filter.html
+    /// [`EnvFilter`]: ../filter/struct.EnvFilter.html
     /// [`with_filter`]: #method.with_filter
     pub fn with_max_level(self, filter: impl Into<LevelFilter>) -> Builder<N, E, LevelFilter, W> {
         let filter = filter.into();

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ## Feature Flags
 //!
-//! - `filter`: Enables the [`Filter`] type, which implements filtering similar
+//! - `filter`: Enables the [`EnvFilter`] type, which implements filtering similar
 //!   to the [`env_logger` crate]. Enabled by default.
 //! - `fmt`: Enables the [`fmt`] module, which provides a subscriber
 //!   implementation for printing formatted representations of trace events.
@@ -25,12 +25,12 @@
 //!   macros in the `fmt` subscriber. On by default.
 //! - [`chrono`]: Enables human-readable time formatting in the `fmt` subscriber.
 //!   Enabled by default.
-//! - [`smallvec`]: Causes the `Filter` type to use the `smallvec` crate (rather
+//! - [`smallvec`]: Causes the `EnvFilter` type to use the `smallvec` crate (rather
 //!   than `Vec`) as a performance optimization. Enabled by default.
 //!
 //! [`tracing`]: https://docs.rs/tracing/latest/tracing/
 //! [`Subscriber`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/trait.Subscriber.html
-//! [`Filter`]: filter/struct.Filter.html
+//! [`EnvFilter`]: filter/struct.EnvFilter.html
 //! [`fmt`]: fmt/index.html
 //! [`tracing-log`]: https://crates.io/crates/tracing-log
 //! [`smallvec`]: https://crates.io/crates/smallvec
@@ -97,7 +97,9 @@ pub mod reload;
 pub(crate) mod thread;
 
 #[cfg(feature = "filter")]
-pub use filter::Filter;
+#[allow(deprecated)]
+pub use filter::{Filter, EnvFilter};
+
 pub use layer::Layer;
 
 #[cfg(feature = "fmt")]

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -248,19 +248,19 @@ mod test {
         static FILTER1_CALLS: AtomicUsize = AtomicUsize::new(0);
         static FILTER2_CALLS: AtomicUsize = AtomicUsize::new(0);
 
-        enum Filter {
+        enum EnvFilter {
             One,
             Two,
         }
-        impl<S: Subscriber> crate::Layer<S> for Filter {
+        impl<S: Subscriber> crate::Layer<S> for EnvFilter {
             fn register_callsite(&self, _: &Metadata<'_>) -> Interest {
                 Interest::sometimes()
             }
 
             fn enabled(&self, _: &Metadata<'_>, _: layer::Context<'_, S>) -> bool {
                 match self {
-                    Filter::One => FILTER1_CALLS.fetch_add(1, Ordering::Relaxed),
-                    Filter::Two => FILTER2_CALLS.fetch_add(1, Ordering::Relaxed),
+                    EnvFilter::One => FILTER1_CALLS.fetch_add(1, Ordering::Relaxed),
+                    EnvFilter::Two => FILTER2_CALLS.fetch_add(1, Ordering::Relaxed),
                 };
                 true
             }
@@ -269,7 +269,7 @@ mod test {
             tracing::trace!("my event");
         }
 
-        let (layer, handle) = Layer::new(Filter::One);
+        let (layer, handle) = Layer::new(EnvFilter::One);
 
         let subscriber =
             tracing_core::dispatcher::Dispatch::new(crate::layer::tests::NopSubscriber.with(layer));
@@ -283,7 +283,7 @@ mod test {
             assert_eq!(FILTER1_CALLS.load(Ordering::Relaxed), 1);
             assert_eq!(FILTER2_CALLS.load(Ordering::Relaxed), 0);
 
-            handle.reload(Filter::Two).expect("should reload");
+            handle.reload(EnvFilter::Two).expect("should reload");
 
             event();
 

--- a/tracing-subscriber/tests/field_filter.rs
+++ b/tracing-subscriber/tests/field_filter.rs
@@ -1,11 +1,11 @@
 mod support;
 use self::support::*;
 use tracing::{self, subscriber::with_default, Level};
-use tracing_subscriber::{filter::Filter, prelude::*};
+use tracing_subscriber::{filter::EnvFilter, prelude::*};
 
 #[test]
 fn field_filter_events() {
-    let filter: Filter = "[{thing}]=debug".parse().expect("filter should parse");
+    let filter: EnvFilter = "[{thing}]=debug".parse().expect("filter should parse");
     let (subscriber, finished) = subscriber::mock()
         .event(
             event::mock()
@@ -34,7 +34,7 @@ fn field_filter_events() {
 
 #[test]
 fn field_filter_spans() {
-    let filter: Filter = "[{enabled=true}]=debug"
+    let filter: EnvFilter = "[{enabled=true}]=debug"
         .parse()
         .expect("filter should parse");
     let (subscriber, finished) = subscriber::mock()
@@ -77,7 +77,7 @@ fn field_filter_spans() {
 
 #[test]
 fn record_after_created() {
-    let filter: Filter = "[{enabled=true}]=debug"
+    let filter: EnvFilter = "[{enabled=true}]=debug"
         .parse()
         .expect("filter should parse");
     let (subscriber, finished) = subscriber::mock()

--- a/tracing-subscriber/tests/filter.rs
+++ b/tracing-subscriber/tests/filter.rs
@@ -1,11 +1,11 @@
 mod support;
 use self::support::*;
 use tracing::{self, subscriber::with_default, Level};
-use tracing_subscriber::{filter::Filter, prelude::*};
+use tracing_subscriber::{filter::EnvFilter, prelude::*};
 
 #[test]
 fn level_filter_event() {
-    let filter: Filter = "info".parse().expect("filter should parse");
+    let filter: EnvFilter = "info".parse().expect("filter should parse");
     let (subscriber, finished) = subscriber::mock()
         .event(event::mock().at_level(Level::INFO))
         .event(event::mock().at_level(Level::WARN))
@@ -27,7 +27,7 @@ fn level_filter_event() {
 
 #[test]
 fn same_name_spans() {
-    let filter: Filter = "[foo{bar}]=trace,[foo{baz}]=trace"
+    let filter: EnvFilter = "[foo{bar}]=trace,[foo{baz}]=trace"
         .parse()
         .expect("filter should parse");
     let (subscriber, finished) = subscriber::mock()
@@ -56,7 +56,7 @@ fn same_name_spans() {
 
 #[test]
 fn level_filter_event_with_target() {
-    let filter: Filter = "info,stuff=debug".parse().expect("filter should parse");
+    let filter: EnvFilter = "info,stuff=debug".parse().expect("filter should parse");
     let (subscriber, finished) = subscriber::mock()
         .event(event::mock().at_level(Level::INFO))
         .event(event::mock().at_level(Level::DEBUG).with_target("stuff"))
@@ -83,7 +83,7 @@ fn level_filter_event_with_target() {
 
 #[test]
 fn span_name_filter_is_dynamic() {
-    let filter: Filter = "info,[cool_span]=debug"
+    let filter: EnvFilter = "info,[cool_span]=debug"
         .parse()
         .expect("filter should parse");
     let (subscriber, finished) = subscriber::mock()
@@ -129,7 +129,7 @@ fn span_name_filter_is_dynamic() {
 
 #[test]
 fn field_filter_events() {
-    let filter: Filter = "[{thing}]=debug".parse().expect("filter should parse");
+    let filter: EnvFilter = "[{thing}]=debug".parse().expect("filter should parse");
     let (subscriber, finished) = subscriber::mock()
         .event(
             event::mock()

--- a/tracing-subscriber/tests/same_len_filters.rs
+++ b/tracing-subscriber/tests/same_len_filters.rs
@@ -4,11 +4,11 @@
 mod support;
 use self::support::*;
 use tracing::{self, subscriber::with_default, Level};
-use tracing_subscriber::{filter::Filter, prelude::*};
+use tracing_subscriber::{filter::EnvFilter, prelude::*};
 
 #[test]
 fn same_length_targets() {
-    let filter: Filter = "foo=trace,bar=trace".parse().expect("filter should parse");
+    let filter: EnvFilter = "foo=trace,bar=trace".parse().expect("filter should parse");
     let (subscriber, finished) = subscriber::mock()
         .event(event::mock().at_level(Level::TRACE))
         .event(event::mock().at_level(Level::TRACE))
@@ -26,7 +26,7 @@ fn same_length_targets() {
 
 #[test]
 fn same_num_fields_event() {
-    let filter: Filter = "[{foo}]=trace,[{bar}]=trace"
+    let filter: EnvFilter = "[{foo}]=trace,[{bar}]=trace"
         .parse()
         .expect("filter should parse");
     let (subscriber, finished) = subscriber::mock()
@@ -53,7 +53,7 @@ fn same_num_fields_event() {
 
 #[test]
 fn same_num_fields_and_name_len() {
-    let filter: Filter = "[foo{bar=1}]=trace,[baz{boz=1}]=trace"
+    let filter: EnvFilter = "[foo{bar=1}]=trace,[baz{boz=1}]=trace"
         .parse()
         .expect("filter should parse");
     let (subscriber, finished) = subscriber::mock()


### PR DESCRIPTION
This branch renames `Filter` to `EnvFilter` and deprecates the previous
name, as suggested in https://github.com/tokio-rs/tracing/pull/336#pullrequestreview-286356811.
This should make the difference between an `EnvFilter` and a
`LevelFilter` clearer.