### PR TITLE
tracing-subscriber: fix #489

### DIFF
--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -304,14 +304,14 @@ where
     /// Returns an Error if the initialization was unsuccessful, likely
     /// because a global subscriber was already installed by another
     /// call to `try_init`.
-    pub fn try_init(self) -> Result<(), impl Error + Send + Sync + 'static> {
-        #[cfg(feature = "tracing-log/std")]
+    pub fn try_init(self) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+        #[cfg(feature = "tracing-log")]
         tracing_log::LogTracer::init().map_err(Box::new)?;
 
         tracing_core::dispatcher::set_global_default(tracing_core::dispatcher::Dispatch::new(
             self.finish(),
-        ))
-        .map_err(Box::new)
+        ))?;
+        Ok(())
     }
 
     /// Install this Subscriber as the global default.
@@ -658,7 +658,7 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
 ///     https://docs.rs/tracing-log/0.1.0/tracing_log/struct.LogTracer.html
 /// [`RUST_LOG` environment variable]:
 ///     ../filter/struct.EnvFilter.html#associatedconstant.DEFAULT_ENV
-pub fn try_init() -> Result<(), impl Error + Send + Sync + 'static> {
+pub fn try_init() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     Subscriber::builder()
         .with_env_filter(crate::EnvFilter::from_default_env())
         .try_init()


### PR DESCRIPTION
Resolves #489.

To get this to compile, I had to change the error types from `impl Error + Send + Sync + 'static` to `Box<dyn Error + Send + Sync + 'static>`.

I verified the corrected behavior by running `cargo run --example log` which, prior to this change, wrote:
```
Dec 21 14:02:15.827  INFO log: this is a tracing line
```
After this change, the `log` example wrote:
```
Dec 21 14:15:20.490 DEBUG log: this is a log line
Dec 21 14:15:20.490 DEBUG log: this is a tracing line
```