### PR TITLE
Implemented Default trait for Dispatch in tracing-core

### DIFF
--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -585,7 +585,7 @@ impl Dispatch {
 }
 
 impl Default for Dispatch {
-    // Creates default dispatcher
+    /// Returns the current default dispatcher
     fn default() -> Self {
         get_default(|default| default.clone())
     }
@@ -812,5 +812,32 @@ mod test {
     fn create_default_dispatcher() {
         let default_dispatcher = Dispatch::default();
         assert!(default_dispatcher.is::<NoSubscriber>());
+    }
+
+    #[test]
+    fn returns_default_dispatcher() {
+        struct TestSubscriber;
+        impl Subscriber for TestSubscriber {
+            fn enabled(&self, _: &Metadata<'_>) -> bool {
+                true
+            }
+
+            fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
+                span::Id::from_u64(0xAAAA)
+            }
+
+            fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
+
+            fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
+
+            fn event(&self, _: &Event<'_>) {}
+
+            fn enter(&self, _: &span::Id) {}
+
+            fn exit(&self, _: &span::Id) {}
+        }
+        let _guard = set_default(&Dispatch::new(TestSubscriber));
+        let default_dispatcher = Dispatch::default();
+        assert!(default_dispatcher.is::<TestSubscriber>());
     }
 }

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -809,7 +809,7 @@ mod test {
     }
 
     #[test]
-    fn default_no_subscriber {
+    fn default_no_subscriber() {
         let default_dispatcher = Dispatch::default();
         assert!(default_dispatcher.is::<NoSubscriber>());
     }

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -809,14 +809,14 @@ mod test {
     }
 
     #[test]
-    fn create_default_dispatcher() {
+    fn default_no_subscriber {
         let default_dispatcher = Dispatch::default();
         assert!(default_dispatcher.is::<NoSubscriber>());
     }
 
     #[cfg(feature = "std")]
     #[test]
-    fn returns_default_dispatcher() {
+    fn default_dispatch() {
         struct TestSubscriber;
         impl Subscriber for TestSubscriber {
             fn enabled(&self, _: &Metadata<'_>) -> bool {

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -814,6 +814,7 @@ mod test {
         assert!(default_dispatcher.is::<NoSubscriber>());
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn returns_default_dispatcher() {
         struct TestSubscriber;

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -837,8 +837,12 @@ mod test {
 
             fn exit(&self, _: &span::Id) {}
         }
-        let _guard = set_default(&Dispatch::new(TestSubscriber));
+        let guard = set_default(&Dispatch::new(TestSubscriber));
         let default_dispatcher = Dispatch::default();
         assert!(default_dispatcher.is::<TestSubscriber>());
+
+        drop(guard);
+        let default_dispatcher = Dispatch::default();
+        assert!(default_dispatcher.is::<NoSubscriber>());
     }
 }

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -584,6 +584,13 @@ impl Dispatch {
     }
 }
 
+impl Default for Dispatch {
+    // Creates default dispatcher
+    fn default() -> Self {
+        get_default(|default| default.clone())
+    }
+}
+
 impl fmt::Debug for Dispatch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Dispatch(...)")
@@ -799,5 +806,11 @@ mod test {
         }
 
         with_default(&Dispatch::new(TestSubscriber), || mk_span())
+    }
+
+    #[test]
+    fn create_default_dispatcher() {
+        let default_dispatcher = Dispatch::default();
+        assert!(default_dispatcher.is::<NoSubscriber>());
     }
 }


### PR DESCRIPTION
This PR addresses the issue outlined in #172 

## Motivation
As outlined in #172 , we can improve the use of default dispatch by implementing `Default` to create `Dispatch::default`, thus ease the use of dispatch.

## Solution
implementation of `Default` trait from standard library that calls `get_default` and produces a clone of default.
