### PR TITLE
Introduce Layer Filtering

### DIFF
--- a/examples/examples/layer.rs
+++ b/examples/examples/layer.rs
@@ -1,0 +1,58 @@
+use std::cmp::Ordering;
+use tracing::{debug, info, instrument, warn, Level, Metadata, Subscriber};
+use tracing_subscriber::{
+    fmt,
+    layer::{Context, Filter, Layer},
+    registry::Registry,
+};
+
+struct LevelFilter {
+    level: Level,
+    ordering: Ordering,
+}
+
+impl<L, S> Filter<L, S> for LevelFilter
+where
+    L: Layer<S>,
+    S: Subscriber,
+{
+    fn filter(&self, metadata: &Metadata<'_>, _: &Context<'_, S>) -> bool {
+        if metadata.level().cmp(&self.level) == self.ordering {
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl LevelFilter {
+    fn new(level: Level, ordering: Ordering) -> Self {
+        Self { level, ordering }
+    }
+}
+
+fn main() {
+    // not inclusive, so this behaves as `>` or `<`, not `>=` or `<=`
+    let warn = LevelFilter::new(Level::INFO, Ordering::Greater);
+    let debug = LevelFilter::new(Level::INFO, Ordering::Less);
+
+    let warn = fmt::Layer::default().with_filter(warn);
+    let debug = fmt::Layer::default().with_filter(debug);
+
+    let subscriber = warn.and_then(debug).with_subscriber(Registry::default());
+    tracing::subscriber::set_global_default(subscriber).expect("Unable to set global subscriber");
+    call_one();
+}
+
+#[instrument(level = "TRACE")]
+fn call_one() {
+    warn!("This is the warning level");
+    info!("This should be ignored");
+    call_two();
+}
+
+#[instrument(level = "TRACE")]
+fn call_two() {
+    debug!("This is the debug level!");
+    info!("This should be ignored");
+}

--- a/examples/examples/layer.rs
+++ b/examples/examples/layer.rs
@@ -7,49 +7,49 @@ use tracing_subscriber::{
     registry::Registry,
 };
 
-struct FilterFn<F, S> {
-    f: F,
-    _s: PhantomData<S>,
-}
+// struct FilterFn<F, S> {
+//     f: F,
+//     _s: PhantomData<S>,
+// }
 
-impl<L, S, F> Filter<L, S> for FilterFn<F, S>
-where
-    L: Layer<S>,
-    S: Subscriber,
-    F: Fn(&Metadata, &Context<'_, S>) -> bool,
-{
-    fn filter(&self, metadata: &Metadata<'_>, ctx: &Context<'_, S>) -> bool {
-        (self.f)(metadata, ctx)
-    }
-}
+// impl<S, F> Filter<S> for FilterFn<F, S>
+// where
+//     // L: Layer<S>,
+//     S: Subscriber,
+//     F: Fn(&Metadata, &Context<'_, S>) -> bool,
+// {
+//     fn filter(&self, metadata: &Metadata<'_>, ctx: &Context<'_, S>) -> bool {
+//         (self.f)(metadata, ctx)
+//     }
+// }
 
-impl<F, S> FilterFn<F, S>
-where
-    S: Subscriber + 'static,
-    F: Fn(&Metadata, &Context<'_, S>) -> bool,
-{
-    fn new(f: F) -> Self {
-        Self { f, _s: PhantomData }
-    }
-}
+// impl<F, S> FilterFn<F, S>
+// where
+//     S: Subscriber + 'static,
+//     F: Fn(&Metadata, &Context<'_, S>) -> bool,
+// {
+//     fn new(f: F) -> Self {
+//         Self { f, _s: PhantomData }
+//     }
+// }
 
 fn main() {
-    let err = FilterFn::new(|metadata, _| {
-        metadata.level() == &Level::WARN || metadata.level() == &Level::ERROR
-    });
-    let info = FilterFn::new(|metadata, _| metadata.level() <= &Level::INFO);
+    // let err = FilterFn::new(|metadata, _| {
+    //     metadata.level() == &Level::WARN || metadata.level() == &Level::ERROR
+    // });
+    // let info = FilterFn::new(|metadata, _| metadata.level() <= &Level::INFO);
 
-    let err = fmt::Layer::builder()
-        .with_writer(io::stderr)
-        .finish()
-        .with_filter(err);
-    let info = fmt::Layer::builder()
-        .with_writer(io::stdout)
-        .finish()
-        .with_filter(info);
+    // let err = fmt::Layer::builder()
+    //     .with_writer(io::stderr)
+    //     .finish()
+    //     .with_filter(err);
+    // let info = fmt::Layer::builder()
+    //     .with_writer(io::stdout)
+    //     .finish()
+    //     .with_filter(info);
 
-    let subscriber = info.and_then(err).with_subscriber(Registry::default());
-    tracing::subscriber::set_global_default(subscriber).expect("Unable to set global subscriber");
+    // let subscriber = info.and_then(err).with_subscriber(Registry::default());
+    // tracing::subscriber::set_global_default(subscriber).expect("Unable to set global subscriber");
     call_one();
 }
 

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -80,3 +80,7 @@ harness = false
 [[bench]]
 name = "fmt"
 harness = false
+
+[[bench]]
+name = "layer_filter"
+harness = false

--- a/tracing-subscriber/benches/layer_filter.rs
+++ b/tracing-subscriber/benches/layer_filter.rs
@@ -1,0 +1,187 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::{
+    sync::{Arc, Barrier},
+    thread,
+    time::{Duration, Instant},
+};
+use tracing::{dispatcher::Dispatch, span, Event, Id, Metadata, Subscriber};
+use tracing_subscriber::{
+    layer::{Context, Filter},
+    prelude::*,
+    registry::Registry,
+    Layer,
+};
+
+mod support;
+use support::MultithreadedBench;
+
+struct NopLayer;
+
+impl<S: Subscriber> Layer<S> for NopLayer {
+    fn on_record(&self, span: &span::Id, values: &span::Record<'_>, ctx: Context<'_, S>) {
+        criterion::black_box((span, values, ctx));
+    }
+
+    fn on_follows_from(&self, span: &span::Id, follows: &span::Id, ctx: Context<'_, S>) {
+        criterion::black_box((span, follows, ctx));
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        criterion::black_box((event, ctx));
+    }
+
+    fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
+        criterion::black_box((id, ctx));
+    }
+
+    fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
+        criterion::black_box((id, ctx));
+    }
+
+    fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
+        criterion::black_box((id, ctx));
+    }
+
+    fn on_id_change(&self, old: &span::Id, new: &span::Id, ctx: Context<'_, S>) {
+        criterion::black_box((old, new, ctx));
+    }
+}
+struct FakeFilter {
+    enabled: bool,
+}
+
+impl<L, S> Filter<L, S> for FakeFilter
+where
+    L: Layer<S>,
+    S: Subscriber,
+{
+    fn filter(&self, metadata: &Metadata<'_>, ctx: &Context<'_, S>) -> bool {
+        criterion::black_box((metadata, ctx));
+        self.enabled
+    }
+}
+
+fn single_threaded(c: &mut Criterion) {
+    let mut group = c.benchmark_group("single_threaded");
+    let mut bench_span = |n_layers: usize, dispatch: fn() -> tracing::Dispatch| {
+        group.bench_with_input(BenchmarkId::new("span", n_layers), &n_layers, |b, _| {
+            let _guard = tracing::dispatcher::set_default(&(dispatch)());
+            b.iter(|| {
+                let span = tracing::info_span!("test");
+                let entered = span.enter();
+                drop(entered);
+                drop(span);
+            })
+        });
+    };
+    bench_span(0, || {
+        let s = Registry::default().with(NopLayer).with(NopLayer);
+        tracing::Dispatch::new(s)
+    });
+
+    bench_span(2, || {
+        let s = Registry::default()
+            .with(NopLayer.with_filter(FakeFilter { enabled: true }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: false }));
+        tracing::Dispatch::new(s)
+    });
+    bench_span(4, || {
+        let s = Registry::default()
+            .with(NopLayer.with_filter(FakeFilter { enabled: true }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: false }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: true }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: false }));
+        tracing::Dispatch::new(s)
+    });
+    bench_span(8, || {
+        let s = Registry::default()
+            .with(NopLayer.with_filter(FakeFilter { enabled: true }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: false }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: true }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: false }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: true }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: false }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: true }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: false }));
+        tracing::Dispatch::new(s)
+    });
+
+    group.finish();
+}
+
+fn multi_threaded(c: &mut Criterion) {
+    let mut group = c.benchmark_group("multithreaded");
+    let mut bench_span = |n_layers: usize, dispatch: fn() -> tracing::Dispatch| {
+        group.bench_with_input(BenchmarkId::new("span", n_layers), &n_layers, |b, _| {
+            b.iter_custom(|iters| {
+                let mut total = Duration::from_secs(0);
+                for _ in 0..iters {
+                    let bench = MultithreadedBench::new(dispatch());
+                    let elapsed = bench
+                        .thread(move || {
+                            let span = tracing::info_span!("test");
+                            let entered = span.enter();
+                            drop(entered);
+                            drop(span);
+                        })
+                        .thread(move || {
+                            let span = tracing::info_span!("test");
+                            let entered = span.enter();
+                            drop(entered);
+                            drop(span);
+                        })
+                        .thread(move || {
+                            let span = tracing::info_span!("test");
+                            let entered = span.enter();
+                            drop(entered);
+                            drop(span);
+                        })
+                        .thread(move || {
+                            let span = tracing::info_span!("test");
+                            let entered = span.enter();
+                            drop(entered);
+                            drop(span);
+                        })
+                        .run();
+                    total += elapsed;
+                }
+                total
+            })
+        });
+    };
+    bench_span(0, || {
+        let s = Registry::default().with(NopLayer).with(NopLayer);
+        tracing::Dispatch::new(s)
+    });
+    bench_span(2, || {
+        let s = Registry::default()
+            .with(NopLayer.with_filter(FakeFilter { enabled: true }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: false }));
+        tracing::Dispatch::new(s)
+    });
+    bench_span(4, || {
+        let s = Registry::default()
+            .with(NopLayer.with_filter(FakeFilter { enabled: true }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: false }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: true }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: false }));
+        tracing::Dispatch::new(s)
+    });
+    bench_span(8, || {
+        let s = Registry::default()
+            .with(NopLayer.with_filter(FakeFilter { enabled: true }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: false }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: true }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: false }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: true }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: false }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: true }))
+            .with(NopLayer.with_filter(FakeFilter { enabled: false }));
+        tracing::Dispatch::new(s)
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, single_threaded, multi_threaded);
+criterion_main!(benches);

