### PR TITLE
ci: try cargo-hack

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,18 @@ jobs:
     - name: Check
       run: cargo check --all --bins --examples --tests --benches
 
+  cargo-hack:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: stable 
+    - uses: actions/checkout@master
+    - name: install cargo-hack
+      run: cargo install cargo-hack
+    - name: cargo hack check --all
+      run: cargo hack check --feature-powerset --no-dev-deps --all
+
   test-versions:
     # Test against the stable, beta, and nightly Rust toolchains on ubuntu-latest.
     needs: check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,15 +19,32 @@ jobs:
 
   cargo-hack:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # cargo hack --feature-powerset will have a significant permutation
+        # number, we can't just use --all as it increases the runtime
+        # further than what we would like to
+        subcrate:
+        - tracing
+        - tracing-attributes
+        - tracing-core
+        - tracing-fmt
+        - tracing-futures
+        - tracing-log
+        - tracing-macros
+        - tracing-serde
+        - tracing-subscriber
+        - tracing-tower
     steps:
     - uses: hecrj/setup-rust-action@v1
       with:
-        rust-version: stable 
+        rust-version: stable
     - uses: actions/checkout@master
     - name: install cargo-hack
       run: cargo install cargo-hack
-    - name: cargo hack check --all
-      run: cargo hack check --feature-powerset --no-dev-deps --all
+    - name: cargo hack check
+      working-directory: ${{ matrix.subcrate }}
+      run: cargo hack check --feature-powerset --no-dev-deps
 
   test-versions:
     # Test against the stable, beta, and nightly Rust toolchains on ubuntu-latest.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,16 +25,17 @@ jobs:
         # number, we can't just use --all as it increases the runtime
         # further than what we would like to
         subcrate:
-        - tracing
         - tracing-attributes
         - tracing-core
-        - tracing-fmt
         - tracing-futures
         - tracing-log
         - tracing-macros
         - tracing-serde
-        - tracing-subscriber
         - tracing-tower
+        # tracing and tracing-subscriber have too many features to be checked by
+        # cargo-hack --feature-powerset, combinatorics there is exploding.
+        #- tracing
+        #- tracing-subscriber
     steps:
     - uses: hecrj/setup-rust-action@v1
       with:
@@ -45,6 +46,51 @@ jobs:
     - name: cargo hack check
       working-directory: ${{ matrix.subcrate }}
       run: cargo hack check --feature-powerset --no-dev-deps
+
+  cargo-check-tracing:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        featureset:
+        - ""
+        - async-await
+        - async-await std
+        - async-await log-always
+        - async-await std log-always
+        - log-always
+        - std log-always
+        - std
+    steps:
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: stable
+    - uses: actions/checkout@master
+    - name: cargo check
+      working-directory: tracing
+      run: cargo check --no-default-features --features "${{ matrix.featureset }}"
+
+  cargo-check-subscriber:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        featureset:
+        - ""
+        - fmt
+        - fmt ansi
+        - fmt json
+        - fmt json ansi
+        - fmt registry
+        - fmt env-filter
+        - registry
+        - env-filter
+    steps:
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: stable
+    - uses: actions/checkout@master
+    - name: cargo check
+      working-directory: tracing-subscriber
+      run: cargo check --no-default-features --features "${{ matrix.featureset }}"
 
   test-versions:
     # Test against the stable, beta, and nightly Rust toolchains on ubuntu-latest.


### PR DESCRIPTION
Fixes #501

## Motivation

I've found multiple compilation error involving non-default features.

## Solution

cargo-hack was a suggested solution (by @davidbarsky and @hawkw) to run compilation checks on all features.
