### PR TITLE
futures: make the executor/futures_03 module compile

### DIFF
--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -20,7 +20,7 @@ license = "MIT"
 [features]
 default = ["std-future", "std"]
 futures-01 = ["futures_01"]
-futures-03 = ["std-future", "futures", "futures-task"]
+futures-03 = ["std-future", "futures", "futures-task", "std"]
 std-future = ["pin-project"]
 std = ["tracing/std"]
 

--- a/tracing-futures/src/executor/mod.rs
+++ b/tracing-futures/src/executor/mod.rs
@@ -8,7 +8,7 @@ mod futures_preview;
 #[cfg(feature = "futures_preview")]
 pub use self::futures_preview::*;
 
-#[cfg(feature = "futures_03")]
+#[cfg(feature = "futures-03")]
 mod futures_03;
-#[cfg(feature = "futures_03")]
+#[cfg(feature = "futures-03")]
 pub use self::futures_03::*;


### PR DESCRIPTION
I tried to use `futures_03` module, but it is unusable in current state. The code has seemingly never been compiled before. On first sight, with this PR, it's actually working as intended.

## Motivation
Current code does not compile.

## Solution
- use correct feature name
- use correct paths to imported types
- use correct trait names
- pass correct types to Spawn and SpawnLocal traits
- remove unused imports

@hawkw 