### PR TITLE
tracing: don't emit log events if a subscriber has been set

### DIFF
--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -59,6 +59,7 @@ release_max_level_trace = []
 async-await = []
 
 std = ["tracing-core/std"]
+log-always = ["log"]
 
 [[bench]]
 name = "subscriber"

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -28,7 +28,7 @@ keywords = ["logging", "tracing", "metrics", "async"]
 edition = "2018"
 
 [dependencies]
-tracing-core = { version = "0.1.5", path = "../tracing-core", default-features = false }
+tracing-core = { version = "0.1.6", default-features = false }
 log = { version = "0.4", optional = true }
 tracing-attributes = "0.1.2"
 cfg-if = "0.1.9"

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -577,10 +577,16 @@
 //!
 //! * A set of features controlling the [static verbosity level].
 //! * `log`: causes trace instrumentation points to emit [`log`] records as well
-//!   as trace events. This is intended for use in libraries whose users may be
-//!   using either `tracing` or `log`.
+//!   as trace events, if a default `tracing` subscriber has not been set. This
+//!   is intended for use in libraries whose users may be using either `tracing`
+//!   or `log`.
 //!   **Note:** `log` support will not work when `tracing` is renamed in `Cargo.toml`,
 //!   due to oddities in macro expansion.
+//! * `log-always`: Emit `log` records from all `tracing` spans and events, even
+//!   a `tracing` subscriber has been set. This should be set only by
+//!   applications which intend to collect traces and logs separately; if an
+//!   adapter is used to convert `log` records into `tracing` events, this will
+//!   cause duplicate events to occur.
 //! * `std`: Depend on the Rust standard library (enabled by default).
 //!
 //!   `no_std` users may disable this feature with `default-features = false`:
@@ -668,8 +674,6 @@ pub mod subscriber;
 #[doc(hidden)]
 pub mod __macro_support {
     pub use crate::stdlib::sync::atomic::{AtomicUsize, Ordering};
-
-    pub const LOG_ENABLED: bool = cfg!(feature = "log");
 
     #[cfg(feature = "std")]
     pub use crate::stdlib::sync::Once;

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -2319,8 +2319,8 @@ macro_rules! __tracing_log {
 #[macro_export]
 macro_rules! __tracing_should_log {
     () => {
-       !$crate::dispatcher::has_been_set()
-    }
+        !$crate::dispatcher::has_been_set()
+    };
 }
 
 #[cfg(all(feature = "log", feature = "log-always"))]
@@ -2329,5 +2329,5 @@ macro_rules! __tracing_should_log {
 macro_rules! __tracing_should_log {
     () => {
         true
-    }
+    };
 }

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -386,20 +386,6 @@ pub struct Entered<'a> {
 
 // ===== impl Span =====
 
-macro_rules! if_log {
-    ($e:expr;) => {
-        if_log! { $e }
-    };
-    ($if_log:expr) => {
-        #[cfg(feature = "log")]
-        {
-            if __tracing_should_log!() {
-                $if_log
-            }
-        }
-    };
-}
-
 impl Span {
     /// Constructs a new `Span` with the given [metadata] and set of
     /// [field values].
@@ -519,9 +505,9 @@ impl Span {
             meta: Some(meta),
         };
 
-        if_log! {
+        if_log_enabled! {{
             span.log(format_args!("++ {}; {}", meta.name(), FmtAttrs(attrs)));
-        }
+        }}
 
         span
     }
@@ -603,11 +589,11 @@ impl Span {
             inner.subscriber.enter(&inner.id);
         }
 
-        if_log! {
+        if_log_enabled! {{
             if let Some(ref meta) = self.meta {
                 self.log(format_args!("-> {}", meta.name()));
             }
-        }
+        }}
 
         Entered { span: self }
     }
@@ -704,11 +690,11 @@ impl Span {
             inner.record(&record);
         }
 
