### PR TITLE
Allow skipping arguments in `#[instrument]`.

### DIFF
--- a/tracing-attributes/tests/instrument.rs
+++ b/tracing-attributes/tests/instrument.rs
@@ -43,7 +43,6 @@ fn override_everything() {
 
 #[test]
 fn fields() {
-    struct UnDebug(pub u32);
 
     #[instrument(target = "my_target", level = "debug")]
     fn my_fn(arg1: usize, arg2: bool) {}

--- a/tracing-attributes/tests/instrument.rs
+++ b/tracing-attributes/tests/instrument.rs
@@ -43,8 +43,10 @@ fn override_everything() {
 
 #[test]
 fn fields() {
-    #[instrument(target = "my_target", level = "debug")]
-    fn my_fn(arg1: usize, arg2: bool) {}
+    struct UnDebug(pub u32);
+
+    #[instrument(target = "my_target", level = "debug", skip(_arg3, _arg4))]
+    fn my_fn(arg1: usize, arg2: bool, _arg3: UnDebug, _arg4: UnDebug) {}
 
     let span = span::mock()
         .named("my_fn")
@@ -80,8 +82,8 @@ fn fields() {
         .run_with_handle();
 
     with_default(subscriber, || {
-        my_fn(2, false);
-        my_fn(3, true);
+        my_fn(2, false, UnDebug(0), UnDebug(1));
+        my_fn(3, true, UnDebug(0), UnDebug(1));
     });
 
     handle.assert_finished();

--- a/tracing-attributes/tests/instrument.rs
+++ b/tracing-attributes/tests/instrument.rs
@@ -43,7 +43,6 @@ fn override_everything() {
 
 #[test]
 fn fields() {
-
     #[instrument(target = "my_target", level = "debug")]
     fn my_fn(arg1: usize, arg2: bool) {}
 

--- a/tracing-attributes/tests/instrument.rs
+++ b/tracing-attributes/tests/instrument.rs
@@ -108,21 +108,16 @@ fn skip() {
         .with_target("my_target");
     let (subscriber, handle) = subscriber::mock()
         .new_span(
-            span.clone().with_field(
-                field::mock("arg1")
-                    .with_value(&format_args!("2"))
-                    .only(),
-            ),
+            span.clone()
+                .with_field(field::mock("arg1").with_value(&format_args!("2")).only()),
         )
         .enter(span.clone())
         .exit(span.clone())
         .drop_span(span)
         .new_span(
-            span2.clone().with_field(
-                field::mock("arg1")
-                    .with_value(&format_args!("3"))
-                    .only(),
-            ),
+            span2
+                .clone()
+                .with_field(field::mock("arg1").with_value(&format_args!("3")).only()),
         )
         .enter(span2.clone())
         .exit(span2.clone())


### PR DESCRIPTION
## Motivation

This adds a `skip` directive to the `#[instrument]` macro that allows
specifying one or more arguments to the function which will not appear
in the generated span.  In particular, this means that it's possible to
use `#[instrument]` on functions with a non-`Debug` parameter.

## Solution

The interior of a `skip(arg1, arg2)` argument is scanned for identifiers and these are filtered out of the identifier list used to generate the span.

This hopefully closes #11.
