### PR TITLE
futures: add support for release futures 0.3.0

### DIFF
--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -20,6 +20,7 @@ license = "MIT"
 [features]
 default = ["futures-01", "tokio"]
 futures-01 = ["futures"]
+futures-03 = ["std-future", "futures-task"]
 std-future = ["pin-project"]
 futures-preview = ["std-future", "futures-core-preview"]
 tokio-alpha = ["std-future", "tokio_02"]
@@ -27,6 +28,7 @@ tokio-alpha = ["std-future", "tokio_02"]
 [dependencies]
 futures = { version = "0.1", optional = true }
 futures-core-preview = { version = "0.3.0-alpha.19", optional = true }
+futures-task = { version = "0.3", optional = true }
 pin-project = { version = "0.4", optional = true }
 tracing = "0.1"
 tokio-executor = { version = "0.1", optional = true }

--- a/tracing-futures/src/executor/futures_03.rs
+++ b/tracing-futures/src/executor/futures_03.rs
@@ -1,0 +1,121 @@
+use crate::{Instrument, Instrumented, WithDispatch};
+use futures_task::{
+    future::FutureObj,
+    task::{LocalSpawn, Spawn, SpawnError},
+};
+use std::future::Future;
+
+impl<T> Spawn for Instrumented<T>
+where
+    T: Spawn,
+{
+    /// Spawns a future that will be run to completion.
+    ///
+    /// # Errors
+    ///
+    /// The executor may be unable to spawn tasks. Spawn errors should
+    /// represent relatively rare scenarios, such as the executor
+    /// having been shut down so that it is no longer able to accept
+    /// tasks.
+    fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
+        let future = future.instrument(self.span.clone());
+        self.inner.spawn_obj(Box::pin(future))
+    }
+
+    /// Determines whether the executor is able to spawn new tasks.
+    ///
+    /// This method will return `Ok` when the executor is *likely*
+    /// (but not guaranteed) to accept a subsequent spawn attempt.
+    /// Likewise, an `Err` return means that `spawn` is likely, but
+    /// not guaranteed, to yield an error.
+    #[inline]
+    fn status(&self) -> Result<(), SpawnError> {
+        self.inner.status()
+    }
+}
+
+impl<T> Spawn for WithDispatch<T>
+where
+    T: Spawn,
+{
+    /// Spawns a future that will be run to completion.
+    ///
+    /// # Errors
+    ///
+    /// The executor may be unable to spawn tasks. Spawn errors should
+    /// represent relatively rare scenarios, such as the executor
+    /// having been shut down so that it is no longer able to accept
+    /// tasks.
+    fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
+        self.inner.spawn_obj(Box::pin(self.with_dispatch(future)))
+    }
+
+    /// Determines whether the executor is able to spawn new tasks.
+    ///
+    /// This method will return `Ok` when the executor is *likely*
+    /// (but not guaranteed) to accept a subsequent spawn attempt.
+    /// Likewise, an `Err` return means that `spawn` is likely, but
+    /// not guaranteed, to yield an error.
+    #[inline]
+    fn status(&self) -> Result<(), SpawnError> {
+        self.inner.status()
+    }
+}
+
+impl<T> LocalSpawn for Instrumented<T>
+where
+    T: LocalSpawn,
+{
+    /// Spawns a future that will be run to completion.
+    ///
+    /// # Errors
+    ///
+    /// The executor may be unable to spawn tasks. Spawn errors should
+    /// represent relatively rare scenarios, such as the executor
+    /// having been shut down so that it is no longer able to accept
+    /// tasks.
+    fn spawn_local_obj(&self, future: LocalFutureObj<'static, ()>) -> Result<(), SpawnError> {
+        let future = future.instrument(self.span.clone());
+        self.inner.spawn_local_obj(Box::pin(future))
+    }
+
+    /// Determines whether the executor is able to spawn new tasks.
+    ///
+    /// This method will return `Ok` when the executor is *likely*
+    /// (but not guaranteed) to accept a subsequent spawn attempt.
+    /// Likewise, an `Err` return means that `spawn` is likely, but
+    /// not guaranteed, to yield an error.
+    #[inline]
+    fn status_local(&self) -> Result<(), SpawnError> {
+        self.inner.status_local()
+    }
+}
+
+impl<T> LocalSpawn for WithDispatch<T>
+where
+    T: Spawn,
+{
+    /// Spawns a future that will be run to completion.
+    ///
+    /// # Errors
+    ///
+    /// The executor may be unable to spawn tasks. Spawn errors should
+    /// represent relatively rare scenarios, such as the executor
+    /// having been shut down so that it is no longer able to accept
+    /// tasks.
+    fn spawn_local_obj(&self, future: LocalFutureObj<'static, ()>) -> Result<(), SpawnError> {
+        self.inner
+            .spawn_local_obj(Box::pin(self.with_dispatch(future)))
+    }
+
+    /// Determines whether the executor is able to spawn new tasks.
+    ///
+    /// This method will return `Ok` when the executor is *likely*
+    /// (but not guaranteed) to accept a subsequent spawn attempt.
+    /// Likewise, an `Err` return means that `spawn` is likely, but
+    /// not guaranteed, to yield an error.
+    #[inline]
+    fn status_local(&self) -> Result<(), SpawnError> {
+        self.inner.status_local()
+    }
+}

--- a/tracing-futures/src/executor/mod.rs
+++ b/tracing-futures/src/executor/mod.rs
@@ -8,6 +8,11 @@ mod futures_preview;
 #[cfg(feature = "futures_preview")]
 pub use self::futures_preview::*;
 
+#[cfg(feature = "futures_03")]
+mod futures_03;
+#[cfg(feature = "futures_03")]
+pub use self::futures_03::*;
+
 #[cfg(feature = "tokio-alpha")]
 mod tokio_alpha;
 #[cfg(feature = "tokio-alpha")]


### PR DESCRIPTION
This adds support for the release version of `futures` 0.3, which was
published today.

The futures-preview code will remain in place to avoid breaking existing
code; the new futures 0.3 support has a separate feature flag.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>