### PR TITLE
Event struct definition link typo

### DIFF
--- a/tracing-core/src/event.rs
+++ b/tracing-core/src/event.rs
@@ -96,7 +96,7 @@ impl<'a> Event<'a> {
 
     /// Returns [metadata] describing this `Event`.
     ///
-    /// [metadata]: ../metadata/struct.Metadata.html
+    /// [metadata]: ../struct.Metadata.html
     pub fn metadata(&self) -> &'static Metadata<'static> {
         self.metadata
     }


### PR DESCRIPTION
Current link in [here](https://docs.rs/tracing/0.1.10/tracing/event/struct.Event.html#method.metadata), which should point to the correct [`metadata`](https://docs.rs/tracing/0.1.10/tracing/struct.Metadata.html) struct definition, instead points to [here](https://docs.rs/tracing/0.1.10/tracing/metadata/struct.Metadata.html).

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Link is broken.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Fix link. :)
