### PR TITLE
CI workflow improvements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -145,10 +145,6 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
         profile: minimal
-    - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
     - name: Run tests
       uses: actions-rs/cargo@v1
       with:
@@ -168,10 +164,6 @@ jobs:
       with:
         toolchain: stable
         profile: minimal
-    - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
     - name: Run tests
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,11 +14,11 @@ jobs:
       matrix:
         rust: [stable, 1.39.0]
     steps:
+    - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
         profile: minimal
-    - uses: actions/checkout@master
     - name: Check
       uses: actions-rs/cargo@v1
       with:
@@ -45,11 +45,11 @@ jobs:
         #- tracing
         #- tracing-subscriber
     steps:
+    - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         profile: minimal
-    - uses: actions/checkout@master
     - name: install cargo-hack
       uses: actions-rs/cargo@v1
       with:
@@ -73,11 +73,11 @@ jobs:
         - std log-always
         - std
     steps:
+    - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         profile: minimal
-    - uses: actions/checkout@master
     - name: cargo check
       working-directory: tracing
       run: cargo check --no-default-features --features "${{ matrix.featureset }}"
@@ -97,11 +97,11 @@ jobs:
         - registry
         - env-filter
     steps:
+    - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         profile: minimal
-    - uses: actions/checkout@master
     - name: cargo check
       working-directory: tracing-subscriber
       run: cargo check --no-default-features --features "${{ matrix.featureset }}"
@@ -114,11 +114,11 @@ jobs:
       matrix:
         rust: [stable, beta, nightly, 1.39.0]
     steps:
+    - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
         profile: minimal
-    - uses: actions/checkout@master
     - name: Build
       uses: actions-rs/cargo@v1
       with:
@@ -137,11 +137,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
+    - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         profile: minimal
-    - uses: actions/checkout@master
     - name: Build
       uses: actions-rs/cargo@v1
       with:
@@ -157,11 +157,11 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         profile: minimal
-    - uses: actions/checkout@master
     - name: "Test log support"
       run: (cd tracing/test-log-support && cargo test)
     - name: "Test static max level"
@@ -181,11 +181,11 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly
         profile: minimal
-    - uses: actions/checkout@master
     - name: "Test tracing-futures std::future support"
       run: (cd tracing-futures/test_std_future && cargo test)
     - name: "Test tracing-attributes async/await support"
@@ -200,12 +200,12 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         components: rustfmt
         profile: minimal
-    - uses: actions/checkout@master
     - name: rustfmt
       uses: actions-rs/cargo@v1
       with:
@@ -216,12 +216,12 @@ jobs:
     # Check for any warnings. This is informational and thus is allowed to fail.
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         components: clippy
         profile: minimal
-    - uses: actions/checkout@master
     - name: Clippy
       uses: actions-rs/clippy-check@v1
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -245,3 +245,26 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         args: --all --bins --examples --tests --benches -- -D warnings
+
+  cargo-audit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Fetch latest release version of cargo-audit
+      run: |
+        mkdir -p .github/caching
+        cargo search cargo-audit | grep '^cargo-audit' | awk '{gsub(/"/,"",$3); print $3}' > .github/caching/cargo-audit.lock
+    - name: Cache cargo-audit/bin
+      id: cache-cargo-audit
+      uses: actions/cache@v1
+      with:
+        path: ${{ runner.tool_cache }}/cargo-audit/bin
+        key: cargo-audit-bin-${{ hashFiles('.github/caching/cargo-audit.lock') }}
+    - name: Install cargo-audit
+      if: "steps.cache-cargo-audit.outputs.cache-hit != 'true'"
+      uses: actions-rs/cargo@v1
+      with:
+        command: install
+        args: --root ${{ runner.tool_cache }}/cargo-audit --force cargo-audit
+    - run: echo "::add-path::${{ runner.tool_cache }}/cargo-audit/bin"
+    - run: cargo audit

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,9 +45,10 @@ jobs:
         #- tracing
         #- tracing-subscriber
     steps:
-    - uses: hecrj/setup-rust-action@v1
+    - uses: actions-rs/toolchain@v1
       with:
-        rust-version: stable
+        toolchain: stable
+        profile: minimal
     - uses: actions/checkout@master
     - name: install cargo-hack
       uses: actions-rs/cargo@v1
@@ -72,9 +73,10 @@ jobs:
         - std log-always
         - std
     steps:
-    - uses: hecrj/setup-rust-action@v1
+    - uses: actions-rs/toolchain@v1
       with:
-        rust-version: stable
+        toolchain: stable
+        profile: minimal
     - uses: actions/checkout@master
     - name: cargo check
       working-directory: tracing
@@ -95,9 +97,10 @@ jobs:
         - registry
         - env-filter
     steps:
-    - uses: hecrj/setup-rust-action@v1
+    - uses: actions-rs/toolchain@v1
       with:
-        rust-version: stable
+        toolchain: stable
+        profile: minimal
     - uses: actions/checkout@master
     - name: cargo check
       working-directory: tracing-subscriber

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,28 @@ jobs:
         command: check
         args: --all --bins --examples --tests --benches
 
