### PR TITLE
tracing: prepare to release 0.1.11

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 0.1.11 (December 20, 2019)
+
+### Added
+
+- `Span::is_none` method (#475)
+- `LevelFilter::into_level` method (#470)
+- `LevelFilter::from_level` function and `From<Level>` impl (#471)
+- Documented minimum supported Rust version (#482)
+
+### Fixed
+
+- Incorrect parameter type to `Span::follows_from` that made it impossible to
+  call (#467)
+- Missing whitespace in `log` records generated when enabling the `log` feature
+  flag (#484)
+- Typos and missing links in documentation (#405, #423, #439)
+
 # 0.1.10 (October 23, 2019)
 
 ### Added

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -29,7 +29,7 @@ edition = "2018"
 [dependencies]
 tracing-core = { version = "0.1.8", default-features = false }
 log = { version = "0.4", optional = true }
-tracing-attributes = "0.1.5"
+tracing-attributes = "0.1.6"
 cfg-if = "0.1.10"
 
 [dev-dependencies]

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -27,7 +27,7 @@ keywords = ["logging", "tracing", "metrics", "async"]
 edition = "2018"
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.8", default-features = false }
+tracing-core = { version = "0.1.8", default-features = false }
 log = { version = "0.4", optional = true }
 tracing-attributes = "0.1.5"
 cfg-if = "0.1.10"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -12,9 +12,9 @@ Application-level tracing for Rust.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.10
+[crates-url]: https://crates.io/crates/tracing/0.1.11
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.10
+[docs-url]: https://docs.rs/tracing/0.1.11
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -50,7 +50,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing = "0.1.10"
+tracing = "0.1.11"
 ```
 
 *Compiler support: requires rustc 1.39+*

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -591,7 +591,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing = { version = "0.1.10", default-features = false }
+//!   tracing = { version = "0.1.11", default-features = false }
 //!   ```
 //!
 //!   *Compiler support: requires rustc 1.39+*
@@ -623,7 +623,7 @@
 //! [static verbosity level]: level_filters/index.html#compile-time-filters
 //! [instrument]: https://docs.rs/tracing-attributes/latest/tracing_attributes/attr.instrument.html
 #![cfg_attr(not(feature = "std"), no_std)]
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.10")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.11")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
# 0.1.11 (December 20, 2019)

### Added

- `Span::is_none` method (#475)
- `LevelFilter::into_level` method (#470)
- `LevelFilter::from_level` function and `From<Level>` impl (#471)
- Documented minimum supported Rust version (#482)

### Fixed

- Incorrect parameter type to `Span::follows_from` that made it impossible to
  call (#467)
- Missing whitespace in `log` records generated when enabling the `log` feature
  flag (#484)
- Typos and missing links in documentation (#405, #423, #439)