-        if_log! {
+        if_log_enabled! {{
             if let Some(ref meta) = self.meta {
                 self.log(format_args!("{}; {}", meta.name(), FmtValues(&record)));
             }
-        }
+        }}
 
         self
     }
@@ -855,11 +841,11 @@ impl Drop for Span {
             subscriber.try_close(id.clone());
         }
 
-        if_log! {
+        if_log_enabled!({
             if let Some(ref meta) = self.meta {
                 self.log(format_args!("-- {}", meta.name()));
             }
-        }
+        })
     }
 }
 
@@ -936,11 +922,11 @@ impl<'a> Drop for Entered<'a> {
             inner.subscriber.exit(&inner.id);
         }
 
-        if_log! {
+        if_log_enabled! {{
             if let Some(ref meta) = self.span.meta {
                 self.span.log(format_args!("<- {}", meta.name()));
             }
-        }
+        }}
     }
 }
 

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -387,14 +387,17 @@ pub struct Entered<'a> {
 // ===== impl Span =====
 
 macro_rules! if_log {
-    ($e:expr;) => { if_log!{ $e }};
+    ($e:expr;) => {
+        if_log! { $e }
+    };
     ($if_log:expr) => {
-        #[cfg(feature = "log")] {
+        #[cfg(feature = "log")]
+        {
             if __tracing_should_log!() {
                 $if_log
             }
         }
-    }
+    };
 }
 
 impl Span {

--- a/tracing/test-log-support/Cargo.toml
+++ b/tracing/test-log-support/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 edition = "2018"
 
 [dependencies]
-tracing = { path = "..", features = ["log"] }
+tracing = { path = "..", features = ["log", "log-always"] }
 log = { version = "0.4", features = ["std"] }

--- a/tracing/test-log-support/tests/log_no_trace.rs
+++ b/tracing/test-log-support/tests/log_no_trace.rs
@@ -29,14 +29,12 @@ fn test_always_log() {
     });
     test.assert_logged("<- foo");
 
-    span!(Level::TRACE, "foo", bar = 3, baz = false);
+    drop(foo);
+    test.assert_logged("-- foo");
+
+
+    let foo = span!(Level::TRACE, "foo", bar = 3, baz = false);
     test.assert_logged("foo; bar=3 baz=false");
 
-    // TODO(#1138): determine a new syntax for uninitialized span fields, and
-    // re-enable these.
-    // let span = span!(Level::TRACE, "foo", bar = _, baz = _);
-    // span.record("bar", &3);
-    // test.assert_logged("foo; bar=3");
-    // span.record("baz", &"a string");
-    // test.assert_logged("foo; baz=\"a string\"");
+    drop(foo);
 }


### PR DESCRIPTION
## Motivation

Currently, when `tracing`'s `log` feature is enabled, all spans and
events will emit `log` records as well as `tracing` events. When
`tracing-log` is being used to convert `log` records into `tracing`
events, this results in duplicate events being observed: those emitted
by the event macros directly, and those generated from the log records
they emit by `tracing-log`.

## Solution

In `tracing-core` 0.1.6, we added an internal API for checking if a
`tracing` subscriber has ever been set. In addition to the performance
optimizations which this was initially intended to enable, this also
gives us a way for `tracing` macros in libraries to check if a
downstream application that depends on those libraries is actually using
`tracing`. If `tracing` is in use and a subscriber has been set, the
macros can be disabled.

In a handful of cases, users _may_ wish to collect `log` records and
`tracing` events totally separately. For example, `log` records might be
output to the console while `tracing` is used to generate metrics or for
performance profiling. In this case, there is an additional `log-always`
feature flag which applications can set to enable all of `tracing`'s log
records regardless of whether a subscriber is in use. In most cases
where the `log` feature is currently used (libraries that want to emit
both `tracing` and `log` diagnostics for their users), this will not be
necessary.

Fixes #204

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
