### PR TITLE
subscriber: For registry-backed layers, delay deletion of span until all layers have processed the event

### DIFF
--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-core"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
@@ -27,16 +27,11 @@ edition = "2018"
 
 [features]
 default = ["std"]
-std = []
+std = ["lazy_static"]
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-lazy_static = "1"
-
-[target.'cfg(not(feature = "std"))'.dependencies]
-spin = "0.5"
-lazy_static = { version = "1", features = ["spin_no_std"] }
-
+lazy_static = { version = "1", optional = true }

--- a/tracing-core/src/lazy_static/LICENSE
+++ b/tracing-core/src/lazy_static/LICENSE
@@ -1,0 +1,26 @@
+
+Copyright (c) 2010 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/tracing-core/src/lazy_static/core_lazy.rs
+++ b/tracing-core/src/lazy_static/core_lazy.rs
@@ -1,0 +1,30 @@
+// Copyright 2016 lazy-static.rs Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::Once;
+
+pub(crate) struct Lazy<T: Sync>(Once<T>);
+
+impl<T: Sync> Lazy<T> {
+    pub(crate) const INIT: Self = Lazy(Once::INIT);
+
+    #[inline(always)]
+    pub(crate) fn get<F>(&'static self, builder: F) -> &T
+    where
+        F: FnOnce() -> T,
+    {
+        self.0.call_once(builder)
+    }
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __lazy_static_create {
+    ($NAME:ident, $T:ty) => {
+        static $NAME: $crate::lazy_static::lazy::Lazy<$T> = $crate::lazy_static::lazy::Lazy::INIT;
+    };
+}

--- a/tracing-core/src/lazy_static/mod.rs
+++ b/tracing-core/src/lazy_static/mod.rs
@@ -1,0 +1,89 @@
+// Copyright 2016 lazy-static.rs Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+/*!
+A macro for declaring lazily evaluated statics.
+Using this macro, it is possible to have `static`s that require code to be
+executed at runtime in order to be initialized.
+This includes anything requiring heap allocations, like vectors or hash maps,
+as well as anything that requires function calls to be computed.
+*/
+
+#[path = "core_lazy.rs"]
+pub(crate) mod lazy;
+
+#[doc(hidden)]
+pub(crate) use core::ops::Deref as __Deref;
+
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! __lazy_static_internal {
+    // optional visibility restrictions are wrapped in `()` to allow for
+    // explicitly passing otherwise implicit information about private items
+    ($(#[$attr:meta])* ($($vis:tt)*) static ref $N:ident : $T:ty = $e:expr; $($t:tt)*) => {
+        __lazy_static_internal!(@MAKE TY, $(#[$attr])*, ($($vis)*), $N);
+        __lazy_static_internal!(@TAIL, $N : $T = $e);
+        lazy_static!($($t)*);
+    };
+    (@TAIL, $N:ident : $T:ty = $e:expr) => {
+        impl $crate::lazy_static::__Deref for $N {
+            type Target = $T;
+            fn deref(&self) -> &$T {
+                #[inline(always)]
+                fn __static_ref_initialize() -> $T { $e }
+
+                #[inline(always)]
+                fn __stability() -> &'static $T {
+                    __lazy_static_create!(LAZY, $T);
+                    LAZY.get(__static_ref_initialize)
+                }
+                __stability()
+            }
+        }
+        impl $crate::lazy_static::LazyStatic for $N {
+            fn initialize(lazy: &Self) {
+                let _ = &**lazy;
+            }
+        }
+    };
+    // `vis` is wrapped in `()` to prevent parsing ambiguity
+    (@MAKE TY, $(#[$attr:meta])*, ($($vis:tt)*), $N:ident) => {
+        #[allow(missing_copy_implementations)]
+        #[allow(non_camel_case_types)]
+        #[allow(dead_code)]
+        $(#[$attr])*
+        $($vis)* struct $N {__private_field: ()}
+        #[doc(hidden)]
+        $($vis)* static $N: $N = $N {__private_field: ()};
+    };
+    () => ()
+}
+
+#[macro_export(local_inner_macros)]
+/// lazy_static (suppress docs_missing warning)
+macro_rules! lazy_static {
+    ($(#[$attr:meta])* static ref $N:ident : $T:ty = $e:expr; $($t:tt)*) => {
+        // use `()` to explicitly forward the information about private items
+        __lazy_static_internal!($(#[$attr])* () static ref $N : $T = $e; $($t)*);
+    };
+    ($(#[$attr:meta])* pub static ref $N:ident : $T:ty = $e:expr; $($t:tt)*) => {
+        __lazy_static_internal!($(#[$attr])* (pub) static ref $N : $T = $e; $($t)*);
+    };
+    ($(#[$attr:meta])* pub ($($vis:tt)+) static ref $N:ident : $T:ty = $e:expr; $($t:tt)*) => {
+        __lazy_static_internal!($(#[$attr])* (pub ($($vis)+)) static ref $N : $T = $e; $($t)*);
+    };
+    () => ()
+}
+
+/// Support trait for enabling a few common operation on lazy static values.
+///
+/// This is implemented by each defined lazy static, and
+/// used by the free functions in this crate.
+pub(crate) trait LazyStatic {
+    #[doc(hidden)]
+    fn initialize(lazy: &Self);
+}

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -95,9 +95,6 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-#[macro_use]
-extern crate lazy_static;
-
 /// Statically constructs an [`Identifier`] for the provided [`Callsite`].
 ///
 /// This may be used in contexts, such as static initializers, where the
@@ -208,6 +205,27 @@ macro_rules! metadata {
         )
     };
 }
+
+// std uses lazy_static from crates.io
+#[cfg(feature = "std")]
+#[macro_use]
+extern crate lazy_static;
+
+// no_std uses vendored version of lazy_static 1.4.0 (4216696) with spin
+// This can conflict when included in a project already using std lazy_static
+// Remove this module when cargo enables specifying dependencies for no_std
+#[cfg(not(feature = "std"))]
+#[macro_use]
+mod lazy_static;
+
+// Trimmed-down vendored version of spin 0.5.2 (0387621)
+// Dependency of no_std lazy_static, not required in a std build
+#[cfg(not(feature = "std"))]
+pub(crate) mod spin;
+
+#[cfg(not(feature = "std"))]
+#[doc(hidden)]
+pub use self::spin::Once;
 
 pub mod callsite;
 pub mod dispatcher;

--- a/tracing-core/src/spin/LICENSE
+++ b/tracing-core/src/spin/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Mathijs van de Nes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tracing-core/src/spin/mod.rs
+++ b/tracing-core/src/spin/mod.rs
@@ -1,0 +1,7 @@
+//! Synchronization primitives based on spinning
+
+pub(crate) use mutex::*;
+pub use once::Once;
+
+mod mutex;
+mod once;

--- a/tracing-core/src/spin/mutex.rs
+++ b/tracing-core/src/spin/mutex.rs
@@ -1,0 +1,109 @@
+use core::cell::UnsafeCell;
+use core::default::Default;
+use core::fmt;
+use core::marker::Sync;
+use core::ops::{Deref, DerefMut, Drop};
+use core::option::Option::{self, None, Some};
+use core::sync::atomic::{spin_loop_hint as cpu_relax, AtomicBool, Ordering};
+
+/// This type provides MUTual EXclusion based on spinning.
+pub(crate) struct Mutex<T: ?Sized> {
+    lock: AtomicBool,
+    data: UnsafeCell<T>,
+}
+
+/// A guard to which the protected data can be accessed
+///
+/// When the guard falls out of scope it will release the lock.
+#[derive(Debug)]
+pub(crate) struct MutexGuard<'a, T: ?Sized> {
+    lock: &'a AtomicBool,
+    data: &'a mut T,
+}
+
+// Same unsafe impls as `std::sync::Mutex`
+unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
+unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
+
+impl<T> Mutex<T> {
+    /// Creates a new spinlock wrapping the supplied data.
+    pub(crate) const fn new(user_data: T) -> Mutex<T> {
+        Mutex {
+            lock: AtomicBool::new(false),
+            data: UnsafeCell::new(user_data),
+        }
+    }
+}
+
+impl<T: ?Sized> Mutex<T> {
+    fn obtain_lock(&self) {
+        while self.lock.compare_and_swap(false, true, Ordering::Acquire) != false {
+            // Wait until the lock looks unlocked before retrying
+            while self.lock.load(Ordering::Relaxed) {
+                cpu_relax();
+            }
+        }
+    }
+
+    /// Locks the spinlock and returns a guard.
+    ///
+    /// The returned value may be dereferenced for data access
+    /// and the lock will be dropped when the guard falls out of scope.
+    pub(crate) fn lock(&self) -> MutexGuard<'_, T> {
+        self.obtain_lock();
+        MutexGuard {
+            lock: &self.lock,
+            data: unsafe { &mut *self.data.get() },
+        }
+    }
+
+    /// Tries to lock the mutex. If it is already locked, it will return None. Otherwise it returns
+    /// a guard within Some.
+    pub(crate) fn try_lock(&self) -> Option<MutexGuard<'_, T>> {
+        if self.lock.compare_and_swap(false, true, Ordering::Acquire) == false {
+            Some(MutexGuard {
+                lock: &self.lock,
+                data: unsafe { &mut *self.data.get() },
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.try_lock() {
+            Some(guard) => write!(f, "Mutex {{ data: ")
+                .and_then(|()| (&*guard).fmt(f))
+                .and_then(|()| write!(f, "}}")),
+            None => write!(f, "Mutex {{ <locked> }}"),
+        }
+    }
+}
+
+impl<T: ?Sized + Default> Default for Mutex<T> {
+    fn default() -> Mutex<T> {
+        Mutex::new(Default::default())
+    }
+}
+
+impl<'a, T: ?Sized> Deref for MutexGuard<'a, T> {
+    type Target = T;
+    fn deref<'b>(&'b self) -> &'b T {
+        &*self.data
+    }
+}
+
+impl<'a, T: ?Sized> DerefMut for MutexGuard<'a, T> {
+    fn deref_mut<'b>(&'b mut self) -> &'b mut T {
+        &mut *self.data
+    }
+}
+
+impl<'a, T: ?Sized> Drop for MutexGuard<'a, T> {
+    /// The dropping of the MutexGuard will release the lock it was created from.
+    fn drop(&mut self) {
+        self.lock.store(false, Ordering::Release);
+    }
+}

--- a/tracing-core/src/spin/once.rs
+++ b/tracing-core/src/spin/once.rs
@@ -1,0 +1,146 @@
+use core::cell::UnsafeCell;
+use core::fmt;
+use core::sync::atomic::{spin_loop_hint as cpu_relax, AtomicUsize, Ordering};
+
+/// A synchronization primitive which can be used to run a one-time global
+/// initialization. Unlike its std equivalent, this is generalized so that the
+/// closure returns a value and it is stored. Once therefore acts something like
+/// a future, too.
+pub struct Once<T> {
+    state: AtomicUsize,
+    data: UnsafeCell<Option<T>>, // TODO remove option and use mem::uninitialized
+}
+
+impl<T: fmt::Debug> fmt::Debug for Once<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.r#try() {
+            Some(s) => write!(f, "Once {{ data: ")
+                .and_then(|()| s.fmt(f))
+                .and_then(|()| write!(f, "}}")),
+            None => write!(f, "Once {{ <uninitialized> }}"),
+        }
+    }
+}
+
+// Same unsafe impls as `std::sync::RwLock`, because this also allows for
+// concurrent reads.
+unsafe impl<T: Send + Sync> Sync for Once<T> {}
+unsafe impl<T: Send> Send for Once<T> {}
+
+// Four states that a Once can be in, encoded into the lower bits of `state` in
+// the Once structure.
+const INCOMPLETE: usize = 0x0;
+const RUNNING: usize = 0x1;
+const COMPLETE: usize = 0x2;
+const PANICKED: usize = 0x3;
+
+use core::hint::unreachable_unchecked as unreachable;
+
+impl<T> Once<T> {
+    /// Initialization constant of `Once`.
+    pub const INIT: Self = Once {
+        state: AtomicUsize::new(INCOMPLETE),
+        data: UnsafeCell::new(None),
+    };
+
+    /// Creates a new `Once` value.
+    pub const fn new() -> Once<T> {
+        Self::INIT
+    }
+
+    fn force_get<'a>(&'a self) -> &'a T {
+        match unsafe { &*self.data.get() }.as_ref() {
+            None => unsafe { unreachable() },
+            Some(p) => p,
+        }
+    }
+
+    /// Performs an initialization routine once and only once. The given closure
+    /// will be executed if this is the first time `call_once` has been called,
+    /// and otherwise the routine will *not* be invoked.
+    ///
+    /// This method will block the calling thread if another initialization
+    /// routine is currently running.
+    ///
+    /// When this function returns, it is guaranteed that some initialization
+    /// has run and completed (it may not be the closure specified). The
+    /// returned pointer will point to the result from the closure that was
+    /// run.
+    pub fn call_once<'a, F>(&'a self, builder: F) -> &'a T
+    where
+        F: FnOnce() -> T,
+    {
+        let mut status = self.state.load(Ordering::SeqCst);
+
+        if status == INCOMPLETE {
+            status = self
+                .state
+                .compare_and_swap(INCOMPLETE, RUNNING, Ordering::SeqCst);
+            if status == INCOMPLETE {
+                // We init
+                // We use a guard (Finish) to catch panics caused by builder
+                let mut finish = Finish {
+                    state: &self.state,
+                    panicked: true,
+                };
+                unsafe { *self.data.get() = Some(builder()) };
+                finish.panicked = false;
+
+                status = COMPLETE;
+                self.state.store(status, Ordering::SeqCst);
+
+                // This next line is strictly an optimization
+                return self.force_get();
+            }
+        }
+
+        loop {
+            match status {
+                INCOMPLETE => unreachable!(),
+                RUNNING => {
+                    // We spin
+                    cpu_relax();
+                    status = self.state.load(Ordering::SeqCst)
+                }
+                PANICKED => panic!("Once has panicked"),
+                COMPLETE => return self.force_get(),
+                _ => unsafe { unreachable() },
+            }
+        }
+    }
+
+    /// Returns a pointer iff the `Once` was previously initialized
+    pub fn r#try<'a>(&'a self) -> Option<&'a T> {
+        match self.state.load(Ordering::SeqCst) {
+            COMPLETE => Some(self.force_get()),
+            _ => None,
+        }
+    }
+
+    /// Like try, but will spin if the `Once` is in the process of being
+    /// initialized
+    pub fn wait<'a>(&'a self) -> Option<&'a T> {
+        loop {
+            match self.state.load(Ordering::SeqCst) {
+                INCOMPLETE => return None,
+                RUNNING => cpu_relax(), // We spin
+                COMPLETE => return Some(self.force_get()),
+                PANICKED => panic!("Once has panicked"),
+                _ => unsafe { unreachable() },
+            }
+        }
+    }
+}
+
+struct Finish<'a> {
+    state: &'a AtomicUsize,
+    panicked: bool,
+}
+
+impl<'a> Drop for Finish<'a> {
+    fn drop(&mut self) {
+        if self.panicked {
+            self.state.store(PANICKED, Ordering::SeqCst);
+        }
+    }
+}

