### PR TITLE
Add `LevelFilter::to_level`

### DIFF
--- a/tracing/src/level_filters.rs
+++ b/tracing/src/level_filters.rs
@@ -95,6 +95,14 @@ impl PartialOrd<LevelFilter> for Level {
     }
 }
 
+impl LevelFilter {
+    /// Attempts to convert `self` into a [`Level`](../struct.Level.html) unless
+    /// `self` is [`OFF`](#associatedconstant.OFF).
+    pub const fn to_level(self) -> Option<Level> {
+        self.0
+    }
+}
+
 /// The statically configured maximum trace level.
 ///
 /// See the [module-level documentation] for information on how to configure

--- a/tracing/src/level_filters.rs
+++ b/tracing/src/level_filters.rs
@@ -75,6 +75,15 @@ impl LevelFilter {
     ///
     /// Designates very low priority, often extremely verbose, information.
     pub const TRACE: LevelFilter = LevelFilter(Some(Level::TRACE));
+
+    /// Returns the most verbose [`Level`] that this filter accepts, or `None`
+    /// if it is [`OFF`].
+    ///
+    /// [`Level`]: ../struct.Level.html
+    /// [`OFF`]: #associatedconstant.OFF
+    pub const fn into_level(self) -> Option<Level> {
+        self.0
+    }
 }
 
 impl PartialEq<LevelFilter> for Level {
@@ -92,14 +101,6 @@ impl PartialOrd<LevelFilter> for Level {
             None => Some(Ordering::Less),
             Some(ref level) => self.partial_cmp(level),
         }
-    }
-}
-
-impl LevelFilter {
-    /// Attempts to convert `self` into a [`Level`](../struct.Level.html) unless
-    /// `self` is [`OFF`](#associatedconstant.OFF).
-    pub const fn to_level(self) -> Option<Level> {
-        self.0
     }
 }
 
@@ -149,7 +150,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn filter_to_level() {
+    fn filter_into_level() {
         let mapping = [
             (LevelFilter::OFF, None),
             (LevelFilter::ERROR, Some(Level::ERROR)),
@@ -159,7 +160,7 @@ mod tests {
             (LevelFilter::TRACE, Some(Level::TRACE)),
         ];
         for (filter, level) in mapping.iter() {
-            assert_eq!(filter.clone().to_level(), level.clone());
+            assert_eq!(filter.clone().into_level(), level.clone());
         }
     }
 }

--- a/tracing/src/level_filters.rs
+++ b/tracing/src/level_filters.rs
@@ -143,3 +143,23 @@ cfg_if! {
         const MAX_LEVEL: LevelFilter = LevelFilter::TRACE;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filter_to_level() {
+        let mapping = [
+            (LevelFilter::OFF, None),
+            (LevelFilter::ERROR, Some(Level::ERROR)),
+            (LevelFilter::WARN, Some(Level::WARN)),
+            (LevelFilter::INFO, Some(Level::INFO)),
+            (LevelFilter::DEBUG, Some(Level::DEBUG)),
+            (LevelFilter::TRACE, Some(Level::TRACE)),
+        ];
+        for (filter, level) in mapping.iter() {
+            assert_eq!(filter.clone().to_level(), level.clone());
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Makes it possible to get a `Level` without having to check which `LevelFilter` is being used.

## Solution

Simply moves the inner `Option<Level>` out of the `LevelFilter`.