### PR TITLE
subscriber: prepare to release 0.1.2

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,33 @@
+# 0.1.2 (September 12, 2019)
+
+### Fixed
+
+- `EnvFilter` ignoring directives with targets that are the same number of
+  characters (#333)
+- `EnvFilter` failing to properly apply filter directives to events generated
+  from `log` records by`tracing-log` (#344)
+
+### Changed
+
+- Renamed `Filter` to `EnvFilter`, deprecated `Filter` (#339)
+- Renamed "filter" feature flag to "env-filter", deprecated "filter" (#339)
+- `FmtSubscriber` now defaults to enabling only the `INFO` level and above when
+  a max level filter or `EnvFilter` is not set (#336)
+- Made `parking_lot` dependency an opt-in feature flag (#348)
+
+### Added
+
+- `EnvFilter::add_directive` to add new directives to filters after they are
+  constructed (#334)
+- `fmt::Builder::with_max_level` to set a global level filter for a
+  `FmtSubscriber` without requiring the use of `EnvFilter` (#336)
+- `Layer` implementation for `LevelFilter` (#336)
+- `EnvFilter` now implements `fmt::Display` (#329)
+
+### Removed
+
+- Removed dependency on `crossbeam-util` (#348)
+
 # 0.1.1 (September 4, 2019)
 
 ### Fixed

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-subscriber/0.1.1/tracing-subscriber"
+documentation = "https://docs.rs/tracing-subscriber/0.1.2/tracing-subscriber"
 description = """
 Utilities for implementing and composing `tracing` subscribers.
 """

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -18,7 +18,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber
+[docs-url]: https://docs.rs/tracing-subscriber/0.1.2
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -41,7 +41,7 @@
 //! [`chrono`]: https://crates.io/crates/chrono
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.1.2")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
### Fixed

- `EnvFilter` ignoring directives with targets that are the same number
  of characters (#333)
- `EnvFilter` failing to properly apply filter directives to events
  generated from `log` records by`tracing-log` (#344)

### Changed

- Renamed `Filter` to `EnvFilter`, deprecated `Filter` (#339)
- Renamed "filter" feature flag to "env-filter", deprecated "filter" (#339)
- `FmtSubscriber` now defaults to enabling only the `INFO` level and
  above when a max level filter or `EnvFilter` is not set (#336)

### Added:

- `EnvFilter::add_directive` to add new directives to filters after they
  are constructed (#334)
- `fmt::Builder::with_max_level` to set a global level filter for a
  `FmtSubscriber` without requiring the use of `EnvFilter` (#336)
- `Layer` implementation for `LevelFilter` (#336)
- `EnvFilter` now implements `fmt::Display` (#329)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>