### PR TITLE
Add error instrumentation type and traits

### DIFF
--- a/examples/examples/instrumented_error.rs
+++ b/examples/examples/instrumented_error.rs
@@ -62,13 +62,19 @@ fn main() {
 // before printing before printing it.
 fn print_extracted_spantraces(error: &(dyn Error + 'static)) {
     let mut error = Some(error);
+    let mut ind = 0;
+
+    eprintln!("Error:");
+
     while let Some(err) = error {
         if let Some(spantrace) = err.span_trace() {
             eprintln!("found a spantrace!:\n{}", spantrace);
         } else {
-            eprintln!("error: {}", err);
+            eprintln!("{:>4}: {}", ind, err);
         }
+
         error = err.source();
+        ind += 1;
     }
 }
 

--- a/examples/examples/instrumented_error.rs
+++ b/examples/examples/instrumented_error.rs
@@ -41,7 +41,6 @@ fn do_another_thing(
     Err(FooError::new("something broke, lol").in_current_span())
 }
 
-
 #[tracing::instrument]
 fn main() {
     let subscriber = Registry::default()

--- a/examples/examples/instrumented_error.rs
+++ b/examples/examples/instrumented_error.rs
@@ -1,0 +1,62 @@
+//! This example demonstrates using the `tracing-error` crate's `SpanTrace` type
+//! to attach a trace context to a custom error type.
+#![deny(rust_2018_idioms)]
+use std::error::Error;
+use std::fmt;
+use tracing_error::{ErrorLayer, Instrument as _, SpanTrace, SpanTraceExt as _};
+use tracing_subscriber::{fmt::Layer as FmtLayer, prelude::*, registry::Registry};
+
+#[derive(Debug)]
+struct FooError {
+    message: &'static str,
+}
+
+impl FooError {
+    fn new(message: &'static str) -> Self {
+        Self { message }
+    }
+}
+
+impl Error for FooError {}
+
+impl fmt::Display for FooError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad(self.message)
+    }
+}
+
+#[tracing::instrument]
+fn do_something(foo: &str) -> Result<&'static str, impl Error + Send + Sync + 'static> {
+    do_another_thing(42, false)
+}
+
+#[tracing::instrument]
+fn do_another_thing(
+    answer: usize,
+    will_succeed: bool,
+) -> Result<&'static str, impl Error + Send + Sync + 'static> {
+    Err(FooError::new("something broke, lol")).in_current_span()
+}
+
+#[tracing::instrument]
+fn main() {
+    let subscriber = Registry::default()
+        .with(FmtLayer::default())
+        // The `ErrorLayer` subscriber layer enables the use of `SpanTrace`.
+        .with(ErrorLayer::default());
+    tracing::subscriber::set_global_default(subscriber).expect("Could not set global default");
+    match do_something("hello world") {
+        Ok(result) => println!("did something successfully: {}", result),
+        Err(e) => {
+            let trait_object: Box<dyn Error + 'static> = Box::new(e);
+            let mut error = Some(trait_object.as_ref());
+            while let Some(err) = error {
+                if let Some(spantrace) = err.spantrace() {
+                    eprintln!("found a spantrace!:\n{}", spantrace);
+                }
+                eprintln!("error: {}", err);
+                error = err.source();
+            }
+        }
+    };
+}

--- a/examples/examples/instrumented_error.rs
+++ b/examples/examples/instrumented_error.rs
@@ -3,7 +3,7 @@
 #![deny(rust_2018_idioms)]
 use std::error::Error;
 use std::fmt;
-use tracing_error::{ErrorLayer, Instrument as _, SpanTrace, SpanTraceExt as _};
+use tracing_error::{prelude::*, ErrorLayer};
 use tracing_subscriber::{fmt::Layer as FmtLayer, prelude::*, registry::Registry};
 
 #[derive(Debug)]
@@ -35,7 +35,9 @@ fn do_another_thing(
     answer: usize,
     will_succeed: bool,
 ) -> Result<&'static str, impl Error + Send + Sync + 'static> {
-    Err(FooError::new("something broke, lol")).in_current_span()
+    Err(FooError::new("something broke, lol"))
+        .in_current_span()
+        .in_current_span()
 }
 
 #[tracing::instrument]

--- a/examples/examples/instrumented_error.rs
+++ b/examples/examples/instrumented_error.rs
@@ -58,6 +58,8 @@ fn main() {
     };
 }
 
