### PR TITLE
tracing: fix missing whitespace in log records

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -2217,7 +2217,7 @@ macro_rules! __mk_format_string {
 
     // === rest is unparseable --- must be fmt args ===
     (@ { $(,)* $($out:expr),* }, $($rest:tt)+) => {
-        tracing::__mk_format_string!(@ { "{}", $($out),* }, )
+        tracing::__mk_format_string!(@ { "{} ", $($out),* }, )
     };
 
     // === entry ===

--- a/tracing/test-log-support/tests/log_no_trace.rs
+++ b/tracing/test-log-support/tests/log_no_trace.rs
@@ -32,6 +32,8 @@ fn test_always_log() {
     drop(foo);
     test.assert_logged("-- foo");
 
+    trace!(foo = 1, bar = 2, "hello world");
+    test.assert_logged("hello world foo=1 bar=2");
 
     let foo = span!(Level::TRACE, "foo", bar = 3, baz = false);
     test.assert_logged("foo; bar=3 baz=false");

--- a/tracing/test-log-support/tests/log_with_trace.rs
+++ b/tracing/test-log-support/tests/log_with_trace.rs
@@ -19,7 +19,9 @@ impl tracing::Subscriber for NopSubscriber {
     fn event(&self, _: &tracing::Event) {}
     fn enter(&self, _: &tracing::span::Id) {}
     fn exit(&self, _: &tracing::span::Id) {}
-    fn try_close(&self, _: tracing::span::Id) -> bool { true }
+    fn try_close(&self, _: tracing::span::Id) -> bool {
+        true
+    }
 }
 
 #[test]
@@ -51,12 +53,14 @@ fn test_always_log() {
     drop(foo);
     test.assert_logged("-- foo");
 
-
     let foo = span!(Level::TRACE, "foo", bar = 3, baz = false);
     test.assert_logged("++ foo; bar=3 baz=false");
 
     drop(foo);
     test.assert_logged("-- foo");
+
+    trace!(foo = 1, bar = 2, "hello world");
+    test.assert_logged("hello world foo=1 bar=2");
 
     // TODO(#1138): determine a new syntax for uninitialized span fields, and
     // re-enable these.


### PR DESCRIPTION
## Motivation

When using the `tracing/log` feature flag to emit log records from
tracing events which contain a message and fields, there is missing
whitespace between the message and the rest of the fields.

For example, events like
```rust
        tracing::trace!(
            sz,
            old = self.window_size.0,
            new = val,
            "inc_window"
        );
```
and
```rust
        tracing::trace!(
            sz,
            window = self.window_size.0,
            available = self.available.0,
            "send_data",
        );
```
result in `log` records like this:
```
TRACE 2019-12-05T18:26:56Z: h2::proto::streams::flow_control: inc_windowsz=65535 old=0 new=65535
TRACE 2019-12-05T18:26:56Z: h2::proto::streams::flow_control: inc_windowsz=65535 old=0 new=65535
TRACE 2019-12-05T18:26:56Z: h2::proto::streams::flow_control: inc_windowsz=65535 old=0 new=65535
TRACE 2019-12-05T18:26:56Z: h2::proto::streams::flow_control: send_datasz=16384 window=65535 available=65535
TRACE 2019-12-05T18:26:56Z: h2::proto::streams::flow_control: send_datasz=16384 window=65535 available=65535
TRACE 2019-12-05T18:26:56Z: h2::proto::streams::flow_control: send_datasz=16384 window=49151 available=49151
TRACE 2019-12-05T18:26:56Z: h2::proto::streams::flow_control: send_datasz=16384 window=49151 available=49151
TRACE 2019-12-05T18:26:56Z: h2::proto::streams::flow_control: send_datasz=10 window=32767 available=32767
TRACE 2019-12-05T18:26:56Z: h2::proto::streams::flow_control: inc_windowsz=32778 old=32757 new=65535
```

Note how the messages ("inc_window" and "send_data") appear concatenated
with the name of the next field ("sz").

## Solution

This branch adds the missing whitespace, fixing the issue.

Closes #459
