### PR TITLE
Implement `LookupSpan` for `Layered`.

### DIFF
--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -618,12 +618,14 @@ where
 }
 
 #[cfg(feature = "registry")]
-impl<L, S> LookupMetadata for Layered<L, S>
+impl<'a, L, S> LookupSpan<'a> for Layered<L, S>
 where
-    S: Subscriber + LookupMetadata,
+    S: Subscriber + LookupSpan<'a>,
 {
-    fn metadata(&self, span: &span::Id) -> Option<&'static Metadata<'static>> {
-        self.inner.metadata(span)
+    type Data = S::Data;
+
+    fn span_data(&'a self, id: &span::Id) -> Option<Self::Data> {
+        self.inner.span_data(id)
     }
 }
 


### PR DESCRIPTION
#  Motivation

What I wanted to achieve: lookup data from a span _outside_ of a `Layer`/`Subscriber` implementation. (i.e. without having a `Context<S>`)

What I was trying: get the configured subscriber with `dispatcher::get_default(...)`, and then downcasting to a `Layered<...., Registry>`. But I (a) cant get access to the inner `Registry` and (b) don't have an implementation of `LookupSpan` for `Layered`.


## Solution


Since there was already a `LookupMetadata` impl, this just seemed like an oversight. So I changed the implementation over.

Note that `LookupMetadata` gets implemented via the blanket impl on `L: LookupSpan`.
