### PR TITLE
chore: rethink warnings

### DIFF
--- a/examples/examples/serde-yak-shave.rs
+++ b/examples/examples/serde-yak-shave.rs
@@ -1,10 +1,10 @@
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
-use tracing::{debug, error, info, span, trace, warn};
+use tracing::debug;
 use tracing_core::{
     event::Event,
-    metadata::{Level, Metadata},
+    metadata::Metadata,
     span::{Attributes, Id, Record},
     subscriber::Subscriber,
 };

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -37,6 +37,32 @@
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [span]: https://docs.rs/tracing/0.1.5/tracing/span/index.html
 //! [instrument]: attr.instrument.html
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub,
+    bad_style,
+    const_err,
+    dead_code,
+    improper_ctypes,
+    legacy_directory_ownership,
+    non_shorthand_field_patterns,
+    no_mangle_generic_items,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    plugin_as_library,
+    private_in_public,
+    safe_extern_statics,
+    unconditional_recursion,
+    unions_with_drop_fields,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true
+)]
 extern crate proc_macro;
 
 use std::collections::HashSet;

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -1,7 +1,3 @@
-#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.5")]
-#![deny(missing_debug_implementations, unreachable_pub)]
-#![cfg_attr(test, deny(warnings))]
-
 //! A procedural macro attribute for instrumenting functions with [`tracing`].
 //!
 //! [`tracing`] is a framework for instrumenting Rust programs to collect
@@ -37,6 +33,7 @@
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [span]: https://docs.rs/tracing/0.1.5/tracing/span/index.html
 //! [instrument]: attr.instrument.html
+#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.5")]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -53,7 +53,6 @@
     private_in_public,
     safe_extern_statics,
     unconditional_recursion,
-
     unused,
     unused_allocation,
     unused_comparisons,

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -53,7 +53,7 @@
     private_in_public,
     safe_extern_statics,
     unconditional_recursion,
-    unions_with_drop_fields,
+
     unused,
     unused_allocation,
     unused_comparisons,

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -86,7 +86,7 @@
     private_in_public,
     safe_extern_statics,
     unconditional_recursion,
-    unions_with_drop_fields,
+
     unused,
     unused_allocation,
     unused_comparisons,

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -86,7 +86,6 @@
     private_in_public,
     safe_extern_statics,
     unconditional_recursion,
-
     unused,
     unused_allocation,
     unused_comparisons,

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -1,7 +1,3 @@
-#![doc(html_root_url = "https://docs.rs/tracing-core/0.1.7")]
-#![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
-#![cfg_attr(test, deny(warnings))]
-
 //! Core primitives for `tracing`.
 //!
 //! [`tracing`] is a framework for instrumenting Rust programs to collect
@@ -69,8 +65,34 @@
 //! [`Dispatch`]: dispatcher/struct.Dispatch.html
 //! [`tokio-rs/tracing`]: https://github.com/tokio-rs/tracing
 //! [`tracing`]: https://crates.io/crates/tracing
+#![doc(html_root_url = "https://docs.rs/tracing-core/0.1.7")]
 #![cfg_attr(not(feature = "std"), no_std)]
-
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub,
+    bad_style,
+    const_err,
+    dead_code,
+    improper_ctypes,
+    legacy_directory_ownership,
+    non_shorthand_field_patterns,
+    no_mangle_generic_items,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    plugin_as_library,
+    private_in_public,
+    safe_extern_statics,
+    unconditional_recursion,
+    unions_with_drop_fields,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true
+)]
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -66,7 +66,6 @@
     private_in_public,
     safe_extern_statics,
     unconditional_recursion,
-
     unused,
     unused_allocation,
     unused_comparisons,

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -66,7 +66,7 @@
     private_in_public,
     safe_extern_statics,
     unconditional_recursion,
-    unions_with_drop_fields,
+
     unused,
     unused_allocation,
     unused_comparisons,

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -51,9 +51,28 @@
     missing_debug_implementations,
     missing_docs,
     rust_2018_idioms,
-    unreachable_pub
+    unreachable_pub,
+    bad_style,
+    const_err,
+    dead_code,
+    improper_ctypes,
+    legacy_directory_ownership,
+    non_shorthand_field_patterns,
+    no_mangle_generic_items,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    plugin_as_library,
+    private_in_public,
+    safe_extern_statics,
+    unconditional_recursion,
+    unions_with_drop_fields,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true
 )]
