### PR TITLE
core: s/soft deprecated/deprecated

### DIFF
--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -320,10 +320,11 @@ pub trait Subscriber: 'static {
         id.clone()
     }
 
-    /// **This method is soft-deprecated.**
+    /// **This method is deprecated.**
     ///
-    /// Although using it won’t cause compilation warning, new code should
-    /// call or implement [`try_close`] instead.
+    /// Using `drop_span` may result in subscribers composed using
+    /// `tracing-subscriber` crate's `Layer` trait from observing close events.
+    /// Use [`try_close`] instead.
     ///
     /// The default implementation of this function does nothing.
     ///


### PR DESCRIPTION
## Motivation

The docs for `drop_span` incorrectly state that the method is
"soft-deprecated", when it's actually...normal deprecated. The RustDoc
says that "using this method won't cause a compilation warning", but
this is incorrect.

## Solution

This branch updates the doc comment.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
