### PR TITLE
futures: no_std support

### DIFF
--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -18,17 +18,18 @@ keywords = ["logging", "profiling", "tracing", "futures", "async"]
 license = "MIT"
 
 [features]
-default = ["std-future"]
+default = ["std-future", "std"]
 futures-01 = ["futures_01"]
 futures-03 = ["std-future", "futures", "futures-task"]
 std-future = ["pin-project"]
+std = ["tracing/std"]
 
 [dependencies]
 futures_01 = { package = "futures", version = "0.1", optional = true }
 futures = { version = "0.3.0", optional = true }
 futures-task = { version = "0.3", optional = true }
 pin-project = { version = "0.4", optional = true }
-tracing = "0.1"
+tracing = { version = "0.1", default-features = false, path = "../tracing" }
 tokio-executor = { version = "0.1", optional = true }
 tokio = { version = "0.1", optional = true }
 

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -29,7 +29,7 @@ futures_01 = { package = "futures", version = "0.1", optional = true }
 futures = { version = "0.3.0", optional = true }
 futures-task = { version = "0.3", optional = true }
 pin-project = { version = "0.4", optional = true }
-tracing = { version = "0.1", default-features = false, path = "../tracing" }
+tracing = { version = "0.1", default-features = false }
 tokio-executor = { version = "0.1", optional = true }
 tokio = { version = "0.1", optional = true }
 

--- a/tracing-futures/src/executor/futures_03.rs
+++ b/tracing-futures/src/executor/futures_03.rs
@@ -1,9 +1,9 @@
+use crate::stdlib::future::Future;
 use crate::{Instrument, Instrumented, WithDispatch};
 use futures_task::{
     future::FutureObj,
     task::{LocalSpawn, Spawn, SpawnError},
 };
-use std::future::Future;
 
 impl<T> Spawn for Instrumented<T>
 where

--- a/tracing-futures/src/executor/futures_preview.rs
+++ b/tracing-futures/src/executor/futures_preview.rs
@@ -1,9 +1,9 @@
+use crate::stdlib::future::Future;
 use crate::{Instrument, Instrumented, WithDispatch};
 use futures_core_preview::{
     future::FutureObj,
     task::{LocalSpawn, Spawn, SpawnError},
 };
