### PR TITLE
#226: support futures 0.3 Streams/Sinks

### DIFF
--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -303,7 +303,7 @@ impl<T: futures_01::Sink> futures_01::Sink for Instrumented<T> {
     }
 }
 
-#[cfg(all(feature = "futures-03", feature = "std"))]
+#[cfg(all(feature = "futures-03", feature = "std-future"))]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "futures-03", feature = "std-future"))))]
 impl<T: futures::Stream> futures::Stream for Instrumented<T> {
     type Item = T::Item;


### PR DESCRIPTION
## Motivation

tracing-futures currently supports instrumenting futures 0.1 Futures, Streams, and Sinks, and std::future::Future from futures 0.3. However, the futures 0.3 Stream and Sink traits in the futures-preview crate are not supported.

## Solution

Implement traits `Sink` and `Stream` from the `futures 0.3` crate for struct `Instrumented`. These new features are guarded by a combination of feature flags `futures-03` and `std-future`.

Add basic unit tests for both new features, closely modelled after existing unit tests for corresponding features for the `futures 0.1` crate.

Move some test structs only used by futures 0.1-related tests "down" into their test module to avoid warnings about unused code when running tests with `futures-03` enabled.

**Note** that compiling `tracing-futures` with `futures-03` enabled produces a warning about unused method `with_dispatch`. This warning, however, existed before and is unrelated to changes from this PR.

Fixes: #226