### PR TITLE
error: prepare to release 0.1.0

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,7 +19,7 @@ tracing = "0.1"
 tracing-core = "0.1"
 tracing-error = { path = "../tracing-error" }
 tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
-tracing-subscriber = { version = "0.2.0-alpha.5", features = ["json", "chrono"] }
+tracing-subscriber = { version = "0.2.0", features = ["json", "chrono"] }
 tracing-futures = { version = "0.2.1", path = "../tracing-futures", features = ["futures-01"] }
 tracing-attributes =  "0.1.2"
 tracing-log = { path = "../tracing-log", version = "0.1.1", features = ["env_logger"] }

--- a/tracing-error/CHANGELOG.md
+++ b/tracing-error/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0 (February 5, 2020)
+
+- Initial release

--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -1,11 +1,45 @@
 [package]
 name = "tracing-error"
+# When releasing to crates.io:
+# - Remove path dependencies
+# - Update html_root_url.
+# - Update doc url
+#   - Cargo.toml
+#   - README.md
+# - Update CHANGELOG.md.
+# - Create "v0.1.x" git tag
 version = "0.1.0"
-authors = ["Eliza Weisman <eliza@buoyant.io>"]
+authors = [
+    "Eliza Weisman <eliza@buoyant.io>",
+    "Jane Lusby <jlusby@yaah.dev>",
+    "Tokio Contributors <team@tokio.rs>"
+]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/tokio-rs/tracing"
+homepage = "https://tokio.rs"
+description = """
+Utilities for enriching erorrs with `tracing`.
+"""
+categories = [
+    "development-tools::debugging",
+    "rust-patterns"
+]
+keywords = [
+    "tracing",
+    "error-handling",
+    "exception-reporting",
+    "backtrace"
+]
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 tracing-subscriber = { version = "0.2.0-alpha.5", default-features = false, features = ["registry", "fmt"] }
 tracing = "0.1"