+// Iterate through the source errors and check if each error is a placeholder for a `SpanTrace`
+// before printing before printing it.
 fn print_extracted_spantraces(error: &(dyn Error + 'static)) {
     let mut error = Some(error);
     while let Some(err) = error {
@@ -70,6 +72,8 @@ fn print_extracted_spantraces(error: &(dyn Error + 'static)) {
     }
 }
 
+// Iterate through source errors and print all sources as errors uniformly, regardless of whether
+// or not that error is actually a placeholder for extracting a SpanTrace
 fn print_naive_spantraces(error: &(dyn Error + 'static)) {
     let mut error = Some(error);
     let mut ind = 0;

--- a/examples/examples/instrumented_error.rs
+++ b/examples/examples/instrumented_error.rs
@@ -61,8 +61,8 @@ fn main() {
     };
 }
 
-// Iterate through the source errors and check if each error is a placeholder for a `SpanTrace`
-// before printing before printing it.
+// Iterate through the source errors and check if each error is actually the attached `SpanTrace`
+// before printing it
 fn print_extracted_spantraces(error: &(dyn Error + 'static)) {
     let mut error = Some(error);
     let mut ind = 0;
@@ -80,7 +80,7 @@ fn print_extracted_spantraces(error: &(dyn Error + 'static)) {
 }
 
 // Iterate through source errors and print all sources as errors uniformly, regardless of whether
-// or not that error is actually a placeholder for extracting a SpanTrace
+// or not that error has a `SpanTrace` attached or not.
 fn print_naive_spantraces(error: &(dyn Error + 'static)) {
     let mut error = Some(error);
     let mut ind = 0;

--- a/examples/examples/instrumented_error.rs
+++ b/examples/examples/instrumented_error.rs
@@ -53,8 +53,9 @@ fn main() {
             while let Some(err) = error {
                 if let Some(spantrace) = err.span_trace() {
                     eprintln!("found a spantrace!:\n{}", spantrace);
+                } else {
+                    eprintln!("error: {}", err);
                 }
-                eprintln!("error: {}", err);
                 error = err.source();
             }
         }

--- a/examples/examples/instrumented_error.rs
+++ b/examples/examples/instrumented_error.rs
@@ -49,15 +49,34 @@ fn main() {
         Ok(result) => println!("did something successfully: {}", result),
         Err(e) => {
             let trait_object: Box<dyn Error + 'static> = Box::new(e);
-            let mut error = Some(trait_object.as_ref());
-            while let Some(err) = error {
-                if let Some(spantrace) = err.span_trace() {
-                    eprintln!("found a spantrace!:\n{}", spantrace);
-                } else {
-                    eprintln!("error: {}", err);
-                }
-                error = err.source();
-            }
+            eprintln!("printing error chain naively");
+            print_naive_spantraces(trait_object.as_ref());
+
+            eprintln!("\nprinting error with extract method");
+            print_extracted_spantraces(trait_object.as_ref());
         }
     };
+}
+
+fn print_extracted_spantraces(error: &(dyn Error + 'static)) {
+    let mut error = Some(error);
+    while let Some(err) = error {
+        if let Some(spantrace) = err.span_trace() {
+            eprintln!("found a spantrace!:\n{}", spantrace);
+        } else {
+            eprintln!("error: {}", err);
+        }
+        error = err.source();
+    }
+}
+
+fn print_naive_spantraces(error: &(dyn Error + 'static)) {
+    let mut error = Some(error);
+    let mut ind = 0;
+    eprintln!("Error:");
+    while let Some(err) = error {
+        eprintln!("{:>4}: {}", ind, err);
+        error = err.source();
+        ind += 1;
+    }
 }

--- a/examples/examples/instrumented_error.rs
+++ b/examples/examples/instrumented_error.rs
@@ -51,7 +51,7 @@ fn main() {
             let trait_object: Box<dyn Error + 'static> = Box::new(e);
             let mut error = Some(trait_object.as_ref());
             while let Some(err) = error {
-                if let Some(spantrace) = err.spantrace() {
+                if let Some(spantrace) = err.span_trace() {
                     eprintln!("found a spantrace!:\n{}", spantrace);
                 }
                 eprintln!("error: {}", err);

--- a/examples/examples/instrumented_error.rs
+++ b/examples/examples/instrumented_error.rs
@@ -27,7 +27,7 @@ impl fmt::Display for FooError {
 
 #[tracing::instrument]
 fn do_something(foo: &str) -> Result<&'static str, impl Error + Send + Sync + 'static> {
-    do_another_thing(42, false)
+    do_another_thing(42, false).in_current_span()
 }
 
 #[tracing::instrument]
@@ -35,9 +35,7 @@ fn do_another_thing(
     answer: usize,
     will_succeed: bool,
 ) -> Result<&'static str, impl Error + Send + Sync + 'static> {
-    Err(FooError::new("something broke, lol"))
-        .in_current_span()
-        .in_current_span()
+    Err(FooError::new("something broke, lol")).in_current_span()
 }
 
 #[tracing::instrument]

--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -33,6 +33,10 @@ keywords = [
 ]
 edition = "2018"
 
+[features]
+
+stack-error = []
+
 [dependencies]
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.0", default-features = false, features = ["registry", "fmt"] }
 tracing = { path = "../tracing", version = "0.1"}

--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -42,7 +42,6 @@ use tracing::{Metadata, Span};
 /// similarly to how Rust formats panics. For example:
 ///
 /// ```text
-/// span backtrace:
 ///    0: custom_error::do_another_thing
 ///         with answer=42 will_succeed=false
 ///           at examples/examples/custom_error.rs:42

--- a/tracing-error/src/heap_error.rs
+++ b/tracing-error/src/heap_error.rs
@@ -1,5 +1,5 @@
 use crate::SpanTrace;
-use crate::{InstrumentError, InstrumentResult, SpanTraceExtract};
+use crate::{ExtractSpanTrace, InstrumentError, InstrumentResult};
 use std::error::Error;
 use std::fmt::{self, Debug, Display};
 
@@ -8,7 +8,7 @@ use std::fmt::{self, Debug, Display};
 /// # Notes
 ///
 /// This type does not print the wrapped `SpanTrace` in either its `Debug` or `Display`
-/// implementations. The `SpanTrace` must be extracted via the `SpanTraceExtract` trait in order to
+/// implementations. The `SpanTrace` must be extracted via the `ExtractSpanTrace` trait in order to
 /// be printed.
 pub struct TracedError {
     spantrace: SpanTrace,
@@ -67,7 +67,7 @@ where
     }
 }
 
-impl SpanTraceExtract for &(dyn Error + 'static) {
+impl ExtractSpanTrace for &(dyn Error + 'static) {
     fn span_trace(&self) -> Option<&SpanTrace> {
         self.downcast_ref::<TracedError>().map(|e| &e.spantrace)
     }

--- a/tracing-error/src/heap_error.rs
+++ b/tracing-error/src/heap_error.rs
@@ -1,5 +1,5 @@
 use crate::SpanTrace;
-use crate::{ExtractSpanTrace, InstrumentError, InstrumentResult};
+use crate::{ExtractSpanTrace, InstrumentError};
 use std::error::Error;
 use std::fmt::{self, Debug, Display};
 
@@ -60,7 +60,7 @@ impl Debug for ErrorImpl {
 
 impl Display for ErrorImpl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "Instrumented Error SpanTrace:")?;
+        writeln!(f, "span backtrace:")?;
         Display::fmt(&self.span_trace, f)
     }
 }
@@ -73,17 +73,6 @@ where
 
     fn in_current_span(self) -> Self::Instrumented {
         TracedError::new(self)
-    }
-}
-
-impl<T, E> InstrumentResult<T> for Result<T, E>
-where
-    E: Error + Send + Sync + 'static,
-{
-    type Instrumented = TracedError;
-
-    fn in_current_span(self) -> Result<T, Self::Instrumented> {
-        self.map_err(TracedError::new)
     }
 }
 

--- a/tracing-error/src/heap_error.rs
+++ b/tracing-error/src/heap_error.rs
@@ -1,0 +1,66 @@
+use crate::SpanTrace;
+use std::error::Error;
+use std::fmt::{self, Debug, Display};
+
+///
+pub struct TracedError {
+    spantrace: SpanTrace,
+    inner: Box<dyn Error + Send + Sync + 'static>,
+}
+
+impl TracedError {
+    fn new<E>(error: E) -> Self
+    where
+        E: Error + Send + Sync + 'static,
+    {
+        Self {
+            spantrace: SpanTrace::capture(),
+            inner: Box::new(error),
+        }
+    }
+}
+
+impl Error for TracedError {
+    fn source<'a>(&'a self) -> Option<&'a (dyn Error + 'static)> {
+        self.inner.source()
+    }
+}
+
+impl Debug for TracedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Debug::fmt(&self.inner, f)
+    }
+}
+
+impl Display for TracedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.inner, f)
+    }
+}
+
+///
+pub trait Instrument<T, E> {
+    ///
+    fn in_current_span(self) -> Result<T, TracedError>;
+}
+
+impl<T, E> Instrument<T, E> for Result<T, E>
+where
+    E: Error + Send + Sync + 'static,
+{
+    fn in_current_span(self) -> Result<T, TracedError> {
+        self.map_err(TracedError::new)
+    }
+}
+
+///
+pub trait SpanTraceExt {
+    ///
+    fn spantrace(&self) -> Option<&SpanTrace>;
+}
+
+impl SpanTraceExt for &(dyn Error + 'static) {
+    fn spantrace(&self) -> Option<&SpanTrace> {
+        self.downcast_ref::<TracedError>().map(|e| &e.spantrace)
+    }
+}

--- a/tracing-error/src/heap_error.rs
+++ b/tracing-error/src/heap_error.rs
@@ -59,7 +59,7 @@ impl Error for ErrorImpl {
 
 impl Debug for ErrorImpl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "Instrumented Error SpanTrace:")?;
+        writeln!(f, "span backtrace:")?;
         Debug::fmt(&self.span_trace, f)
     }
 }

--- a/tracing-error/src/heap_error.rs
+++ b/tracing-error/src/heap_error.rs
@@ -4,12 +4,6 @@ use std::error::Error;
 use std::fmt::{self, Debug, Display};
 
 /// A wrapper type for Errors that bundles a `SpanTrace` with an inner `Error` type.
-///
-/// # Notes
-///
-/// This type does not print the wrapped `SpanTrace` in either its `Debug` or `Display`
-/// implementations. The `SpanTrace` must be extracted via the `ExtractSpanTrace` trait in order to
-/// be printed.
 pub struct TracedError {
     inner: ErrorImpl,
 }

--- a/tracing-error/src/heap_error.rs
+++ b/tracing-error/src/heap_error.rs
@@ -3,7 +3,7 @@ use crate::{ExtractSpanTrace, InstrumentError, InstrumentResult};
 use std::error::Error;
 use std::fmt::{self, Debug, Display};
 
-/// A wrapper type for Errors that bundles a SpanTrace with an inner `Error` type.
+/// A wrapper type for Errors that bundles a `SpanTrace` with an inner `Error` type.
 ///
 /// # Notes
 ///

--- a/tracing-error/src/heap_error.rs
+++ b/tracing-error/src/heap_error.rs
@@ -59,12 +59,14 @@ impl Error for ErrorImpl {
 
 impl Debug for ErrorImpl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Instrumented Error SpanTrace:")?;
         Debug::fmt(&self.span_trace, f)
     }
 }
 
 impl Display for ErrorImpl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Instrumented Error SpanTrace:")?;
         Display::fmt(&self.span_trace, f)
     }
 }

