### PR TITLE
Run clippy-check action on CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,9 +10,10 @@ jobs:
       matrix:
         rust: [stable, 1.39.0]
     steps:
-    - uses: hecrj/setup-rust-action@v1
+    - uses: actions-rs/toolchain@v1
       with:
-        rust-version: ${{ matrix.rust }}
+        toolchain: ${{ matrix.rust }}
+        components: clippy
     - uses: actions/checkout@master
     - name: Check
       run: cargo check --all --bins --examples --tests --benches
@@ -100,9 +101,9 @@ jobs:
       matrix:
         rust: [stable, beta, nightly, 1.39.0]
     steps:
-    - uses: hecrj/setup-rust-action@v1
+    - uses: actions-rs/toolchain@v1
       with:
-        rust-version: ${{ matrix.rust }}
+        toolchain: ${{ matrix.rust }}
     - uses: actions/checkout@master
     - name: Build
       run: cargo build
@@ -117,9 +118,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-    - uses: hecrj/setup-rust-action@v1
+    - uses: actions-rs/toolchain@v1
       with:
-        rust-version: stable
+        toolchain: stable
     - uses: actions/checkout@master
     - name: Build
       run: cargo build
@@ -131,9 +132,9 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: hecrj/setup-rust-action@v1
+    - uses: actions-rs/toolchain@v1
       with:
-        rust-version: stable
+        toolchain: stable
     - uses: actions/checkout@master
     - name: "Test log support"
       run: (cd tracing/test-log-support && cargo test)
@@ -151,9 +152,9 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: hecrj/setup-rust-action@v1
+    - uses: actions-rs/toolchain@v1
       with:
-        rust-version: nightly
+        toolchain: nightly
     - uses: actions/checkout@master
     - name: "Test tracing-futures std::future support"
       run: (cd tracing-futures/test_std_future && cargo test)
@@ -169,9 +170,10 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: hecrj/setup-rust-action@v1
+    - uses: actions-rs/toolchain@v1
       with:
-        rust-version: stable
+        toolchain: stable
+        components: rustfmt
     - uses: actions/checkout@master
     - name: rustfmt
       run: cargo fmt --all -- --check
@@ -181,9 +183,9 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: hecrj/setup-rust-action@v1
+    - uses: actions-rs/toolchain@v1
       with:
-        rust-version: stable
+        toolchain: stable
     - uses: actions/checkout@master
     - name: warnings
       run: RUSTFLAGS="-Dwarnings" cargo check --all

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
         components: clippy
+        profile: minimal
     - uses: actions/checkout@master
     - name: Check
       run: cargo check --all --bins --examples --tests --benches
@@ -104,6 +105,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
+        profile: minimal
     - uses: actions/checkout@master
     - name: Build
       run: cargo build
@@ -121,6 +123,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
+        profile: minimal
     - uses: actions/checkout@master
     - name: Build
       run: cargo build
@@ -135,6 +138,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
+        profile: minimal
     - uses: actions/checkout@master
     - name: "Test log support"
       run: (cd tracing/test-log-support && cargo test)
@@ -155,6 +159,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly
+        profile: minimal
     - uses: actions/checkout@master
     - name: "Test tracing-futures std::future support"
       run: (cd tracing-futures/test_std_future && cargo test)
@@ -174,6 +179,7 @@ jobs:
       with:
         toolchain: stable
         components: rustfmt
+        profile: minimal
     - uses: actions/checkout@master
     - name: rustfmt
       run: cargo fmt --all -- --check
@@ -186,6 +192,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
+        profile: minimal
     - uses: actions/checkout@master
     - name: warnings
       run: RUSTFLAGS="-Dwarnings" cargo check --all

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,6 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
-        components: clippy
         profile: minimal
     - uses: actions/checkout@master
     - name: Check
@@ -186,13 +185,16 @@ jobs:
 
   warnings:
     # Check for any warnings. This is informational and thus is allowed to fail.
-    needs: check
     runs-on: ubuntu-latest
     steps:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
+        components: clippy
         profile: minimal
     - uses: actions/checkout@master
