### PR TITLE
subscriber: fix `Layered` layers not downcasting to themselves

### DIFF
--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -532,6 +532,9 @@ where
 
     #[doc(hidden)]
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+        if id == TypeId::of::<Self>() {
+            return Some(self as *const _ as *const ());
+        }
         self.layer
             .downcast_raw(id)
             .or_else(|| self.inner.downcast_raw(id))
@@ -623,6 +626,9 @@ where
 
     #[doc(hidden)]
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+        if id == TypeId::of::<Self>() {
+            return Some(self as *const _ as *const ());
+        }
         self.layer
             .downcast_raw(id)
             .or_else(|| self.inner.downcast_raw(id))


### PR DESCRIPTION
Currently, a `Layered` struct's implementations of `Subscriber` and
`Layer` will successfully downcast to either the the `Layer` type or the
inner type, but *not* to `Layered<Layer, Inner>`. This means that when a
`Layer` tries to downcast the wrapped subscriber to a known type, and it
is a `Layered` (so, any time more than one layer wraps a subscriber and
a layer other than the first one tries to downcast to the inner type it
wraps), the downcast will fail incorrectly.

This commit fixes the issue by checking if the downcast target `TypeId`
equals the `Layered` type's `TypeId`, _before_ trying to downcast to the
layer itself or to the inner type.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>