### PR TITLE
Specify path dependencies for workspace crates

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -35,13 +35,6 @@ verify() {
         err "git tag \`$TAG\` already exists"
         exit 1
     fi
-
-    PATH_DEPS=$(grep -F "path = \"" Cargo.toml | sed -e 's/^/  /')
-    if [ -n "$PATH_DEPS" ]; then
-        err "crate \`$CRATE\` contained path dependencies:\n$PATH_DEPS"
-        echo "path dependencies must be removed prior to release"
-        exit 1
-    fi
 }
 
 release() {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,13 +15,13 @@ tower-h2 = { git = "https://github.com/tower-rs/tower-h2.git", optional = true }
 [dev-dependencies]
 
 # tracing crates
-tracing = "0.1"
-tracing-core = "0.1"
+tracing = { path = "../tracing", version = "0.1"}
+tracing-core = { path = "../tracing-core", version = "0.1"}
 tracing-error = { path = "../tracing-error" }
 tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
-tracing-subscriber = { version = "0.2.0-alpha.5", features = ["json", "chrono"] }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.0-alpha.5", features = ["json", "chrono"] }
 tracing-futures = { version = "0.2.1", path = "../tracing-futures", features = ["futures-01"] }
-tracing-attributes =  "0.1.2"
+tracing-attributes =  { path = "../tracing-attributes", version = "0.1.2"}
 tracing-log = { path = "../tracing-log", version = "0.1.1", features = ["env_logger"] }
 tracing-serde = { path = "../tracing-serde" }
 

--- a/nightly-examples/Cargo.toml
+++ b/nightly-examples/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 edition = "2018"
 
 [dev-dependencies]
-tracing = "0.1"
+tracing = { path = "../tracing", version = "0.1"}
 tracing-subscriber = { version = "0.2.0-alpha.1", path = "../tracing-subscriber", features = ["json"] }
 tracing-futures = { path = "../tracing-futures", default-features = false, features = ["std-future"] }
 futures = "0.3"

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -43,8 +43,8 @@ quote = "1"
 
 
 [dev-dependencies]
-tracing = "0.1"
-tracing-futures = "0.2"
+tracing = { path = "../tracing", version = "0.1" }
+tracing-futures = { path = "../tracing-futures", version = "0.2" }
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-attributes/test_async_await/Cargo.toml
+++ b/tracing-attributes/test_async_await/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2018"
 
 [dev-dependencies]
 tokio-test = { git = "https://github.com/tokio-rs/tokio.git" }
-tracing = "0.1"
-tracing-core = "0.1"
+tracing = { path = "../../tracing", version = "0.1"}
+tracing-core = { path = "../../tracing-core", version = "0.1"}
 tracing-futures = { path = "../../tracing-futures", features = ["std-future"] }
 tracing-attributes = { path = ".." }
 test_std_future = { path = "../../tracing-futures/test_std_future" }

--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tracing-subscriber = { version = "0.2.0-alpha.5", default-features = false, features = ["registry", "fmt"] }
-tracing = "0.1"
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.0-alpha.5", default-features = false, features = ["registry", "fmt"] }
+tracing = { path = "../tracing", version = "0.1"}

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -29,7 +29,7 @@ futures_01 = { package = "futures", version = "0.1", optional = true }
 futures = { version = "0.3.0", optional = true }
 futures-task = { version = "0.3", optional = true }
 pin-project = { version = "0.4", optional = true }
-tracing = { version = "0.1", default-features = false }
+tracing = { path = "../tracing", version = "0.1", default-features = false }
 tokio-executor = { version = "0.1", optional = true }
 tokio = { version = "0.1", optional = true }
 

--- a/tracing-futures/test_std_future/Cargo.toml
+++ b/tracing-futures/test_std_future/Cargo.toml
@@ -13,6 +13,6 @@ edition = "2018"
 
 [dependencies]
 tokio-test = { git = "https://github.com/tokio-rs/tokio.git" }
-tracing = "0.1"
-tracing-core = "0.1.2"
+tracing = { path = "../../tracing", version = "0.1" }
+tracing-core = { path = "../../tracing-core", version = "0.1.2" }
 tracing-futures = { path = ".." }

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -23,13 +23,13 @@ log-tracer = []
 trace-logger = []
 
 [dependencies]
-tracing-core = "0.1.2"
+tracing-core = { path = "../tracing-core", version = "0.1.2"}
 log = { version = "0.4" }
 lazy_static = "1.3.0"
 env_logger = { version = "0.6", optional = true }
 
 [dev-dependencies]
-tracing = "0.1"
+tracing = { path = "../tracing", version = "0.1"}
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["logging", "tracing", "serialization"]
 
 [dependencies]
 serde = "1"
-tracing-core = "0.1.2"
+tracing-core = { path = "../tracing-core", version = "0.1.2"}
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -31,7 +31,7 @@ registry = ["sharded-slab"]
 json = ["tracing-serde", "serde", "serde_json"]
 
 [dependencies]
-tracing-core = "0.1.2"
+tracing-core = { path = "../tracing-core", version = "0.1.2" }
 
 # only required by the filter feature
 matchers = { optional = true, version = "0.0.1" }
@@ -40,14 +40,14 @@ smallvec = { optional = true, version = "1"}
 lazy_static = { optional = true, version = "1" }
 
 # fmt
-tracing-log = { version = "0.1", optional = true, default-features = false, features = ["log-tracer", "std"] }
+tracing-log = { path = "../tracing-log", version = "0.1", optional = true, default-features = false, features = ["log-tracer", "std"] }
 ansi_term = { version = "0.11", optional = true }
 chrono = { version = "0.4", optional = true }
 
 # only required by the json feature
 serde_json = { version = "1.0", optional = true }
 serde = { version = "1.0", optional = true }
-tracing-serde = { version = "0.1.0", optional = true }
+tracing-serde = { path = "../tracing-serde", version = "0.1.0", optional = true }
 
 # opt-in deps
 parking_lot = { version = ">= 0.7, < 0.10", optional = true }
@@ -56,9 +56,9 @@ parking_lot = { version = ">= 0.7, < 0.10", optional = true }
 sharded-slab = { version = "0.0.8", optional = true }
 
 [dev-dependencies]
-tracing = "0.1"
+tracing = { path = "../tracing", version = "0.1"}
 log = "0.4"
-tracing-log = { version = "0.1" }
+tracing-log = { path = "../tracing-log", version = "0.1" }
 criterion = { version = "0.3", default_features = false }
 
 [badges]

--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -24,7 +24,7 @@ tower-make = [
 ]
 
 [dependencies]
-tracing = "0.1"
+tracing = { path = "../tracing", version = "0.1"}
 tracing-futures = { version = "0.2.1", path = "../tracing-futures", features = ["std-future"] }
 futures = "0.3"
 tower-service = "0.3"

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -29,7 +29,7 @@ edition = "2018"
 [dependencies]
 tracing-core = { path = "../tracing-core", version = "0.1.9", default-features = false }
 log = { version = "0.4", optional = true }
-tracing-attributes = "0.1.6"
+tracing-attributes = { path = "../tracing-attributes", version = "0.1.6"}
 cfg-if = "0.1.10"
 
 [dev-dependencies]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation
Intra-workspace dependencies can go out of sync if only referencing crates.io, where changing one crate locally and testing the whole library will result in errors stemming from two different versions of the same trait etc. This is hard to keep track of and makes development more difficult than it needs to be. 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Afaik it's common practice to specify both a version and a path as per https://github.com/rust-lang/cargo/blob/master/src/doc/src/reference/specifying-dependencies.md#multiple-locations. This is what tokio does with its subcrates too.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