+  cache-cargo-hack:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Fetch latest release version of cargo-hack
+      run: |
+        mkdir -p .github/caching
+        curl -sL https://api.github.com/repos/taiki-e/cargo-hack/releases/latest | jq -r '.name' > .github/caching/cargo-hack.lock
+    - name: Cache cargo-hack/bin
+      id: cache-cargo-hack
+      uses: actions/cache@v1
+      with:
+        path: ${{ runner.tool_cache }}/cargo-hack/bin
+        key: cargo-hack-bin-${{ hashFiles('.github/caching/cargo-hack.lock') }}
+    - name: Install cargo-hack
+      if: "steps.cache-cargo-hack.outputs.cache-hit != 'true'"
+      uses: actions-rs/cargo@v1
+      with:
+        command: install
+        args: --root ${{ runner.tool_cache }}/cargo-hack --force cargo-hack
+
   cargo-hack:
+    needs: cache-cargo-hack
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -50,11 +71,16 @@ jobs:
       with:
         toolchain: stable
         profile: minimal
-    - name: install cargo-hack
-      uses: actions-rs/cargo@v1
+    - name: Fetch latest release version of cargo-hack
+      run: |
+        mkdir -p .github/caching
+        curl -sL https://api.github.com/repos/taiki-e/cargo-hack/releases/latest | jq -r '.name' > .github/caching/cargo-hack.lock
+    - name: Restore cargo-hack/bin
+      uses: actions/cache@v1
       with:
-        command: install
-        args: cargo-hack
+        path: ${{ runner.tool_cache }}/cargo-hack/bin
+        key: cargo-hack-bin-${{ hashFiles('.github/caching/cargo-hack.lock') }}
+    - run: echo "::add-path::${{ runner.tool_cache }}/cargo-hack/bin"
     - name: cargo hack check
       working-directory: ${{ matrix.subcrate }}
       run: cargo hack check --feature-powerset --no-dev-deps

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,10 @@ jobs:
         profile: minimal
     - uses: actions/checkout@master
     - name: Check
-      run: cargo check --all --bins --examples --tests --benches
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --all --bins --examples --tests --benches
 
   cargo-hack:
     runs-on: ubuntu-latest
@@ -47,7 +50,10 @@ jobs:
         rust-version: stable
     - uses: actions/checkout@master
     - name: install cargo-hack
-      run: cargo install cargo-hack
+      uses: actions-rs/cargo@v1
+      with:
+        command: install
+        args: cargo-hack
     - name: cargo hack check
       working-directory: ${{ matrix.subcrate }}
       run: cargo hack check --feature-powerset --no-dev-deps
@@ -111,9 +117,14 @@ jobs:
         profile: minimal
     - uses: actions/checkout@master
     - name: Build
-      run: cargo build
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
     - name: Run tests
-      run: cargo test --all
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --all
 
   test-os:
     # Test against stable Rust across macOS, Windows, and Linux.
@@ -129,9 +140,14 @@ jobs:
         profile: minimal
     - uses: actions/checkout@master
     - name: Build
-      run: cargo build
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
     - name: Run tests
-      run: cargo test --all
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --all
 
   features-stable:
     # Feature flag tests that run on stable Rust.
@@ -152,7 +168,10 @@ jobs:
     - name: "Test tracing no-std support"
       run: (cd tracing && cargo test --no-default-features)
     - name: "Test tracing all features"
-      run: cargo test -p tracing --all-features
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: -p tracing --all-features
 
   features-nightly:
     # Feature flag tests for features that require nightly Rust.
@@ -185,7 +204,10 @@ jobs:
         profile: minimal
     - uses: actions/checkout@master
     - name: rustfmt
-      run: cargo fmt --all -- --check
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
 
   warnings:
     # Check for any warnings. This is informational and thus is allowed to fail.


### PR DESCRIPTION
I've made some improvements to the CI workflow script.

I've consistently used the `actions-rs` actions where possible and have enabled caching for several of the jobs, bringing their completion time from minutes down to seconds. I've also added a job that runs `cargo audit`.

I added the `.gitattributes` since I was developing on windows. The rust-lang repo [also uses this](https://github.com/rust-lang/rust/blob/caa231d998a5e853c7ba1455d7a05b500df9d63c/.gitattributes#L3).

The `Cargo.lock` needs to be committed (or regenerated on CI if you prefer; although this will need to be done for each job which is why I've opted not to do that) in order to generate the hashes for caching keys. Note that when `Cargo.lock` is updated, the first subsequent CI run will be slower since the caches need to be repopulated.

Some further improvements would be to cache `~/.rustup` but I'm not sure the best way to do that here. Options would be to either manually maintain a lock file used to drive the caching functionality (this is what I've opted for on my own projects) or alternatively to try and scrape the currently available versions from some command that fetches info from upstream.

This adds a fair bit of complexity to the CI script and some of the choices (committing the lock file for a library) are maybe a bit controversial so if you'd rather not merge it's okay. Just thought I'd try to make things a little more efficient!