### PR TITLE
subscriber: fix tracing-log feature flag for init + try_init

### DIFF
--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -18,9 +18,10 @@ license = "MIT"
 readme = "README.md"
 
 [features]
-default = ["log-tracer", "trace-logger"]
+default = ["log-tracer", "trace-logger", "std"]
 log-tracer = []
 trace-logger = []
+std = ["log/std"]
 
 [dependencies]
 tracing-core = "0.1.2"

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -40,7 +40,7 @@ smallvec = { optional = true, version = "0.6.10"}
 lazy_static = { optional = true, version = "1" }
 
 # fmt
-tracing-log = { version = "0.1", optional = true, default-features = false, features = ["log-tracer"] }
+tracing-log = { path = "../tracing-log", version = "0.1", optional = true, default-features = false, features = ["std", "log-tracer"] }
 ansi_term = { version = "0.11", optional = true }
 owning_ref = { version = "0.4.0", optional = true }
 chrono = { version = "0.4", optional = true }
@@ -56,7 +56,7 @@ parking_lot = { version = ">= 0.7, < 0.10", features = ["owning_ref"], optional 
 [dev-dependencies]
 tracing = "0.1"
 log = "0.4"
-tracing-log = "0.1"
+tracing-log = { path = "../tracing-log", version = "0.1" }
 criterion = { version = "0.3", default_features = false }
 
 [badges]

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -40,7 +40,7 @@ smallvec = { optional = true, version = "0.6.10"}
 lazy_static = { optional = true, version = "1" }
 
 # fmt
-tracing-log = { version = "0.1", optional = true, default-features = false }
+tracing-log = { version = "0.1", optional = true, default-features = false, features = ["log-tracer"] }
 ansi_term = { version = "0.11", optional = true }
 owning_ref = { version = "0.4.0", optional = true }
 chrono = { version = "0.4", optional = true }

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -101,17 +101,14 @@
 //!     https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
 //! [`tracing`]: https://crates.io/crates/tracing
 use std::{any::TypeId, cell::RefCell, error::Error, io};
-use tracing_core::{dispatcher, subscriber::Interest, Event, Metadata};
+use tracing_core::{subscriber::Interest, Event, Metadata};
 
 pub mod format;
 mod span;
 pub mod time;
 pub mod writer;
 
-#[cfg(feature = "tracing_log")]
-use tracing_log::LogTracer;
-
-use crate::filter::{EnvFilter, LevelFilter};
+use crate::filter::LevelFilter;
 use crate::layer::{self, Layer};
 
 #[doc(inline)]
@@ -444,7 +441,7 @@ where
     /// Install this Subscriber as the global default if one is
     /// not already set.
     ///
-    /// If the `tracing_log` feature is enabled, this will also install
+    /// If the `tracing-log` feature is enabled, this will also install
     /// the LogTracer to convert `Log` records into `tracing` `Event`s.
     ///
     /// # Errors
@@ -452,15 +449,18 @@ where
     /// because a global subscriber was already installed by another
     /// call to `try_init`.
     pub fn try_init(self) -> Result<(), impl Error + Send + Sync + 'static> {
-        #[cfg(feature = "tracing_log")]
+        #[cfg(feature = "tracing-log/std")]
         tracing_log::LogTracer::init().map_err(Box::new)?;
 
-        dispatcher::set_global_default(dispatcher::Dispatch::new(self.finish())).map_err(Box::new)
+        tracing_core::dispatcher::set_global_default(tracing_core::dispatcher::Dispatch::new(
+            self.finish(),
+        ))
+        .map_err(Box::new)
     }
 
     /// Install this Subscriber as the global default.
     ///
-    /// If the `tracing_log` feature is enabled, this will also install
+    /// If the `tracing-log` feature is enabled, this will also install
     /// the LogTracer to convert `Log` records into `tracing` `Event`s.
     ///
     /// # Panics
@@ -846,7 +846,7 @@ impl Default for Settings {
 /// filters based on the value of the [`RUST_LOG` environment variable],
 /// if one is not already set.
 ///
-/// If the `tracing_log` feature is enabled, this will also install
+/// If the `tracing-log` feature is enabled, this will also install
 /// the [`LogTracer`] to convert `log` records into `tracing` `Event`s.
 ///
 ///
@@ -861,14 +861,14 @@ impl Default for Settings {
 ///     ../filter/struct.EnvFilter.html#associatedconstant.DEFAULT_ENV
 pub fn try_init() -> Result<(), impl Error + Send + Sync + 'static> {
     Subscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
+        .with_env_filter(crate::EnvFilter::from_default_env())
         .try_init()
 }
 
 /// Install a global tracing subscriber that listens for events and
 /// filters based on the value of the [`RUST_LOG` environment variable].
 ///
-/// If the `tracing_log` feature is enabled, this will also install
+/// If the `tracing-log` feature is enabled, this will also install
 /// the LogTracer to convert `Log` records into `tracing` `Event`s.
 ///
 /// # Panics


### PR DESCRIPTION
## Motivation

https://github.com/tokio-rs/tracing/pull/385 incorrectly used the feature flag `tracing_log` when it should have been `tracing-log`. As a result, you need to specify both in order to make `try_init` initialize the global logger.

## Solution

Use the correct feature flag