--- a/tracing-core/src/stdlib.rs
+++ b/tracing-core/src/stdlib.rs
@@ -49,9 +49,9 @@ mod no_std {
     }
 
     pub(crate) mod sync {
+        pub(crate) use crate::spin::MutexGuard;
         pub(crate) use alloc::sync::*;
         pub(crate) use core::sync::*;
-        pub(crate) use spin::MutexGuard;
 
         /// This wraps `spin::Mutex` to return a `Result`, so that it can be
         /// used with code written against `std::sync::Mutex`.
@@ -60,17 +60,17 @@ mod no_std {
         /// by `lock` will always be `Ok`.
         #[derive(Debug, Default)]
         pub(crate) struct Mutex<T> {
-            inner: spin::Mutex<T>,
+            inner: crate::spin::Mutex<T>,
         }
 
         impl<T> Mutex<T> {
             pub(crate) fn new(data: T) -> Self {
                 Self {
-                    inner: spin::Mutex::new(data),
+                    inner: crate::spin::Mutex::new(data),
                 }
             }
 
-            pub(crate) fn lock(&self) -> Result<MutexGuard<T>, ()> {
+            pub(crate) fn lock(&self) -> Result<MutexGuard<'_, T>, ()> {
                 Ok(self.inner.lock())
             }
         }

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -387,10 +387,6 @@ where
         });
     }
 
