### PR TITLE
subscriber: prepare to release 0.2.0-alpha.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ fn main() {
 ```toml
 [dependencies]
 tracing = "0.1"
-tracing-subscriber = "0.2.0-alpha.4"
+tracing-subscriber = "0.2.0-alpha.5"
 ```
 
 This subscriber will be used as the default in all threads for the remainder of the duration

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 0.2.0-alpha.5 (January 31, 2020)
+
+### Added
+
+- **env_filter**: Documentation for filtering directives (#554)
+- **registry**, **env_filter**: Updated `smallvec` dependency to 0.1 (#543)
+
+### Fixed
+
+- **registry**: Fixed a memory leak in the slab used to store per-span data
+  (3c35048)
+- **Layer**: Fixed `Layered` subscribers failing to downcast to their own type
+  (#549)
+- **fmt**: Fixed a panic when multiple layers insert `FormattedFields`
+  extensions from the same formatter type (1c3bb70)
+- **fmt**: Fixed `fmt::Layer::on_record` inserting a new `FormattedFields` when
+  formatted fields for a span already exist (1c3bb70)
+
 # 0.2.0-alpha.4 (January 11, 2020)
 
 ### Fixed

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -17,7 +17,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.2.0-alpha.4
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.0-alpha.5
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -51,7 +51,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.0-alpha.4")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.0-alpha.5")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(
     missing_debug_implementations,

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -93,7 +93,7 @@ fn main() {
 ```toml
 [dependencies]
 tracing = "0.1"
-tracing-subscriber = "0.2.0-alpha.4"
+tracing-subscriber = "0.2.0-alpha.5"
 ```
 
 This subscriber will be used as the default in all threads for the remainder of the duration


### PR DESCRIPTION
### Added:

- **env_filter**: Documentation for filtering directives (#554)
- **registry**, **env_filter**: Updated `smallvec` dependency to 0.1
  (#543)

### Fixed:

- **registry**: Fixed a memory leak in the slab used to store per-span
  data (3c35048)
- **Layer**: Fixed `Layered` subscribers failing to downcast to their
  own type (#549)
- **fmt**: Fixed a panic when multiple layers insert `FormattedFields`
  extensions from the same formatter type (1c3bb70)
- **fmt**: Fixed `fmt::Layer::on_record` inserting a new
  `FormattedFields` when  formatted fields for a span already exist
  (1c3bb70)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>