### PR TITLE
core: no thread_local support for global dispatcher

### DIFF
--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -35,3 +35,4 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 lazy_static = { version = "1", optional = true }
+lock_api = "0.3"

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -27,7 +27,7 @@ keywords = ["logging", "tracing", "metrics", "async"]
 edition = "2018"
 
 [dependencies]
-tracing-core = { version = "0.1.8", default-features = false }
+tracing-core = { version = "0.1.8", default-features = false, path = "../tracing-core" }
 log = { version = "0.4", optional = true }
 tracing-attributes = "0.1.6"
 cfg-if = "0.1.10"


### PR DESCRIPTION
## Motivation
Some embedded platform do not have support for thread_local.

## Solution
I believe it's okay to use a `static mut` var instead. This is hidden behind an
`unsafe_global` feature.