### PR TITLE
docs: add third-party crates to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ The crates included as part of Tracing are:
 [sub-crates]: https://crates.io/crates/tracing-subscriber
 [sub-docs]: https://docs.rs/tracing-subscriber
 
-
 ## Related Crates
 
 In addition to this repository, here are also several third-party crates which
@@ -127,7 +126,7 @@ please let us know!)
 [`tracing-timing`]: https://crates.io/crates/tracing-timing
 [`tracing-opentelemetry`]: https://crates.io/crates/tracing-opentelemetry
 [OpenTelemetry]: https://opentelemetry.io/
-[`tracing-opentelemetry`]: https://crates.io/crates/honeycomb-tracing
+[`tracing-honeycomb`]: https://crates.io/crates/honeycomb-tracing
 [honeycomb.io]: https://www.honeycomb.io/
 [`tracing-actix]: https://crates.io/crates/tracing-actix
 [`tracing-gelf`]: https://crates.io/crates/tracing-gelf

--- a/README.md
+++ b/README.md
@@ -101,6 +101,43 @@ The crates included as part of Tracing are:
 [sub-crates]: https://crates.io/crates/tracing-subscriber
 [sub-docs]: https://docs.rs/tracing-subscriber
 
+
+## Related Crates
+
+In addition to this repository, here are also several third-party crates which
+are not maintained by the `tokio` project. These include:
+
+- [`tracing-timing`] implements inter-event timing metrics on top of `tracing`.
+  It provides a subscriber that records the time elapsed between pairs of
+  `tracing` events and generates histograms.
+- [`tracing-opentelemetry`] provides a subscriber for emitting traces to
+  [OpenTelemetry]-compatible distributed tracing systems.
+- [`tracing-honeycomb`] implements a subscriber for reporting traces to
+  [honeycomb.io].
+- [`tracing-actix`] provides `tracing` integration for the `actix` actor
+  framework.
+- [`tracing-gelf`] implements a subscriber for exporting traces in Greylog
+  GELF format.
+- [`tracing-coz`] provides integration with the [coz] causal profiler
+  (Linux-only).
+
+(if you're the maintainer of a `tracing` ecosystem crate not in this list,
+please let us know!)
+
+[`tracing-timing`]: https://crates.io/crates/tracing-timing
+[`tracing-opentelemetry`]: https://crates.io/crates/tracing-opentelemetry
+[OpenTelemetry]: https://opentelemetry.io/
+[`tracing-opentelemetry`]: https://crates.io/crates/honeycomb-tracing
+[honeycomb.io]: https://www.honeycomb.io/
+[`tracing-actix]: https://crates.io/crates/tracing-actix
+[`tracing-gelf`]: https://crates.io/crates/tracing-gelf
+[`tracing-coz`]: https://crates.io/crates/tracing-coz
+[coz]: https://github.com/plasma-umass/coz
+
+**Note:** that some of the ecosystem crates are currently unreleased and
+undergoing active development. They may be less stable than `tracing` and
+`tracing-core`.
+
 ## External Resources
 
 This is a list of links to blog posts, conference talks, and tutorials about

--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "tracing-error"
+version = "0.1.0"
+authors = ["Eliza Weisman <eliza@buoyant.io>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -273,7 +273,9 @@ In particular, the following crates are likely to be of interest:
 - [`tracing-log`] provides a compatibility layer with the [`log`] crate,
   allowing log messages to be recorded as `tracing` `Event`s within the
   trace tree. This is useful when a project using `tracing` have
-  dependencies which use `log`.
+  dependencies which use `log`. Note that if you're using
+  `tracing-subscriber`'s `FmtSubscriber`, you don't need to depend on
+  `tracing-log` directly.
 
 Additionally, there are also several third-party crates which are not
 maintained by the `tokio` project. These include:
@@ -292,8 +294,8 @@ maintained by the `tokio` project. These include:
 - [`tracing-coz`] provides integration with the [coz] causal profiler
   (Linux-only).
 
-(if you're the maintainer of a `tracing` ecosystem crate not in this list,
-please let us know!)
+If you're the maintainer of a `tracing` ecosystem crate not listed above,
+please let us know! We'd love to add your project to the list!
 
 [`tracing-timing`]: https://crates.io/crates/tracing-timing
 [`tracing-opentelemetry`]: https://crates.io/crates/tracing-opentelemetry

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -298,7 +298,7 @@ please let us know!)
 [`tracing-timing`]: https://crates.io/crates/tracing-timing
 [`tracing-opentelemetry`]: https://crates.io/crates/tracing-opentelemetry
 [OpenTelemetry]: https://opentelemetry.io/
