### PR TITLE
Fix global LogTracer installation by using InitError enum instead of Boxed errors 

### DIFF
--- a/examples/examples/log.rs
+++ b/examples/examples/log.rs
@@ -1,0 +1,8 @@
+fn main() {
+    tracing_subscriber::fmt::Subscriber::builder()
+        .with_max_level(tracing::Level::TRACE)
+        .init();
+
+    log::debug!("this is a log line");
+    tracing::debug!("this is a tracing line");
+}

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -18,10 +18,9 @@ license = "MIT"
 readme = "README.md"
 
 [features]
-default = ["log-tracer", "trace-logger", "std"]
+default = ["log-tracer", "trace-logger"]
 log-tracer = []
 trace-logger = []
-std = ["log/std"]
 
 [dependencies]
 tracing-core = "0.1.2"

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -18,13 +18,14 @@ license = "MIT"
 readme = "README.md"
 
 [features]
-default = ["log-tracer", "trace-logger"]
+default = ["log-tracer", "trace-logger", "std"]
+std = ["log/std"]
 log-tracer = []
 trace-logger = []
 
 [dependencies]
 tracing-core = "0.1.2"
-log = { version = "0.4", features = ["std"] }
+log = { version = "0.4" }
 lazy_static = "1.3.0"
 env_logger = { version = "0.6", optional = true }
 

