### PR TITLE
subscriber: Move visit_spans impl to layer::Context

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -438,37 +438,11 @@ where
     /// The provided closure will be called first with the current span,
     /// and then with that span's parent, and then that span's parent,
     /// and so on until a root span is reached.
-    pub fn visit_spans<E, F>(&self, mut f: F) -> Result<(), E>
+    pub fn visit_spans<E, F>(&self, f: F) -> Result<(), E>
     where
         F: FnMut(&SpanRef<'_, S>) -> Result<(), E>,
     {
-        let current_span = self.ctx.current_span();
-        let id = match current_span.id() {
-            Some(id) => id,
-            None => return Ok(()),
-        };
-        let span = match self.ctx.span(id) {
-            Some(span) => span,
-            None => return Ok(()),
-        };
-
-        #[cfg(feature = "smallvec")]
-        type SpanRefVec<'span, S> = smallvec::SmallVec<[SpanRef<'span, S>; 16]>;
-        #[cfg(not(feature = "smallvec"))]
-        type SpanRefVec<'span, S> = Vec<SpanRef<'span, S>>;
-
-        // an alternative way to handle this would be to the recursive approach that
-        // `fmt` uses that _does not_ entail any allocation in this fmt'ing
-        // spans path.
-        let parents = span.parents().collect::<SpanRefVec<'_, _>>();
-        let mut iter = parents.iter().rev();
-        // visit all the parent spans...
-        while let Some(parent) = iter.next() {
-            f(parent)?;
-        }
-        // and finally, print out the current span.
-        f(&span)?;
-        Ok(())
+        self.ctx.scope(f)
     }
 }
 


### PR DESCRIPTION
This patch moves the current `FmtContext::visit_spans`
implementation into a new method `layer::Context::scope`, leaving
`visit_spans` itself in place in order to maintain compatibility.

Fixes #427

This is based on my interpretation of the requirements from the issue's descriptions - Happy to make any changes or suggestions!
