### PR TITLE
tracing: add `Span::is_none`

### DIFF
--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -701,9 +701,28 @@ impl Span {
 
     /// Returns `true` if this span was disabled by the subscriber and does not
     /// exist.
+    ///
+    /// See also [`is_none`].
+    ///
+    /// [`is_none`]: #method.is_none
     #[inline]
     pub fn is_disabled(&self) -> bool {
         self.inner.is_none()
+    }
+
+    /// Returns `true` if this span was constructed by [`Span::none`] and is
+    /// empty.
+    ///
+    /// If `is_none` returns `true` for a given span, then [`is_disabled`] will
+    /// also return `true`.  However, when a span is disabled by the subscriber
+    /// rather than constructed by `Span::none`, this method will return
+    /// `false`, while `is_disabled` will return `true`.
+    ///
+    /// [`Span::none`]: #method.none
+    /// [`is_disabled`]: #method.is_disabled
+    #[inline]
+    pub fn is_none(&self) -> bool {
+        self.is_disabled() && self.meta.is_none()
     }
 
     /// Indicates that the span with the given ID has an indirect causal


### PR DESCRIPTION
## Motivation

There is currently no way to detect when a span is "empty" (i.e., it was
created with `Span::none`). This would be handy in cases where you want
to perform some (perhaps costly) additional metric-gathering when a
particular request _is_ being traced (i.e., it has a `Span`).

## Solution

This branch adds `Span::is_none`.

Closes #469 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>