-[`tracing-opentelemetry`]: https://crates.io/crates/honeycomb-tracing
+[`tracing-honeycomb`]: https://crates.io/crates/honeycomb-tracing
 [honeycomb.io]: https://www.honeycomb.io/
 [`tracing-actix]: https://crates.io/crates/tracing-actix
 [`tracing-gelf`]: https://crates.io/crates/tracing-gelf

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -254,6 +254,8 @@ Any trace events generated outside the context of a subscriber will not be colle
 Once a subscriber has been set, instrumentation points may be added to the
 executable using the `tracing` crate's macros.
 
+## Related Crates
+
 In addition to `tracing` and `tracing-core`, the [`tokio-rs/tracing`] repository
 contains several additional crates designed to be used with the `tracing` ecosystem.
 This includes a collection of `Subscriber` implementations, as well as utility
@@ -262,19 +264,46 @@ applications.
 
 In particular, the following crates are likely to be of interest:
 
- - [`tracing-futures`] provides a compatibility layer with the `futures`
-   crate, allowing spans to be attached to `Future`s, `Stream`s, and `Executor`s.
- - [`tracing-subscriber`] provides `Subscriber` implementations and
-   utilities for working with `Subscriber`s. This includes a [`FmtSubscriber`]
-   `FmtSubscriber` for logging formatted trace data to stdout, with similar
-   filtering and formatting to the [`env_logger`] crate.
- - [`tracing-log`] provides a compatibility layer with the [`log`] crate,
-   allowing log messages to be recorded as `tracing` `Event`s within the
-   trace tree. This is useful when a project using `tracing` have
-   dependencies which use `log`.
- - [`tracing-timing`] implements inter-event timing metrics on top of `tracing`.
-   It provides a subscriber that records the time elapsed between pairs of
-   `tracing` events and generates histograms.
+- [`tracing-futures`] provides a compatibility layer with the `futures`
+  crate, allowing spans to be attached to `Future`s, `Stream`s, and `Executor`s.
+- [`tracing-subscriber`] provides `Subscriber` implementations and
+  utilities for working with `Subscriber`s. This includes a [`FmtSubscriber`]
+  `FmtSubscriber` for logging formatted trace data to stdout, with similar
+  filtering and formatting to the [`env_logger`] crate.
+- [`tracing-log`] provides a compatibility layer with the [`log`] crate,
+  allowing log messages to be recorded as `tracing` `Event`s within the
+  trace tree. This is useful when a project using `tracing` have
+  dependencies which use `log`.
+
+Additionally, there are also several third-party crates which are not
+maintained by the `tokio` project. These include:
+
+- [`tracing-timing`] implements inter-event timing metrics on top of `tracing`.
+  It provides a subscriber that records the time elapsed between pairs of
+  `tracing` events and generates histograms.
+- [`tracing-opentelemetry`] provides a subscriber for emitting traces to
+  [OpenTelemetry]-compatible distributed tracing systems.
+- [`tracing-honeycomb`] implements a subscriber for reporting traces to
+  [honeycomb.io].
+- [`tracing-actix`] provides `tracing` integration for the `actix` actor
+  framework.
+- [`tracing-gelf`] implements a subscriber for exporting traces in Greylog
+  GELF format.
+- [`tracing-coz`] provides integration with the [coz] causal profiler
+  (Linux-only).
+
+(if you're the maintainer of a `tracing` ecosystem crate not in this list,
+please let us know!)
+
+[`tracing-timing`]: https://crates.io/crates/tracing-timing
+[`tracing-opentelemetry`]: https://crates.io/crates/tracing-opentelemetry
+[OpenTelemetry]: https://opentelemetry.io/
+[`tracing-opentelemetry`]: https://crates.io/crates/honeycomb-tracing
+[honeycomb.io]: https://www.honeycomb.io/
+[`tracing-actix]: https://crates.io/crates/tracing-actix
+[`tracing-gelf`]: https://crates.io/crates/tracing-gelf
+[`tracing-coz`]: https://crates.io/crates/tracing-coz
+[coz]: https://github.com/plasma-umass/coz
 
 **Note:** that some of the ecosystem crates are currently unreleased and
 undergoing active development. They may be less stable than `tracing` and
@@ -286,7 +315,6 @@ undergoing active development. They may be less stable than `tracing` and
 [`tracing-futures`]: https://github.com/tokio-rs/tracing/tree/master/tracing-futures
 [`tracing-subscriber`]: https://github.com/tokio-rs/tracing/tree/master/tracing-subscriber
 [`tracing-log`]: https://github.com/tokio-rs/tracing/tree/master/tracing-log
