### PR TITLE
subscriber: traverse SpanStack on pop

### DIFF
--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -349,7 +349,7 @@ impl<'a> SpanData<'a> for Data<'a> {
 }
 
 #[cfg(test)]
-pub(crate) mod tests {
+mod tests {
     use super::{Registry, CURRENT_SPANS};
     use crate::{layer::Context, registry::LookupSpan, Layer};
     use std::sync::{

--- a/tracing-subscriber/src/registry/stack.rs
+++ b/tracing-subscriber/src/registry/stack.rs
@@ -67,7 +67,7 @@ thread_local! {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{Id, SpanStack};
 
     #[test]
     fn pop_last_span() {

--- a/tracing-subscriber/src/registry/stack.rs
+++ b/tracing-subscriber/src/registry/stack.rs
@@ -66,7 +66,7 @@ thread_local! {
 }
 
 #[cfg(test)]
-pub(crate) mod tests {
+mod tests {
     use super::*;
 
     #[test]

--- a/tracing-subscriber/src/registry/stack.rs
+++ b/tracing-subscriber/src/registry/stack.rs
@@ -34,8 +34,14 @@ impl SpanStack {
     }
 
     pub(crate) fn pop(&mut self, expected_id: &Id) -> Option<Id> {
-        if &self.stack.last()?.id == expected_id {
-            let ContextId { id, duplicate } = self.stack.pop()?;
+        if let Some((idx, _)) = self
+            .stack
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, ctx_id)| ctx_id.id == *expected_id)
+        {
+            let ContextId { id, duplicate } = self.stack.remove(idx);
             if !duplicate {
                 self.ids.remove(&id);
             }
@@ -57,4 +63,28 @@ impl SpanStack {
 
 thread_local! {
     static CONTEXT: RefCell<SpanStack> = RefCell::new(SpanStack::new());
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    #[test]
+    fn pop_last_span() {
+        let mut stack = SpanStack::new();
+        let id = Id::from_u64(1);
+        stack.push(id.clone());
+
+        assert_eq!(Some(id.clone()), stack.pop(&id));
+    }
+
+    #[test]
+    fn pop_first_span() {
+        let mut stack = SpanStack::new();
+        stack.push(Id::from_u64(1));
+        stack.push(Id::from_u64(2));
+
+        let id = Id::from_u64(1);
+        assert_eq!(Some(id.clone()), stack.pop(&id));
+    }
 }


### PR DESCRIPTION
In cases where spans are not popped in FILO (first-in-last-out) order,
`pop` would return `None`. This would cause issues in `Registry` where
spans that are exited out of order would not be closed properly.

Fixes #495