### PR TITLE
futures: prepare to publish 0.1.1

### DIFF
--- a/tracing-futures/CHANGELOG.md
+++ b/tracing-futures/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.1 (Oct 25, 2019)
+
+### Added
+
+- `Instrumented::inner` and `inner_mut` methods that expose access to the
+  instrumented future (#386)
+
 # 0.1.0 (Oct 8, 2019)
 
 - Initial release

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-futures"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"

--- a/tracing-futures/README.md
+++ b/tracing-futures/README.md
@@ -13,9 +13,9 @@ Utilities for instrumenting futures-based code with [`tracing`].
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-futures.svg
-[crates-url]: https://crates.io/crates/tracing-futures/0.1.0
+[crates-url]: https://crates.io/crates/tracing-futures/0.1.1
 [docs-badge]: https://docs.rs/tracing-futures/badge.svg
-[docs-url]: https://docs.rs/tracing-futures/0.1.0/tracing_futures
+[docs-url]: https://docs.rs/tracing-futures/0.1.1/tracing_futures
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_futures
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -41,8 +41,8 @@ The crate provides the following traits:
 * [`WithSubscriber`] allows a `tracing` [`Subscriber`] to be attached to a
   future, sink, stream, or executor.
 
-[`Instrument`]: https://docs.rs/tracing-futures/0.1.0/tracing_futures/trait.Instrument.html
-[`WithSubscriber`]: https://docs.rs/tracing-futures/0.1.0/tracing_futures/trait.WithSubscriber.html
+[`Instrument`]: https://docs.rs/tracing-futures/0.1.1/tracing_futures/trait.Instrument.html
+[`WithSubscriber`]: https://docs.rs/tracing-futures/0.1.1/tracing_futures/trait.WithSubscriber.html
 [span]: https://docs.rs/tracing/0.1.9/tracing/span/index.html
 [`Subscriber`]: https://docs.rs/tracing/0.1.9/tracing/subscriber/index.html
 [`tracing`]: https://crates.io/tracing

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -46,7 +46,7 @@
 //! [`Instrument`]: trait.Instrument.html
 //! [`WithSubscriber`]: trait.WithSubscriber.html
 //! [`futures`]: https://crates.io/crates/futures
-#![doc(html_root_url = "https://docs.rs/tracing-futures/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-futures/0.1.1")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
### Added

- `Instrumented::inner` and `inner_mut` methods that expose access to the
  instrumented future (#386)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