-[`tracing-timing`]: https://crates.io/crates/tracing-timing
 [`env_logger`]: https://crates.io/crates/env_logger
 [`FmtSubscriber`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Subscriber.html
 [`examples`]: https://github.com/tokio-rs/tracing/tree/master/examples

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -560,7 +560,9 @@
 //!  - [`tracing-log`] provides a compatibility layer with the [`log`] crate,
 //!    allowing log messages to be recorded as `tracing` `Event`s within the
 //!    trace tree. This is useful when a project using `tracing` have
-//!    dependencies which use `log`.
+//!    dependencies which use `log`. Note that if you're using
+//!    `tracing-subscriber`'s `FmtSubscriber`, you don't need to depend on
+//!    `tracing-log` directly.
 //!
 //! Additionally, there are also several third-party crates which are not
 //! maintained by the `tokio` project. These include:
@@ -579,8 +581,8 @@
 //!  - [`tracing-coz`] provides integration with the [coz] causal profiler
 //!    (Linux-only).
 //!
-//! (if you're the maintainer of a `tracing` ecosystem crate not in this list,
-//! please let us know!)
+//! If you're the maintainer of a `tracing` ecosystem crate not listed above,
+//! please let us know! We'd love to add your project to the list!
 //!
 //! [`tracing-opentelemetry`]: https://crates.io/crates/tracing-opentelemetry
 //! [OpenTelemetry]: https://opentelemetry.io/

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -561,9 +561,35 @@
 //!    allowing log messages to be recorded as `tracing` `Event`s within the
 //!    trace tree. This is useful when a project using `tracing` have
 //!    dependencies which use `log`.
+//!
+//! Additionally, there are also several third-party crates which are not
+//! maintained by the `tokio` project. These include:
+//!
 //!  - [`tracing-timing`] implements inter-event timing metrics on top of `tracing`.
 //!    It provides a subscriber that records the time elapsed between pairs of
 //!    `tracing` events and generates histograms.
+//!  - [`tracing-opentelemetry`] provides a subscriber for emitting traces to
+//!    [OpenTelemetry]-compatible distributed tracing systems.
+//!  - [`tracing-honeycomb`] implements a subscriber for reporting traces to
+//!    [honeycomb.io].
+//!  - [`tracing-actix`] provides `tracing` integration for the `actix` actor
+//!    framework.
+//!  - [`tracing-gelf`] implements a subscriber for exporting traces in Greylog
+//!    GELF format.
+//!  - [`tracing-coz`] provides integration with the [coz] causal profiler
+//!    (Linux-only).
+//!
+//! (if you're the maintainer of a `tracing` ecosystem crate not in this list,
+//! please let us know!)
+//!
+//! [`tracing-opentelemetry`]: https://crates.io/crates/tracing-opentelemetry
+//! [OpenTelemetry]: https://opentelemetry.io/
+//! [`tracing-opentelemetry`]: https://crates.io/crates/honeycomb-tracing
+//! [honeycomb.io]: https://www.honeycomb.io/
+//! [`tracing-actix]: https://crates.io/crates/tracing-actix
+//! [`tracing-gelf`]: https://crates.io/crates/tracing-gelf
+//! [`tracing-coz`]: https://crates.io/crates/tracing-coz
+//! [coz]: https://github.com/plasma-umass/coz
 //!
 //! **Note:** that some of the ecosystem crates are currently unreleased and
 //! undergoing active development. They may be less stable than `tracing` and

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -584,7 +584,7 @@
 //!
 //! [`tracing-opentelemetry`]: https://crates.io/crates/tracing-opentelemetry
 //! [OpenTelemetry]: https://opentelemetry.io/
-//! [`tracing-opentelemetry`]: https://crates.io/crates/honeycomb-tracing
+//! [`tracing-honeycomb`]: https://crates.io/crates/honeycomb-tracing
 //! [honeycomb.io]: https://www.honeycomb.io/
 //! [`tracing-actix]: https://crates.io/crates/tracing-actix
 //! [`tracing-gelf`]: https://crates.io/crates/tracing-gelf


### PR DESCRIPTION
This branch adds a list of related crates not in this repository to the
`tracing` RustDoc, the `tracing` README, and the root repository README.

(cc @jonhoo, @jtescher, @pkinsky, @GregBowyer, @zanria, @hlb8122)

Closes #373

Signed-off-by: Eliza Weisman <eliza@buoyant.io>