### PR TITLE
attributes: prepare to release 0.1.4

### DIFF
--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.4 (September 26, 2019)
+
+### Added
+
+- Optional `skip` argument to `#[instrument]` for excluding function parameters
+  from generated spans (#359)
+
 # 0.1.3 (September 12, 2019)
 
 ### Fixed

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-attributes"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.3"
+version = "0.1.4"
 authors = [
     "Tokio Contributors <team@tokio.rs>",
     "Eliza Weisman <eliza@buoyant.io>",

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -15,7 +15,7 @@ Macro attributes for application-level tracing.
 [crates-badge]: https://img.shields.io/crates/v/tracing-attributes.svg
 [crates-url]: https://crates.io/crates/tracing-attributes
 [docs-badge]: https://docs.rs/tracing-attributes/badge.svg
-[docs-url]: https://docs.rs/tracing-attributes/0.1.3
+[docs-url]: https://docs.rs/tracing-attributes/0.1.4
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_attributes
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -40,7 +40,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing-attributes = "0.1.3"
+tracing-attributes = "0.1.4"
 ```
 
 This crate provides the `#[instrument]` attribute for instrumenting a function

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.3")]
+#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.4")]
 #![deny(missing_debug_implementations, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
Added:

- Optional `skip` argument to `#[instrument]` for excluding function
  parameters from generated spans (#359)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>