--- a/tracing-error/src/heap_error.rs
+++ b/tracing-error/src/heap_error.rs
@@ -53,14 +53,14 @@ impl Error for ErrorImpl {
 
 impl Debug for ErrorImpl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "span backtrace:")?;
+        f.pad("span backtrace:\n")?;
         Debug::fmt(&self.span_trace, f)
     }
 }
 
 impl Display for ErrorImpl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "span backtrace:")?;
+        f.pad("span backtrace:\n")?;
         Display::fmt(&self.span_trace, f)
     }
 }

--- a/tracing-error/src/heap_error.rs
+++ b/tracing-error/src/heap_error.rs
@@ -39,6 +39,21 @@ impl Display for TracedError {
 }
 
 ///
+pub trait IntoTracedError<E> {
+    ///
+    fn in_current_span(self) -> TracedError;
+}
+
+impl<E> IntoTracedError<E> for E
+where
+    E: Error + Send + Sync + 'static,
+{
+    fn in_current_span(self) -> TracedError {
+        TracedError::new(self)
+    }
+}
+
+///
 pub trait Instrument<T, E> {
     ///
     fn in_current_span(self) -> Result<T, TracedError>;

--- a/tracing-error/src/heap_error.rs
+++ b/tracing-error/src/heap_error.rs
@@ -3,7 +3,13 @@ use crate::{InstrumentError, InstrumentResult, SpanTraceExtract};
 use std::error::Error;
 use std::fmt::{self, Debug, Display};
 
+/// A wrapper type for Errors that bundles a SpanTrace with an inner `Error` type.
 ///
+/// # Notes
+///
+/// This type does not print the wrapped `SpanTrace` in either its `Debug` or `Display`
+/// implementations. The `SpanTrace` must be extracted via the `SpanTraceExtract` trait in order to
+/// be printed.
 pub struct TracedError {
     spantrace: SpanTrace,
     inner: Box<dyn Error + Send + Sync + 'static>,

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -20,6 +20,15 @@
 //!
 //! *Compiler support: requires `rustc` 1.39+*
 //!
+//! ## Feature Flags
+//!
+//! - `stack-error` - Enables an unstable experimental version of TracedError that is parameterized
+//! on the error it wraps, letting it store the error on the stack rather than on the heap in a Box
+//! while still allowing the `SpanTrace`s to be extracted from the error regardless of what type it
+//! is parameterized on. It does so by inserting a dummy error into the chain and uses the `source`
+//! call on this dummy error to transmute the pointer to itself to a type erased version from which
+//! we can extract the actual SpanTrace.
+//!
 //! ## Usage
 //!
 //! Currently, `tracing-error` provides the [`SpanTrace`] type, which captures
@@ -172,13 +181,13 @@ pub trait InstrumentResult<T> {
 }
 
 /// A trait for extracting SpanTraces created by `in_current_span()` from `dyn Error` trait objects
-pub trait SpanTraceExtract {
+pub trait ExtractSpanTrace {
     /// Attempts to downcast to a `TracedError` and return a reference to its SpanTrace
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use tracing_error::SpanTraceExtract;
+    /// use tracing_error::ExtractSpanTrace;
     /// use std::error::Error;
     ///
     /// fn print_span_trace(e: &(dyn Error + 'static)) {
@@ -193,8 +202,8 @@ pub trait SpanTraceExtract {
 
 /// The `tracing-error` prelude.
 ///
-/// This brings into scope the `InstrumentError` and `SpanTraceExtract` extension traits that are used to
+/// This brings into scope the `InstrumentError` and `ExtractSpanTrace` extension traits that are used to
 /// attach Spantraces to errors and subsequently retrieve them from dyn Errors.
 pub mod prelude {
-    pub use crate::{InstrumentError as _, InstrumentResult as _, SpanTraceExtract as _};
+    pub use crate::{ExtractSpanTrace as _, InstrumentError as _, InstrumentResult as _};
 }

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -118,6 +118,8 @@
 )]
 mod backtrace;
 mod layer;
+mod stack_error;
 
 pub use self::backtrace::SpanTrace;
 pub use self::layer::ErrorLayer;
+pub use self::stack_error::{Instrument, SpanTraceExt, TracedError};

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! - `stack-error` - Enables an experimental version of [`TracedError`] that
 //! statically wraps an error type without using heap allocations. The contained
-//! [`SpanTrace`] can still extract its SpanTrace from behind a
+//! [`SpanTrace`] can still be extracted from behind a
 //! [`std::error::Error`] trait object via type erasure.
 //!
 //! ## Usage
@@ -90,7 +90,7 @@
 //! ```
 //!
 //! Once an error has been wrapped with with a [`TracedError`] the [`SpanTrace`]
-//! can be extracted one of 3 ways, either via [`TracedError`]'s
+//! can be extracted one of 3 ways: either via [`TracedError`]'s
 //! `Display`/`Debug` implementations, or via the [`ExtractSpanTrace`] trait.
 //!
 //! For example, here is how one might print the errors but specialize the
@@ -120,7 +120,7 @@
 //!
 //! ```
 //!
-//! Where-as here we can still display the content of the `SpanTraces` without
+//! Whereas here, we can still display the content of the `SpanTraces` without
 //! any special casing by simply printing all errors in our error chain.
 //!
 //! ```rust
@@ -161,10 +161,10 @@
 //!
 //! [`SpanTrace`]: struct.SpanTrace.html
 //! [`ErrorLayer`]: struct.ErrorLayer.html
-//! [`TracedError`]: struct.ErrorLayer.html
-//! [`InstrumentResult`]: trait.SpanTrace.html
-//! [`InstrumentError`]: trait.SpanTrace.html
-//! [`ExtractSpanTrace`]: trait.SpanTrace.html
+//! [`TracedError`]: struct.TracedError.html
+//! [`InstrumentResult`]: trait.InstrumentResult.html
+//! [`InstrumentError`]: trait.InstrumentError.html
+//! [`ExtractSpanTrace`]: trait.ExtractSpanTrace.html
 //! [`in_current_span()`]: trait.InstrumentResult.html#tymethod.in_current_span
 //! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 //! [event]: https://docs.rs/tracing/latest/tracing/struct.Event.html
@@ -284,8 +284,8 @@ pub trait ExtractSpanTrace {
 
 /// The `tracing-error` prelude.
 ///
-/// This brings into scope the `InstrumentError` and `ExtractSpanTrace`
-/// extension traits that are used to attach Spantraces to errors and
+/// This brings into scope the `InstrumentError, `InstrumentResult`, and `ExtractSpanTrace`
+/// extension traits. These traits allow attaching `SpanTrace`s to errors and
 /// subsequently retrieve them from dyn Errors.
 pub mod prelude {
     pub use crate::{ExtractSpanTrace as _, InstrumentError as _, InstrumentResult as _};

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -117,17 +117,20 @@
     while_true
 )]
 mod backtrace;
+///
+pub mod heap_error;
 mod layer;
-mod stack_error;
+///
+pub mod stack_error;
 
 pub use self::backtrace::SpanTrace;
 pub use self::layer::ErrorLayer;
-pub use self::stack_error::TracedError;
 
 /// The `tracing-error` prelude.
 ///
 /// This brings into scope the `Instrument` and `SpanTraceExt` extension traits that are used to
 /// attach Spantraces to errors and subsequently retrieve them from dyn Errors.
 pub mod prelude {
-    pub use crate::stack_error::{Instrument as _, SpanTraceExt as _};
+    pub use crate::heap_error::{Instrument as _, SpanTraceExt as _};
+    // pub use crate::stack_error::{Instrument as _, SpanTraceExt as _};
 }

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -122,4 +122,12 @@ mod stack_error;
 
 pub use self::backtrace::SpanTrace;
 pub use self::layer::ErrorLayer;
-pub use self::stack_error::{Instrument, SpanTraceExt, TracedError};
+pub use self::stack_error::TracedError;
+
+/// The `tracing-error` prelude.
+///
+/// This brings into scope the `Instrument` and `SpanTraceExt` extension traits that are used to
+/// attach Spantraces to errors and subsequently retrieve them from dyn Errors.
+pub mod prelude {
+    pub use crate::stack_error::{Instrument as _, SpanTraceExt as _};
+}

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -118,19 +118,27 @@
 )]
 mod backtrace;
 ///
-pub mod heap_error;
+#[cfg(not(feature = "stack-error"))]
+mod heap_error;
 mod layer;
 ///
-pub mod stack_error;
+#[cfg(feature = "stack-error")]
+mod stack_error;
 
 pub use self::backtrace::SpanTrace;
+#[cfg(not(feature = "stack-error"))]
+pub use self::heap_error::TracedError;
 pub use self::layer::ErrorLayer;
+#[cfg(feature = "stack-error")]
+pub use self::stack_error::TracedError;
 
 /// The `tracing-error` prelude.
 ///
 /// This brings into scope the `Instrument` and `SpanTraceExt` extension traits that are used to
 /// attach Spantraces to errors and subsequently retrieve them from dyn Errors.
 pub mod prelude {
-    // pub use crate::heap_error::{Instrument as _, SpanTraceExt as _};
-    pub use crate::stack_error::{Instrument as _, SpanTraceExt as _};
+    #[cfg(not(feature = "stack-error"))]
+    pub use crate::heap_error::{Instrument as _, IntoTracedError as _, SpanTraceExt as _};
+    #[cfg(feature = "stack-error")]
+    pub use crate::stack_error::{Instrument as _, IntoTracedError as _, SpanTraceExt as _};
 }

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -249,6 +249,17 @@ pub trait InstrumentResult<T> {
     fn in_current_span(self) -> Result<T, Self::Instrumented>;
 }
 
+impl<T, E> InstrumentResult<T> for Result<T, E>
+where
+    E: InstrumentError,
+{
+    type Instrumented = <E as InstrumentError>::Instrumented;
+
+    fn in_current_span(self) -> Result<T, Self::Instrumented> {
+        self.map_err(E::in_current_span)
+    }
+}
+
 /// A trait for extracting SpanTraces created by `in_current_span()` from `dyn
 /// Error` trait objects
 pub trait ExtractSpanTrace {

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -286,7 +286,7 @@ pub trait ExtractSpanTrace {
 ///
 /// This brings into scope the `InstrumentError, `InstrumentResult`, and `ExtractSpanTrace`
 /// extension traits. These traits allow attaching `SpanTrace`s to errors and
-/// subsequently retrieve them from dyn Errors.
+/// subsequently retrieving them from `dyn Error` trait objects.
 pub mod prelude {
     pub use crate::{ExtractSpanTrace as _, InstrumentError as _, InstrumentResult as _};
 }

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -30,7 +30,7 @@
 //! ## Feature Flags
 //!
 //! - `stack-error` - Enables an experimental version of [`TracedError`] that
-//! statically wraps an error type without using Heap Allocations. The contained
+//! statically wraps an error type without using heap allocations. The contained
 //! [`SpanTrace`] can still extract its SpanTrace from behind a
 //! [`std::error::Error`] trait object via type erasure.
 //!

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -131,6 +131,6 @@ pub use self::layer::ErrorLayer;
 /// This brings into scope the `Instrument` and `SpanTraceExt` extension traits that are used to
 /// attach Spantraces to errors and subsequently retrieve them from dyn Errors.
 pub mod prelude {
-    pub use crate::heap_error::{Instrument as _, SpanTraceExt as _};
-    // pub use crate::stack_error::{Instrument as _, SpanTraceExt as _};
+    // pub use crate::heap_error::{Instrument as _, SpanTraceExt as _};
+    pub use crate::stack_error::{Instrument as _, SpanTraceExt as _};
 }

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -132,13 +132,32 @@ pub use self::layer::ErrorLayer;
 #[cfg(feature = "stack-error")]
 pub use self::stack_error::TracedError;
 
+///
+pub trait InstrumentError {
+    type Instrumented;
+
+    ///
+    fn in_current_span(self) -> Self::Instrumented;
+}
+
+///
+pub trait InstrumentResult<T> {
+    type Instrumented;
+
+    ///
+    fn in_current_span(self) -> Result<T, Self::Instrumented>;
+}
+
+///
+pub trait SpanTraceExtract {
+    ///
+    fn span_trace(&self) -> Option<&SpanTrace>;
+}
+
 /// The `tracing-error` prelude.
 ///
-/// This brings into scope the `Instrument` and `SpanTraceExt` extension traits that are used to
+/// This brings into scope the `InstrumentError` and `SpanTraceExtract` extension traits that are used to
 /// attach Spantraces to errors and subsequently retrieve them from dyn Errors.
 pub mod prelude {
-    #[cfg(not(feature = "stack-error"))]
-    pub use crate::heap_error::{Instrument as _, IntoTracedError as _, SpanTraceExt as _};
-    #[cfg(feature = "stack-error")]
-    pub use crate::stack_error::{Instrument as _, IntoTracedError as _, SpanTraceExt as _};
+    pub use crate::{InstrumentError as _, InstrumentResult as _, SpanTraceExtract as _};
 }

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -130,25 +130,64 @@ pub use self::layer::ErrorLayer;
 #[cfg(feature = "stack-error")]
 pub use self::stack_error::TracedError;
 
-///
+/// Extension trait for instrumenting errors with `SpanTrace`s
 pub trait InstrumentError {
+    /// The type of the wrapped error after instrumentation
     type Instrumented;
 
+    /// Instrument an Error by bundling it with a SpanTrace
     ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tracing_error::{TracedError, InstrumentError};
+    ///
+    /// fn wrap_error(e: impl std::error::Error + Send + Sync + 'static) -> TracedError {
+    ///     e.in_current_span()
+    /// }
+    /// ```
     fn in_current_span(self) -> Self::Instrumented;
 }
 
-///
+/// Extension trait for instrumenting errors in `Result`s with `SpanTrace`s
 pub trait InstrumentResult<T> {
+    /// The type of the wrapped error after instrumentation
     type Instrumented;
 
+    /// Instrument an Error by bundling it with a SpanTrace
     ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use std::{io, fs};
+    /// use tracing_error::{TracedError, InstrumentResult};
+    ///
+    /// # fn fallible_fn() -> io::Result<()> { fs::read_dir("......").map(drop) };
+    ///
+    /// fn do_thing() -> Result<(), TracedError> {
+    ///     fallible_fn().in_current_span()
+    /// }
+    /// ```
     fn in_current_span(self) -> Result<T, Self::Instrumented>;
 }
 
-///
+/// A trait for extracting SpanTraces created by `in_current_span()` from `dyn Error` trait objects
 pub trait SpanTraceExtract {
+    /// Attempts to downcast to a `TracedError` and return a reference to its SpanTrace
     ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tracing_error::SpanTraceExtract;
+    /// use std::error::Error;
+    ///
+    /// fn print_span_trace(e: &(dyn Error + 'static)) {
+    ///     let span_trace = e.span_trace();
+    ///     if let Some(span_trace) = span_trace {
+    ///         println!("{}", span_trace);
+    ///     }
+    /// }
+    /// ```
     fn span_trace(&self) -> Option<&SpanTrace>;
 }
 

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -117,11 +117,9 @@
     while_true
 )]
 mod backtrace;
-///
 #[cfg(not(feature = "stack-error"))]
 mod heap_error;
 mod layer;
-///
 #[cfg(feature = "stack-error")]
 mod stack_error;
 

--- a/tracing-error/src/stack_error.rs
+++ b/tracing-error/src/stack_error.rs
@@ -25,7 +25,7 @@ where
         // The repr(C) is necessary to ensure that the struct is layed out in the order we
         // specified it so that we can safely access the vtable and spantrace fields thru a type
         // erased pointer to the original object.
-        let vtable = ErrorVTable {
+        let vtable = &ErrorVTable {
             object_ref: object_ref::<E>,
         };
 
@@ -41,7 +41,7 @@ where
 
 #[repr(C)]
 struct ErrorImpl<E> {
-    vtable: ErrorVTable,
+    vtable: &'static ErrorVTable,
     spantrace: SpanTrace,
     // NOTE: Don't use directly. Use only through vtable. Erased type may have
     // different alignment.

--- a/tracing-error/src/stack_error.rs
+++ b/tracing-error/src/stack_error.rs
@@ -18,8 +18,8 @@ where
         // # SAFETY
         //
         // This function + the repr(C) on the ErrorImpl make the type erasure throughout the rest
-        // of the class safe. This saves a function pointer that is parameterized on the Error type
-        // being stored inside the ErrorImpl, this lets the object_ref function safely cast a type
+        // of this struct's methods safe. This saves a function pointer that is parameterized on the Error type
+        // being stored inside the ErrorImpl. This lets the object_ref function safely cast a type
         // erased `ErrorImpl` back to its original type, which is needed in order to forward our
         // error/display/debug impls to the internal error type from the type erased error type.
         //

--- a/tracing-error/src/stack_error.rs
+++ b/tracing-error/src/stack_error.rs
@@ -128,14 +128,14 @@ impl Error for ErrorImpl<Erased> {
 
 impl Debug for ErrorImpl<Erased> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "span backtrace:")?;
+        f.pad("span backtrace:\n")?;
         Debug::fmt(&self.span_trace, f)
     }
 }
 
 impl Display for ErrorImpl<Erased> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "span backtrace:")?;
