### PR TITLE
future: futures-03 & std-future is the default

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ stages:
    jobs:
      - template: azure/cargo-check.yml@templates
        parameters:
-         rust: 1.34.0
+         rust: 1.36.0
          all_features: false
  - stage: custom
    displayName: "Special tests"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,7 +11,7 @@ tracing = "0.1"
 tracing-core = "0.1"
 tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
 tracing-subscriber = { version = "0.2.0-alpha.1", path = "../tracing-subscriber", features = ["json", "chrono"] }
-tracing-futures = { version = "0.1.0", path = "../tracing-futures" }
+tracing-futures = { version = "0.2.0", path = "../tracing-futures" }
 tracing-attributes =  "0.1.2"
 tracing-log = { path = "../tracing-log", version = "0.1.1", features = ["env_logger"] }
 tracing-serde = { path = "../tracing-serde" }

--- a/nightly-examples/Cargo.toml
+++ b/nightly-examples/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 tracing = "0.1"
 tracing-subscriber = { version = "0.2.0-alpha.1", path = "../tracing-subscriber", features = ["json"] }
 tracing-futures = { path = "../tracing-futures", default-features = false, features = ["std-future"] }
-futures-preview = { version = "0.3.0-alpha.19", features = ["async-await"] }
+futures = "0.3.0"
 tokio = "0.2.0-alpha.6"
 tracing-attributes = { path = "../tracing-attributes" }
 clap = "2.33"

--- a/tracing-futures/CHANGELOG.md
+++ b/tracing-futures/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.0 (Nov XX, 2019)
+
+### Changed
+
+- the default `Future` implementation comes from the `std-future` feature.
+  Compatibility with futures v0.1 is available via the `futures-01` feature.
+
 # 0.1.1 (Oct 25, 2019)
 
 ### Added

--- a/tracing-futures/CHANGELOG.md
+++ b/tracing-futures/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Changed
 
-- the default `Future` implementation comes from the `std-future` feature.
+- **Breaking Change**: the default `Future` implementation comes from the `std-future` feature.
   Compatibility with futures v0.1 is available via the `futures-01` feature.
 
 # 0.1.1 (Oct 25, 2019)

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["logging", "profiling", "tracing", "futures", "async"]
 license = "MIT"
 
 [features]
-default = ["std-future", "tokio"]
+default = ["std-future"]
 futures-01 = ["futures_01"]
 futures-03 = ["std-future", "futures", "futures-task"]
 std-future = ["pin-project"]

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-futures"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"
@@ -18,16 +18,15 @@ keywords = ["logging", "profiling", "tracing", "futures", "async"]
 license = "MIT"
 
 [features]
-default = ["futures-01", "tokio"]
-futures-01 = ["futures"]
-futures-03 = ["std-future", "futures-task"]
+default = ["std-future", "tokio"]
+futures-01 = ["futures_01"]
+futures-03 = ["std-future", "futures", "futures-task"]
 std-future = ["pin-project"]
-futures-preview = ["std-future", "futures-core-preview"]
 tokio-alpha = ["std-future", "tokio_02"]
 
 [dependencies]
-futures = { version = "0.1", optional = true }
-futures-core-preview = { version = "0.3.0-alpha.19", optional = true }
+futures_01 = { package = "futures", version = "0.1", optional = true }
+futures = { version = "0.3.0", optional = true }
 futures-task = { version = "0.3", optional = true }
 pin-project = { version = "0.4", optional = true }
 tracing = "0.1"

--- a/tracing-futures/README.md
+++ b/tracing-futures/README.md
@@ -13,9 +13,9 @@ Utilities for instrumenting futures-based code with [`tracing`].
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-futures.svg
-[crates-url]: https://crates.io/crates/tracing-futures/0.1.1
+[crates-url]: https://crates.io/crates/tracing-futures/0.2.0
 [docs-badge]: https://docs.rs/tracing-futures/badge.svg
-[docs-url]: https://docs.rs/tracing-futures/0.1.1/tracing_futures
+[docs-url]: https://docs.rs/tracing-futures/0.2.0/tracing_futures
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_futures
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -41,8 +41,8 @@ The crate provides the following traits:
 * [`WithSubscriber`] allows a `tracing` [`Subscriber`] to be attached to a
   future, sink, stream, or executor.
 
-[`Instrument`]: https://docs.rs/tracing-futures/0.1.1/tracing_futures/trait.Instrument.html
-[`WithSubscriber`]: https://docs.rs/tracing-futures/0.1.1/tracing_futures/trait.WithSubscriber.html
+[`Instrument`]: https://docs.rs/tracing-futures/0.2.0/tracing_futures/trait.Instrument.html
+[`WithSubscriber`]: https://docs.rs/tracing-futures/0.2.0/tracing_futures/trait.WithSubscriber.html
 [span]: https://docs.rs/tracing/0.1.9/tracing/span/index.html
 [`Subscriber`]: https://docs.rs/tracing/0.1.9/tracing/subscriber/index.html
 [`tracing`]: https://crates.io/tracing

--- a/tracing-futures/src/executor/futures_01.rs
+++ b/tracing-futures/src/executor/futures_01.rs
@@ -1,5 +1,5 @@
 use crate::{Instrument, Instrumented, WithDispatch};
-use futures::{
+use futures_01::{
     future::{ExecuteError, Executor},
     Future,
 };
@@ -43,7 +43,7 @@ pub use self::tokio::*;
 #[cfg(feature = "tokio")]
 mod tokio {
     use crate::{Instrument, Instrumented, WithDispatch};
-    use futures::Future;
+    use futures_01::Future;
     use tokio::{
         executor::{Executor, SpawnError, TypedExecutor},
         runtime::{current_thread, Runtime, TaskExecutor},

--- a/tracing-futures/test_std_future/Cargo.toml
+++ b/tracing-futures/test_std_future/Cargo.toml
@@ -15,4 +15,4 @@ edition = "2018"
 tokio-test = { git = "https://github.com/tokio-rs/tokio.git" }
 tracing = "0.1"
 tracing-core = "0.1.2"
-tracing-futures = { path = "..", features = ["std-future"] }
+tracing-futures = { path = ".." }

--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -21,7 +21,7 @@ default = ["tower-layer", "tower-util", "http"]
 
 [dependencies]
 tracing = "0.1"
-tracing-futures = { version = "0.1.0", path = "../tracing-futures" }
+tracing-futures = { version = "0.2.0", path = "../tracing-futures", features = ["futures-01"] }
 futures = "0.1"
 tower-service = "0.2"
 tower-layer = { version = "0.1", optional = true }


### PR DESCRIPTION
Also upgrades futures-03 to the non-preview crate and renames the `futures` feature to `futures-01`.

Fixes #418