+
+[badges]
+maintenance = { status = "actively-developed" }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -34,7 +34,7 @@ keywords = [
 edition = "2018"
 
 [dependencies]
-tracing-subscriber = { version = "0.2.0-alpha.5", default-features = false, features = ["registry", "fmt"] }
+tracing-subscriber = { version = "0.2.0", default-features = false, features = ["registry", "fmt"] }
 tracing = "0.1"
 
 [badges]

--- a/tracing-error/README.md
+++ b/tracing-error/README.md
@@ -1,0 +1,126 @@
+# tracing-error
+
+Utilities for instrumenting errors with [`tracing`].
+
+[![Crates.io][crates-badge]][crates-url]
+[![Documentation][docs-badge]][docs-url]
+[![Documentation (master)][docs-master-badge]][docs-master-url]
+[![MIT licensed][mit-badge]][mit-url]
+[![Build Status][actions-badge]][actions-url]
+[![Discord chat][discord-badge]][discord-url]
+![maintenance status][maint-badge]
+
+[Documentation (release)][docs-url] | [Documentation (master)][docs-master-url] | [Chat][discord-url]
+
+[crates-badge]: https://img.shields.io/crates/v/tracing-error.svg
+[crates-url]: https://crates.io/crates/tracing-error/0.1.0
+[docs-badge]: https://docs.rs/tracing-error/badge.svg
+[docs-url]: https://docs.rs/tracing-error/0.1.0/tracing_error
+[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
+[docs-master-url]: https://tracing-rs.netlify.com/tracing_error
+[mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
+[mit-url]: LICENSE
+[actions-badge]: https://github.com/tokio-rs/tracing/workflows/CI/badge.svg
+[actions-url]:https://github.com/tokio-rs/tracing/actions?query=workflow%3ACI
+[discord-badge]: https://img.shields.io/discord/500028886025895936?logo=discord&label=discord&logoColor=white
+[discord-url]: https://discord.gg/EeF3cQw
+[maint-badge]: https://img.shields.io/badge/maintenance-experimental-blue.svg
+
+## Overview
+
+[`tracing`] is a framework for instrumenting Rust programs to collect
+scoped, structured, and async-aware diagnostics. This crate provides
+integrations between [`tracing`] instrumentation and Rust error handling. It
+enables enriching error types with diagnostic information from `tracing`
+[span] contexts, formatting those contexts when errors are displayed, and
+automatically generate `tracing` [events] when errors occur.
+
+The crate provides the following:
+
+* [`SpanTrace`], a captured trace of the current `tracing` [span] context
+
+* [`ErrorLayer`], a [subscriber layer] which enables capturing `SpanTrace`s
+
+**Note**: This crate is currently experimental.
+
+*Compiler support: requires `rustc` 1.39+*
+
+## Usage
+
+Currently, `tracing-error` provides the [`SpanTrace`] type, which captures
+the current `tracing` span context when it is constructed and allows it to
+be displayed at a later time.
+
+This crate does not _currently_ provide any actual error types implementing
+`std::error::Error`. Instead, user-constructed errors or libraries
+implementing error types may capture a [`SpanTrace`] and include it as part
+of their error types.
+
+For example:
+
+```rust
+use std::{fmt, error::Error};
+use tracing_error::SpanTrace;
+
+#[derive(Debug)]
+pub struct MyError {
+    context: SpanTrace,
+    // ...
+}
+
+impl fmt::Display for MyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // ... format other parts of the error ...
+        self.context.fmt(f)?;
+        // ... format other error context information, cause chain, etc ...
+    }
+}
+
+impl Error for MyError {}
+
+impl MyError {
+    pub fn new() -> Self {
+        Self {
+            context: SpanTrace::capture(),
+            // ... other error information ...
+        }
+    }
+}
+```
+
+In the future, this crate may also provide its own `Error` types as well,
+for users who do not wish to use other error-handling libraries.
+Applications that wish to use `tracing-error`-enabled errors should
+construct an [`ErrorLayer`] and add it to their [`Subscriber`] in order to
+enable capturing [`SpanTrace`]s. For example:
+
+```rust
+use tracing_error::ErrorLayer;
+use tracing_subscriber::prelude::*;
+
+fn main() {
+    let subscriber = tracing_subscriber::Registry::default()
+        // any number of other subscriber layers may be added before or
+        // after the `ErrorLayer`...
+        .with(ErrorLayer::default());
+    // set the subscriber as the default for the application
+    tracing::subscriber::set_global_default(subscriber);
+}
+```
+
+[`SpanTrace`]: https://docs.rs/tracing-error/0.1.0/tracing_error/struct.SpanTrace.html
+[`ErrorLayer`]: https://docs.rs/tracing-error/0.1.0/tracing_error/struct.ErrorLayer.html
+[span]: https://docs.rs/tracing/latest/tracing/span/index.html
+[event]: https://docs.rs/tracing/latest/tracing/struct.Event.html
+[subscriber layer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/trait.Layer.html
+[`tracing`]: https://crates.io/tracing
+
+## License
+
+This project is licensed under the [MIT license](LICENSE).
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in Tracing by you, shall be licensed as MIT, without any additional
+terms or conditions.

--- a/tracing-error/src/layer.rs
+++ b/tracing-error/src/layer.rs
@@ -1,4 +1,5 @@
-use std::any::TypeId;
+use std::any::{type_name, TypeId};
+use std::fmt;
 use std::marker::PhantomData;
 use tracing::{span, Dispatch, Metadata, Subscriber};
 use tracing_subscriber::fmt::format::{DefaultFields, FormatFields};
@@ -18,7 +19,6 @@ use tracing_subscriber::{
 /// [`SpanTrace`]: ../struct.SpanTrace.html
 /// [field formatter]: https://docs.rs/tracing-subscriber/0.2.0/tracing_subscriber/fmt/trait.FormatFields.html
 /// [default format]: https://docs.rs/tracing-subscriber/0.2.0/tracing_subscriber/fmt/format/struct.DefaultFields.html
-#[derive(Debug)]
 pub struct ErrorLayer<S, F = DefaultFields> {
     format: F,
 
@@ -121,5 +121,14 @@ where
 {
     fn default() -> Self {
         Self::new(DefaultFields::default())
+    }
+}
+
+impl<S, F: fmt::Debug> fmt::Debug for ErrorLayer<S, F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ErrorLayer")
+            .field("format", &self.format)
+            .field("subscriber", &format_args!("{}", type_name::<S>()))
+            .finish()
     }
 }

--- a/tracing-error/src/layer.rs
+++ b/tracing-error/src/layer.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::{
 /// [`SpanTrace`]: ../struct.SpanTrace.html
 /// [field formatter]: https://docs.rs/tracing-subscriber/0.2.0/tracing_subscriber/fmt/trait.FormatFields.html
 /// [default format]: https://docs.rs/tracing-subscriber/0.2.0/tracing_subscriber/fmt/format/struct.DefaultFields.html
+#[derive(Debug)]
 pub struct ErrorLayer<S, F = DefaultFields> {
     format: F,
 

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -11,6 +11,29 @@
 //! **Note**: This crate is currently experimental.
 //!
 //! [`tracing`]: https://docs.rs/tracing
+#![doc(html_root_url = "https://docs.rs/tracing-error/0.1.0")]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub,
+    bad_style,
+    const_err,
+    dead_code,
+    improper_ctypes,
+    non_shorthand_field_patterns,
+    no_mangle_generic_items,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    private_in_public,
+    unconditional_recursion,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true
+)]
 mod backtrace;
 mod layer;
 

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -1,15 +1,96 @@
 //! Utilities for enriching error handling with [`tracing`] diagnostic
 //! information.
 //!
+//! # Overview
+//!
 //! [`tracing`] is a framework for instrumenting Rust programs to collect
 //! scoped, structured, and async-aware diagnostics. This crate provides
-//! integrations between [`tracing`] instrumentation and Rust error handling,
-//! allowing error types to capture the current [`tracing`] span context when
-//! they are constructed, format those contexts when they are displayed, and
-//! automatically generate [`tracing`] events when errors occur.
+//! integrations between [`tracing`] instrumentation and Rust error handling. It
+//! enables enriching error types with diagnostic information from `tracing`
+//! [span] contexts, formatting those contexts when errors are displayed, and
+//! automatically generate `tracing` [events] when errors occur.
+//!
+//! The crate provides the following:
+//!
+//! * [`SpanTrace`], a captured trace of the current `tracing` [span] context
+//!
+//! * [`ErrorLayer`], a [subscriber layer] which enables capturing `SpanTrace`s
 //!
 //! **Note**: This crate is currently experimental.
 //!
+//! *Compiler support: requires `rustc` 1.39+*
+//!
+//! ## Usage
+//!
+//! Currently, `tracing-error` provides the [`SpanTrace`] type, which captures
+//! the current `tracing` span context when it is constructed and allows it to
+//! be displayed at a later time.
+//!
+//! This crate does not _currently_ provide any actual error types implementing
+//! `std::error::Error`. Instead, user-constructed errors or libraries
+//! implementing error types may capture a [`SpanTrace`] and include it as part
+//! of their error types.
+//!
+//! For example:
+//!
+//! ```rust
+//! use std::{fmt, error::Error};
+//! use tracing_error::SpanTrace;
+//!
+//! #[derive(Debug)]
+//! pub struct MyError {
+//!     context: SpanTrace,
+//!     // ...
+//! }
+//!
+//! impl fmt::Display for MyError {
+//!     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+//!         // ... format other parts of the error ...
+//!
+//!         self.context.fmt(f)?;
+//!
+//!         // ... format other error context information, cause chain, etc ...
+//!     }
+//! }
+//!
+//! impl Error for MyError {}
+//!
+//! impl MyError {
+//!     pub fn new() -> Self {
+//!         Self {
+//!             context: SpanTrace::capture(),
+//!             // ... other error information ...
+//!         }
+//!     }
+//! }
+//! ```
+//! In the future, this crate may also provide its own `Error` types as well,
+//! for users who do not wish to use other error-handling libraries.
+//!
+//! Applications that wish to use `tracing-error`-enabled errors should
+//! construct an [`ErrorLayer`] and add it to their [`Subscriber`] in order to
+//! enable capturing [`SpanTrace`]s. For example:
+//!
+//! ```rust
+//! use tracing_error::ErrorLayer;
+//! use tracing_subscriber::prelude::*;
+//!
+//! fn main() {
+//!     let subscriber = tracing_subscriber::Registry::default()
+//!         // any number of other subscriber layers may be added before or
+//!         // after the `ErrorLayer`...
+//!         .with(ErrorLayer::default());
+//!
+//!     // set the subscriber as the default for the application
+//!     tracing::subscriber::set_global_default(subscriber);
+//! }
+//! ```
+//!
+//! [`SpanTrace`]: struct.SpanTrace.html
+//! [`ErrorLayer`]: struct.ErrorLayer.html
+//! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
+//! [event]: https://docs.rs/tracing/latest/tracing/struct.Event.html
+//! [subscriber layer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/trait.Layer.html
 //! [`tracing`]: https://docs.rs/tracing
 #![doc(html_root_url = "https://docs.rs/tracing-error/0.1.0")]
 #![warn(

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -50,6 +50,7 @@
 //!         self.context.fmt(f)?;
 //!
 //!         // ... format other error context information, cause chain, etc ...
+//!         # Ok(())
 //!     }
 //! }
 //!


### PR DESCRIPTION
This branch prepares `tracing-error` to publish to crates.io.