### PR TITLE
tracing, core: re-implement empty fields

### DIFF
--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-core"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -27,7 +27,7 @@ keywords = ["logging", "tracing", "metrics", "async"]
 edition = "2018"
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.9", default-features = false }
+tracing-core = { path = "../tracing-core", version = "0.1.10", default-features = false }
 log = { version = "0.4", optional = true }
 tracing-attributes = "0.1.6"
 cfg-if = "0.1.10"

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -327,6 +327,23 @@
 //! # }
 //! ```
 //!
+//! Additionally, a span may declare fields with the special value [`Empty`],
+//! which indicates that that the value for that field does not currently exist
+//! but may be recorded later. For example:
+//!
+//! ```
+//! use tracing::{trace_span, field};
+//!
+//! // Create a span with two fields: `greeting`, with the value "hello world", and
+//! // `parting`, without a value.
+//! let span = trace_span!("my_span", greeting = "hello world", parting = field::Empty);
+//!
+//! // ...
+//!
+//! // Now, record a value for parting as well.
+//! span.record("parting", &"goodbye world!");
+//! ```
+//!
 //! Note that a span may have up to 32 fields. The following will not compile:
 //!
 //! ```rust,compile_fail
@@ -379,6 +396,7 @@
 //! [`fmt::Debug`]: https://doc.rust-lang.org/std/fmt/trait.Debug.html
 //! [`fmt::Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
 //! [fmt]: https://doc.rust-lang.org/std/fmt/#usage
+//! [`Empty`]: field/struct.Empty.html
 //!
 //! ### Shorthand Macros
 //!

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -635,7 +635,43 @@ impl Span {
         self.field(field).is_some()
     }
 
-    /// Visits that the field described by `field` has the value `value`.
+    /// Records that the field described by `field` has the value `value`.
+    ///
+    /// This may be used with [`field::Empty`] to declare fields whose values
+    /// are not known when the span is created, and record them later:
+    /// ```
+    /// use tracing::{trace_span, field};
+    ///
+    /// // Create a span with two fields: `greeting`, with the value "hello world", and
+    /// // `parting`, without a value.
+    /// let span = trace_span!("my_span", greeting = "hello world", parting = field::Empty);
+    ///
+    /// // ...
+    ///
+    /// // Now, record a value for parting as well.
+    /// span.record("parting", &"goodbye world!");
+    /// ```
+    /// However, it may also be used to record a _new_ value for a field whose
+    /// value was already recorded:
+    /// ```
+    /// use tracing::info_span;
+    /// # fn do_something() -> Result<(), ()> { Err(()) }
+    ///
+    /// // Initially, let's assume that our attempt to do something is going okay...
+    /// let span = info_span!("doing_something", is_okay = true);
+    /// let _e = span.enter();
+    ///
+    /// match do_something() {
+    ///     Ok(something) => {
+    ///         // ...
+    ///     }
+    ///     Err(_) => {
+    ///         // Things are no longer okay!
+    ///         span.record("is_okay", &false);
+    ///     }
+    /// }
+    /// ```
+    /// [`field::Empty`]: ../field/struct.Empty.html
     pub fn record<Q: ?Sized, V>(&self, field: &Q, value: &V) -> &Self
     where
         Q: field::AsField,
@@ -654,7 +690,7 @@ impl Span {
         self
     }
 
-    /// Visit all the fields in the span
+    /// Records all the fields in the provided `ValueSet`.
     pub fn record_all(&self, values: &field::ValueSet<'_>) -> &Self {
         let record = Record::new(values);
         if let Some(ref inner) = self.inner {

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -649,6 +649,7 @@ impl Span {
     /// // ...
     ///
     /// // Now, record a value for parting as well.
+    /// // (note that the field name is passed as a string slice)
     /// span.record("parting", &"goodbye world!");
     /// ```
     /// However, it may also be used to record a _new_ value for a field whose


### PR DESCRIPTION
Right now, there is no way to indicate that a span field _currently_
has no value but that a value will be recorded later. Tracing used to
support this concept, but when we added local-variable shorthand, it was
removed from the macros, as we needed to use the previous syntax for
indicating empty fields for local variable shorthand. See #77 for
details.

This commit side-steps the problem of determining an appropriate
_syntax_ for empty fields by adding a special value _type_, called
`Empty`. Now, empty values can be indicated like
```rust
span!("my_span", foo = 5, bar = tracing::field::Empty);
```
The `Empty` type implements `Value`, but its' `record` method is a no-op
that doesn't' call any functions on the visitor. Therefore, when a field
is empty, the visitor will not see it. An empty field can then be
recorded later using `Subscriber::record` (or the corresponding `Span`
method in `tracing`).

Closes #77 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>