### PR TITLE
subscriber: prepare to release 0.2.0-alpha.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ fn main() {
 ```toml
 [dependencies]
 tracing = "0.1"
-tracing-subscriber = "0.2.0-alpha.5"
+tracing-subscriber = "0.2.0-alpha.6"
 ```
 
 This subscriber will be used as the default in all threads for the remainder of the duration

--- a/tracing-error/src/layer.rs
+++ b/tracing-error/src/layer.rs
@@ -14,10 +14,10 @@ use tracing_subscriber::{
 /// when formatting the fields of each span in a trace. When no formatter is
 /// provided, the [default format] is used instead.
 ///
-/// [`Layer`]: https://docs.rs/tracing-subscriber/0.2.0-alpha.5/tracing_subscriber/layer/trait.Layer.html
+/// [`Layer`]: https://docs.rs/tracing-subscriber/0.2.0-alpha.6/tracing_subscriber/layer/trait.Layer.html
 /// [`SpanTrace`]: ../struct.SpanTrace.html
-/// [field formatter]: https://docs.rs/tracing-subscriber/0.2.0-alpha.5/tracing_subscriber/fmt/trait.FormatFields.html
-/// [default format]: https://docs.rs/tracing-subscriber/0.2.0-alpha.5/tracing_subscriber/fmt/format/struct.DefaultFields.html
+/// [field formatter]: https://docs.rs/tracing-subscriber/0.2.0-alpha.6/tracing_subscriber/fmt/trait.FormatFields.html
+/// [default format]: https://docs.rs/tracing-subscriber/0.2.0-alpha.6/tracing_subscriber/fmt/format/struct.DefaultFields.html
 pub struct ErrorLayer<S, F = DefaultFields> {
     format: F,
 
@@ -69,7 +69,7 @@ where
 {
     /// Returns a new `ErrorLayer` with the provided [field formatter].
     ///
-    /// [field formatter]: https://docs.rs/tracing-subscriber/0.2.0-alpha.5/tracing_subscriber/fmt/trait.FormatFields.html
+    /// [field formatter]: https://docs.rs/tracing-subscriber/0.2.0-alpha.6/tracing_subscriber/fmt/trait.FormatFields.html
     pub fn new(format: F) -> Self {
         Self {
             format,

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.2.0-alpha.6 (February 3, 2020)
+
+### Fixed
+
+- **fmt**: Fixed empty `{}` printed after spans with no fields (f079f2d)
+- **fmt**: Fixed inconsistent formatting when ANSI colors are disabled (506a482)
+- **fmt**: Fixed mis-aligned levels when ANSI colors are disabled (eba1adb)
+- Fixed warnings on nightly Rust compilers (#558)
+
 # 0.2.0-alpha.5 (January 31, 2020)
 
 ### Added

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.0-alpha.5"
+version = "0.2.0-alpha.6"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -17,7 +17,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.2.0-alpha.5
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.0-alpha.6
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -51,7 +51,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.0-alpha.5")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.0-alpha.6")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(
     missing_debug_implementations,

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -93,7 +93,7 @@ fn main() {
 ```toml
 [dependencies]
 tracing = "0.1"
-tracing-subscriber = "0.2.0-alpha.5"
+tracing-subscriber = "0.2.0-alpha.6"
 ```
 
 This subscriber will be used as the default in all threads for the remainder of the duration


### PR DESCRIPTION
Fixed

- **fmt**: Fixed empty `{}` printed after spans with no fields (f079f2d)
- **fmt**: Fixed inconsistent formatting when ANSI colors are disabled (506a482)
- **fmt**: Fixed mis-aligned levels when ANSI colors are disabled (eba1adb)
- Fixed warnings on nightly Rust compilers (#558)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