-use std::future::Future;
 
 impl<T> Spawn for Instrumented<T>
 where

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -168,6 +168,7 @@ pub trait Instrument: Sized {
 /// a `tracing` [`Subscriber`].
 ///
 /// [`Subscriber`]: https://docs.rs/tracing/0.1.9/tracing/subscriber/trait.Subscriber.html
+#[cfg(feature = "std")]
 pub trait WithSubscriber: Sized {
     /// Attaches the provided [`Subscriber`] to this type, returning a
     /// `WithDispatch` wrapper.
@@ -225,6 +226,7 @@ pub struct Instrumented<T> {
 
 /// A future, stream, sink, or executor that has been instrumented with a
 /// `tracing` subscriber.
+#[cfg(feature = "std")]
 #[cfg_attr(feature = "std-future", pin_project)]
 #[derive(Clone, Debug)]
 pub struct WithDispatch<T> {
@@ -317,9 +319,10 @@ impl<T> Instrumented<T> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<T: Sized> WithSubscriber for T {}
 
-#[cfg(feature = "futures-01")]
+#[cfg(all(feature = "futures-01", feature = "std"))]
 impl<T: futures_01::Future> futures_01::Future for WithDispatch<T> {
     type Item = T::Item;
     type Error = T::Error;
@@ -330,7 +333,7 @@ impl<T: futures_01::Future> futures_01::Future for WithDispatch<T> {
     }
 }
 
-#[cfg(feature = "std-future")]
+#[cfg(all(feature = "std-future", feature = "std"))]
 impl<T: crate::stdlib::future::Future> crate::stdlib::future::Future for WithDispatch<T> {
     type Output = T::Output;
 
@@ -342,6 +345,7 @@ impl<T: crate::stdlib::future::Future> crate::stdlib::future::Future for WithDis
     }
 }
 
+#[cfg(feature = "std")]
 impl<T> WithDispatch<T> {
     #[cfg(any(feature = "tokio", feature = "tokio-alpha", feature = "futures-03"))]
     pub(crate) fn with_dispatch<U: Sized>(&self, inner: U) -> WithDispatch<U> {

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -37,8 +37,16 @@
 //!   crate's `Spawn` and `LocalSpawn` traits.
 //! - `tokio-alpha`: Enables compatibility with `tokio` 0.2's alpha releases,
 //!   including the `tokio` 0.2 `Executor` and `TypedExecutor` traits.
+//! - `std`: Depend on the Rust standard library.
 //!
-//! The `tokio` and `std-future` features are enabled by default.
+//!   `no_std` users may disable this feature with `default-features = false`:
+//!
+//!   ```toml
+//!   [dependencies]
+//!   tracing-futures = { version = "0.2", default-features = false }
+//!   ```
+//!
+//! The `tokio`, `std-future` and `std` features are enabled by default.
 //!
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [span]: https://docs.rs/tracing/0.1.9/tracing/span/index.html

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -72,10 +72,14 @@
     unused_parens,
     while_true
 )]
+#![cfg_attr(not(feature = "std"), no_std)]
 #[cfg(feature = "std-future")]
 use pin_project::pin_project;
+
+pub(crate) mod stdlib;
+
 #[cfg(feature = "std-future")]
-use std::{pin::Pin, task::Context};
+use crate::stdlib::{pin::Pin, task::Context};
 
 #[cfg(feature = "futures-01")]
 use futures_01::{Sink, StartSend, Stream};
@@ -236,10 +240,10 @@ pub struct WithDispatch<T> {
 impl<T: Sized> Instrument for T {}
 
 #[cfg(feature = "std-future")]
-impl<T: std::future::Future> std::future::Future for Instrumented<T> {
+impl<T: crate::stdlib::future::Future> crate::stdlib::future::Future for Instrumented<T> {
     type Output = T::Output;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> std::task::Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> crate::stdlib::task::Poll<Self::Output> {
         let this = self.project();
         let _enter = this.span.enter();
         this.inner.poll(cx)
@@ -327,10 +331,10 @@ impl<T: futures_01::Future> futures_01::Future for WithDispatch<T> {
 }
 
 #[cfg(feature = "std-future")]
-impl<T: std::future::Future> std::future::Future for WithDispatch<T> {
+impl<T: crate::stdlib::future::Future> crate::stdlib::future::Future for WithDispatch<T> {
     type Output = T::Output;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> std::task::Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> crate::stdlib::task::Poll<Self::Output> {
         let this = self.project();
         let dispatch = this.dispatch;
         let future = this.inner;

--- a/tracing-futures/src/stdlib.rs
+++ b/tracing-futures/src/stdlib.rs
@@ -1,0 +1,44 @@
+//! Re-exports either the Rust `std` library or `core` and `alloc` when `std` is
+//! disabled.
+//!
+//! `crate::stdlib::...` should be used rather than `std::` when adding code that
+//! will be available with the standard library disabled.
+//!
+//! Note that this module is called `stdlib` rather than `std`, as Rust 1.34.0
+//! does not permit redefining the name `stdlib` (although this works on the
+//! latest stable Rust).
+#[cfg(feature = "std")]
+pub(crate) use std::*;
+
+#[cfg(not(feature = "std"))]
+pub(crate) use self::no_std::*;
+
+#[cfg(not(feature = "std"))]
+mod no_std {
+    // We pre-emptively export everything from libcore/liballoc, (even modules
+    // we aren't using currently) to make adding new code easier. Therefore,
+    // some of these imports will be unused.
+    #![allow(unused_imports)]
+
+    pub(crate) use core::{
+        any, array, ascii, cell, char, clone, cmp, convert, default, f32, f64, ffi, future, hash,
+        hint, i128, i16, i8, isize, iter, marker, mem, num, ops, option, pin, ptr, result, task,
+        time, u128, u16, u32, u8, usize,
+    };
+
+    pub(crate) mod borrow {
+        pub(crate) use core::borrow::*;
+    }
+
+    pub(crate) mod fmt {
+        pub(crate) use core::fmt::*;
+    }
+
+    pub(crate) mod slice {
+        pub(crate) use core::slice::*;
+    }
+
+    pub(crate) mod str {
+        pub(crate) use core::str::*;
+    }
+}


### PR DESCRIPTION
## Motivation

Being able to trace futures in platforms that do not support stdlib would be nice.

## Solution
