### PR TITLE
chore: fix nightly CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,3 +93,4 @@ resources:
       type: github
       name: crate-ci/azure-pipelines
       endpoint: tracing
+      ref: refs/headers/fix-empty-features

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,4 +93,4 @@ resources:
       type: github
       name: crate-ci/azure-pipelines
       endpoint: tracing
-      ref: refs/headers/fix-empty-features
+      ref: refs/head/fix-empty-features

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,4 +93,4 @@ resources:
       type: github
       name: crate-ci/azure-pipelines
       endpoint: tracing
-      ref: refs/heads/fix-empty-features
+      ref: refs/heads/v0.2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,4 +93,4 @@ resources:
       type: github
       name: crate-ci/azure-pipelines
       endpoint: tracing
-      ref: refs/head/fix-empty-features
+      ref: refs/heads/fix-empty-features


### PR DESCRIPTION
This updates our CI configs to use crate-ci/azure-pipelines#65, which fixes
the build failures on recent nightly Rust compilers.

Since there's some uncertainty over when and how that upstream PR will
be merged to master (see https://github.com/crate-ci/azure-pipelines/pull/65#issuecomment-543929460), I think
it's best to depend on the branch for now, until `crate-ci`'s master branch
no longer breaks our build.

This should fix all the nightly CI builds.