### PR TITLE
tracing: prepare to release 0.1.10

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 0.1.10 (October 23, 2019)
+
+### Added
+
+- Support for destructuring in arguments to `#[instrument]`ed functions (#397)
+- Generated field for `self` parameters when `#[instrument]`ing methods (#397)
+- Optional `skip` argument to `#[instrument]` for excluding function parameters
+  from generated spans (#359)
+- Added `dispatcher::set_default` and `subscriber::set_default` APIs, which
+  return a drop guard (#388)
+
+### Fixed
+
+- Some minor documentation errors (#356, #370)
+
 # 0.1.9 (September 13, 2019)
 
 ### Fixed

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -28,9 +28,9 @@ keywords = ["logging", "tracing", "metrics", "async"]
 edition = "2018"
 
 [dependencies]
-tracing-core = { version = "0.1.7", path = "../tracing-core", default-features = false }
+tracing-core = { version = "0.1.7", default-features = false }
 log = { version = "0.4", optional = true }
-tracing-attributes = "0.1.3"
+tracing-attributes = "0.1.5"
 cfg-if = "0.1.9"
 
 [dev-dependencies]

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,13 +8,13 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing/0.1.9/tracing"
+documentation = "https://docs.rs/tracing/0.1.10/tracing"
 description = """
 Application-level tracing for Rust.
 """
@@ -31,7 +31,7 @@ edition = "2018"
 tracing-core = { version = "0.1.7", default-features = false }
 log = { version = "0.4", optional = true }
 tracing-attributes = "0.1.5"
-cfg-if = "0.1.9"
+cfg-if = "0.1.10"
 
 [dev-dependencies]
 futures = "0.1"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -14,9 +14,9 @@ Application-level tracing for Rust.
 [Chat (gitter)][gitter-url] | [Chat (discord)][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.9
+[crates-url]: https://crates.io/crates/tracing/0.1.10
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.9
+[docs-url]: https://docs.rs/tracing/0.1.10
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -54,7 +54,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing = "0.1.9"
+tracing = "0.1.10"
 ```
 
 This crate provides macros for creating `Span`s and `Event`s, which represent

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.9")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.10")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 
@@ -593,7 +593,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing = { version = "0.1.9", default-features = false }
+//!   tracing = { version = "0.1.10", default-features = false }
 //!   ```
 //!   **Note**:`tracing`'s `no_std` support requires `liballoc`.
 //!


### PR DESCRIPTION
Added

- Support for destructuring in arguments to `#[instrument]`ed functions
  (#397)
- Generated field for `self` parameters when `#[instrument]`ing methods
  (#397)
- Optional `skip` argument to `#[instrument]` for excluding function
  parametersfrom generated spans (#359)
- Added `dispatcher::set_default` and `subscriber::set_default` APIs,
  which return a drop guard (#388)

Fixed

- Some minor documentation errors (#356, #370)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>