### PR TITLE
error: switch tracing-subscriber to crates.io dependency

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,7 +19,7 @@ tracing = "0.1"
 tracing-core = "0.1"
 tracing-error = { path = "../tracing-error" }
 tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
-tracing-subscriber = { version = "0.2.0-alpha.1", path = "../tracing-subscriber", features = ["json", "chrono"] }
+tracing-subscriber = { version = "0.2.0-alpha.5", features = ["json", "chrono"] }
 tracing-futures = { version = "0.2.1", path = "../tracing-futures", features = ["futures-01"] }
 tracing-attributes =  "0.1.2"
 tracing-log = { path = "../tracing-log", version = "0.1.1", features = ["env_logger"] }

--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tracing-subscriber = { path = "../tracing-subscriber", features = ["registry", "fmt"]}
+tracing-subscriber = { version = "0.2.0-alpha.5", default-features = false, features = ["registry", "fmt"] }
 tracing = "0.1"


### PR DESCRIPTION
This updates `tracing-error` to depend on `tracing-subscriber` from
crates.io, rather than via a path dependency. This means that git deps
on `tracing-error` should "actually work" now.

Additionally, I've updated the `tracing-subscriber` dep to only enable
the feature flags `tracing-error` requires. This means that depending on
`tracing-error` won't enable `tracing-subscriber`'s default features
unless they are actually needed.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>