### PR TITLE
add with_subscriber to span

### DIFF
--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -821,6 +821,12 @@ impl Span {
             }
         }
     }
+
+
+    /// Run the provided function with this span's id and dispatcher, if this span is active.
+    pub fn with_subscriber<T>(&self, f: impl FnOnce((&Id, &Dispatch)) -> T) -> Option<T> {
+        self.inner.as_ref().map( |inner| f((&inner.id, &inner.subscriber)) )
+    }
 }
 
 impl cmp::PartialEq for Span {

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -823,7 +823,11 @@ impl Span {
     }
 
 
-    /// Run the provided function with this span's id and dispatcher, if this span is active.
+    /// Invokes a function with a reference to this span's ID and subscriber.
+    ///
+    /// if this span is enabled, the provided function is called, and the result is returned. 
+    /// If the span is disabled, the function is not called, and this method returns `None` 
+    /// instead. 
     pub fn with_subscriber<T>(&self, f: impl FnOnce((&Id, &Dispatch)) -> T) -> Option<T> {
         self.inner.as_ref().map( |inner| f((&inner.id, &inner.subscriber)) )
     }

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -822,14 +822,15 @@ impl Span {
         }
     }
 
-
     /// Invokes a function with a reference to this span's ID and subscriber.
     ///
-    /// if this span is enabled, the provided function is called, and the result is returned. 
-    /// If the span is disabled, the function is not called, and this method returns `None` 
-    /// instead. 
+    /// if this span is enabled, the provided function is called, and the result is returned.
+    /// If the span is disabled, the function is not called, and this method returns `None`
+    /// instead.
     pub fn with_subscriber<T>(&self, f: impl FnOnce((&Id, &Dispatch)) -> T) -> Option<T> {
-        self.inner.as_ref().map( |inner| f((&inner.id, &inner.subscriber)) )
+        self.inner
+            .as_ref()
+            .map(|inner| f((&inner.id, &inner.subscriber)))
     }
 }
 


### PR DESCRIPTION
Intended to allow library authors to access a span's dispatcher for out-of-band interaction with subscribers/layers. 

see #473 for details

Closes #473 