### PR TITLE
subscriber: fix missing rustdoc-args on docs.rs

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -67,6 +67,7 @@ maintenance = { status = "experimental" }
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [[bench]]
 name = "filter"


### PR DESCRIPTION
This should fix the `doc-cfg` attributes not being present in the
docs.rs docs.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
