### PR TITLE
subscriber: prepare to release 0.1.5

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.5 (October 7, 2019)
+
+### Fixed
+
+- Spans not being closed properly when `FmtSubscriber::current_span` is used
+  (#371)
+
 # 0.1.4 (September 26, 2019)
 
 ### Fixed

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "tracing-subscriber"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-subscriber/0.1.4/tracing-subscriber"
+documentation = "https://docs.rs/tracing-subscriber/0.1.5/tracing-subscriber"
 description = """
 Utilities for implementing and composing `tracing` subscribers.
 """

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -19,7 +19,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.1.4
+[docs-url]: https://docs.rs/tracing-subscriber/0.1.5
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -41,7 +41,7 @@
 //! [`chrono`]: https://crates.io/crates/chrono
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.1.4")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.1.5")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
### Fixed

- Spans not being closed properly after calling
  `FmtSubscriber::current_span` (#371)