### PR TITLE
futures: add Instrumented::{inner,inner_mut}

### DIFF
--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -277,6 +277,16 @@ impl<T> Instrumented<T> {
         &mut self.span
     }
 
+    /// Borrows the wrapped type.
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+
+    /// Mutably borrows the wrapped type.
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
     /// Consumes the `Instrumented`, returning the wrapped type.
     ///
     /// Note that this drops the span.


### PR DESCRIPTION
## Motivation

Currently it is not possible to implement 3rd party traits for `Instrumented` because there is no way to access the `inner` type without consuming the `Instrumented` wrapper.

## Solution

This adds `inner` and `inner_mut` methods to `Instrumented`