### PR TITLE
Fix type annotations in ansi fmt

### DIFF
--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -523,7 +523,7 @@ where
                 write!(f, "{}", metadata.name())?;
             }
 
-            Ok(())
+            Ok(()) as fmt::Result
         })?;
         if seen {
             f.pad(" ")?;


### PR DESCRIPTION
## Motivation

Latest master cannot infer types in the `fmt` function.

## Solution

Tell the compiler the result type. Funnily I couldn't reproduce this directly from `tracing` repo, but when I have `tracing` as a dependency following it from github, the later versions would not pass `cargo check`

We used to be on this version `16fee661ac1f5dd175491e611ff4c08b33c070fa`, and `cargo update` would break the project.