### PR TITLE
subscriber: remove `LookupMetadata` trait

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -573,10 +573,10 @@ mod test {
     }
 
     #[test]
-    fn is_lookup_meta() {
-        fn assert_lookup_meta<T: crate::registry::LookupMetadata>(_: T) {}
+    fn is_lookup_span() {
+        fn assert_lookup_span<T: for<'a> crate::registry::LookupSpan<'a>>(_: T) {}
         let fmt = fmt::Layer::builder().finish();
         let subscriber = fmt.with_subscriber(Registry::default());
-        assert_lookup_meta(subscriber)
+        assert_lookup_span(subscriber)
     }
 }

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -3,7 +3,7 @@ use crate::{
     field::MakeVisitor,
     fmt::fmt_layer::FmtContext,
     fmt::fmt_layer::FormattedFields,
-    registry::{LookupMetadata, LookupSpan},
+    registry::{LookupSpan},
 };
 use serde::ser::{SerializeMap, Serializer as _};
 use serde_json::Serializer;
@@ -29,7 +29,7 @@ pub struct Json;
 
 impl<S, N, T> FormatEvent<S, N> for Format<Json, T>
 where
-    S: Subscriber + for<'lookup> LookupSpan<'lookup> + LookupMetadata,
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
     N: for<'writer> FormatFields<'writer> + 'static,
     T: FormatTime,
 {
@@ -40,7 +40,7 @@ where
         event: &Event<'_>,
     ) -> fmt::Result
     where
-        S: Subscriber + for<'a> LookupSpan<'a> + LookupMetadata,
+        S: Subscriber + for<'a> LookupSpan<'a>,
     {
         use serde_json::{json, Value};
         use tracing_serde::fields::AsMap;

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -1,9 +1,7 @@
 use super::{Format, FormatEvent, FormatFields, FormatTime};
 use crate::{
-    field::MakeVisitor,
-    fmt::fmt_layer::FmtContext,
-    fmt::fmt_layer::FormattedFields,
-    registry::{LookupSpan},
+    field::MakeVisitor, fmt::fmt_layer::FmtContext, fmt::fmt_layer::FormattedFields,
+    registry::LookupSpan,
 };
 use serde::ser::{SerializeMap, Serializer as _};
 use serde_json::Serializer;

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -133,7 +133,11 @@ pub mod writer;
 pub use fmt_layer::{FmtContext, FormattedFields, Layer, LayerBuilder};
 
 use crate::layer::Layer as _;
-use crate::{filter::LevelFilter, layer, registry::{Registry, LookupSpan}};
+use crate::{
+    filter::LevelFilter,
+    layer,
+    registry::{LookupSpan, Registry},
+};
 
 #[doc(inline)]
 pub use self::{

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -133,7 +133,7 @@ pub mod writer;
 pub use fmt_layer::{FmtContext, FormattedFields, Layer, LayerBuilder};
 
 use crate::layer::Layer as _;
-use crate::{filter::LevelFilter, layer, registry::Registry};
+use crate::{filter::LevelFilter, layer, registry::{Registry, LookupSpan}};
 
 #[doc(inline)]
 pub use self::{
@@ -274,6 +274,17 @@ where
         } else {
             self.inner.downcast_raw(id)
         }
+    }
+}
+
+impl<'a, N, E, F, W> LookupSpan<'a> for Subscriber<N, E, F, W>
+where
+    layer::Layered<F, Formatter<N, E, W>>: LookupSpan<'a>,
+{
+    type Data = <layer::Layered<F, Formatter<N, E, W>> as LookupSpan<'a>>::Data;
+
+    fn span_data(&'a self, id: &span::Id) -> Option<Self::Data> {
+        self.inner.span_data(id)
     }
 }
 

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -277,18 +277,6 @@ where
     }
 }
 