-    - name: warnings
-      run: RUSTFLAGS="-Dwarnings" cargo check --all
+    - name: Clippy
+      uses: actions-rs/clippy-check@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: --all --bins --examples --tests --benches -- -D warnings

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -95,7 +95,6 @@ use syn::{
 ///     tracing::info!("inside my_function!");
 ///     // ...
 /// }
-/// # fn main() {}
 /// ```
 /// Setting the level for the generated span:
 /// ```
@@ -104,7 +103,6 @@ use syn::{
 /// pub fn my_function() {
 ///     // ...
 /// }
-/// # fn main() {}
 /// ```
 /// Overriding the generated span's target:
 /// ```
@@ -113,7 +111,6 @@ use syn::{
 /// pub fn my_function() {
 ///     // ...
 /// }
-/// # fn main() {}
 /// ```
 ///
 /// To skip recording an argument, pass the argument's name to the `skip`:
@@ -126,7 +123,6 @@ use syn::{
 /// fn my_function(arg: usize, non_debug: NonDebug) {
 ///     // ...
 /// }
-/// # fn main() {}
 /// ```
 ///
 /// If `tracing_futures` is specified as a dependency in `Cargo.toml`,
@@ -139,7 +135,6 @@ use syn::{
 ///     // ...
 ///     # Ok(())
 /// }
-/// # fn main() {}
 /// ```
 ///
 /// [span]: https://docs.rs/tracing/0.1.6/tracing/span/index.html

--- a/tracing-attributes/test_async_await/tests/async_fn.rs
+++ b/tracing-attributes/test_async_await/tests/async_fn.rs
@@ -1,5 +1,3 @@
-#![feature(async_await)]
-
 use test_std_future::{
     PollN,
     block_on_future,

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -38,12 +38,10 @@
 //! #   fn exit(&self, _: &Id) {}
 //! # }
 //! # impl FooSubscriber { fn new() -> Self { FooSubscriber } }
-//! # fn main() {
 //! use dispatcher::Dispatch;
 //!
 //! let my_subscriber = FooSubscriber::new();
 //! let my_dispatch = Dispatch::new(my_subscriber);
-//! # }
 //! ```
 //! Then, we can use [`with_default`] to set our `Dispatch` as the default for
 //! the duration of a block:
@@ -63,7 +61,6 @@
 //! #   fn exit(&self, _: &Id) {}
 //! # }
 //! # impl FooSubscriber { fn new() -> Self { FooSubscriber } }
-//! # fn main() {
 //! # let my_subscriber = FooSubscriber::new();
 //! # let my_dispatch = dispatcher::Dispatch::new(my_subscriber);
 //! // no default subscriber
@@ -74,7 +71,6 @@
 //! });
 //!
 //! // no default subscriber again
-//! # }
 //! ```
 //! It's important to note that `with_default` will not propagate the current
 //! thread's default subscriber to any threads spawned within the `with_default`
@@ -100,7 +96,6 @@
 //! #   fn exit(&self, _: &Id) {}
 //! # }
 //! # impl FooSubscriber { fn new() -> Self { FooSubscriber } }
-//! # fn main() {
 //! # let my_subscriber = FooSubscriber::new();
 //! # let my_dispatch = dispatcher::Dispatch::new(my_subscriber);
 //! // no default subscriber
@@ -111,7 +106,6 @@
 //!     .expect("global default was already set!");
 //!
 //! // `my_subscriber` is now the default
-//! # }
 //! ```
 //!
 //! **Note**: the thread-local scoped dispatcher (`with_default`) requires the
@@ -258,7 +252,7 @@ pub fn set_global_default(dispatcher: Dispatch) -> Result<(), SetGlobalDefaultEr
     if GLOBAL_INIT.compare_and_swap(UNINITIALIZED, INITIALIZING, Ordering::SeqCst) == UNINITIALIZED
     {
         unsafe {
-            GLOBAL_DISPATCH = Some(dispatcher.clone());
+            GLOBAL_DISPATCH = Some(dispatcher);
         }
         GLOBAL_INIT.store(INITIALIZED, Ordering::SeqCst);
         EXISTS.store(true, Ordering::Release);

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -102,7 +102,6 @@ pub struct Iter {
 /// # extern crate tracing_core as tracing;
 /// use std::fmt::{self, Write};
 /// use tracing::field::{Value, Visit, Field};
-/// # fn main() {
 /// pub struct StringVisitor<'a> {
 ///     string: &'a mut String,
 /// }
@@ -112,7 +111,6 @@ pub struct Iter {
 ///         write!(self.string, "{} = {:?}; ", field.name(), value).unwrap();
 ///     }
 /// }
-/// # }
 /// ```
 /// This visitor will format each recorded value using `fmt::Debug`, and
 /// append the field name and formatted value to the provided string,
@@ -135,7 +133,6 @@ pub struct Iter {
 /// # extern crate tracing_core as tracing;
 /// # use std::fmt::{self, Write};
 /// # use tracing::field::{Value, Visit, Field};
-/// # fn main() {
 /// pub struct SumVisitor {
 ///     sum: i64,
 /// }
@@ -153,7 +150,6 @@ pub struct Iter {
 ///         // Do nothing
 ///     }
 /// }
-/// # }
 /// ```
 ///
 /// This visitor (which is probably not particularly useful) keeps a running

--- a/tracing-subscriber/src/field/mod.rs
+++ b/tracing-subscriber/src/field/mod.rs
@@ -81,7 +81,6 @@ pub trait VisitOutput<Out>: Visit {
 ///     let mut visitor = MyVisitor::new();
 ///     r.record(&mut visitor);
 /// }
-/// # fn main() {}
 /// ```
 /// [visitor]: https://docs.rs/tracing-core/latest/tracing_core/field/trait.Visit.html
 /// [attr]: https://docs.rs/tracing-core/latest/tracing_core/span/struct.Attributes.html

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -139,10 +139,8 @@ impl EnvFilter {
     /// # Examples
     /// ```rust
     /// use tracing_subscriber::filter::{EnvFilter, LevelFilter};
-    /// # fn main() {
     /// let mut filter = EnvFilter::from_default_env()
     ///     .add_directive(LevelFilter::INFO.into());
-    /// # }
     /// ```
     /// ```rust
     /// use tracing_subscriber::filter::{EnvFilter, Directive};
@@ -153,7 +151,6 @@ impl EnvFilter {
     ///     .add_directive("my_crate::my_other_module::something=info".parse()?);
     /// # Ok(())
     /// # }
-    /// # fn main() {}
     /// ```
     pub fn add_directive(mut self, directive: Directive) -> Self {
         if let Some(stat) = directive.to_static() {

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -200,7 +200,6 @@ where
     /// ```rust
     /// # use tracing_subscriber::layer::Layer;
     /// # use tracing_core::Subscriber;
-    /// # fn main() {
     /// pub struct FooLayer {
     ///     // ...
     /// }
@@ -243,7 +242,6 @@ where
     /// let subscriber = FooLayer::new()
     ///     .and_then(BarLayer::new())
     ///     .with_subscriber(MySubscriber::new());
-    /// # }
     /// ```
     ///
     /// Multiple layers may be composed in this manner:
@@ -251,7 +249,6 @@ where
     /// ```rust
     /// # use tracing_subscriber::layer::Layer;
     /// # use tracing_core::Subscriber;
-    /// # fn main() {
     /// # pub struct FooLayer {}
     /// # pub struct BarLayer {}
     /// # pub struct MySubscriber {}
@@ -289,7 +286,6 @@ where
     ///     .and_then(BarLayer::new())
     ///     .and_then(BazLayer::new())
     ///     .with_subscriber(MySubscriber::new());
-    /// # }
     /// ```
     fn and_then<L>(self, layer: L) -> Layered<L, Self, S>
     where
@@ -313,7 +309,6 @@ where
     /// ```rust
     /// # use tracing_subscriber::layer::Layer;
     /// # use tracing_core::Subscriber;
-    /// # fn main() {
     /// pub struct FooLayer {
     ///     // ...
     /// }
@@ -344,7 +339,6 @@ where
     /// # }
     /// let subscriber = FooLayer::new()
     ///     .with_subscriber(MySubscriber::new());
-    /// # }
     ///```
     ///
     /// [`Subscriber`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -16,7 +16,6 @@
 //! ```rust
 //! use tracing_subscriber::{registry::Registry, Layer};
 //! # use tracing_core::Subscriber;
-//! # fn main() {
 //! # pub struct FooLayer {}
 //! # pub struct BarLayer {}
 //! # impl<S: Subscriber> Layer<S> for FooLayer {}
@@ -31,7 +30,6 @@
 //! let subscriber = FooLayer::new()
 //!     .and_then(BarLayer::new())
 //!     .with_subscriber(Registry::default());
-//! # }
 //! ```
 //!
 //! If a type implementing `Layer` depends on the functionality of a `Registry`
@@ -42,7 +40,6 @@
 //! use tracing_subscriber::{registry, Layer};
 //! use tracing_core::Subscriber;
 //!
-//! # fn main() {
 //! pub struct MyLayer {
 //!     // ...
 //! }
@@ -53,7 +50,6 @@
 //! {
 //!     // ...
 //! }
-//! # }
 //! ```
 //! When this bound is added, the `Layer` implementation will be guaranteed
 //! access to the [`Context`][ctx] methods, such as [`Context::span`][lookup], that

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -29,15 +29,11 @@
 //!
 //! For example:
 //! ```rust
-//! #[macro_use]
-//! extern crate tracing;
-//! use tracing::Level;
+//! use tracing::{span, Level};
 //!
-//! # fn main() {
 //! /// Construct a new span at the `INFO` level named "my_span", with a single
 //! /// field named answer , with the value `42`.
 //! let my_span = span!(Level::INFO, "my_span", answer = 42);
-//! # }
 //! ```
 //!
 //! The documentation for the [`span!`] macro provides additional examples of
@@ -71,7 +67,6 @@
 //! ```
 //! # #[macro_use] extern crate tracing;
 //! # use tracing::Level;
-//! # fn main() {
 //! let my_var: u64 = 5;
 //! let my_span = span!(Level::TRACE, "my_span", my_var);
 //!
@@ -82,7 +77,6 @@
 //!
 //! // Perform some work inside of the context of `my_span`...
 //! // Dropping the `_enter` guard will exit the span.
-//! # }
 //!```
 //!
 //! `in_scope` takes a closure or function pointer and executes it inside the
@@ -90,7 +84,6 @@
 //! ```
 //! # #[macro_use] extern crate tracing;
 //! # use tracing::Level;
-//! # fn main() {
 //! let my_var: u64 = 5;
 //! let my_span = span!(Level::TRACE, "my_span", my_var = &my_var);
 //!
@@ -103,7 +96,6 @@
 //! my_span.in_scope(|| {
 //!     // Perform some more work in the context of `my_span`.
 //! });
-//! # }
 //! ```
 //!
 //! **Note:** Since entering a span takes `&self`, and `Span`s are `Clone`,
@@ -122,7 +114,6 @@
 //! ```
 //! # #[macro_use] extern crate tracing;
 //! # use tracing::Level;
-//! # fn main() {
 //! // this span is considered the "root" of a new trace tree:
 //! span!(Level::INFO, "root").in_scope(|| {
 //!     // since we are now inside "root", this span is considered a child
@@ -136,7 +127,6 @@
 //!     });
 //!     // another span created here would also be a child of "root".
 //! });
-//! # }
 //!```
 //!
 //! In addition, the parent of a span may be explicitly specified in
@@ -145,7 +135,6 @@
 //! ```rust
 //! # #[macro_use] extern crate tracing;
 //! # use tracing::Level;
-//! # fn main() {
 //! // Create, but do not enter, a span called "foo".
 //! let foo = span!(Level::INFO, "foo");
 //!
@@ -156,7 +145,6 @@
 //! // Although we have currently entered "bar", "baz"'s parent span
 //! // will be "foo".
 //! let baz = span!(parent: &foo, Level::INFO, "baz");
-//! # }
 //! ```
 //!
 //! A child span should typically be considered _part_ of its parent. For
@@ -231,7 +219,6 @@
 //! ```
 //! # #[macro_use] extern crate tracing;
 //! # use tracing::Level;
-//! # fn main() {
 //! {
 //!     span!(Level::TRACE, "my_span").in_scope(|| {
 //!         // perform some work in the context of `my_span`...
@@ -241,7 +228,6 @@
 //!     // dropped, the subscriber will be informed via `drop_span`.
 //!
 //! } // --> Subscriber::drop_span(my_span)
-//! # }
 //! ```
 //!
 //! However, if multiple handles exist, the span can still be re-entered even if
@@ -267,7 +253,6 @@
 //! ```rust
 //! # #[macro_use] extern crate tracing;
 //! # use tracing::Level;
-//! # fn main() {
 //! # let n = 1;
 //! let span = span!(Level::TRACE, "my_loop");
 //! let _enter = span.enter();
@@ -275,20 +260,17 @@
 //!     # let _ = i;
 //!     // ...
 //! }
-//! # }
 //! ```
 //! Or, should we create a new span for each iteration of the loop, as in:
 //! ```rust
 //! # #[macro_use] extern crate tracing;
 //! # use tracing::Level;
-//! # fn main() {
 //! # let n = 1u64;
 //! for i in 0..n {
 //!     let span = span!(Level::TRACE, "my_loop", iteration = i);
 //!     let _enter = span.enter();
 //!     // ...
 //! }
-//! # }
 //! ```
 //!
 //! Depending on the circumstances, we might want to do either, or both. For
@@ -523,7 +505,6 @@ impl Span {
     /// ```
     /// #[macro_use] extern crate tracing;
     /// # use tracing::Level;
-    /// # fn main() {
     /// let span = span!(Level::INFO, "my_span");
     /// let guard = span.enter();
     ///
@@ -533,14 +514,12 @@ impl Span {
     ///
     /// // code here is no longer within the span
     ///
-    /// # }
     /// ```
     ///
     /// Guards need not be explicitly dropped:
     ///
     /// ```
     /// #[macro_use] extern crate tracing;
-    /// # fn main() {
     /// fn my_function() -> String {
     ///     // enter a span for the duration of this function.
     ///     let span = trace_span!("my_function");
@@ -556,7 +535,6 @@ impl Span {
     /// fn my_other_function() {
     ///     // ...
     /// }
-    /// # }
     /// ```
     ///
     /// Sub-scopes may be created to limit the duration for which the span is
@@ -564,7 +542,6 @@ impl Span {
     ///
     /// ```
     /// #[macro_use] extern crate tracing;
-    /// # fn main() {
     /// let span = info_span!("my_great_span");
     ///
     /// {
@@ -578,7 +555,6 @@ impl Span {
     ///
     /// // this event is not inside the span.
     /// info!("i'm outside the span!")
-    /// # }
     /// ```
     ///
     /// [`Subscriber::enter`]: ../subscriber/trait.Subscriber.html#method.enter
@@ -612,7 +588,6 @@ impl Span {
     /// ```
     /// # #[macro_use] extern crate tracing;
     /// # use tracing::Level;
-    /// # fn main() {
     /// let my_span = span!(Level::TRACE, "my_span");
     ///
     /// my_span.in_scope(|| {
@@ -622,23 +597,19 @@ impl Span {
     ///
     /// // this event occurs outside the span.
     /// trace!("i'm not in the span!");
-    /// # }
     /// ```
     ///
     /// Calling a function and returning the result:
     /// ```
-    /// # #[macro_use] extern crate tracing;
-    /// # use tracing::Level;
+    /// # use tracing::{info_span, Level};
     /// fn hello_world() -> String {
     ///     "Hello world!".to_owned()
     /// }
     ///
-    /// # fn main() {
     /// let span = info_span!("hello_world");
     /// // the span will be entered for the duration of the call to
     /// // `hello_world`.
     /// let a_string = span.in_scope(hello_world);
-    /// # }
     ///
     pub fn in_scope<F: FnOnce() -> T, T>(&self, f: F) -> T {
         let _enter = self.enter();
@@ -745,40 +716,32 @@ impl Span {
     /// Setting a `follows_from` relationship with a `Span`:
     /// ```
     /// # use tracing::{span, Id, Level, Span};
-    /// # fn main() {
     /// let span1 = span!(Level::INFO, "span_1");
     /// let span2 = span!(Level::DEBUG, "span_2");
     /// span2.follows_from(span1);
-    /// # }
     /// ```
     ///
     /// Setting a `follows_from` relationship with the current span:
     /// ```
     /// # use tracing::{span, Id, Level, Span};
-    /// # fn main() {
     /// let span = span!(Level::INFO, "hello!");
     /// span.follows_from(Span::current());
-    /// # }
     /// ```
     ///
     /// Setting a `follows_from` relationship with a `Span` reference:
     /// ```
     /// # use tracing::{span, Id, Level, Span};
-    /// # fn main() {
     /// let span = span!(Level::INFO, "hello!");
     /// let curr = Span::current();
     /// span.follows_from(&curr);
-    /// # }
     /// ```
     ///
     /// Setting a `follows_from` relationship with an `Id`:
     /// ```
     /// # use tracing::{span, Id, Level, Span};
-    /// # fn main() {
     /// let span = span!(Level::INFO, "hello!");
     /// let id = span.id();
     /// span.follows_from(id);
-    /// # }
     /// ```
     pub fn follows_from(&self, from: impl Into<Option<Id>>) -> &Self {
         if let Some(ref inner) = self.inner {

--- a/tracing/tests/span.rs
+++ b/tracing/tests/span.rs
@@ -188,6 +188,8 @@ fn cloning_a_span_calls_clone_span() {
         .run_with_handle();
     with_default(subscriber, || {
         let span = span!(Level::TRACE, "foo");
+        // Allow the "redundant" `.clone` since it is used to call into the `.clone_span` hook.
+        #[allow(clippy::redundant_clone)]
         let _span2 = span.clone();
     });
 


### PR DESCRIPTION
This is a follow up draft PR for #477 that runs clippy on CI. It is not using [actions-rs/clippy-check](https://github.com/actions-rs/clippy-check) yet but I will switch over to that shortly.

I've created this as a draft because it looks like there are some additional clippy warnings that will need to be fixed first.

I've also just replaced the `check` step with `clippy` since running both would be a little redundant (`cargo clippy` runs `cargo check` already). However, I can change this if you'd like to keep them separate.