### PR TITLE
ci: remove `on: pull_request`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: push
 
 jobs:
   check:

--- a/tracing/src/dispatcher.rs
+++ b/tracing/src/dispatcher.rs
@@ -38,12 +38,10 @@
 //! #   fn exit(&self, _: &Id) {}
 //! # }
 //! # impl FooSubscriber { fn new() -> Self { FooSubscriber } }
-//! # fn main() {
 //! use dispatcher::Dispatch;
 //!
 //! let my_subscriber = FooSubscriber::new();
 //! let my_dispatch = Dispatch::new(my_subscriber);
-//! # }
 //! ```
 //! Then, we can use [`with_default`] to set our `Dispatch` as the default for
 //! the duration of a block:
@@ -63,7 +61,6 @@
 //! #   fn exit(&self, _: &Id) {}
 //! # }
 //! # impl FooSubscriber { fn new() -> Self { FooSubscriber } }
-//! # fn main() {
 //! # let my_subscriber = FooSubscriber::new();
 //! # let my_dispatch = dispatcher::Dispatch::new(my_subscriber);
 //! // no default subscriber
@@ -74,7 +71,6 @@
 //! });
 //!
 //! // no default subscriber again
-//! # }
 //! ```
 //! It's important to note that `with_default` will not propagate the current
 //! thread's default subscriber to any threads spawned within the `with_default`
@@ -100,7 +96,6 @@
 //! #   fn exit(&self, _: &Id) {}
 //! # }
 //! # impl FooSubscriber { fn new() -> Self { FooSubscriber } }
-//! # fn main() {
 //! # let my_subscriber = FooSubscriber::new();
 //! # let my_dispatch = dispatcher::Dispatch::new(my_subscriber);
 //! // no default subscriber
@@ -111,7 +106,6 @@
 //!     .expect("global default was already set!");
 //!
 //! // `my_subscriber` is now the default
-//! # }
 //! ```
 //!
 //! **Note**: the thread-local scoped dispatcher (`with_default`) requires the


### PR DESCRIPTION
## Motivation

It appears that this setting doesn't actually do what I thought it did.
Having this seems to result in all the CI actions being run one
additional time *when the PR is opened* (which should be identical to
the first push?), and if it fails, it marks the PR as failing
permanently. Subsequent pushes don't appear to change the PR's state.
This is clearly not what we want — I think `on: pull_request` was
intended for stuff like labeling the PR or posting a welcome message for
new contributors, not for running CI jobs.

## Solution

Therefore, I've removed it.