### PR TITLE
subscriber: prepare to release 0.1.4

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.1.4 (September 26, 2019)
+
+### Fixed
+
+- Spans entered twice on the same thread sometimes being completely exited when
+  the more deeply-nested entry is exited (#361)
+- Setting `with_ansi(false)` on `FmtSubscriber` not disabling ANSI color
+  formatting for timestamps (#354)
+- Incorrect reference counting in `FmtSubscriber` that could cause spans to not
+  be closed when all references are dropped (#366)
+
 # 0.1.3 (September 16, 2019)
 
 ### Fixed

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "tracing-subscriber"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-subscriber/0.1.3/tracing-subscriber"
+documentation = "https://docs.rs/tracing-subscriber/0.1.4/tracing-subscriber"
 description = """
 Utilities for implementing and composing `tracing` subscribers.
 """

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -18,7 +18,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.1.3
+[docs-url]: https://docs.rs/tracing-subscriber/0.1.4
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -41,7 +41,7 @@
 //! [`chrono`]: https://crates.io/crates/chrono
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.1.3")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.1.4")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
Fixed:

- Spans entered twice on the same thread sometimes being completely
  exited when the more deeply-nested entry is exited (#361)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>