-#[cfg(feature = "registry")]
-#[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
-impl<N, E, F, W> crate::registry::LookupMetadata for Subscriber<N, E, F, W>
-where
-    layer::Layered<F, Formatter<N, E, W>>: crate::registry::LookupMetadata,
-{
-    #[inline]
-    fn metadata(&self, id: &span::Id) -> Option<&'static Metadata<'static>> {
-        self.inner.metadata(id)
-    }
-}
-
 // ===== impl SubscriberBuilder =====
 
 impl Default for SubscriberBuilder {
@@ -808,9 +796,9 @@ mod test {
     }
 
     #[test]
-    fn is_lookup_meta() {
-        fn assert_lookup_meta<T: crate::registry::LookupMetadata>(_: T) {}
+    fn is_lookup_span() {
+        fn assert_lookup_span<T: for<'a> crate::registry::LookupSpan<'a>>(_: T) {}
         let subscriber = Subscriber::new();
-        assert_lookup_meta(subscriber)
+        assert_lookup_span(subscriber)
     }
 }

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -786,14 +786,10 @@ impl<'a, S: Subscriber> Context<'a, S> {
     #[cfg(feature = "registry")]
     #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
     pub fn exists(&self, id: &span::Id) -> bool
-
     where
         S: for<'lookup> LookupSpan<'lookup>,
     {
-        self.subscriber
-            .as_ref()
-            .and_then(|s| s.span(id))
-            .is_some()
+        self.subscriber.as_ref().and_then(|s| s.span(id)).is_some()
     }
 
     /// Returns [stored data] for the span that the wrapped subscriber considers

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -743,7 +743,8 @@ impl<'a, S: Subscriber> Context<'a, S> {
     where
         S: for<'lookup> LookupSpan<'lookup>,
     {
-        self.subscriber.as_ref()?.span(id)?.metadata()
+        let span = self.subscriber.as_ref()?.span(id)?;
+        Some(span.metadata())
     }
 
     /// Returns [stored data] for the span with the given `id`, if it exists.

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -743,7 +743,7 @@ impl<'a, S: Subscriber> Context<'a, S> {
     where
         S: for<'lookup> LookupSpan<'lookup>,
     {
-        self.subscriber.as_ref()?.span(id)?.metadata(id)
+        self.subscriber.as_ref()?.span(id)?.metadata()
     }
 
     /// Returns [stored data] for the span with the given `id`, if it exists.

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -60,7 +60,7 @@
 //! [`Registry`]: struct.Registry.html
 //! [ctx]: ../layer/struct.Context.html
 //! [lookup]: ../layer/struct.Context.html#method.span
-//! [`LookupSpan`]: trait.LookupSpan.html=
+//! [`LookupSpan`]: trait.LookupSpan.html
 //! [`SpanData`]: trait.SpanData.html
 use tracing_core::{field::FieldSet, span::Id, Metadata};
 

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -24,12 +24,12 @@ use tracing_core::{
 /// implementing various behaviors may be [added]. Unlike other types
 /// implementing `Subscriber` `Registry` does not actually record traces itself:
 /// instead, it collects and stores span data that is exposed to any `Layer`s
-/// wrapping it through implementations of the [`LookupSpan`] and
-/// [`LookupMetadata`] traits. The `Registry` is responsible for storing span
-/// metadata, recording relationships between spans, and tracking which spans
-/// are active and whicb are closed. In addition, it provides a mechanism
-/// `Layer`s to store user-defined per-span data, called [extensions], in the
-/// registry. This allows `Layer`-specific data to benefit from the `Registry`'s
+/// wrapping it through implementations of the [`LookupSpan`] trait.
+/// The `Registry` is responsible for storing span metadata, recording
+/// relationships between spans, and tracking which spans  are active and whicb
+/// are closed. In addition, it provides a mechanism for `Layer`s to store
+/// user-defined per-span data, called [extensions], in the registry. This
+/// allows `Layer`-specific data to benefit from the `Registry`'s
 /// high-performance concurrent storage.
 ///
 /// This registry is implemented using a [lock-free sharded slab][slab], and is
@@ -41,7 +41,6 @@ use tracing_core::{
 /// [`Layer`]: ../trait.Layer.html
 /// [added]: ../trait.Layer.html#method.with_subscriber
 /// [`LookupSpan`]: trait.LookupSpan.html
-/// [`LookupMetadata`]: trait.LookupMetadata.html
 /// [extensions]: extensions/index.html
 #[cfg(feature = "registry")]
 #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]


### PR DESCRIPTION
## Motivation

The `LookupMetadata` trait was essentially a prototype for `LookupSpan`,
and was intended to allow subscribers to implement more granular sets of
"registry" behavior. However, in practice, nothing ended up using it and
it was generally eclipsed by `LookupSpan`. The model of allowing
`Layer` implementations to opt in to more granular capabilities doesn't
make a whole lot of sense when there are only two such traits available
and one is a more powerful superset of the other. Before we release
`tracing-subscriber` 0.2.0, we should try to remove any APIs that aren't
necessary, since removing them later is a breaking change.

## Solution

Therefore, this commit removes `LookupMetadata`, and rewrites the
`Context::metadata` method to use `LookupSpan` to look up the metadata,
instead.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