-    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
-        dbg!(ctx.span(&id).unwrap().metadata());
-    }
-
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
         // This `downcast_raw` impl allows downcasting a `fmt` layer to any of
         // its components (event formatter, field formatter, and `MakeWriter`)

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -387,6 +387,10 @@ where
         });
     }
 
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        dbg!(ctx.span(&id).unwrap().metadata());
+    }
+
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
         // This `downcast_raw` impl allows downcasting a `fmt` layer to any of
         // its components (event formatter, field formatter, and `MakeWriter`)

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -342,7 +342,7 @@ where
         let span = ctx.span(id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
         if let Some(FormattedFields { ref mut fields, .. }) =
-            extensions.get_mut::<FormattedFields<Self>>()
+            extensions.get_mut::<FormattedFields<N>>()
         {
             let _ = self.fmt_fields.format_fields(fields, values);
         } else {

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -342,7 +342,7 @@ where
         let span = ctx.span(id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
         if let Some(FormattedFields { ref mut fields, .. }) =
-            extensions.get_mut::<FormattedFields<N>>()
+            extensions.get_mut::<FormattedFields<Self>>()
         {
             let _ = self.fmt_fields.format_fields(fields, values);
         } else {

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -494,11 +494,12 @@ where
     }
 
     fn try_close(&self, id: span::Id) -> bool {
+        #[cfg(feature = "registry")]
         let subscriber = &self.inner as &dyn Subscriber;
-        let _guard = match subscriber.downcast_ref::<Registry>() {
-            Some(registry) => Some(registry.ref_guard(id.clone())),
-            None => None,
-        };
+        #[cfg(feature = "registry")]
+        let _guard = subscriber
+            .downcast_ref::<Registry>()
+            .and_then(|registry| Some(registry.start_close(id.clone())));
 
         let id2 = id.clone();
         if self.inner.try_close(id) {

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -496,7 +496,7 @@ where
     fn try_close(&self, id: span::Id) -> bool {
         let subscriber = &self.inner as &dyn Subscriber;
         let _guard = match subscriber.downcast_ref::<Registry>() {
-            Some(registry) => Some(registry.ref_guard()),
+            Some(registry) => Some(registry.ref_guard(id.clone())),
             None => None,
         };
 

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -225,6 +225,7 @@ impl Subscriber for Registry {
             None if std::thread::panicking() => return false,
             None => panic!("tried to drop a ref to {:?}, but no such span exists!", id),
         };
+
         let refs = span.ref_count.fetch_sub(1, Ordering::Release);
         if !std::thread::panicking() {
             assert!(refs < std::usize::MAX, "reference count overflow!");

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -89,7 +89,7 @@ fn id_to_idx(id: &Id) -> usize {
     id.into_u64() as usize - 1
 }
 
-// CloseGuard is used to track how many Registry-backed Layers have
+// A guard that tracks how many Registry-backed Layers have
 // processed an `on_close` event. Once all Layers have processed this
 // event, the registry knows that is able to safely remove the span
 // tracked by `id`.
@@ -109,7 +109,7 @@ impl Registry {
         self.spans.get(id_to_idx(id))
     }
 
-    // `start_close` creates a guard which tracks how many layers have
+    // Returns a guard which tracks how many layers have
     // processed a close event via the `CLOSE_COUNT` thread-local. Once
     // the `CLOSE_COUNT` is 0, the registry knows that is is safe to
     // remove a span. It does so via the Drop implementation on

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -27,7 +27,7 @@ keywords = ["logging", "tracing", "metrics", "async"]
 edition = "2018"
 
 [dependencies]
-tracing-core = { version = "0.1.7", default-features = false }
+tracing-core = { path = "../tracing-core", version = "0.1.8", default-features = false }
 log = { version = "0.4", optional = true }
 tracing-attributes = "0.1.5"
 cfg-if = "0.1.10"
@@ -71,6 +71,3 @@ harness = false
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
 maintenance = { status = "actively-developed" }
-
-[target.'cfg(not(feature = "std"))'.dependencies]
-spin = "0.5"

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -701,7 +701,7 @@ pub mod __macro_support {
     pub use crate::stdlib::sync::Once;
 
     #[cfg(not(feature = "std"))]
-    pub type Once = spin::Once<()>;
+    pub type Once = tracing_core::Once<()>;
 }
 
 mod sealed {


### PR DESCRIPTION
This PR implements the second option ("The One With The `downcast_ref`") in @hawkw's [comment](https://github.com/tokio-rs/tracing/issues/429#issuecomment-554077428). The benchmarks of this change, relative to the master branch, are available [here](https://gist.github.com/davidbarsky/3620247e6cf74e77e1d5d4c24014c6d1). 

Edit: The same benchmarks running on a significantly less noisy c3.8xlarge: https://gist.github.com/davidbarsky/111814dcc55e89580e5ee283b9900bbf.

Resolves #429