### PR TITLE
core: Add u8 to the list of generated Value implementations

### DIFF
--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -314,7 +314,7 @@ macro_rules! impl_value {
 
 impl_values! {
     record_u64(u64),
-    record_u64(usize, u32, u16 as u64),
+    record_u64(usize, u32, u16, u8 as u64),
     record_i64(i64),
     record_i64(isize, i32, i16, i8 as i64),
     record_bool(bool)


### PR DESCRIPTION
## Motivation

u8 had been forgotten from the list of automatically generated implementations for the Value Trait.
See bug report #389 

## Solution

Added u8 to the list of automatically generated implementations for the Value Trait.

Fixes: #389
