### PR TITLE
subscriber: remove `dbg!` macros from registry

### DIFF
--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -133,7 +133,7 @@ impl Registry {
     /// [`CloseGuard`]: ./struct.CloseGuard.html
     pub(crate) fn start_close(&self, id: Id) -> CloseGuard<'_> {
         CLOSE_COUNT.with(|count| {
-            let c = dbg!(count.get());
+            let c = count.get();
             count.set(c + 1);
         });
         CloseGuard {
@@ -243,11 +243,10 @@ impl Subscriber for Registry {
         };
 
         let refs = span.ref_count.fetch_sub(1, Ordering::Release);
-        dbg!((span.metadata.name(), refs));
         if !std::thread::panicking() {
             assert!(refs < std::usize::MAX, "reference count overflow!");
         }
-        if dbg!(refs > 1) {
+        if refs > 1 {
             return false;
         }
 


### PR DESCRIPTION
These were added while debugging issue #511. They were never intended to
be committed, but apparently I missed a few while removing them, and
they slipped into PR #514 by mistake.

Once this merges, I'll publish `tracing-subscriber` 0.2.0-alpha.4. We may
want to consider yanking alpha.3.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>