-
 #[cfg(feature = "std-future")]
 use pin_project::pin_project;
 #[cfg(feature = "std-future")]

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -108,7 +108,7 @@
     private_in_public,
     safe_extern_statics,
     unconditional_recursion,
-    unions_with_drop_fields,
+
     unused,
     unused_allocation,
     unused_comparisons,

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -93,36 +93,27 @@
     missing_debug_implementations,
     missing_docs,
     rust_2018_idioms,
-    unreachable_pub
-)]
-#![cfg_attr(
-    test,
-    deny(
-        missing_debug_implementations,
-        missing_docs,
-        rust_2018_idioms,
-        unreachable_pub,
-        bad_style,
-        const_err,
-        dead_code,
-        improper_ctypes,
-        legacy_directory_ownership,
-        non_shorthand_field_patterns,
-        no_mangle_generic_items,
-        overflowing_literals,
-        path_statements,
-        patterns_in_fns_without_body,
-        plugin_as_library,
-        private_in_public,
-        safe_extern_statics,
-        unconditional_recursion,
-        unions_with_drop_fields,
-        unused,
-        unused_allocation,
-        unused_comparisons,
-        unused_parens,
-        while_true
-    )
+    unreachable_pub,
+    bad_style,
+    const_err,
+    dead_code,
+    improper_ctypes,
+    legacy_directory_ownership,
+    non_shorthand_field_patterns,
+    no_mangle_generic_items,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    plugin_as_library,
+    private_in_public,
+    safe_extern_statics,
+    unconditional_recursion,
+    unions_with_drop_fields,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true
 )]
 use lazy_static::lazy_static;
 

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -108,7 +108,6 @@
     private_in_public,
     safe_extern_statics,
     unconditional_recursion,
-
     unused,
     unused_allocation,
     unused_comparisons,

--- a/tracing-serde/src/fields.rs
+++ b/tracing-serde/src/fields.rs
@@ -5,7 +5,7 @@ use super::*;
 pub struct SerializeFieldMap<'a, T>(&'a T);
 
 pub trait AsMap: Sized + sealed::Sealed {
-    fn field_map(&self) -> SerializeFieldMap<Self> {
+    fn field_map(&self) -> SerializeFieldMap<'_, Self> {
         SerializeFieldMap(self)
     }
 }

--- a/tracing-serde/src/lib.rs
+++ b/tracing-serde/src/lib.rs
@@ -17,7 +17,7 @@
     private_in_public,
     safe_extern_statics,
     unconditional_recursion,
-    unions_with_drop_fields,
+
     unused,
     unused_allocation,
     unused_comparisons,

--- a/tracing-serde/src/lib.rs
+++ b/tracing-serde/src/lib.rs
@@ -24,9 +24,6 @@
     unused_parens,
     while_true
 )]
-extern crate serde;
-extern crate tracing_core;
-
 use std::fmt;
 
 use serde::{

--- a/tracing-serde/src/lib.rs
+++ b/tracing-serde/src/lib.rs
@@ -1,3 +1,29 @@
+#![warn(
+    missing_debug_implementations,
+    // missing_docs, // TODO: add documentation
+    rust_2018_idioms,
+    unreachable_pub,
+    bad_style,
+    const_err,
+    dead_code,
+    improper_ctypes,
+    legacy_directory_ownership,
+    non_shorthand_field_patterns,
+    no_mangle_generic_items,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    plugin_as_library,
+    private_in_public,
+    safe_extern_statics,
+    unconditional_recursion,
+    unions_with_drop_fields,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true
+)]
 extern crate serde;
 extern crate tracing_core;
 

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -56,36 +56,27 @@
     missing_debug_implementations,
     missing_docs,
     rust_2018_idioms,
-    unreachable_pub
-)]
-#![cfg_attr(
-    test,
-    deny(
-        missing_debug_implementations,
-        missing_docs,
-        rust_2018_idioms,
-        unreachable_pub,
-        bad_style,
-        const_err,
-        dead_code,
-        improper_ctypes,
-        legacy_directory_ownership,
-        non_shorthand_field_patterns,
-        no_mangle_generic_items,
-        overflowing_literals,
-        path_statements,
-        patterns_in_fns_without_body,
-        plugin_as_library,
-        private_in_public,
-        safe_extern_statics,
-        unconditional_recursion,
-        unions_with_drop_fields,
-        unused,
-        unused_allocation,
-        unused_comparisons,
-        unused_parens,
-        while_true
-    )
+    unreachable_pub,
+    bad_style,
+    const_err,
+    dead_code,
+    improper_ctypes,
+    legacy_directory_ownership,
+    non_shorthand_field_patterns,
+    no_mangle_generic_items,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    plugin_as_library,
+    private_in_public,
+    safe_extern_statics,
+    unconditional_recursion,
+    unions_with_drop_fields,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true
 )]
 use tracing_core::span::Id;
 

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -71,7 +71,6 @@
     private_in_public,
     safe_extern_statics,
     unconditional_recursion,
