### PR TITLE
fmt: Track duplicate spans in fmt context

### DIFF
--- a/tracing-subscriber/tests/duplicate_spans.rs
+++ b/tracing-subscriber/tests/duplicate_spans.rs
@@ -1,7 +1,6 @@
 mod support;
-use self::support::*;
-use tracing::{self, subscriber::with_default, Level, Span};
-use tracing_subscriber::{filter::EnvFilter, prelude::*, FmtSubscriber};
+use tracing::{self, subscriber::with_default, Span};
+use tracing_subscriber::{filter::EnvFilter, FmtSubscriber};
 
 #[test]
 fn duplicate_spans() {

--- a/tracing-subscriber/tests/duplicate_spans.rs
+++ b/tracing-subscriber/tests/duplicate_spans.rs
@@ -1,0 +1,37 @@
+mod support;
+use self::support::*;
+use tracing::{self, subscriber::with_default, Level, Span};
+use tracing_subscriber::{filter::EnvFilter, prelude::*, FmtSubscriber};
+
+#[test]
+fn duplicate_spans() {
+    let subscriber = FmtSubscriber::builder()
+        .with_env_filter(EnvFilter::new("[root]=debug"))
+        .finish();
+
+    with_default(subscriber, || {
+        let root = tracing::debug_span!("root");
+        let _enter = root.enter();
+        // root:
+        assert_eq!(root, Span::current());
+        {
+            let leaf = tracing::debug_span!("leaf");
+            let _enter_leaf = leaf.enter();
+            // root:leaf:
+            assert_eq!(leaf, Span::current());
+
+            let _reenter_root = root.enter();
+            // root:leaf:
+            assert_eq!(leaf, Span::current());
+        }
+        // root:
+        assert_eq!(root, Span::current());
+        {
+            let _reenter_root = root.enter();
+            // root:
+            assert_eq!(root, Span::current());
+        }
+        // root:
+        assert_eq!(root, Span::current());
+    });
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

Entering twice in the same span causes the span to be lost after the second span got droped, see #358 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Duplicate spans are tracked in the `CONTEXT` thread local stack  and ignored when finding the current span id. Spans are always pushed on the `CONTEXT` stack. This way, when a span is dropped, its ref count reflects the content of the thread local

Fixes #358 
