### PR TITLE
subscriber: Fixup compilation error with features disabled

### DIFF
--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -839,6 +839,7 @@ impl<'a, S: Subscriber> Context<'a, S> {
     ///
     /// [stored data]: ../registry/struct.SpanRef.html
     /// [`LookupSpan`]: ../registry/trait.LookupSpan.html
+    #[cfg(feature = "registry")]
     pub fn scope(&self) -> Scope<'_, S>
     where
         S: for<'lookup> registry::LookupSpan<'lookup>,


### PR DESCRIPTION
This fixes the following compilation error:
```
error[E0433]: failed to resolve: use of undeclared type or module `registry`
   --> tracing-subscriber/src/layer.rs:844:25
    |
844 |         S: for<'lookup> registry::LookupSpan<'lookup>,
    |                         ^^^^^^^^ use of undeclared type or module `registry`

error[E0412]: cannot find type `Scope` in this scope
   --> tracing-subscriber/src/layer.rs:842:28
    |
842 |     pub fn scope(&self) -> Scope<'_, S>
    |                            ^^^^^ not found in this scope

error[E0425]: cannot find function, tuple struct or tuple variant `Scope` in this scope
   --> tracing-subscriber/src/layer.rs:850:9
    |
850 |         Scope(scope)
    |         ^^^^^ help: a local variable with a similar name exists (notice the capitalization): `scope`
```
