### PR TITLE
docs: add doc-cfg attributes to tracing and tracing-core

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   command = """
-  curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly \
+  curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly --profile minimal \
   && source $HOME/.cargo/env \
   && RUSTDOCFLAGS=\"--cfg docsrs\" cargo +nightly doc --no-deps
   """

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = """
   curl https://sh.rustup.rs -sSf | sh -s -- -y \
   && source $HOME/.cargo/env \
-  && RUSTDOCFLAGS=\"--cfg docsrs\" cargo doc --no-deps
+  && RUSTDOCFLAGS=\"--cfg docsrs\" cargo +nightly doc --no-deps
   """
   publish = "target/doc"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "curl https://sh.rustup.rs -sSf | sh -s -- -y && source $HOME/.cargo/env && cargo doc --no-deps"
+  command = "curl https://sh.rustup.rs -sSf | sh -s -- -y && source $HOME/.cargo/env && RUSTDOCFLAGS=\"--cfg docsrs\" cargo doc --no-deps"
   publish = "target/doc"
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,9 @@
 [build]
-  command = "curl https://sh.rustup.rs -sSf | sh -s -- -y && source $HOME/.cargo/env && RUSTDOCFLAGS=\"--cfg docsrs\" cargo doc --no-deps"
+  command = """
+  curl https://sh.rustup.rs -sSf | sh -s -- -y \
+  && source $HOME/.cargo/env \
+  && RUSTDOCFLAGS=\"--cfg docsrs\" cargo doc --no-deps
+  """
   publish = "target/doc"
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   command = """
-  curl https://sh.rustup.rs -sSf | sh -s -- -y \
+  curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly \
   && source $HOME/.cargo/env \
   && RUSTDOCFLAGS=\"--cfg docsrs\" cargo +nightly doc --no-deps
   """

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -35,3 +35,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 lazy_static = { version = "1", optional = true }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -201,6 +201,7 @@ struct State {
 /// A guard that resets the current default dispatcher to the prior
 /// default dispatcher when dropped.
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[derive(Debug)]
 pub struct DefaultGuard(Option<Dispatch>);
 
@@ -217,6 +218,7 @@ pub struct DefaultGuard(Option<Dispatch>);
 /// [`Event`]: ../event/struct.Event.html
 /// [`set_global_default`]: ../fn.set_global_default.html
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn with_default<T>(dispatcher: &Dispatch, f: impl FnOnce() -> T) -> T {
     // When this guard is dropped, the default dispatcher will be reset to the
     // prior default. Using this (rather than simply resetting after calling
@@ -234,6 +236,7 @@ pub fn with_default<T>(dispatcher: &Dispatch, f: impl FnOnce() -> T) -> T {
 ///
 /// [`set_global_default`]: ../fn.set_global_default.html
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn set_default(dispatcher: &Dispatch) -> DefaultGuard {
     // When this guard is dropped, the default dispatcher will be reset to the
     // prior default. Using this ensures that we always reset to the prior
@@ -291,6 +294,7 @@ impl fmt::Display for SetGlobalDefaultError {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl error::Error for SetGlobalDefaultError {}
 
 /// Executes a closure with a reference to this thread's current [dispatcher].

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -198,6 +198,7 @@ pub trait Visit {
     /// **Note**: this is only enabled when the Rust standard library is
     /// present.
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
         self.record_debug(field, &format_args!("{}", value))
     }
@@ -332,6 +333,7 @@ impl Value for str {
 impl crate::sealed::Sealed for dyn std::error::Error + 'static {}
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl Value for dyn std::error::Error + 'static {
     fn record(&self, key: &Field, visitor: &mut dyn Visit) {
         visitor.record_error(key, self)

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -70,6 +70,7 @@
 //! [`tracing`]: https://crates.io/crates/tracing
 #![doc(html_root_url = "https://docs.rs/tracing-core/0.1.8")]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -274,6 +274,7 @@ impl fmt::Display for Level {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl crate::stdlib::error::Error for ParseLevelError {}
 
 impl FromStr for Level {

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -39,3 +39,7 @@ tokio = "0.1.22"
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
 maintenance = { status = "actively-developed" }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -78,6 +78,7 @@
     while_true
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #[cfg(feature = "std-future")]
 use pin_project::pin_project;
 

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -174,6 +174,7 @@ pub trait Instrument: Sized {
 ///
 /// [`Subscriber`]: https://docs.rs/tracing/0.1.9/tracing/subscriber/trait.Subscriber.html
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub trait WithSubscriber: Sized {
     /// Attaches the provided [`Subscriber`] to this type, returning a
     /// `WithDispatch` wrapper.
@@ -232,6 +233,7 @@ pub struct Instrumented<T> {
 /// A future, stream, sink, or executor that has been instrumented with a
 /// `tracing` subscriber.
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[cfg_attr(feature = "std-future", pin_project)]
 #[derive(Clone, Debug)]
 pub struct WithDispatch<T> {

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -71,3 +71,7 @@ harness = false
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }
 maintenance = { status = "actively-developed" }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/tracing/src/dispatcher.rs
+++ b/tracing/src/dispatcher.rs
@@ -1,0 +1,151 @@
+//! Dispatches trace events to [`Subscriber`]s.
+//!
+//! The _dispatcher_ is the component of the tracing system which is responsible
+//! for forwarding trace data from the instrumentation points that generate it
+//! to the subscriber that collects it.
+//!
+//! # Using the Trace Dispatcher
+//!
+//! Every thread in a program using `tracing` has a _default subscriber_. When
+//! events occur, or spans are created, they are dispatched to the thread's
+//! current subscriber.
+//!
+//! ## Setting the Default Subscriber
+//!
+//! By default, the current subscriber is an empty implementation that does
+//! nothing. To use a subscriber implementation, it must be set as the default.
+//! There are two methods for doing so: [`with_default`] and
+//! [`set_global_default`]. `with_default` sets the default subscriber for the
+//! duration of a scope, while `set_global_default` sets a default subscriber
+//! for the entire process.
+//!
+//! To use either of these functions, we must first wrap our subscriber in a
+//! [`Dispatch`], a cloneable, type-erased reference to a subscriber. For
+//! example:
+//! ```rust
+//! # pub struct FooSubscriber;
+//! # use tracing_core::{
+//! #   dispatcher, Event, Metadata,
+//! #   span::{Attributes, Id, Record}
+//! # };
+//! # impl tracing_core::Subscriber for FooSubscriber {
+//! #   fn new_span(&self, _: &Attributes) -> Id { Id::from_u64(0) }
+//! #   fn record(&self, _: &Id, _: &Record) {}
+//! #   fn event(&self, _: &Event) {}
+//! #   fn record_follows_from(&self, _: &Id, _: &Id) {}
+//! #   fn enabled(&self, _: &Metadata) -> bool { false }
+//! #   fn enter(&self, _: &Id) {}
+//! #   fn exit(&self, _: &Id) {}
+//! # }
+//! # impl FooSubscriber { fn new() -> Self { FooSubscriber } }
+//! # fn main() {
+//! use dispatcher::Dispatch;
+//!
+//! let my_subscriber = FooSubscriber::new();
+//! let my_dispatch = Dispatch::new(my_subscriber);
+//! # }
+//! ```
+//! Then, we can use [`with_default`] to set our `Dispatch` as the default for
+//! the duration of a block:
+//! ```rust
+//! # pub struct FooSubscriber;
+//! # use tracing_core::{
+//! #   dispatcher, Event, Metadata,
+//! #   span::{Attributes, Id, Record}
+//! # };
+//! # impl tracing_core::Subscriber for FooSubscriber {
+//! #   fn new_span(&self, _: &Attributes) -> Id { Id::from_u64(0) }
+//! #   fn record(&self, _: &Id, _: &Record) {}
+//! #   fn event(&self, _: &Event) {}
+//! #   fn record_follows_from(&self, _: &Id, _: &Id) {}
+//! #   fn enabled(&self, _: &Metadata) -> bool { false }
+//! #   fn enter(&self, _: &Id) {}
+//! #   fn exit(&self, _: &Id) {}
+//! # }
+//! # impl FooSubscriber { fn new() -> Self { FooSubscriber } }
+//! # fn main() {
+//! # let my_subscriber = FooSubscriber::new();
+//! # let my_dispatch = dispatcher::Dispatch::new(my_subscriber);
+//! // no default subscriber
+//!
+//! # #[cfg(feature = "std")]
+//! dispatcher::with_default(&my_dispatch, || {
+//!     // my_subscriber is the default
+//! });
+//!
+//! // no default subscriber again
+//! # }
+//! ```
+//! It's important to note that `with_default` will not propagate the current
+//! thread's default subscriber to any threads spawned within the `with_default`
+//! block. To propagate the default subscriber to new threads, either use
+//! `with_default` from the new thread, or use `set_global_default`.
+//!
+//! As an alternative to `with_default`, we can use [`set_global_default`] to
+//! set a `Dispatch` as the default for all threads, for the lifetime of the
+//! program. For example:
+//! ```rust
+//! # pub struct FooSubscriber;
+//! # use tracing_core::{
+//! #   dispatcher, Event, Metadata,
+//! #   span::{Attributes, Id, Record}
+//! # };
+//! # impl tracing_core::Subscriber for FooSubscriber {
+//! #   fn new_span(&self, _: &Attributes) -> Id { Id::from_u64(0) }
+//! #   fn record(&self, _: &Id, _: &Record) {}
+//! #   fn event(&self, _: &Event) {}
+//! #   fn record_follows_from(&self, _: &Id, _: &Id) {}
+//! #   fn enabled(&self, _: &Metadata) -> bool { false }
+//! #   fn enter(&self, _: &Id) {}
+//! #   fn exit(&self, _: &Id) {}
+//! # }
+//! # impl FooSubscriber { fn new() -> Self { FooSubscriber } }
+//! # fn main() {
+//! # let my_subscriber = FooSubscriber::new();
+//! # let my_dispatch = dispatcher::Dispatch::new(my_subscriber);
+//! // no default subscriber
+//!
+//! dispatcher::set_global_default(my_dispatch)
+//!     // `set_global_default` will return an error if the global default
+//!     // subscriber has already been set.
+//!     .expect("global default was already set!");
+//!
+//! // `my_subscriber` is now the default
+//! # }
+//! ```
+//!
+//! **Note**: the thread-local scoped dispatcher (`with_default`) requires the
+//! Rust standard library. `no_std` users should use [`set_global_default`]
+//! instead.
+//!
+//! Finally, `tokio` users should note that versions of `tokio` >= 0.1.22
+//! support an `experimental-tracing` feature flag. When this flag is enabled,
+//! the `tokio` runtime's thread pool will automatically propagate the default
+//! subscriber. This means that if `tokio::runtime::Runtime::new()` or
+//! `tokio::run()` are invoked when a default subscriber is set, it will also be
+//! set by all worker threads created by that runtime.
+//!
+//! ## Accessing the Default Subscriber
+//!
+//! A thread's current default subscriber can be accessed using the
+//! [`get_default`] function, which executes a closure with a reference to the
+//! currently default `Dispatch`. This is used primarily by `tracing`
+//! instrumentation.
+//!
+//! [`Subscriber`]: struct.Subscriber.html
+//! [`with_default`]: fn.with_default.html
+//! [`set_global_default`]: fn.set_global_default.html
+//! [`get_default`]: fn.get_default.html
+//! [`Dispatch`]: struct.Dispatch.html
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+pub use tracing_core::dispatcher::set_default;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+pub use tracing_core::dispatcher::with_default;
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+pub use tracing_core::dispatcher::DefaultGuard;
+pub use tracing_core::dispatcher::{
+    get_default, set_global_default, Dispatch, SetGlobalDefaultError,
+};

--- a/tracing/src/dispatcher.rs
+++ b/tracing/src/dispatcher.rs
@@ -149,3 +149,11 @@ pub use tracing_core::dispatcher::DefaultGuard;
 pub use tracing_core::dispatcher::{
     get_default, set_global_default, Dispatch, SetGlobalDefaultError,
 };
+
+/// Private API for internal use by tracing's macros.
+///
+/// This function is *not* considered part of `tracing`'s public API, and has no
+/// stability guarantees. If you use it, and it breaks or disappears entirely,
+/// don't say we didn;'t warn you.
+#[doc(hidden)]
+pub use tracing_core::dispatcher::has_been_set;

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -623,6 +623,7 @@
 //! [static verbosity level]: level_filters/index.html#compile-time-filters
 //! [instrument]: https://docs.rs/tracing-attributes/latest/tracing_attributes/attr.instrument.html
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(html_root_url = "https://docs.rs/tracing/0.1.11")]
 #![warn(
     missing_debug_implementations,

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -670,7 +670,7 @@ pub use self::{
     event::Event,
     field::Value,
     subscriber::Subscriber,
-    tracing_core::{dispatcher, event, Level, Metadata},
+    tracing_core::{event, Level, Metadata},
 };
 
 #[doc(hidden)]
@@ -690,6 +690,7 @@ pub use tracing_attributes::instrument;
 #[macro_use]
 mod macros;
 
+pub mod dispatcher;
 pub mod field;
 pub mod level_filters;
 pub mod span;

--- a/tracing/src/subscriber.rs
+++ b/tracing/src/subscriber.rs
@@ -2,6 +2,7 @@
 pub use tracing_core::subscriber::*;
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use tracing_core::dispatcher::DefaultGuard;
 
 /// Sets this subscriber as the default for the duration of a closure.
@@ -15,6 +16,7 @@ pub use tracing_core::dispatcher::DefaultGuard;
 /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
 /// [`Event`]: :../event/struct.Event.html
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn with_default<T, S>(subscriber: S, f: impl FnOnce() -> T) -> T
 where
     S: Subscriber + Send + Sync + 'static,
@@ -54,6 +56,7 @@ where
 /// [`Event`]: :../event/struct.Event.html
 /// [`DefaultGuard`]: ../dispatcher/struct.DefaultGuard.html
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn set_default<S>(subscriber: S) -> DefaultGuard
 where
     S: Subscriber + Send + Sync + 'static,


### PR DESCRIPTION
Starts on #440.

This branch adds `doc_cfg` attributes to `tracing` and `tracing-core`,
when a `docsrs` cfg flag is passed to rustdoc. It also adds 
docs.rs crate metadata to configure docs.rs to set that flag, and adds
it to the Netlify config as well.

Co-authored-by: Jane Lusby <jlusby@yaah.dev>