### PR TITLE
Add init and try_init functions

### DIFF
--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -69,8 +69,8 @@ enum ErrorKind {
 }
 
 impl EnvFilter {
-    /// The default environment variable used by [`EnvFilter::from_default_env`]
-    /// and [`EnvFilter::try_from_default_env`].
+    /// `RUST_LOG` is the default environment variable used by
+    /// [`EnvFilter::from_default_env`] and [`EnvFilter::try_from_default_env`].
     ///
     /// [`EnvFilter::from_default_env`]: #method.from_default_env
     /// [`EnvFilter::try_from_default_env`]: #method.try_from_default_env

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -13,7 +13,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tracing-subscriber = "0.1"
+//! tracing-subscriber = "0.2"
 //! ```
 //!
 //! Add the following to your executable to initialize the default subscriber:
@@ -25,23 +25,29 @@
 //!
 //! ## Filtering Events with Environment Variables
 //!
-//! The default subscriber installed by `init` enables you to filter events at runtime using environment variables (using the [`EnvFilter`]).
+//! The default subscriber installed by `init` enables you to filter events
+//! at runtime using environment variables (using the [`EnvFilter`]).
 //!
-//! The filter syntax is a superset of the [`env_logger`](https://docs.rs/env_logger/) syntax.
+//! The filter syntax is a superset of the [`env_logger`] syntax.
 //!
 //! For example:
-//! - Setting `RUST_LOG=debug` enables all `Span`s and `Event`s set to the log level `DEBUG` or higher
-//! - Setting `RUST_LOG=my_crate=trace` enables `Span`s and `Event`s in `my_crate` at all log levels
+//! - Setting `RUST_LOG=debug` enables all `Span`s and `Event`s
+//!     set to the log level `DEBUG` or higher
+//! - Setting `RUST_LOG=my_crate=trace` enables `Span`s and `Event`s
+//!     in `my_crate` at all log levels
 //!
-//! **Note**: This should **not** be called by libraries. Libraries should use [`tracing`] to publish `tracing` `Event`s.
+//! **Note**: This should **not** be called by libraries. Libraries should use
+//! [`tracing`] to publish `tracing` `Event`s.
 //!
 //! ## Configuration
 //!
-//! You can configure a subscriber instead of using the defaults with the following functions:
+//! You can configure a subscriber instead of using the defaults with
+//! the following functions:
 //!
 //! ### Subscriber
 //!
-//! The [`FmtSubscriber`] formats and records `tracing` events as line-oriented logs. You can create one by calling:
+//! The [`FmtSubscriber`] formats and records `tracing` events as line-oriented logs.
+//! You can create one by calling:
 //!
 //! ```rust
 //! use tracing_subscriber::FmtSubscriber;
@@ -51,7 +57,7 @@
 //!     .finish();
 //! ```
 //!
-//! You can find the configuration methods for [`FmtSubscriber`] in the docs.
+//! You can find the configuration methods for [`FmtSubscriber`] in [`fmt::Builder`].
 //!
 //! ### Filters
 //!
@@ -86,10 +92,14 @@
 //! // Note this will only fail if you try to set the global default
 //! // subscriber multiple times
 //! ```
-//!
-//! [`tracing`]: https://crates.io/crates/tracing
+//! [`EnvFilter`]: ../filter/struct.EnvFilter.html
+//! [`env_logger`]: https://docs.rs/env_logger/
+//! [`filter`]: ../filter/index.html
+//! [`fmt::Builder`]: ./struct.Builder.html
+//! [`FmtSubscriber`]: ./struct.Subscriber.html
 //! [`Subscriber`]:
 //!     https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
+//! [`tracing`]: https://crates.io/crates/tracing
 use std::{any::TypeId, cell::RefCell, error::Error, io};
 use tracing_core::{dispatcher, subscriber::Interest, Event, Metadata};
 
@@ -791,7 +801,7 @@ impl Default for Settings {
 /// if one is not already set.
 ///
 /// If the `tracing_log` feature is enabled, this will also install
-/// the LogTracer to convert `Log` records into `tracing` `Event`s.
+/// the [`LogTracer`] to convert `log` records into `tracing` `Event`s.
 ///
 ///
 /// # Errors
@@ -799,6 +809,8 @@ impl Default for Settings {
 /// likely because a global subscriber was already installed by another
 /// call to `try_init`.
 ///
+/// [`LogTracer`]:
+///     https://docs.rs/tracing-log/0.1.0/tracing_log/struct.LogTracer.html
 /// [`RUST_LOG` environment variable]:
 ///     ../filter/struct.EnvFilter.html#associatedconstant.DEFAULT_ENV
 pub fn try_init() -> Result<(), impl Error + Send + Sync + 'static> {

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -7,18 +7,101 @@
 //! implementation of the [`Subscriber`] trait that records `tracing`'s `Event`s
 //! and `Span`s by formatting them as text and logging them to stdout.
 //!
+//! ## Usage
+//!
+//! First, add this to your `Cargo.toml` file:
+//!
+//! ```toml
+//! [dependencies]
+//! tracing-subscriber = "0.1"
+//! ```
+//!
+//! Add the following to your executable to initialize the default subscriber:
+//! ```rust
+//! use tracing_subscriber;
+//!
+//! tracing_subscriber::fmt::init();
+//! ```
+//!
+//! ## Filtering Events with Environment Variables
+//!
+//! The default subscriber installed by `init` enables you to filter events at runtime using environment variables (using the [`EnvFilter`]).
+//!
+//! The filter syntax is a superset of the [`env_logger`](https://docs.rs/env_logger/) syntax.
+//!
+//! For example:
+//! - Setting `RUST_LOG=debug` enables all `Span`s and `Event`s set to the log level `DEBUG` or higher
+//! - Setting `RUST_LOG=my_crate=trace` enables `Span`s and `Event`s in `my_crate` at all log levels
+//!
+//! **Note**: This should **not** be called by libraries. Libraries should use [`tracing`] to publish `tracing` `Event`s.
+//!
+//! ## Configuration
+//!
+//! You can configure a subscriber instead of using the defaults with the following functions:
+//!
+//! ### Subscriber
+//!
+//! The [`FmtSubscriber`] formats and records `tracing` events as line-oriented logs. You can create one by calling:
+//!
+//! ```rust
+//! use tracing_subscriber::FmtSubscriber;
+//!
+//! let subscriber = FmtSubscriber::builder()
+//!     // ... add configuration
+//!     .finish();
+//! ```
+//!
+//! You can find the configuration methods for [`FmtSubscriber`] in the docs.
+//!
+//! ### Filters
+//!
+//! If you want to filter the `tracing` `Events` based on environment
+//! variables, you can use the [`EnvFilter`] as follows:
+//!
+//! ```rust
+//! use tracing_subscriber::EnvFilter;
+//!
+//! let filter = EnvFilter::from_default_env();
+//! ```
+//!
+//! As mentioned above, the [`EnvFilter`] allows `Span`s and `Event`s to
+//! be filtered at runtime by setting the `RUST_LOG` environment variable.
+//!
+//! You can find the other available [`filter`]s in the documentation.
+//!
+//! ### Using Your Subscriber
+//!
+//! Finally, once you have configured your `Subscriber`, you need to
+//! configure your executable to use it.
+//!
+//! A subscriber can be installed globally using:
+//! ```rust
+//! use tracing;
+//! use tracing_subscriber::FmtSubscriber;
+//!
+//! let subscriber = FmtSubscriber::new();
+//!
+//! tracing::subscriber::set_global_default(subscriber)
+//!     .map_err(|_err| eprintln!("Unable to set global default subscriber"));
+//! // Note this will only fail if you try to set the global default
+//! // subscriber multiple times
+//! ```
 //!
 //! [`tracing`]: https://crates.io/crates/tracing
-//! [`Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
-use std::{any::TypeId, cell::RefCell, io};
-use tracing_core::{subscriber::Interest, Event, Metadata};
+//! [`Subscriber`]:
+//!     https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
+use std::{any::TypeId, cell::RefCell, error::Error, io};
+use tracing_core::{dispatcher, subscriber::Interest, Event, Metadata};
 
 pub mod format;
 mod span;
 pub mod time;
 pub mod writer;
 
-use crate::filter::LevelFilter;
+#[cfg(feature = "tracing_log")]
+use tracing_log::LogTracer;
+
+use crate::filter::{EnvFilter, LevelFilter};
 use crate::layer::{self, Layer};
 
 #[doc(inline)]
@@ -662,6 +745,42 @@ impl Default for Settings {
             initial_span_capacity: 32,
         }
     }
+}
+
+/// Install a global tracing subscriber that listens for events and
+/// filters based on the value of the [`RUST_LOG` environment variable],
+/// if one is not already set.
+///
+/// Returns whether the initialization was successful.
+///
+/// If the `tracing_log` feature is enabled, this will also install
+/// the LogTracer to convert `Log` records into `tracing` `Event`s.
+///
+/// [`RUST_LOG` environment variable]:
+///     ../filter/struct.EnvFilter.html#associatedconstant.DEFAULT_ENV
+pub fn try_init() -> Result<(), impl Error + Send + Sync + 'static> {
+    #[cfg(feature = "tracing_log")]
+    tracing_log::LogTracer::init().map_err(Box::new)?;
+
+    dispatcher::set_global_default(dispatcher::Dispatch::new(
+        Subscriber::builder()
+            .with_env_filter(EnvFilter::from_default_env())
+            .finish(),
+    ))
+    .map_err(Box::new)
+}
+
+/// Install a global tracing subscriber that listens for
+/// events and filters based on environment variables.
+///
+/// See [`try_init`] for more details
+///
+/// # Panics
+/// Panics if there is already a global subscriber set.
+///
+/// [`try_init`]: ./fn.try_init.html
+pub fn init() {
+    try_init().expect("Unable to install global subscriber")
 }
 
 #[cfg(test)]

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -10,6 +10,12 @@
 //! `tracing-subscriber` is intended for use by both `Subscriber` authors and
 //! application authors using `tracing` to instrument their applications.
 //!
+//! ## Included Subscribers
+//!
+//! The following `Subscriber`s are provided for application authors:
+//!
+//! - [`fmt`] - Formats and logs tracing data (requires the `fmt` feature flag)
+//!
 //! ## Feature Flags
 //!
 //! - `env-filter`: Enables the [`EnvFilter`] type, which implements filtering


### PR DESCRIPTION
## Motivation

Configuring the `FmtSubscriber` with the `EnvFilter` and installing it globally is very verbose.

## Solution

This adds `init` and `try_init` functions (modeled after `env_logger` [`init`](https://docs.rs/env_logger/0.7.0/env_logger/fn.init.html) and [`try_init`](https://docs.rs/env_logger/0.7.0/env_logger/fn.try_init.html)) to simplify setup for users that do not want to configure their own `Subscriber`.

Note, these functions are currently behind the `env-logger-compat` feature flag but enabled by default. We can remove the feature flag if you think this should always be included (note it does add the dependency on `tracing`).