-
     unused,
     unused_allocation,
     unused_comparisons,

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -71,7 +71,7 @@
     private_in_public,
     safe_extern_statics,
     unconditional_recursion,
-    unions_with_drop_fields,
+
     unused,
     unused_allocation,
     unused_comparisons,

--- a/tracing-tower/src/lib.rs
+++ b/tracing-tower/src/lib.rs
@@ -17,7 +17,7 @@
     private_in_public,
     safe_extern_statics,
     unconditional_recursion,
-    unions_with_drop_fields,
+
     unused,
     unused_allocation,
     unused_comparisons,

--- a/tracing-tower/src/lib.rs
+++ b/tracing-tower/src/lib.rs
@@ -1,3 +1,30 @@
+#![warn(
+    missing_debug_implementations,
+    // missing_docs, // TODO: add documentation!
+    rust_2018_idioms,
+    unreachable_pub,
+    bad_style,
+    const_err,
+    dead_code,
+    improper_ctypes,
+    legacy_directory_ownership,
+    non_shorthand_field_patterns,
+    no_mangle_generic_items,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    plugin_as_library,
+    private_in_public,
+    safe_extern_statics,
+    unconditional_recursion,
+    unions_with_drop_fields,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true
+)]
+
 use std::fmt;
 use tower_service::Service;
 use tracing::Level;

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1,7 +1,3 @@
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.10")]
-#![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
-#![cfg_attr(test, deny(warnings))]
-
 //! A scoped, structured logging and diagnostics system.
 //!
 //! # Overview
@@ -622,6 +618,33 @@
 //! [static verbosity level]: level_filters/index.html#compile-time-filters
 //! [instrument]: https://docs.rs/tracing-attributes/latest/tracing_attributes/attr.instrument.html
 #![cfg_attr(not(feature = "std"), no_std)]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.10")]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub,
+    bad_style,
+    const_err,
+    dead_code,
+    improper_ctypes,
+    legacy_directory_ownership,
+    non_shorthand_field_patterns,
+    no_mangle_generic_items,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    plugin_as_library,
+    private_in_public,
+    safe_extern_statics,
+    unconditional_recursion,
+    unions_with_drop_fields,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true
+)]
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -638,7 +638,6 @@
     private_in_public,
     safe_extern_statics,
     unconditional_recursion,
-
     unused,
     unused_allocation,
     unused_comparisons,

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -638,7 +638,7 @@
     private_in_public,
     safe_extern_statics,
     unconditional_recursion,
-    unions_with_drop_fields,
+
     unused,
     unused_allocation,
     unused_comparisons,


### PR DESCRIPTION
## Motivation

Currently, most crates in `tracing` are configured to deny all compiler
warnings when compiling tests. This means that if the compiler reports
any warnings, the build will fail. This can be an issue when changes are
made locally that introduce warnings (i.e. unused code is added, imports
are no longer needed, etc) and a contributor wishes to test an
incomplete state to ensure their changes are on the right path. With
warnings denied, tests will not run if the project contains any
warnings, so contributors must either fix all warnings or disable the
deny attribute. Disabling the deny attribute when making changes locally
has become a fairly common practice, but it's error-prone: sometimes,
the deny attribute is commented out and then accidentally committed. 

## Solution

This branch removes all `#![deny(warnings)]` attributes, in order to
allow code with warnings to compile and be tested locally while changes
are in progress. We already have [a CI job][1] that checks for compiler
warnings by trying to compile `tracing` with `RUSTFLAGS="-Dwarnings"`.
If we make this CI job required rather than allowing it to fail, we'll
still be able to ensure that no code with warnings is merged.

Additionally, I've updated all crates to use the same consistent list of
lints to apply in the `#![warn]` attribute. Previously, some crates
warned on more lints than others, which is not great. I've fixed all the
new warnings produced by the additional lints.