### PR TITLE
subscriber: prepare to release 0.2.0 stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ fn main() {
 ```toml
 [dependencies]
 tracing = "0.1"
-tracing-subscriber = "0.2.0-alpha.6"
+tracing-subscriber = "0.2.0"
 ```
 
 This subscriber will be used as the default in all threads for the remainder of the duration

--- a/tracing-error/src/layer.rs
+++ b/tracing-error/src/layer.rs
@@ -14,10 +14,10 @@ use tracing_subscriber::{
 /// when formatting the fields of each span in a trace. When no formatter is
 /// provided, the [default format] is used instead.
 ///
-/// [`Layer`]: https://docs.rs/tracing-subscriber/0.2.0-alpha.6/tracing_subscriber/layer/trait.Layer.html
+/// [`Layer`]: https://docs.rs/tracing-subscriber/0.2.0/tracing_subscriber/layer/trait.Layer.html
 /// [`SpanTrace`]: ../struct.SpanTrace.html
-/// [field formatter]: https://docs.rs/tracing-subscriber/0.2.0-alpha.6/tracing_subscriber/fmt/trait.FormatFields.html
-/// [default format]: https://docs.rs/tracing-subscriber/0.2.0-alpha.6/tracing_subscriber/fmt/format/struct.DefaultFields.html
+/// [field formatter]: https://docs.rs/tracing-subscriber/0.2.0/tracing_subscriber/fmt/trait.FormatFields.html
+/// [default format]: https://docs.rs/tracing-subscriber/0.2.0/tracing_subscriber/fmt/format/struct.DefaultFields.html
 pub struct ErrorLayer<S, F = DefaultFields> {
     format: F,
 
@@ -69,7 +69,7 @@ where
 {
     /// Returns a new `ErrorLayer` with the provided [field formatter].
     ///
-    /// [field formatter]: https://docs.rs/tracing-subscriber/0.2.0-alpha.6/tracing_subscriber/fmt/trait.FormatFields.html
+    /// [field formatter]: https://docs.rs/tracing-subscriber/0.2.0/tracing_subscriber/fmt/trait.FormatFields.html
     pub fn new(format: F) -> Self {
         Self {
             format,

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,44 @@
+# 0.2.0 (February 4, 2020)
+
+### Breaking Changes
+
+- **fmt**: Renamed `Context` to `FmtContext` (#420, #425)
+- **fmt**: Renamed `Builder` to `SubscriberBuilder` (#420)
+- **filter**: Removed `Filter`. Use `EnvFilter` instead (#434)
+
+### Added
+
+- **registry**: `Registry`, a `Subscriber` implementation that `Layer`s can use
+  as a high-performance, in-memory span store. (#420, #425, #432, #433, #435)
+- **registry**: Added `LookupSpan` trait, implemented by `Subscriber`s to expose
+  stored span data to `Layer`s (#420)
+- **fmt**: Added `fmt::Layer`, to allow composing log formatting with other `Layer`s
+- **fmt**: Added support for JSON field and event formatting (#377, #415)
+- **filter**: Documentation for filtering directives (#554)
+
+### Changed
+
+- **fmt**: Renamed `Context` to `FmtContext` (#420, #425) (BREAKING)
+- **fmt**: Renamed `Builder` to `SubscriberBuilder` (#420) (BREAKING)
+- **fmt**: Reimplemented `fmt::Subscriber` in terms of the `Registry`
+  and `Layer`s (#420)
+
+### Removed
+
+- **filter**: Removed `Filter`. Use `EnvFilter` instead (#434) (BREAKING)
+
+### Fixed
+
+- **fmt**: Fixed memory leaks in the slab used to store per-span data
+  (3c35048)
+- **fmt**: `fmt::SubscriberBuilder::init` not setting up `log` compatibility
+  (#489)
+- **fmt**: Spans closed by a child span closing not also closing _their_
+  parents (#514)
+- **Layer**: Fixed `Layered` subscribers failing to downcast to their own type
+  (#549)
+- **Layer**: Fixed `Layer::downcast_ref` returning invalid references (#454)
+
 # 0.2.0-alpha.6 (February 3, 2020)
 
 ### Fixed

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.0-alpha.6"
+version = "0.2.0"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -17,7 +17,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.2.0-alpha.6
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.0
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -51,7 +51,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.0-alpha.6")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.0")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(
     missing_debug_implementations,

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -93,7 +93,7 @@ fn main() {
 ```toml
 [dependencies]
 tracing = "0.1"
-tracing-subscriber = "0.2.0-alpha.6"
+tracing-subscriber = "0.2.0"
 ```
 
 This subscriber will be used as the default in all threads for the remainder of the duration


### PR DESCRIPTION
# 0.2.0 (February 4, 2020)

### Breaking Changes

- **fmt**: Renamed `Context` to `FmtContext` (#420, #425)
- **fmt**: Renamed `Builder` to `SubscriberBuilder` (#420)
- **filter**: Removed `Filter`. Use `EnvFilter` instead (#434)

### Added

- **registry**: `Registry`, a `Subscriber` implementation that `Layer`s can use
  as a high-performance, in-memory span store. (#420, #425, #432, #433, #435)
- **registry**: Added `LookupSpan` trait, implemented by `Subscriber`s to expose
  stored span data to `Layer`s (#420)
- **fmt**: Added `fmt::Layer`, to allow composing log formatting with other `Layer`s
- **fmt**: Added support for JSON field and event formatting (#377, #415)
- **filter**: Documentation for filtering directives (#554)

### Changed

- **fmt**: Renamed `Context` to `FmtContext` (#420, #425) (BREAKING)
- **fmt**: Renamed `Builder` to `SubscriberBuilder` (#420) (BREAKING)
- **fmt**: Reimplemented `fmt::Subscriber` in terms of the `Registry`
  and `Layer`s (#420)

### Removed

- **filter**: Removed `Filter`. Use `EnvFilter` instead (#434) (BREAKING)

### Fixed

- **fmt**: Fixed memory leaks in the slab used to store per-span data (3c35048)
- **fmt**: `fmt::SubscriberBuilder::init` not setting up `log` compatibility (#489)
- **fmt**: Spans closed by a child span closing not also closing _their_
  parents (#514)
- **Layer**: Fixed `Layered` subscribers failing to downcast to their own type (#549)
- **Layer**: Fixed `Layer::downcast_ref` returning invalid references (#454)