### PR TITLE
subscriber: feature flag registry implementation only

### DIFF
--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -98,8 +98,6 @@ pub mod filter;
 pub mod fmt;
 pub mod layer;
 pub mod prelude;
-#[cfg(feature = "registry")]
-#[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
 pub mod registry;
 pub mod reload;
 pub(crate) mod sync;

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -68,11 +68,18 @@ use tracing_core::{field::FieldSet, span::Id, Metadata};
 
 /// A module containing a type map of span extensions.
 mod extensions;
+#[cfg(feature = "registry")]
 mod sharded;
+#[cfg(feature = "registry")]
 mod stack;
 
 pub use extensions::{Extensions, ExtensionsMut};
-pub use sharded::{Data, Registry};
+#[cfg(feature = "registry")]
+#[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
+pub use sharded::Data;
+#[cfg(feature = "registry")]
+#[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
+pub use sharded::Registry;
 
 /// Provides access to stored span metadata.
 ///

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -43,6 +43,8 @@ use tracing_core::{
 /// [`LookupSpan`]: trait.LookupSpan.html
 /// [`LookupMetadata`]: trait.LookupMetadata.html
 /// [extensions]: extensions/index.html
+#[cfg(feature = "registry")]
+#[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
 #[derive(Debug)]
 pub struct Registry {
     spans: Slab<DataInner>,
@@ -58,6 +60,8 @@ pub struct Registry {
 /// [`Registry`]: struct.Registry.html
 /// [`Layer`s]: ../trait.Layer.html
 /// [extensions]: extensions/index.html
+#[cfg(feature = "registry")]
+#[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
 #[derive(Debug)]
 pub struct Data<'a> {
     inner: Guard<'a, DataInner>,


### PR DESCRIPTION
## Motivation

Currently, both the `Registry` type _and_ the `LookupSpan` and
`SpanData` traits require the "registry" feature flag. This means that
if a user wishes to implement their own custom registry type that
implements `LookupSpan`, they must enable the "registry" feature flag,
which also enables the `Registry` type and its dependencies.

## Solution

This commit changes the feature flag so that only the `Registry` and
`Data` types are conditional on the "registry" feature. The `LookupSpan`
and `SpanData` traits are now always enabled, as they are not much code
& don't require any additional internal dependencies (although if anyone
thinks it's important for them to have their own separate feature flag,
I am willing to change that).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>