### PR TITLE
subscriber: Fix incorrect extensions lookup in `fmt::Layer::on_record`

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -342,7 +342,7 @@ where
         let span = ctx.span(id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
         if let Some(FormattedFields { ref mut fields, .. }) =
-            extensions.get_mut::<FormattedFields<Self>>()
+            extensions.get_mut::<FormattedFields<N>>()
         {
             let _ = self.fmt_fields.format_fields(fields, values);
         } else {


### PR DESCRIPTION
`fmt::Layer::on_record` was looking up extensions using `FormattedFields<Self>>` when it _should_ have been using `FormattedFields<N>>`. While `on_record` _probably_ hasn't ever been called, this code code was still wrong.