### PR TITLE
Derive Copy on struct Level

### DIFF
--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -83,7 +83,7 @@ pub struct Metadata<'a> {
 pub struct Kind(KindInner);
 
 /// Describes the level of verbosity of a span or event.
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Level(LevelInner);
 
 // ===== impl Metadata =====

--- a/tracing/src/level_filters.rs
+++ b/tracing/src/level_filters.rs
@@ -177,7 +177,7 @@ mod tests {
         for (filter, level) in mapping.iter() {
             assert_eq!(filter.clone().into_level(), *level);
             if let Some(level) = level {
-                assert_eq!(LevelFilter::from_level(level.clone()), *filter);
+                assert_eq!(LevelFilter::from_level(*level), *filter);
             }
         }
     }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

It is useful to be able to declare a local variable set to  `Level::foo`.  Currently one must clone this variable because `Level` does not implement `Copy`.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
`Level` contains a single field `LevelInner` which derives `Copy`, we can therefore derive `Copy` on `Level` also.  