### PR TITLE
Fix env_logger feature name in README

### DIFF
--- a/tracing-log/README.md
+++ b/tracing-log/README.md
@@ -41,7 +41,7 @@ This crate provides:
 - [`LogTracer`], a [`log::Log`] implementation that consumes [`log::Record`]s
   and outputs them as [`tracing::Event`]s.
 - An [`env_logger`] module, with helpers for using the [`env_logger` crate]
-  with `tracing` (optional, enabled by the `env-logger` feature).
+  with `tracing` (optional, enabled by the `env_logger` feature).
 
 [`tracing`]: https://crates.io/crates/tracing
 [`log`]: https://crates.io/crates/log


### PR DESCRIPTION
## Motivation

I stumbled upon this issue when trying to get tracing-log working with env_logger. The comments in-code are right, but the README uses a hyphen instead of an underscore.

## Solution

Switched the hyphen for an underscore :)