### PR TITLE
subscriber: several small `fmt` formatting fixes

### DIFF
--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -576,7 +576,10 @@ where
             let fields = &ext
                 .get::<FormattedFields<N>>()
                 .expect("Unable to find FormattedFields in extensions; this is a bug");
-            write!(f, "{}{}{}:", bold.paint("{"), fields, bold.paint("}"))
+            if !fields.is_empty() {
+                write!(f, "{}{}{}", bold.paint("{"), fields, bold.paint("}"))?;
+            }
+            f.pad(":")
         })?;
 
         if seen {

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -516,7 +516,7 @@ where
         })?;
 
         if seen {
-            f.pad(" ")?;
+            f.write_char(' ')?;
         }
         Ok(())
     }
@@ -548,12 +548,12 @@ where
     }
 
     fn bold(&self) -> Style {
-        #[cfg(feature = "ansi")] {
+        #[cfg(feature = "ansi")]
+        {
             if self.ansi {
                 return Style::new().bold();
             }
         }
-
 
         Style::new()
     }
@@ -579,11 +579,11 @@ where
             if !fields.is_empty() {
                 write!(f, "{}{}{}", bold.paint("{"), fields, bold.paint("}"))?;
             }
-            f.pad(":")
+            f.write_char(':')
         })?;
 
         if seen {
-            f.pad(" ")?;
+            f.write_char(' ')?;
         }
         Ok(())
     }
@@ -594,7 +594,9 @@ struct Style;
 
 #[cfg(not(feature = "ansi"))]
 impl Style {
-    fn new() -> Self { Style }
+    fn new() -> Self {
+        Style
+    }
     fn paint(&self, d: impl fmt::Display) -> impl fmt::Display {
         d
     }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -643,15 +643,21 @@ impl<'a> FmtLevel<'a> {
     }
 }
 
+const TRACE_STR: &str = "TRACE";
+const DEBUG_STR: &str = "DEBUG";
+const INFO_STR: &str = " INFO";
+const WARN_STR: &str = " WARN";
+const ERROR_STR: &str = "ERROR";
+
 #[cfg(not(feature = "ansi"))]
 impl<'a> fmt::Display for FmtLevel<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self.level {
-            Level::TRACE => f.pad("TRACE"),
-            Level::DEBUG => f.pad("DEBUG"),
-            Level::INFO => f.pad("INFO"),
-            Level::WARN => f.pad("WARN"),
-            Level::ERROR => f.pad("ERROR"),
+            Level::TRACE => f.pad(TRACE_STR),
+            Level::DEBUG => f.pad(DEBUG_STR),
+            Level::INFO => f.pad(INFO_STR),
+            Level::WARN => f.pad(WARN_STR),
+            Level::ERROR => f.pad(ERROR_STR),
         }
     }
 }
@@ -661,19 +667,19 @@ impl<'a> fmt::Display for FmtLevel<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.ansi {
             match *self.level {
-                Level::TRACE => write!(f, "{}", Colour::Purple.paint("TRACE")),
-                Level::DEBUG => write!(f, "{}", Colour::Blue.paint("DEBUG")),
-                Level::INFO => write!(f, "{}", Colour::Green.paint(" INFO")),
-                Level::WARN => write!(f, "{}", Colour::Yellow.paint(" WARN")),
-                Level::ERROR => write!(f, "{}", Colour::Red.paint("ERROR")),
+                Level::TRACE => write!(f, "{}", Colour::Purple.paint(TRACE_STR)),
+                Level::DEBUG => write!(f, "{}", Colour::Blue.paint(DEBUG_STR)),
+                Level::INFO => write!(f, "{}", Colour::Green.paint(INFO_STR)),
+                Level::WARN => write!(f, "{}", Colour::Yellow.paint(WARN_STR)),
+                Level::ERROR => write!(f, "{}", Colour::Red.paint(ERROR_STR)),
             }
         } else {
             match *self.level {
-                Level::TRACE => f.pad("TRACE"),
-                Level::DEBUG => f.pad("DEBUG"),
-                Level::INFO => f.pad("INFO"),
-                Level::WARN => f.pad("WARN"),
-                Level::ERROR => f.pad("ERROR"),
+                Level::TRACE => f.pad(TRACE_STR),
+                Level::DEBUG => f.pad(DEBUG_STR),
+                Level::INFO => f.pad(INFO_STR),
+                Level::WARN => f.pad(WARN_STR),
+                Level::ERROR => f.pad(ERROR_STR),
             }
         }
     }
@@ -771,7 +777,7 @@ mod test {
         }
 
         let make_writer = || MockWriter::new(&BUF);
-        let expected = "fake time INFO tracing_subscriber::fmt::format::test: some ansi test\n";
+        let expected = "fake time  INFO tracing_subscriber::fmt::format::test: some ansi test\n";
 
         test_ansi(make_writer, expected, false, &BUF);
     }
@@ -784,7 +790,7 @@ mod test {
         }
 
         let make_writer = || MockWriter::new(&BUF);
-        let expected = "fake time INFO tracing_subscriber::fmt::format::test: some ansi test\n";
+        let expected = "fake time  INFO tracing_subscriber::fmt::format::test: some ansi test\n";
         let subscriber = crate::fmt::Subscriber::builder()
             .with_writer(make_writer)
             .with_timer(MockTime)


### PR DESCRIPTION
* subscriber: fix misaligned levels with ANSI disabled

Currently, when ANSI color formatting is enabled, `tracing-subscriber`'s
`fmt` module left-pads the INFO and WARN levels so that log lines are
aligned. However, when ANSI colors are off, these levels are not padded.

I've fixed this by replacing the string literals in the ANSI and
not-ANSI implementations with constants, to ensure the same string is
used regardless.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>

* subscriber: make ANSI and not-ANSI formatting consistent

Currently, the `tracing-subscriber` crate's `fmt` module has two
separate `fmt::Display` impls for its' `FmtCtx` and `FullCtx` types,
depending on whether the feature flag that enables ANSI colors is set.
Since a lot of the `fmt::Display` implementations doesn't have anything
to do with ANSI colors, this means that we have a lot of repeated code,
and in order to keep the formatting consistent, we have to keep these
implementations in sync manually. There are currently some
inconsistencies in formatting with ANSI colors on and off, implying that
we have failed to do that.

This commit simplifies the situation significantly by consolidating the
`fmt::Display` impls into one implementation, and only feature flagging
the code that actually needs to be different. We do this by introducing
a `Style` type which exposes no-op versions of methods with the same
names as the `ansi-term` crate's `Style` when ANSI formatting is
disabled. Now, the conditional logic is hidden in the function that
returns a `Style`, and the rest of the `fmt::Display` implementations
can be agnostic of ANSI colors. In release mode, `rustc` should be able
to optimize out the no-op methods and empty struct entirely.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>

* subscriber: don't print curly braces on spans with no fields

Previously, when `tracing-subscriber`'s `fmt` module printed span
contexts, curly braces were only added around a span's fields. When we
replaced the previous implementation with the new `fmt::Layer`, this
behavior was lost, and empty curly braces were added to spans without
fields.

This commit fixes this by putting back the `if` conditional that used to
guard the printing of span fields.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>

* subscriber: use `Formatter::write_char` rather than `pad`

This commit replaces uses of `Formatter::pad` with
`Formatter::write_char` wherever a single character is written to a
formatter. This prevents us from inadvertantly padding these characters
incorrectly, and may avoid some overhead.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
