### PR TITLE
Add RustConf 2019 Talk to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ Tracing.
 #### Talks
 
 * [Bay Area Rust Meetup talk and Q&A][bay-rust-2018-03], March 2018
+* [RustConf 2019 - Tokio-Trace: Scoped, Structured, Async-Aware Diagnostics][rust-conf-2019-08], August 2019
 
 [bay-rust-2018-03]: https://www.youtube.com/watch?v=j_kXRg3zlec
+[rust-conf-2019-08]: https://www.youtube.com/watch?v=JjItsfqFIdo
 
 Help us expand this list! If you've written or spoken about Tracing, or
 know of resources that aren't listed, please open a pull request adding them.

--- a/README.md
+++ b/README.md
@@ -115,10 +115,11 @@ Tracing.
 #### Talks
 
 * [Bay Area Rust Meetup talk and Q&A][bay-rust-2018-03], March 2018
-* [RustConf 2019 - Tokio-Trace: Scoped, Structured, Async-Aware Diagnostics][rust-conf-2019-08], August 2019
+* [RustConf 2019 talk][rust-conf-2019-08-video] and [slides][rust-conf-2019-08-slides], August 2019
 
 [bay-rust-2018-03]: https://www.youtube.com/watch?v=j_kXRg3zlec
-[rust-conf-2019-08]: https://www.youtube.com/watch?v=JjItsfqFIdo
+[rust-conf-2019-08-video]: https://www.youtube.com/watch?v=JjItsfqFIdo
+[rust-conf-2019-08-slides]: https://www.elizas.website/slides/rustconf-8-2019.pdf
 
 Help us expand this list! If you've written or spoken about Tracing, or
 know of resources that aren't listed, please open a pull request adding them.


### PR DESCRIPTION
## Motivation

I viewed the amazing talk from Eliza Weisman on the RustConf 2019 on Youtube. Saw that it is missing in the list of Talks.

## Solution

Add it ;)