### PR TITLE
tracing: fix hidden lifetime params in types

### DIFF
--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -764,7 +764,7 @@ impl Span {
 
     #[cfg(feature = "log")]
     #[inline]
-    fn log(&self, message: fmt::Arguments) {
+    fn log(&self, message: fmt::Arguments<'_>) {
         if let Some(ref meta) = self.meta {
             let logger = log::logger();
             let log_meta = log::Metadata::builder()
@@ -969,7 +969,7 @@ struct FmtValues<'a>(&'a Record<'a>);
 
 #[cfg(feature = "log")]
 impl<'a> fmt::Display for FmtValues<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut res = Ok(());
         self.0.record(&mut |k: &field::Field, v: &dyn fmt::Debug| {
             res = write!(f, "{}={:?} ", k, v);
@@ -983,7 +983,7 @@ struct FmtAttrs<'a>(&'a Attributes<'a>);
 
 #[cfg(feature = "log")]
 impl<'a> fmt::Display for FmtAttrs<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut res = Ok(());
         self.0.record(&mut |k: &field::Field, v: &dyn fmt::Debug| {
             res = write!(f, "{}={:?} ", k, v);


### PR DESCRIPTION
Hidden lifetime parameters in types are deprecated in Rust 2018. These
specific instances were missed as they are in code that is only compiled
with the `log` feature enabled, and the CI warnings step does not enable
that feature.

This PR adds explicit empty lifetimes.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>