--- a/tracing-log/src/log_tracer.rs
+++ b/tracing-log/src/log_tracer.rs
@@ -111,6 +111,7 @@ impl LogTracer {
     /// initializing it.
     ///
     /// [`builder`]: #method.builder
+    #[cfg(feature = "std")]
     pub fn init_with_filter(level: log::LevelFilter) -> Result<(), SetLoggerError> {
         Self::builder().with_max_level(level).init()
     }
@@ -144,6 +145,7 @@ impl LogTracer {
     ///
     /// [`init_with_filter`]: #method.init_with_filter
     /// [`builder`]: #method.builder
+    #[cfg(feature = "std")]
     pub fn init() -> Result<(), SetLoggerError> {
         Self::builder().init()
     }
@@ -238,6 +240,7 @@ impl Builder {
     /// as the default logger.
     ///
     /// Setting a global logger can only be done once.
+    #[cfg(feature = "std")]
     pub fn init(self) -> Result<(), SetLoggerError> {
         let ignore_crates = self.ignore_crates.into_boxed_slice();
         let logger = Box::new(LogTracer { ignore_crates });

--- a/tracing-log/src/log_tracer.rs
+++ b/tracing-log/src/log_tracer.rs
@@ -28,6 +28,7 @@
 //! [ignore]: struct.Builder.html#method.ignore_crate
 use crate::{format_trace, AsTrace};
 use log;
+pub use log::SetLoggerError;
 use tracing_core::dispatcher;
 
 /// A simple "logger" that converts all log records into `tracing` `Event`s.
@@ -110,7 +111,7 @@ impl LogTracer {
     /// initializing it.
     ///
     /// [`builder`]: #method.builder
-    pub fn init_with_filter(level: log::LevelFilter) -> Result<(), log::SetLoggerError> {
+    pub fn init_with_filter(level: log::LevelFilter) -> Result<(), SetLoggerError> {
         Self::builder().with_max_level(level).init()
     }
 
@@ -143,7 +144,7 @@ impl LogTracer {
     ///
     /// [`init_with_filter`]: #method.init_with_filter
     /// [`builder`]: #method.builder
-    pub fn init() -> Result<(), log::SetLoggerError> {
+    pub fn init() -> Result<(), SetLoggerError> {
         Self::builder().init()
     }
 }
@@ -237,7 +238,7 @@ impl Builder {
     /// as the default logger.
     ///
     /// Setting a global logger can only be done once.
-    pub fn init(self) -> Result<(), log::SetLoggerError> {
+    pub fn init(self) -> Result<(), SetLoggerError> {
         let ignore_crates = self.ignore_crates.into_boxed_slice();
         let logger = Box::new(LogTracer { ignore_crates });
         log::set_boxed_logger(logger)?;

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -40,7 +40,7 @@ smallvec = { optional = true, version = "0.6.10"}
 lazy_static = { optional = true, version = "1" }
 
 # fmt
-tracing-log = { path = "../tracing-log", version = "0.1", optional = true, default-features = false, features = ["log-tracer"] }
+tracing-log = { path = "../tracing-log", version = "0.1", optional = true, default-features = false, features = ["log-tracer", "std"] }
 ansi_term = { version = "0.11", optional = true }
 owning_ref = { version = "0.4.0", optional = true }
 chrono = { version = "0.4", optional = true }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -40,7 +40,7 @@ smallvec = { optional = true, version = "0.6.10"}
 lazy_static = { optional = true, version = "1" }
 
 # fmt
-tracing-log = { path = "../tracing-log", version = "0.1", optional = true, default-features = false, features = ["std", "log-tracer"] }
+tracing-log = { path = "../tracing-log", version = "0.1", optional = true, default-features = false, features = ["log-tracer"] }
 ansi_term = { version = "0.11", optional = true }
 owning_ref = { version = "0.4.0", optional = true }
 chrono = { version = "0.4", optional = true }

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -100,7 +100,7 @@
 //! [`Subscriber`]:
 //!     https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
 //! [`tracing`]: https://crates.io/crates/tracing
-use std::{any::TypeId, cell::RefCell, error::Error, io};
+use std::{any::TypeId, cell::RefCell, error::Error, fmt, io};
 use tracing_core::{subscriber::Interest, Event, Metadata};
 
 pub mod format;
@@ -430,6 +430,24 @@ where
     }
 }
 
+#[derive(Debug)]
+enum InitError {
+    #[cfg(feature = "tracing-log")]
+    Log(tracing_log::log_tracer::SetLoggerError),
+    Dispatcher(tracing_core::dispatcher::SetGlobalDefaultError),
+}
+
+impl fmt::Display for InitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InitError::Log(err) => err.fmt(f),
+            InitError::Dispatcher(err) => err.fmt(f),
+        }
+    }
+}
+
+impl Error for InitError {}
+
 impl<N, E, F, W> Builder<N, E, F, W>
 where
     N: for<'writer> FormatFields<'writer> + 'static,
@@ -449,13 +467,13 @@ where
     /// because a global subscriber was already installed by another
     /// call to `try_init`.
     pub fn try_init(self) -> Result<(), impl Error + Send + Sync + 'static> {
-        #[cfg(feature = "tracing-log/std")]
-        tracing_log::LogTracer::init().map_err(Box::new)?;
+        #[cfg(feature = "tracing-log")]
+        tracing_log::LogTracer::init().map_err(InitError::Log)?;
 
         tracing_core::dispatcher::set_global_default(tracing_core::dispatcher::Dispatch::new(
             self.finish(),
         ))
-        .map_err(Box::new)
+        .map_err(InitError::Dispatcher)
     }
 
     /// Install this Subscriber as the global default.

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -454,7 +454,8 @@ where
 
         tracing_core::dispatcher::set_global_default(tracing_core::dispatcher::Dispatch::new(
             self.finish(),
-        )).map_err(Into::into)
+        ))
+        .map_err(Into::into)
     }
 
     /// Install this Subscriber as the global default.


### PR DESCRIPTION
:man_facepalming: 

## Motivation

I thought the boxing errors solution implemented in https://github.com/tokio-rs/tracing/pull/400 was equivalent to the enum solution in https://github.com/emschwartz/tracing/commit/f22bae5a2daa18e60c063db4afad67288e0d3bd7, but the current master doesn't actually work to install the global `LogTracer`.

I can't figure out why the current cargo features don't end up turning on [this line](https://github.com/tokio-rs/tracing/blob/master/tracing-subscriber/src/fmt/mod.rs#L452-L453), but I confirmed with the log example in https://github.com/tokio-rs/tracing/commit/4511325b29ab074a604c0fc462bed2edc18efaee that it's not currently working.

## Solution

Using an enum for the two types of errors instead of boxing them solves the problem.
