### PR TITLE
docs: Fix broken links to Layer trait

### DIFF
--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -388,7 +388,7 @@ pub trait SubscriberExt: Subscriber + crate::sealed::Sealed {
 /// Represents information about the current context provided to [`Layer`]s by the
 /// wrapped [`Subscriber`].
 ///
-/// [`Layer`]: ../struct.Layer.html
+/// [`Layer`]: ../layer/trait.Layer.html
 /// [`Subscriber`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html
 #[derive(Debug)]
 pub struct Context<'a, S> {
@@ -398,7 +398,7 @@ pub struct Context<'a, S> {
 /// A [`Subscriber`] composed of a `Subscriber` wrapped by one or more
 /// [`Layer`]s.
 ///
-/// [`Layer`]: ../struct.Layer.html
+/// [`Layer`]: ../layer/trait.Layer.html
 /// [`Subscriber`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html
 #[derive(Clone, Debug)]
 pub struct Layered<L, I, S = I> {

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -59,7 +59,7 @@
 //! access to the [`Context`][ctx] methods, such as [`Context::span`][lookup], that
 //! require the root subscriber to be a registry.
 //!
-//! [`Layer`]: ../struct.Layer.html
+//! [`Layer`]: ../layer/trait.Layer.html
 //! [`Subscriber`]:
 //!     https://docs.rs/tracing-core/latest/tracing_core/subscriber/trait.Subscriber.html
 //! [`Registry`]: struct.Registry.html
@@ -84,7 +84,7 @@ pub use sharded::{Data, Registry};
 /// implement this trait; if they do, any [`Layer`]s wrapping them can look up
 /// metadata via the [`Context`] type's [`metadata()`] method.
 ///
-/// [`Layer`]: ../layer/struct.Layer.html
+/// [`Layer`]: ../layer/trait.Layer.html
 /// [`Context`]: ../layer/struct.Context.html
 /// [`metadata()`]: ../layer/struct.Context.html#method.metadata
 pub trait LookupMetadata {
@@ -116,7 +116,7 @@ pub trait LookupMetadata {
 /// implement this trait; if they do, any [`Layer`]s wrapping them can look up
 /// metadata via the [`Context`] type's [`span()`] method.
 ///
-/// [`Layer`]: ../layer/struct.Layer.html
+/// [`Layer`]: ../layer/trait.Layer.html
 /// [`Context`]: ../layer/struct.Context.html
 /// [`span()`]: ../layer/struct.Context.html#method.metadata
 pub trait LookupSpan<'a> {


### PR DESCRIPTION
Currently there are some links that 404 because they contain
a reference to a struct 'struct.Layer.html' which presumably
should be the trait 'layer/trait.Layer.html'.
