### PR TITLE
chore: fix warnings on nightly

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -58,6 +58,7 @@
     unused_parens,
     while_true
 )]
+#[allow(unused)]
 extern crate proc_macro;
 
 use std::collections::HashSet;

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -58,7 +58,8 @@
     unused_parens,
     while_true
 )]
-#[allow(unused)]
+// TODO: once `tracing` bumps its MSRV to 1.42, remove this allow.
+#![allow(unused)]
 extern crate proc_macro;
 
 use std::collections::HashSet;

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -406,8 +406,8 @@ impl From<env::VarError> for FromEnvError {
 impl fmt::Display for FromEnvError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
-            ErrorKind::Parse(ref p) => write!(f, "{}", p.to_string()),
-            ErrorKind::Env(ref e) => write!(f, "{}", e.to_string()),
+            ErrorKind::Parse(ref p) => p.fmt(f),
+            ErrorKind::Env(ref e) => e.fmt(f),
         }
     }
 }

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -406,20 +406,13 @@ impl From<env::VarError> for FromEnvError {
 impl fmt::Display for FromEnvError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
-            ErrorKind::Parse(ref p) => p.fmt(f),
-            ErrorKind::Env(ref e) => e.fmt(f),
+            ErrorKind::Parse(ref p) => write!(f, "{}", p.to_string()),
+            ErrorKind::Env(ref e) => write!(f, "{}", e.to_string()),
         }
     }
 }
 
 impl Error for FromEnvError {
-    fn description(&self) -> &str {
-        match self.kind {
-            ErrorKind::Parse(ref p) => p.description(),
-            ErrorKind::Env(ref e) => e.description(),
-        }
-    }
-
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self.kind {
             ErrorKind::Parse(ref p) => Some(p),

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -232,7 +232,7 @@ impl fmt::Display for Error {
             ErrorKind::SubscriberGone => "subscriber no longer exists",
             ErrorKind::Poisoned => "lock poisoned",
         };
-        write!(f, "{}", msg)
+        f.pad(msg)
     }
 }
 

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -228,15 +228,12 @@ impl Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        error::Error::description(self).fmt(f)
+        let msg = match self.kind {
+            ErrorKind::SubscriberGone => "subscriber no longer exists",
+            ErrorKind::Poisoned => "lock poisoned",
+        };
+        write!(f, "{}", msg)
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match self.kind {
-            ErrorKind::SubscriberGone => "subscriber no longer exists",
-            ErrorKind::Poisoned => "lock poisoned",
-        }
-    }
-}
+impl error::Error for Error {}


### PR DESCRIPTION
This PR fixes two types of warnings:
1. Usage of deprecated methods on `std::error::Error`.
2. An unused warning on `extern crate proc_macro` in tracing-attributes. This does not occur on the stable release of `1.41`, but it does occur on `1.42.0-beta.1` and `1.42.0-nightly (cd1ef390e 2020-01-31)`. 

Prior to merging this PR, I'd like to determine whether the second warning is a deliberate change or a regression.