+        f.pad("span backtrace:\n")?;
         Display::fmt(&self.span_trace, f)
     }
 }

--- a/tracing-error/src/stack_error.rs
+++ b/tracing-error/src/stack_error.rs
@@ -70,13 +70,13 @@ struct ErrorVTable {
 // # SAFETY
 //
 // This function must be parameterized on the type E of the original error that is being stored
-// inside of the `ErrorImpl`. When it is correctly parameterized it defines a function that safely
-// casts the Erased ErrorImpl pointer type back to the original pointer type.
+// inside of the `ErrorImpl`. When it is parameterized by the correct type, it safely
+// casts the erased `ErrorImpl` pointer type back to the original pointer type.
 unsafe fn object_ref<E>(e: &ErrorImpl<Erased>) -> &(dyn Error + Send + Sync + 'static)
 where
     E: Error + Send + Sync + 'static,
 {
-    // Attach E's native Error vtable onto a pointer to self.error.
+    // Attach E's native Error vtable onto a pointer to e.error.
     &(*(e as *const ErrorImpl<Erased> as *const ErrorImpl<E>)).error
 }
 
@@ -94,7 +94,7 @@ where
     // This function is necessary for the `downcast_ref` in `ExtractSpanTrace` to work, because it
     // needs a concrete type to downcast to and we cannot downcast to ErrorImpls parameterized on
     // errors defined in other crates. By erasing the type here we can always cast back to the
-    // Erased version of the ErrorImpl pointer and still access the internal error type safely
+    // Erased version of the ErrorImpl pointer, and still access the internal error type safely
     // through the vtable.
     fn source<'a>(&'a self) -> Option<&'a (dyn Error + 'static)> {
         let erased = unsafe { &*(&self.inner as *const ErrorImpl<E> as *const ErrorImpl<Erased>) };

--- a/tracing-error/src/stack_error.rs
+++ b/tracing-error/src/stack_error.rs
@@ -15,7 +15,7 @@ where
     E: Error + Send + Sync + 'static,
 {
     fn from(error: E) -> Self {
-        // SAFETY
+        // # SAFETY
         //
         // This function + the repr(C) on the ErrorImpl make the type erasure throughout the rest
         // of the class safe. This saves a function pointer that is parameterized on the Error type
@@ -51,7 +51,9 @@ struct ErrorImpl<E> {
 
 impl ErrorImpl<Erased> {
     pub(crate) fn error(&self) -> &(dyn Error + Send + Sync + 'static) {
-        // safety: this function is used to cast a type-erased pointer to a pointer to error's
+        // # SAFETY
+        //
+        // this function is used to cast a type-erased pointer to a pointer to error's
         // original type. the `ErrorImpl::error` method, which calls this function, requires that
         // the type this function casts to be the original erased type of the error; failure to
         // uphold this is UB. since the `From` impl is parameterized over the original error type,

--- a/tracing-error/src/stack_error.rs
+++ b/tracing-error/src/stack_error.rs
@@ -1,5 +1,5 @@
 use crate::SpanTrace;
-use crate::{InstrumentError, InstrumentResult, SpanTraceExtract};
+use crate::{ExtractSpanTrace, InstrumentError, InstrumentResult};
 use std::error::Error;
 use std::fmt::{self, Debug, Display};
 
@@ -10,7 +10,7 @@ struct Erased;
 /// # Notes
 ///
 /// This type does not print the wrapped `SpanTrace` in either its `Debug` or `Display`
-/// implementations. The `SpanTrace` must be extracted via the `SpanTraceExtract` trait in order to
+/// implementations. The `SpanTrace` must be extracted via the `ExtractSpanTrace` trait in order to
 /// be printed.
 pub struct TracedError<E> {
     inner: ErrorImpl<E>,
@@ -94,7 +94,7 @@ impl<E> Error for TracedError<E> {
     // function in the vtable to safely convert the pointer type back to the original type then
     // returns the reference to the internal error.
     //
-    // This function is necessary for the `downcast_ref` in `SpanTraceExtract` to work, because it
+    // This function is necessary for the `downcast_ref` in `ExtractSpanTrace` to work, because it
     // needs a concrete type to downcast to and we cannot downcast to ErrorImpls parameterized on
     // errors defined in other crates. By erasing the type here we can always cast back to the
     // Erased version of the ErrorImpl pointer and still access the internal error type safely
@@ -184,7 +184,7 @@ where
     }
 }
 
-impl SpanTraceExtract for &(dyn Error + 'static) {
+impl ExtractSpanTrace for &(dyn Error + 'static) {
     fn span_trace(&self) -> Option<&SpanTrace> {
         self.downcast_ref::<ErrorImpl<Erased>>()
             .map(|inner| &inner.spantrace)

--- a/tracing-error/src/stack_error.rs
+++ b/tracing-error/src/stack_error.rs
@@ -1,0 +1,150 @@
+use crate::SpanTrace;
+use std::error::Error;
+use std::fmt::{self, Debug, Display};
+
+struct Erased;
+
+///
+pub struct TracedError<E> {
+    inner: ErrorImpl<E>,
+}
+
+impl<E> From<E> for TracedError<E>
+where
+    E: Error + Send + Sync + 'static,
+{
+    fn from(error: E) -> Self {
+        let vtable = &ErrorVTable {
+            object_ref: object_ref::<E>,
+        };
+
+        Self {
+            inner: ErrorImpl {
+                vtable,
+                spantrace: SpanTrace::capture(),
+                _object: error,
+            },
+        }
+    }
+}
+
+#[repr(C)]
+struct ErrorImpl<E> {
+    vtable: &'static ErrorVTable,
+    spantrace: SpanTrace,
+    // NOTE: Don't use directly. Use only through vtable. Erased type may have
+    // different alignment.
+    _object: E,
+}
+
+impl ErrorImpl<Erased> {
+    pub(crate) fn error(&self) -> &(dyn Error + Send + Sync + 'static) {
+        // Use vtable to attach E's native StdError vtable for the right
+        // original type E.
+        unsafe { &*(self.vtable.object_ref)(self) }
+    }
+}
+
+struct ErrorVTable {
+    object_ref: unsafe fn(&ErrorImpl<Erased>) -> &(dyn Error + Send + Sync + 'static),
+}
+
+unsafe fn object_ref<E>(e: &ErrorImpl<Erased>) -> &(dyn Error + Send + Sync + 'static)
+where
+    E: Error + Send + Sync + 'static,
+{
+    // Attach E's native Error vtable onto a pointer to self._object.
+    &(*(e as *const ErrorImpl<Erased> as *const ErrorImpl<E>))._object
+}
+
+impl<E> Error for TracedError<E> {
+    fn source<'a>(&'a self) -> Option<&'a (dyn Error + 'static)> {
+        let erased = unsafe { &*(&self.inner as *const ErrorImpl<E> as *const ErrorImpl<Erased>) };
+        Some(erased)
+    }
+}
+
+impl<E> Debug for TracedError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TRACED ERROR PLACEHOLDER")
+    }
+}
+
+impl<E> Display for TracedError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TRACED ERROR PLACEHOLDER")
+    }
+}
+
+impl Error for ErrorImpl<Erased> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.error().source()
+    }
+}
+
+impl Debug for ErrorImpl<Erased> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Debug::fmt(self.error(), f)
+    }
+}
+
+impl Display for ErrorImpl<Erased> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(self.error(), f)
+    }
+}
+
+impl<E> Error for ErrorImpl<E>
+where
+    E: Error + Send + Sync + 'static,
+{
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self._object)
+    }
+}
+
+impl<E> Debug for ErrorImpl<E>
+where
+    E: Error + Send + Sync + 'static,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Debug::fmt(&self._object, f)
+    }
+}
+
+impl<E> Display for ErrorImpl<E>
+where
+    E: Error + Send + Sync + 'static,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self._object, f)
+    }
+}
+
+///
+pub trait Instrument<T, E> {
+    ///
+    fn in_current_span(self) -> Result<T, TracedError<E>>;
+}
+
+impl<T, E> Instrument<T, E> for Result<T, E>
+where
+    E: Error + Send + Sync + 'static,
+{
+    fn in_current_span(self) -> Result<T, TracedError<E>> {
+        self.map_err(TracedError::from)
+    }
+}
+
+///
+pub trait SpanTraceExt {
+    ///
+    fn spantrace(&self) -> Option<&SpanTrace>;
+}
+
+impl SpanTraceExt for &(dyn Error + 'static) {
+    fn spantrace(&self) -> Option<&SpanTrace> {
+        self.downcast_ref::<ErrorImpl<Erased>>()
+            .map(|inner| &inner.spantrace)
+    }
+}