--- a/tracing-subscriber/src/filter2.rs
+++ b/tracing-subscriber/src/filter2.rs
@@ -1,0 +1,46 @@
+use std::mem;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+pub trait Filterable {
+    fn register_filter(&self) -> FilterId;
+    fn disable_span(&self, filter: FilterId, span: &span::Id);
+    fn is_enabled_by(&self, filter: FilterId, span: &span::Id) -> bool;
+}
+
+pub struct Filtered<F, L, I, S = I> {
+    layer: L,
+    next: I,
+    filter: F,
+    id: usize,
+    _s: PhantomData<fn(S)>,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct FilterId(usize);
+
+#[derive(Default)]
+pub(crate) struct FilterMap {
+    bitmap: [AtomicUsize; BITMAP_SHARDS],
+}
+
+impl FilterMap {
+    pub const MAX_FILTERS: usize = 512;
+    const BITMAP_SHARDS: usize = MAX_FILTERS / BITS_PER_SHARD;
+    const BITS_PER_SHARD: usize = mem::size_of::<AtomicUsize>() * 8;
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn disable(&self, FilterId(filter): FilterId) {
+        let idx = filter / Self::BITMAP_SHARDS;
+        let bit = 1 << (filter % Self::BITS_PER_SHARD);
+        self.bitmap[idx].fetch_or(1 << bit, Ordering::Release);
+    }
+
+    pub fn is_enabled(&self, FilterId(filter): FilterId) {
+        let idx = filter / Self::BITMAP_SHARDS;
+        let bit = 1 << (filter % Self::BITS_PER_SHARD);
+        self.bitmap[idx].load(Ordering::Acquire) & bit != 0
+    }
+}

--- a/tracing-subscriber/src/filter2.rs
+++ b/tracing-subscriber/src/filter2.rs
@@ -1,22 +1,94 @@
-use std::mem;
-use std::sync::atomic::{AtomicUsize, Ordering};
-
+use crate::layer::{Filter, Layer, Layered, Context};
+use std::{
+    any::TypeId,
+    mem,
+    sync::atomic::{AtomicUsize, Ordering},
+    marker::PhantomData,
+};
+// use tracing_core::{
+    use tracing_core::{Event, span};
+    use tracing_core::subscriber::{Interest, Subscriber};
+// };
+use tracing_core::Metadata;
 pub trait Filterable {
-    fn register_filter(&self) -> FilterId;
+    fn register_filter(&mut self) -> FilterId;
     fn disable_span(&self, filter: FilterId, span: &span::Id);
     fn is_enabled_by(&self, filter: FilterId, span: &span::Id) -> bool;
 }
 
-pub struct Filtered<F, L, I, S = I> {
-    layer: L,
-    next: I,
-    filter: F,
-    id: usize,
-    _s: PhantomData<fn(S)>,
+pub struct Filtered<F, L> {
+    pub(crate) layer: L,
+    // next: I,
+    pub(crate) filter: F,
+    pub(crate) id: FilterId,
 }
 
-#[derive(Copy, Clone, Debug)]
-pub struct FilterId(u8);
+impl<S, F, L> Layer<S> for Filtered<F, L>
+where
+    S: Subscriber + Filterable,
+    F: Filter<S> + 'static,
+    L: Layer<S> + 'static
+{
+    fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
+        if self.enabled(metadata, Context::none()) {
+            Interest::always()
+        } else {
+            Interest::never()
+        }
+    }
+
+    fn enabled(&self, metadata: &Metadata<'_>, ctx: Context<'_, S>) -> bool {
+        let _ = (metadata, ctx);
+        true
+    }
+
+    fn new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {}
+    // fn on_record(&self, _span: &span::Id, _values: &span::Record<'_>, _ctx: Context<'_, S>) {}
+
+    // fn on_follows_from(&self, _span: &span::Id, _follows: &span::Id, _ctx: Context<'_, S>) {}
+
+    // fn on_event(&self, _event: &Event<'_>, _ctx: Context<'_, S>) {}
+
+    // fn on_enter(&self, _id: &span::Id, _ctx: Context<'_, S>) {}
+
+    // fn on_exit(&self, _id: &span::Id, _ctx: Context<'_, S>) {}
+
+    // fn on_close(&self, _id: span::Id, _ctx: Context<'_, S>) {}
+
+    // fn on_id_change(&self, _old: &span::Id, _new: &span::Id, _ctx: Context<'_, S>) {}
+
+    fn and_then<L2>(self, layer: L2) -> Layered<L2, Self, S>
+    where
+        L2: Layer<S>,
+        Self: Sized,
+    {
+        unimplemented!()
+    }
+
+    fn with_subscriber(self, mut inner: S) -> Layered<Self, S>
+    where
+        Self: Sized,
+    {
+        let id = inner.register_filter();
+        Layered {
+            layer: Self { id, ..self },
+            inner,
+            _s: PhantomData,
+        }
+    }
+
+    #[doc(hidden)]
+    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+        match id {
+            id if id == TypeId::of::<Self>() => Some(self as *const _ as *const ()),
+            id if id == TypeId::of::<F>() => Some(&self.filter as *const _ as *const ()),
+            _ => self.layer.downcast_raw(id),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct FilterId(pub(crate) u8);
 
 #[derive(Default)]
 pub(crate) struct FilterMap {
@@ -33,13 +105,99 @@ impl FilterMap {
 
     pub fn disable(&mut self, FilterId(filter): FilterId) {
         let idx = filter as usize / 8;
-        let bit = 1 << (filter % Self::SHARDS);
+        let bit = 1 << (filter % Self::SHARDS as u8);
         self.bitmap[idx] |= bit;
     }
 
     pub fn is_enabled(&self, FilterId(filter): FilterId) -> bool {
         let idx = filter as usize / 8;
-        let bit = 1 << (filter % Self::SHARDS);
+        let bit = 1 << (filter % Self::SHARDS as u8);
         self.bitmap[idx] & bit == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layer::tests::NopLayer;
+    use crate::prelude::*;
+
+    struct NopFilterable {
+        next_id: u8,
+    }
+
+    impl Subscriber for NopFilterable {
+        fn register_callsite(&self, _: &'static Metadata<'static>) -> Interest {
+            Interest::never()
+        }
+
+        fn enabled(&self, _: &Metadata<'_>) -> bool {
+            false
+        }
+
+        fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
+            span::Id::from_u64(1)
+        }
+
+        fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
+        fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
+        fn event(&self, _: &Event<'_>) {}
+        fn enter(&self, _: &span::Id) {}
+        fn exit(&self, _: &span::Id) {}
+    }
+
+    impl Filterable for NopFilterable {
+        fn register_filter(&mut self) -> FilterId {
+            let id = self.next_id;
+            self.next_id += 1;
+            FilterId(id)
+        }
+
+        fn disable_span(&self, filter: FilterId, span: &span::Id) {
+            unimplemented!()
+        }
+        fn is_enabled_by(&self, filter: FilterId, span: &span::Id) -> bool {
+            unimplemented!()
+        }
+    }
+
+    struct NopFilter1;
+
+    impl<S: Subscriber + Filterable> Filter<S> for NopFilter1 {
+        /// Filter on a specific span or event's metadata.
+        fn filter(&self, metadata: &Metadata<'_>, ctx: &Context<'_, S>) -> bool {
+            true
+        }
+    }
+    struct NopFilter2;
+
+    impl<S: Subscriber + Filterable> Filter<S> for NopFilter2 {
+        /// Filter on a specific span or event's metadata.
+        fn filter(&self, metadata: &Metadata<'_>, ctx: &Context<'_, S>) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn with_id_generation() {
+        let subscriber = NopFilterable { next_id: 0 }
+            .with(NopLayer.with_filter(NopFilter1))
+            .with(NopLayer.with_filter(NopFilter2));
+        let subscriber = tracing_core::Dispatch::new(subscriber);
+
+        assert_eq!(
+            subscriber
+                .downcast_ref::<Filtered<NopFilter1, NopLayer>>()
+                .expect("downcast")
+                .id,
+            FilterId(0)
+        );
+        assert_eq!(
+            subscriber
+                .downcast_ref::<Filtered<NopFilter2, NopLayer>>()
+                .expect("downcast")
+                .id,
+            FilterId(1)
+        );
     }
 }

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -7,7 +7,7 @@ use tracing_core::{
 };
 
 #[cfg(feature = "registry")]
-use crate::registry::{self, LookupMetadata, LookupSpan, Registry, SpanRef};
+use crate::registry::{self, LookupSpan, Registry, SpanRef};
 use std::{
     any::TypeId,
     collections::HashSet,

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -430,7 +430,7 @@ where
     }
 
     /// TODO: docs
-    fn with_filter<F>(self, filter: F) -> crate::filter2::Filtered<F, Self>
+    fn with_filter<F>(self, filter: F) -> crate::filter2::Filtered<F, Self, S>
     where
         F: Filter<S>,
         S: crate::filter2::Filterable,
@@ -440,6 +440,7 @@ where
             layer: self,
             filter,
             id: crate::filter2::FilterId(0),
+            _s: PhantomData,
         }
     }
 

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -7,8 +7,8 @@ use tracing_core::{
 };
 
 #[cfg(feature = "registry")]
-use crate::registry::{self, LookupSpan, Registry, SpanRef};
-use std::{any::TypeId, marker::PhantomData};
+use crate::registry::{self, LookupMetadata, LookupSpan, Registry, SpanRef};
+use std::{any::TypeId, collections::HashSet, marker::PhantomData, sync::RwLock};
 
 /// A composable handler for `tracing` events.
 ///
@@ -433,6 +433,7 @@ where
         Filtered {
             layer: self,
             filter,
+            disabled_spans: RwLock::new(HashSet::new()),
             _s: PhantomData,
         }
     }
@@ -541,10 +542,11 @@ pub struct Layered<L, I, S = I> {
 /// [`Layer`]: ../layer/trait.Layer.html
 /// [`Subscriber`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html
 /// [`Filter`]: ../layer/trait.Layer.html
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Filtered<L, S, F> {
     layer: L,
     filter: F,
+    disabled_spans: RwLock<HashSet<span::Id>>,
     _s: PhantomData<fn(S)>,
 }
 
@@ -556,6 +558,10 @@ where
     L: Layer<S>,
     S: Subscriber + 'static,
 {
+    fn filter_callsite(&self, metadata: &Metadata<'_>) -> tracing_core::subscriber::Interest {
+        tracing_core::subscriber::Interest::sometimes()
+    }
+
     /// Filter on a specific span or event's metadata.
     fn filter(&self, metadata: &Metadata<'_>, ctx: &Context<'_, S>) -> bool;
 }
@@ -581,6 +587,8 @@ where
     fn new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
         if self.filter.filter(attrs.metadata(), &ctx) {
             self.layer.new_span(attrs, id, ctx);
+        } else {
+            self.disabled_spans.write().unwrap().insert(id.clone());
         }
     }
 
@@ -589,6 +597,30 @@ where
         if self.filter.filter(event.metadata(), &ctx) {
             self.layer.on_event(event, ctx);
         }
+    }
+
+    /// Notifies this layer that a span with the given ID was entered.
+    fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
+        if self.disabled_spans.read().unwrap().contains(id) {
+            return;
+        }
+        self.layer.on_enter(id, ctx)
+    }
+
+    /// Notifies this layer that the span with the given ID was exited.
+    fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
+        if self.disabled_spans.read().unwrap().contains(id) {
+            return;
+        }
+        self.layer.on_exit(id, ctx)
+    }
+
+    /// Notifies this layer that the span with the given ID has been closed.
+    fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
+        if self.disabled_spans.write().unwrap().remove(&id) {
+            return;
+        }
+        self.layer.on_close(id, ctx)
     }
 }
 

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -435,12 +435,27 @@ where
         F: Filter<Self, S>,
         Self: Sized,
     {
+<<<<<<< Updated upstream
         static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
 
         Filtered {
             layer: self,
             filter,
             id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
+=======
+        static ID: AtomicUsize = AtomicUsize::new(0);
+        let id = ID.fetch_add(1, Ordering::Relaxed);
+        if id == std::usize::MAX {
+            panic!(
+                "you tried to construct {} unique filters, why would you do this?",
+                std::usize::MAX
+            );
+        }
+        Filtered {
+            layer: self,
+            filter,
+            id,
+>>>>>>> Stashed changes
             _s: PhantomData,
         }
     }
@@ -565,9 +580,13 @@ where
     L: Layer<S>,
     S: Subscriber + 'static,
 {
+<<<<<<< Updated upstream
     fn filter_callsite(&self, metadata: &Metadata<'_>) -> tracing_core::subscriber::Interest {
         tracing_core::subscriber::Interest::sometimes()
     }
+=======
+    fn filter_callsite(&self, metadata: &Metadata<'static>) -> tracing_core::subscriber::Interest;
+>>>>>>> Stashed changes
 
     /// Filter on a specific span or event's metadata.
     fn filter(&self, metadata: &Metadata<'_>, ctx: &Context<'_, S>) -> bool;

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -522,6 +522,45 @@ pub struct Layered<L, I, S = I> {
     _s: PhantomData<fn(S)>,
 }
 
+#[derive(Clone, Debug)]
+pub struct Filtered<L, S, F> {
+    layer: L,
+    filter: F,
+    _s: PhantomData<fn(S)>,
+}
+
+pub trait Filter<L, S>
+where
+    S: Subscriber + 'static,
+{
+    fn filter(&self, metadata: &Metadata<'_>, ctx: &Context<'_, S>) -> bool;
+}
+
+impl<L, S, F> Filter<L, S> for F
+where
+    L: Layer<S>,
+    S: Subscriber + 'static,
+    F: Fn(&Metadata<'_>, &Context<'_, S>) -> bool,
+{
+    fn filter(&self, metadata: &Metadata<'_>, ctx: &Context<'_, S>) -> bool {
+        (self)(metadata, ctx)
+    }
+}
+
+impl<L, S, F> Layer<S> for Filtered<L, S, F>
+where
+    L: Layer<S>,
+    S: Subscriber + 'static,
+    F: Filter<L, S> + 'static,
+{
+    #[inline]
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        if self.filter.filter(event.metadata(), &ctx) {
+            self.layer.on_event(event, ctx);
+        }
+    }
+}
+
 /// A layer that does nothing.
 #[derive(Clone, Debug, Default)]
 pub struct Identity {
@@ -1056,10 +1095,6 @@ pub(crate) mod tests {
 
     struct NopLayer;
     impl<S: Subscriber> Layer<S> for NopLayer {}
-
-    #[allow(dead_code)]
-    struct NopLayer2;
-    impl<S: Subscriber> Layer<S> for NopLayer2 {}
 
     /// A layer that holds a string.
     ///

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -93,6 +93,7 @@ macro_rules! try_lock {
 
 pub mod field;
 pub mod filter;
+pub mod filter2;
 #[cfg(feature = "fmt")]
 #[cfg_attr(docsrs, doc(cfg(feature = "fmt")))]
 pub mod fmt;


### PR DESCRIPTION
Resolves https://github.com/tokio-rs/tracing/issues/302.

Currently, spans and events can only be enabled/disable on a global subscriber basis. This PR adds _per-layer_ filtering in `tracing-subscriber`, which means that layers can conditionally filter spans and events without impacting others layers. In practice, this enables layers to conditionally filter on metadata like source and levels and forward those spans and events to different outputs sinks. This also allows for the creation of sampling or rate-limiting filters.

With this PR, customers will be able to write something like:

```rust
let err_filter = FilterFn::new(|metadata, _| {
    metadata.level() == &Level::WARN || metadata.level() == &Level::ERROR
});
let info_filter = FilterFn::new(|metadata, _| metadata.level() <= &Level::INFO);

let err = fmt::Layer::builder()
    .with_writer(io::stderr)
    .finish()
let info = fmt::Layer::builder()
    .with_writer(io::stdout)
    .finish()

let subscriber = Registry::default()
    .with(info.with_filter(info_filter))
    .with(err.with_filter(err_filter));

tracing::subscriber::set_global_default(subscriber).expect("Unable to set global subscriber");
```

Still to do:

- [ ] Documentation
- [ ] Examples
- [ ] Implementing all of Layer's methods on `Filtered`.