### PR TITLE
subscriber: remove deprecated items and notices

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -26,9 +26,6 @@ ansi = ["fmt", "ansi_term"]
 registry = ["sharded-slab"]
 json = ["tracing-serde", "serde", "serde_json"]
 
-# Alias for `env-filter`; renamed in version 0.1.2, and will be removed in 0.2.
-filter = ["env-filter"]
-
 [dependencies]
 tracing-core = "0.1.2"
 

--- a/tracing-subscriber/benches/fmt.rs
+++ b/tracing-subscriber/benches/fmt.rs
@@ -1,12 +1,6 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use std::{
-    io,
-    sync::{Arc, Barrier},
-    thread,
-    time::{Duration, Instant},
-};
-use tracing::{dispatcher::Dispatch, span, Event, Id, Metadata};
-use tracing_subscriber::{prelude::*, EnvFilter};
+use std::{io, time::Duration};
+use tracing_subscriber;
 
 mod support;
 use support::MultithreadedBench;

--- a/tracing-subscriber/benches/fmt.rs
+++ b/tracing-subscriber/benches/fmt.rs
@@ -57,7 +57,7 @@ fn bench_new_span(c: &mut Criterion) {
                         })
                         .thread(move || {
                             for n in 0..i {
-                                let _span = tracing::info_span!("span", i);
+                                let _span = tracing::info_span!("span", n);
                             }
                         })
                         .thread(move || {

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -29,13 +29,7 @@ use tracing_core::{
 /// A `Layer` which filters spans and events based on a set of filter
 /// directives.
 // TODO(eliza): document filter directive syntax?
-#[cfg_attr(
-    feature = "filter",
-    deprecated(
-        since = "0.1.2",
-        note = "the `filter` feature flag was renamed to `env-filter` and will be removed in 0.2",
-    )
-)]
+#[cfg(feature = "env-filter")]
 #[derive(Debug)]
 pub struct EnvFilter {
     // TODO: eventually, this should be exposed by the registry.

--- a/tracing-subscriber/src/filter/mod.rs
+++ b/tracing-subscriber/src/filter/mod.rs
@@ -10,11 +10,3 @@ pub use self::level::{LevelFilter, ParseError as LevelParseError};
 
 #[cfg(feature = "env-filter")]
 pub use self::env::*;
-
-/// A `Layer` which filters spans and events based on a set of filter
-/// directives.
-///
-/// **Note**: renamed to `EnvFilter` in 0.1.2; use that instead.
-#[cfg(feature = "env-filter")]
-#[deprecated(since = "0.1.2", note = "renamed to `EnvFilter`")]
-pub type Filter = EnvFilter;

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -151,15 +151,6 @@ pub struct SubscriberBuilder<
     inner: LayerBuilder<Registry, N, E, W>,
 }
 
-/// Configures and constructs `Subscriber`s.
-#[deprecated(since = "0.2.0", note = "renamed to `SubscriberBuilder`")]
-pub type Builder<
-    N = format::DefaultFields,
-    E = format::Format<format::Full>,
-    F = LevelFilter,
-    W = fn() -> io::Stdout,
-> = SubscriberBuilder<N, E, F, W>;
-
 impl Subscriber {
     /// The maximum [verbosity level] that is enabled by a `Subscriber` by
     /// default.
@@ -544,26 +535,6 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
             inner: self.inner,
         }
     }
-    /// Sets the [`EnvFilter`] that the subscriber will use to determine if
-    /// a span or event is enabled.
-    ///
-    /// **Note**: this method was renamed to [`with_env_filter`] in version
-    /// 0.1.2. This method just wraps a call to `with_env_filter`, and will be
-    /// removed in version 0.2.
-    ///
-    /// [`EnvFilter`]: ../filter/struct.EnvFilter.html
-    /// [`with_env_filter`]: #method.with_env_filter
-    #[cfg(feature = "env-filter")]
-    #[deprecated(since = "0.1.2", note = "renamed to `with_env_filter`")]
-    pub fn with_filter(
-        self,
-        filter: impl Into<crate::EnvFilter>,
-    ) -> SubscriberBuilder<N, E, crate::EnvFilter, W>
-    where
-        Formatter<N, E, W>: tracing_core::Subscriber + 'static,
-    {
-        self.with_env_filter(filter)
-    }
 
     /// Sets the maximum [verbosity level] that will be enabled by the
     /// subscriber.
@@ -606,18 +577,6 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
             filter,
             inner: self.inner,
         }
-    }
-
-    /// Sets the function that the subscriber being built should use to format
-    /// events that occur.
-    #[deprecated(since = "0.2.0", note = "renamed to `event_format`.")]
-    pub fn on_event<E2>(self, fmt_event: E2) -> SubscriberBuilder<N, E2, F, W>
-    where
-        E2: FormatEvent<Registry, N> + 'static,
-        N: for<'writer> FormatFields<'writer> + 'static,
-        W: MakeWriter + 'static,
-    {
-        self.event_format(fmt_event)
     }
 
     /// Sets the function that the subscriber being built should use to format

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -601,6 +601,18 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
         self
     }
 
+    /// Sets the function that the subscriber being built should use to format
+    /// events that occur.
+    #[deprecated(since = "0.2.0", note = "renamed to `event_format`.")]
+    pub fn on_event<E2>(self, fmt_event: E2) -> SubscriberBuilder<N, E2, F, W>
+    where
+        E2: FormatEvent<Registry, N> + 'static,
+        N: for<'writer> FormatFields<'writer> + 'static,
+        W: MakeWriter + 'static,
+    {
+        self.event_format(fmt_event)
+    }
+
     /// Sets the [`MakeWriter`] that the subscriber being built will use to write events.
     ///
     /// # Examples

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -106,7 +106,6 @@ pub(crate) mod sync;
 pub(crate) mod thread;
 
 #[cfg(feature = "env-filter")]
-#[allow(deprecated)]
 pub use filter::EnvFilter;
 
 pub use layer::Layer;

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -107,7 +107,7 @@ pub(crate) mod thread;
 
 #[cfg(feature = "env-filter")]
 #[allow(deprecated)]
-pub use filter::{EnvFilter, Filter};
+pub use filter::EnvFilter;
 
 pub use layer::Layer;
 

--- a/tracing/benches/subscriber.rs
+++ b/tracing/benches/subscriber.rs
@@ -1,9 +1,7 @@
-#[macro_use]
-extern crate tracing;
-#[macro_use]
 extern crate criterion;
+extern crate tracing;
 
-use criterion::{black_box, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use tracing::Level;
 
 use std::{


### PR DESCRIPTION
This PR removes the deprecated items, notices and aliases in preparation of releasing tracing-subscriber 0.2.0-alpha.1.