### PR TITLE
subscriber: prepare to release 0.2.0-alpha.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ fn main() {
 ```toml
 [dependencies]
 tracing = "0.1"
-tracing-subscriber = "0.2.0-alpha.2"
+tracing-subscriber = "0.2.0-alpha.3"
 ```
 
 This subscriber will be used as the default in all threads for the remainder of the duration
@@ -96,7 +96,7 @@ fn main() {
         // will be written to stdout.
         .with_max_level(Level::TRACE)
         // builds the subscriber.
-        .finish();   
+        .finish();
 
     tracing::subscriber::with_default(subscriber, || {
         info!("This will be logged to stdout");
@@ -221,7 +221,7 @@ my_future
     .await
 ```
 
-`Future::instrument` attaches a span to the future, ensuring that the span's lifetime 
+`Future::instrument` attaches a span to the future, ensuring that the span's lifetime
 is as long as the future's.
 
 The second, and preferred, option is through the

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 0.2.0-alpha.3 (December 8, 2019)
+
+### Added
+
+- **fmt**: Public `FormattedFields::new` constructor (#478)
+- **fmt**: Added examples to `fmt::Layer` documentation (#510)
+- Documentation now shows what feature flags are required by each API item (#525)
+
+### Fixed
+
+- **fmt**: Missing space between timestamp and level (#480)
+- **fmt**: Incorrect formatting with `with_target(false)` (#481)
+- **fmt**: `fmt::SubscriberBuilder::init` not setting up `log` compatibility
+  (#489)
+- **registry**: Spans exited out of order not being closed properly on exit
+  (#509)
+- **registry**: Memory leak when spans are closed by a child span closing (#514)
+- **registry**: Spans closed by a child span closing not also closing _their_
+  parents (#514)
+- Compilation errors with `no-default-features` (#499, #500)
+
 # 0.2.0-alpha.2 (December 8, 2019)
 
 ### Added

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.2.0-alpha.3 (December 8, 2019)
+# 0.2.0-alpha.3 (January 10, 2020)
 
 ### Added
 

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 license = "MIT"

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "tracing-subscriber"
 version = "0.2.0-alpha.3"
-authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
+authors = [
+    "Eliza Weisman <eliza@buoyant.io>",
+    "David Barsky <me@davidbarsky.com>",
+    "Tokio Contributors <team@tokio.rs>"
+]
 edition = "2018"
 license = "MIT"
 readme = "README.md"

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -17,7 +17,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.1.5
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.0-alpha.3
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -51,7 +51,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.1.5")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.0-alpha.3")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(
     missing_debug_implementations,

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -93,7 +93,7 @@ fn main() {
 ```toml
 [dependencies]
 tracing = "0.1"
-tracing-subscriber = "0.2.0-alpha.2"
+tracing-subscriber = "0.2.0-alpha.3"
 ```
 
 This subscriber will be used as the default in all threads for the remainder of the duration
@@ -111,7 +111,7 @@ fn main() {
         // will be written to stdout.
         .with_max_level(Level::TRACE)
         // builds the subscriber.
-        .finish();   
+        .finish();
 
     tracing::subscriber::with_default(subscriber, || {
         info!("This will be logged to stdout");
@@ -236,7 +236,7 @@ my_future
     .await
 ```
 
-`Future::instrument` attaches a span to the future, ensuring that the span's lifetime 
+`Future::instrument` attaches a span to the future, ensuring that the span's lifetime
 is as long as the future's.
 
 The second, and preferred, option is through the


### PR DESCRIPTION

# 0.2.0-alpha.3 (December 8, 2019)

### Added

- **fmt**: Public `FormattedFields::new` constructor (#478)
- **fmt**: Added examples to `fmt::Layer` documentation (#510)
- Documentation now shows what feature flags are required by each API item (#525)

### Fixed

- **fmt**: Missing space between timestamp and level (#480)
- **fmt**: Incorrect formatting with `with_target(false)` (#481)
- **fmt**: `fmt::SubscriberBuilder::init` not setting up `log` compatibility
  (#489)
- **registry**: Spans exited out of order not being closed properly on exit
  (#509)
- **registry**: Memory leak when spans are closed by a child span closing (#514)
- **registry**: Spans closed by a child span closing not also closing _their_
  parents (#514)
- Compilation errors with `no-default-features` (#499, #500)