--- a/tracing-error/src/stack_error.rs
+++ b/tracing-error/src/stack_error.rs
@@ -6,12 +6,6 @@ use std::fmt::{self, Debug, Display};
 struct Erased;
 
 /// A wrapper type for Errors that bundles a SpanTrace with an inner `Error` type.
-///
-/// # Notes
-///
-/// This type does not print the wrapped `SpanTrace` in either its `Debug` or `Display`
-/// implementations. The `SpanTrace` must be extracted via the `ExtractSpanTrace` trait in order to
-/// be printed.
 pub struct TracedError<E> {
     inner: ErrorImpl<E>,
 }

--- a/tracing-error/src/stack_error.rs
+++ b/tracing-error/src/stack_error.rs
@@ -134,12 +134,14 @@ impl Error for ErrorImpl<Erased> {
 
 impl Debug for ErrorImpl<Erased> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Instrumented Error SpanTrace:")?;
         Debug::fmt(&self.span_trace, f)
     }
 }
 
 impl Display for ErrorImpl<Erased> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Instrumented Error SpanTrace:")?;
         Display::fmt(&self.span_trace, f)
     }
 }

--- a/tracing-error/src/stack_error.rs
+++ b/tracing-error/src/stack_error.rs
@@ -5,7 +5,13 @@ use std::fmt::{self, Debug, Display};
 
 struct Erased;
 
