### PR TITLE
subscriber: fix duplicate clone_span in `FmtSubscriber`

### DIFF
--- a/tracing-subscriber/src/fmt/span.rs
+++ b/tracing-subscriber/src/fmt/span.rs
@@ -285,7 +285,7 @@ impl Store {
     #[inline]
     pub(crate) fn current(&self) -> Option<Id> {
         CONTEXT
-            .try_with(|current| current.borrow().current().map(|id| self.clone_span(id)))
+            .try_with(|current| current.borrow().current().cloned())
             .ok()?
     }
 
@@ -451,7 +451,7 @@ impl Data {
         let parent = if attrs.is_root() {
             None
         } else if attrs.is_contextual() {
-            store.current()
+            store.current().as_ref().map(|id| store.clone_span(id))
         } else {
             attrs.parent().map(|id| store.clone_span(id))
         };


### PR DESCRIPTION
## Motivation

The `tracing_subscriber` `FmtSubscriber` currently clones span IDs in
calls to `Subscriber::current_span`. However, this is incorrect --- IDs
should only be cloned when constructing an _entering span handle_; the
`tracing-core` `span::Current` type does not call `drop_span` on drop.
In `tracing`, `Span::current` already clones the ID returned by
`Subscriber::current_span`.

This means that any use of `Subscriber::current_span` or `Span::current`
with `FmtSubscriber` will result in the current span being "leaked" and
never dropped.

## Solution

This commit removes the unnecessary `clone_span`.

Thanks to @twissel for reporting the bug!

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
