### PR TITLE
subscriber: prepare to release 0.2.0-alpha.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ fn main() {
 ```toml
 [dependencies]
 tracing = "0.1"
-tracing-subscriber = "0.2.0-alpha.3"
+tracing-subscriber = "0.2.0-alpha.4"
 ```
 
 This subscriber will be used as the default in all threads for the remainder of the duration

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.0-alpha.4 (January 11, 2020)
+
+### Fixed
+
+- **registry**: Removed inadvertantly committed `dbg!` macros (#533)
+
 # 0.2.0-alpha.3 (January 10, 2020)
 
 ### Added

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 
-- **registry**: Removed inadvertantly committed `dbg!` macros (#533)
+- **registry**: Removed inadvertently committed `dbg!` macros (#533)
 
 # 0.2.0-alpha.3 (January 10, 2020)
 

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -17,7 +17,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.2.0-alpha.3
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.0-alpha.4
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -51,7 +51,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.0-alpha.3")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.0-alpha.4")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(
     missing_debug_implementations,

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -93,7 +93,7 @@ fn main() {
 ```toml
 [dependencies]
 tracing = "0.1"
-tracing-subscriber = "0.2.0-alpha.3"
+tracing-subscriber = "0.2.0-alpha.4"
 ```
 
 This subscriber will be used as the default in all threads for the remainder of the duration


### PR DESCRIPTION
# 0.2.0-alpha.4 (January 11, 2020)

### Fixed

- **registry**: Removed inadvertently committed `dbg!` macros (#533)