### PR TITLE
subscriber: Add Fmt option to log span enter/exit events

### DIFF
--- a/examples/examples/fmt-span-lifecycle.rs
+++ b/examples/examples/fmt-span-lifecycle.rs
@@ -1,0 +1,23 @@
+use tracing::subscriber::with_default;
+use tracing_subscriber::fmt::{self, format};
+use tracing_subscriber::layer::Layer;
+use tracing_subscriber::Registry;
+
+fn main() {
+    let f = format::Format::default().with_spans().with_entry();
+    let fmt = fmt::Layer::builder().event_format(f).finish();
+    let subscriber = fmt.with_subscriber(Registry::default());
+
+    with_default(subscriber, || {
+        let root = tracing::info_span!("root");
+        root.in_scope(|| {
+            let child = tracing::info_span!("child");
+            child.in_scope(|| {
+                let leaf = tracing::info_span!("leafA");
+                leaf.in_scope(|| {});
+                let leaf = tracing::info_span!("leafB");
+                leaf.in_scope(|| {});
+            });
+        });
+    });
+}


### PR DESCRIPTION
This commit introduces the option (turned off by default) to
log on the following events via `FmtLayer`:
* `Layer::new_span`, `Layer::on_close` via `Format::with_spans`
* `Layer::on_enter`, `Layer::on_exit` via `Format::with_entry`

Fixes #161

This PR adapts https://github.com/tokio-rs/tracing/compare/eliza/fmt-spans?expand=1 to fit the new APIs.
Happy to change anything that isn't right!