### PR TITLE
subscriber: prepare release 0.2.0-alpha.1 release

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
-tracing-subscriber = { version = "0.1", path = "../tracing-subscriber", features = ["json", "chrono"] }
+tracing-subscriber = { version = "0.2.0-alpha.1", path = "../tracing-subscriber", features = ["json", "chrono"] }
 tracing-futures = { version = "0.1.0", path = "../tracing-futures" }
 tracing-attributes =  "0.1.2"
 tracing-log = { path = "../tracing-log", version = "0.1.1", features = ["env_logger"] }

--- a/nightly-examples/Cargo.toml
+++ b/nightly-examples/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dev-dependencies]
 tracing = "0.1"
-tracing-subscriber = { version = "0.1", path = "../tracing-subscriber", features = ["json"] }
+tracing-subscriber = { version = "0.2.0-alpha.1", path = "../tracing-subscriber", features = ["json"] }
 tracing-futures = { path = "../tracing-futures", default-features = false, features = ["std-future"] }
 futures-preview = { version = "0.3.0-alpha.19", features = ["async-await"] }
 tokio = "0.2.0-alpha.6"

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,57 @@
+# 0.2.0-alpha.1 (November 18, 2019)
+
+### Added
+
+- `Registry`, a reusable span store that `Layer`s can use a
+  high-performance, in-memory store. (#420, #425, #432, #433, #435)
+- Reimplemented `fmt::Subscriber` in terms of the `Registry`
+  and `Layer`s (#420)
+- Add benchmarks for fmt subscriber (#421)
+- Add support for JSON field and event formatting (#377, #415)
+
+### Changed
+
+- **BREAKING**: Change `fmt::format::FormatFields` and
+  `fmt::format::FormatEvent` to accept a mandatory `FmtContext`. These
+  `FormatFields` and `FormatEvent` will likely see additional breaking
+  changes in subsequent alpha. (#420, #425)
+- **BREAKING**: Removed `Filter`. Use `EnvFilter` instead (#434)
+
+### Contributers
+
+Thanks to all the contributers to this release!
+
+- @pimeys for #377 and #415
+
+# 0.1.6 (October 29, 2019)
+
+### Added
+
+- Add `init` and `try_init` functions to `FmtSubscriber` (#385)
+- Add `ChronoUtc` and `ChronoLocal` timers, RFC 3339 support (#387)
+- Add `tracing::subscriber::set_default` which sets the default
+  subscriber and returns a drop guard. This drop guard will reset the
+  dispatch on drop (#388).
+
+### Fixed
+
+- Fix default level for `EnvFilter`. Setting `RUST_LOG=target`
+  previously only the `ERROR` level, while it should enable everything.
+  `tracing-subscriber` now defaults to `TRACE` if no level is specified
+  (#401)
+- Fix `tracing-log` feature flag for init + try_init. The feature flag
+  `tracing_log` was used instead of the correct `tracing-log`. As a
+  result, both `tracing-log` and `tracing_log` needed to be specified in
+  order to initialize the global logger. Only `tracing-log` needs to be
+  specified now (#400).
+
+### Contributers
+
+Thanks to all the contributers to this release!
+
+- @emschwartz for #385, #387, #400 and #401
+- @bIgBV for #388
+
 # 0.1.5 (October 7, 2019)
 
 ### Fixed

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.1.5"
+version = "0.2.0-alpha.1"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 license = "MIT"
@@ -19,7 +19,7 @@ keywords = ["logging", "tracing", "metrics", "subscriber"]
 
 [features]
 
-default = ["env-filter", "smallvec", "fmt", "ansi", "chrono", "tracing-log"]
+default = ["env-filter", "smallvec", "fmt", "ansi", "chrono", "tracing-log", "json"]
 env-filter = ["matchers", "regex", "lazy_static"]
 fmt = ["registry"]
 ansi = ["fmt", "ansi_term"]
@@ -43,7 +43,7 @@ chrono = { version = "0.4", optional = true }
 # only required by the json feature
 serde_json = { version = "1.0", optional = true }
 serde = { version = "1.0", optional = true }
-tracing-serde = { path = "../tracing-serde", optional = true }
+tracing-serde = { version = "0.1.0", path = "../tracing-serde", optional = true }
 
 # opt-in deps
 parking_lot = { version = ">= 0.7, < 0.10", optional = true }


### PR DESCRIPTION
Note that this `tracing-subscriber` release will also need a release of `tracing-serde`.