### PR TITLE
subscriber: upgrade to smallvec 1.1.0

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -36,7 +36,7 @@ tracing-core = "0.1.2"
 # only required by the filter feature
 matchers = { optional = true, version = "0.0.1" }
 regex = { optional = true, version = "1" }
-smallvec = { optional = true, version = "0.6.10"}
+smallvec = { optional = true, version = "1"}
 lazy_static = { optional = true, version = "1" }
 
 # fmt


### PR DESCRIPTION
# Motivation

The smallvec 0.6 dependency is causing some duplicate dependencies in quinn. smallvec 1.0 has been released in November, it would be nice not to have to build it twice.

## Solution

Upgrade to the 1.1.0 version from December.