### PR TITLE
chore: add discord links to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Application-level tracing for Rust.
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
+[![Discord chat][discord-badge]][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
 [crates-url]: https://crates.io/crates/tracing
@@ -21,6 +22,8 @@ Application-level tracing for Rust.
 [azure-url]: https://dev.azure.com/tracing/tracing/_build/latest?definitionId=1&branchName=master
 [gitter-badge]: https://img.shields.io/gitter/room/tokio-rs/tracing.svg
 [gitter-url]: https://gitter.im/tokio-rs/tracing
+[discord-badge]: https://img.shields.io/discord/500028886025895936?logo=discord&label=discord&logoColor=white
+[discord-url]: https://discordapp.com/invite/XdPzyTZ
 
 [Website](https://tokio.rs) |
 [Chat](https://gitter.im/tracing-rs/tracing) | [Documentation (master branch)](https://tracing-rs.netlify.com/)

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -8,9 +8,10 @@ Macro attributes for application-level tracing.
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
+[![Discord chat][discord-badge]][discord-url]
 
 [Documentation][docs-url] |
-[Chat][gitter-url]
+[Chat (gitter)][gitter-url] | [Chat (discord)][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-attributes.svg
 [crates-url]: https://crates.io/crates/tracing-attributes
@@ -24,6 +25,8 @@ Macro attributes for application-level tracing.
 [azure-url]: https://dev.azure.com/tracing/tracing/_build/latest?definitionId=1&branchName=master
 [gitter-badge]: https://img.shields.io/gitter/room/tokio-rs/tracing.svg
 [gitter-url]: https://gitter.im/tokio-rs/tracing
+[discord-badge]: https://img.shields.io/discord/500028886025895936?logo=discord&label=discord&logoColor=white
+[discord-url]: https://discordapp.com/invite/XdPzyTZ
 
 ## Overview
 

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -8,9 +8,10 @@ Core primitives for application-level tracing.
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
+[![Discord chat][discord-badge]][discord-url]
 
 [Documentation][docs-url] |
-[Chat][gitter-url]
+[Chat (gitter)][gitter-url] | [Chat (discord)][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-core.svg
 [crates-url]: https://crates.io/crates/tracing-core/0.1.6
@@ -24,6 +25,8 @@ Core primitives for application-level tracing.
 [azure-url]: https://dev.azure.com/tracing/tracing/_build/latest?definitionId=1&branchName=master
 [gitter-badge]: https://img.shields.io/gitter/room/tokio-rs/tracing.svg
 [gitter-url]: https://gitter.im/tokio-rs/tracing
+[discord-badge]: https://img.shields.io/discord/500028886025895936?logo=discord&label=discord&logoColor=white
+[discord-url]: https://discordapp.com/invite/XdPzyTZ
 
 ## Overview
 

--- a/tracing-futures/README.md
+++ b/tracing-futures/README.md
@@ -10,9 +10,10 @@ Utilities for instrumenting futures-based code with [`tracing`].
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
+[![Discord chat][discord-badge]][discord-url]
 
 [Documentation][docs-url] |
-[Chat][gitter-url]
+[Chat (gitter)][gitter-url] | [Chat (discord)][discord-url]
 
 [`tracing`]: https://github.com/tokio-rs/tracing/tree/master/tracing
 [crates-badge]: https://img.shields.io/crates/v/tracing-futures.svg
@@ -27,6 +28,8 @@ Utilities for instrumenting futures-based code with [`tracing`].
 [azure-url]: https://dev.azure.com/tracing/tracing/_build/latest?definitionId=1&branchName=master
 [gitter-badge]: https://img.shields.io/gitter/room/tokio-rs/tracing.svg
 [gitter-url]: https://gitter.im/tokio-rs/tracing
+[discord-badge]: https://img.shields.io/discord/500028886025895936?logo=discord&label=discord&logoColor=white
+[discord-url]: https://discordapp.com/invite/XdPzyTZ
 
 ## License
 

--- a/tracing-log/README.md
+++ b/tracing-log/README.md
@@ -8,10 +8,13 @@
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
+[![Discord chat][discord-badge]][discord-url]
 ![maintenance status][maint-badge]
 
+
 [Documentation][docs-url] |
-[Chat][gitter-url]
+[Chat (gitter)][gitter-url] | [Chat (discord)][discord-url]
+
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-log.svg
 [crates-url]: https://crates.io/crates/tracing-log
@@ -25,6 +28,8 @@
 [azure-url]: https://dev.azure.com/tracing/tracing/_build/latest?definitionId=1&branchName=master
 [gitter-badge]: https://img.shields.io/gitter/room/tokio-rs/tracing.svg
 [gitter-url]: https://gitter.im/tokio-rs/tracing
+[discord-badge]: https://img.shields.io/discord/500028886025895936?logo=discord&label=discord&logoColor=white
+[discord-url]: https://discordapp.com/invite/XdPzyTZ
 [maint-badge]: https://img.shields.io/badge/maintenance-experimental-blue.svg
 
 ## Overview

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -8,10 +8,11 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
+[![Discord chat][discord-badge]][discord-url]
 ![maintenance status][maint-badge]
 
 [Documentation][docs-url] |
-[Chat][gitter-url]
+[Chat (gitter)][gitter-url] | [Chat (discord)][discord-url]
 
 [tracing]: https://github.com/tokio-rs/tracing/tree/master/tracing
 [tracing-fmt]: https://github.com/tokio-rs/tracing/tree/master/tracing-subscriber
@@ -27,6 +28,8 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [azure-url]: https://dev.azure.com/tracing/tracing/_build/latest?definitionId=1&branchName=master
 [gitter-badge]: https://img.shields.io/gitter/room/tokio-rs/tracing.svg
 [gitter-url]: https://gitter.im/tokio-rs/tracing
+[discord-badge]: https://img.shields.io/discord/500028886025895936?logo=discord&label=discord&logoColor=white
+[discord-url]: https://discordapp.com/invite/XdPzyTZ
 [maint-badge]: https://img.shields.io/badge/maintenance-experimental-blue.svg
 
 ## License

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -8,9 +8,10 @@ Application-level tracing for Rust.
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][azure-badge]][azure-url]
 [![Gitter chat][gitter-badge]][gitter-url]
+[![Discord chat][discord-badge]][discord-url]
 
 [Documentation][docs-url] |
-[Chat][gitter-url]
+[Chat (gitter)][gitter-url] | [Chat (discord)][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
 [crates-url]: https://crates.io/crates/tracing/0.1.9
@@ -24,6 +25,9 @@ Application-level tracing for Rust.
 [azure-url]: https://dev.azure.com/tracing/tracing/_build/latest?definitionId=1&branchName=master
 [gitter-badge]: https://img.shields.io/gitter/room/tokio-rs/tracing.svg
 [gitter-url]: https://gitter.im/tokio-rs/tracing
+[discord-badge]: https://img.shields.io/discord/500028886025895936?logo=discord&label=discord&logoColor=white
+[discord-url]: https://discordapp.com/invite/XdPzyTZ
+
 
 ## Overview
 


### PR DESCRIPTION
Tokio is experimenting with Discord, and the Tokio discord server has
a Tracing channel. This PR adds Discord links to READMEs.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>