### PR TITLE
subscriber: fix `Layer::downcast_ref` returning invalid references

### DIFF
--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -362,7 +362,7 @@ where
     #[doc(hidden)]
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
         if id == TypeId::of::<Self>() {
-            Some(&self as *const _ as *const ())
+            Some(self as *const _ as *const ())
         } else {
             None
         }


### PR DESCRIPTION
## Motivation

Currently, `Layer::downcast_raw` constructs a pointer with:
```rust
&self as *const _ as *const ()
```
This is wrong. The method's receiver is already `&self`, so this code
constructs a reference _to_ the `&self` reference, and converts _that_
into a pointer. Since this is not the actual memory address of the
layer, this is invalid.

We didn't catch this because the tests for downcasting layers are
also wrong: they never actually dereference the ref created by 
`downcast_ref`. Therefore, if an invalid pointer is returned, the 
test can still pass, as long as _any_ pointer is returned.

## Solution

This branch changes the pointer to:
```rust
self as *const _ as *const ()
```
Now, the returned pointer is valid.

In addition, it changes the tests  to try and access data through the
returned references. The new tests fail with the current master 
implementation of `downcast_ref`, which is correct.

Fixes #453
