### PR TITLE
subscriber: export `FmtContext`

### DIFF
--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -107,7 +107,7 @@ mod fmt_layer;
 pub mod format;
 pub mod time;
 pub mod writer;
-pub use fmt_layer::{FormattedFields, Layer, LayerBuilder};
+pub use fmt_layer::{FmtContext, FormattedFields, Layer, LayerBuilder};
 
 use crate::layer::Layer as _;
 use crate::{filter::LevelFilter, layer, registry::Registry};


### PR DESCRIPTION
With #420, we introduced `FmtContext`, and made it a required parameter on `FormatEvent`'s primary methods. However, I forgot to export it, making it impossible to write custom `FormatEvent` implementations. This PR fixes that oversight. Thanks to @samscott89 for noticing this!

Signed-off-by: David Barsky <me@davidbarsky.com>

