### PR TITLE
subscriber: upgrade sharded-slab to 0.0.7 to fix 32-bit build

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -49,7 +49,7 @@ tracing-serde = { version = "0.1.0", optional = true }
 parking_lot = { version = ">= 0.7, < 0.10", optional = true }
 
 # registry
-sharded-slab = { version = "0.0.6", optional = true }
+sharded-slab = { version = "0.0.7", optional = true }
 
 [dev-dependencies]
 tracing = "0.1"


### PR DESCRIPTION
Currently tracing-subscriber doesn't compile on 32-bit platforms as discussed here: https://github.com/hawkw/sharded-slab/issues/9

The underlying issue has been fixed by @hawkw. This pull simply updates the dependency inside this project. Thanks for your work on this!