### PR TITLE
Fix small format bug in tracing documentation

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -389,7 +389,7 @@
 //! similarly to the [`event!`] macro, but with the [`Level`] argument already
 //! specified, while the corresponding [`trace_span!`], [`debug_span!`],
 //! [`info_span!`], [`warn_span!`], and [`error_span!`] macros are the same,
-//! but for the `[span!`] macro.
+//! but for the [`span!`] macro.
 //!
 //! These are intended both as a shorthand, and for compatibility with the [`log`]
 //! crate (see the next section).

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -385,7 +385,7 @@
 //! ### Shorthand Macros
 //!
 //! `tracing` also offers a number of macros with preset verbosity levels.
-//! The [`trace!`], [`debug!`], [`info!`], [`warn!]`, and [`error!`] behave
+//! The [`trace!`], [`debug!`], [`info!`], [`warn!`], and [`error!`] behave
 //! similarly to the [`event!`] macro, but with the [`Level`] argument already
 //! specified, while the corresponding [`trace_span!`], [`debug_span!`],
 //! [`info_span!`], [`warn_span!`], and [`error_span!`] macros are the same,


### PR DESCRIPTION
Fix typo on the docs index page in sector [shorthand macros](https://tracing-rs.netlify.com/tracing/#shorthand-macros) which prevents link rendering.