### PR TITLE
Remove redundant documentation metadata

### DIFF
--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -16,7 +16,6 @@ authors = [
 ]
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-attributes/0.1.0/tracing_attributes"
 description = """
 Procedural macro attributes for automatically instrumenting functions.
 """

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -14,7 +14,6 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-core/0.1.7/tracing_core"
 description = """
 Core primitives for application-level tracing.
 """

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"
-documentation = "https://docs.rs/tracing-futures/0.1.0/tracing_futures"
 readme = "README.md"
 homepage = "https://tokio.rs"
 description = """

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-log/0.1.0/tracing_log"
 description = """
 Provides compatibility between `tracing` and the `log` crate.
 """

--- a/tracing-macros/Cargo.toml
+++ b/tracing-macros/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-macros/0.1.0/tracing_macros"
 description = """
 Macros for emitting trace events
 """

--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -6,7 +6,6 @@ license = "MIT"
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-serde/0.1.0/tracing_serde"
 description = """
 A compatibility layer for serializing trace data with `serde`
 """

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-subscriber/0.1.5/tracing-subscriber"
 description = """
 Utilities for implementing and composing `tracing` subscribers.
 """

--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing-tower/0.1.0/tracing_tower"
 description = """
 Compatibility with the `tower` ecosystem.
 """

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -14,7 +14,6 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tracing/0.1.10/tracing"
 description = """
 Application-level tracing for Rust.
 """


### PR DESCRIPTION
These were set to the value that crates.io implicitly applies, except for those which had already fallen out of date, illustrating the maintenance hazard.