### PR TITLE
subscriber: fix default level for env filter

### DIFF
--- a/tracing-subscriber/src/filter/env/directive.rs
+++ b/tracing-subscriber/src/filter/env/directive.rs
@@ -257,7 +257,7 @@ impl FromStr for Directive {
         let level = caps
             .name("level")
             .and_then(|l| l.as_str().parse().ok())
-            // Setting the target without the level enables every level
+            // Setting the target without the level enables every level for that target
             .unwrap_or(LevelFilter::TRACE);
 
         Ok(Directive {

--- a/tracing-subscriber/src/filter/env/directive.rs
+++ b/tracing-subscriber/src/filter/env/directive.rs
@@ -257,7 +257,8 @@ impl FromStr for Directive {
         let level = caps
             .name("level")
             .and_then(|l| l.as_str().parse().ok())
-            .unwrap_or(LevelFilter::ERROR);
+            // Setting the target without the level enables every level
+            .unwrap_or(LevelFilter::TRACE);
 
         Ok(Directive {
             level,
@@ -829,7 +830,7 @@ mod test {
         assert_eq!(dirs[0].in_span, None);
 
         assert_eq!(dirs[1].target, Some("crate1::mod2".to_string()));
-        assert_eq!(dirs[1].level, LevelFilter::ERROR);
+        assert_eq!(dirs[1].level, LevelFilter::TRACE);
         assert_eq!(dirs[1].in_span, None);
 
         assert_eq!(dirs[2].target, Some("crate2".to_string()));
@@ -974,7 +975,7 @@ mod test {
         let dirs = parse_directives("crate1::mod1=wrong,crate2=");
         assert_eq!(dirs.len(), 1, "\nparsed: {:#?}", dirs);
         assert_eq!(dirs[0].target, Some("crate2".to_string()));
-        assert_eq!(dirs[0].level, LevelFilter::ERROR);
+        assert_eq!(dirs[0].level, LevelFilter::TRACE);
         assert_eq!(dirs[0].in_span, None);
     }
 
@@ -1001,7 +1002,7 @@ mod test {
         assert_eq!(dirs[0].in_span, Some("foo".to_string()));
 
         assert_eq!(dirs[1].target, Some("crate1::mod2".to_string()));
-        assert_eq!(dirs[1].level, LevelFilter::ERROR);
+        assert_eq!(dirs[1].level, LevelFilter::TRACE);
         assert_eq!(dirs[1].in_span, Some("bar".to_string()));
 
         assert_eq!(dirs[2].target, Some("crate2".to_string()));


### PR DESCRIPTION
## Motivation

Setting `RUST_LOG=target` currently enables only the `ERROR` level, while it should enable everything.

## Solution

Change the default to `TRACE` if no level is specified