+/// A wrapper type for Errors that bundles a SpanTrace with an inner `Error` type.
 ///
+/// # Notes
+///
+/// This type does not print the wrapped `SpanTrace` in either its `Debug` or `Display`
+/// implementations. The `SpanTrace` must be extracted via the `SpanTraceExtract` trait in order to
+/// be printed.
 pub struct TracedError<E> {
     inner: ErrorImpl<E>,
 }


### PR DESCRIPTION
## Motivation

The tracing_error crate should provide some basic functionality for instrumenting Errors with `SpanTraces` generically. The goal is to make it easy for users to instrument their errors without needing to add a `SpanTrace` to every error they construct.

## Solution

Critically this trait provides 3 traits for instrumenting errors, `InstrumentResult`, `InstrumentError`, and `ExtractSpanTrace`. The first two traits expose a `in_current_span()` method that can work on a `Result<T, E: InstrumentError>` and an `Error`, respectively, that wraps the error type in a `TracedError` that stores the inner error and a SpanTrace. The third trait, `ExtractSpanTrace`, is used to retrieve the span_trace member of a `TracedError` from a `&dyn Error` trait object.

This is done by downcasting the error to a `TracedError` and returning the inner `span_trace` if it is successful. By default this only works because the inner error is stored in a Box as a trait object, which prevents it from being part of the type signature for `TracedError`.

However, this crate also exposes a second version of `TracedError` that does not box the inner error, thus avoiding the need for heap allocation, which it accomplishes by type erasing the `TracedError<E>` into a `TracedError<()>` while iterating through the error `source()` chain.