### PR TITLE
docs: fix minor spelling error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ fn main() {
         .finish();
 
     tracing::subscriber::set_global_default(subscriber)
-        .expect("setting defualt subscriber failed");
+        .expect("setting default subscriber failed");
 
     let number_of_yaks = 3;
     // this creates a new event, outside of any spans.


### PR DESCRIPTION
## Motivation

Found a simple spelling error in the README.

## Solution

Fixed it. :)

Fixes #577