### PR TITLE
futures: prepare to release 0.2.2

### DIFF
--- a/tracing-futures/CHANGELOG.md
+++ b/tracing-futures/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.2.2 (Feb 14, 2020)
+
+### Added
+
+- Support for `futures` 0.3 `Stream`s and `Sink`s (#544)
+
+### Fixed
+
+- Compilation errors when using the `futures-03` feature (#576)
+
+Thanks to @obergner and @najamelan for their contributions to this release!
+
 # 0.2.1 (Jan 15, 2020)
 
 ### Added

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-futures"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -49,12 +49,12 @@
 //! The `tokio`, `std-future` and `std` features are enabled by default.
 //!
 //! [`tracing`]: https://crates.io/crates/tracing
-//! [span]: https://docs.rs/tracing/0.1.11/tracing/span/index.html
-//! [`Subscriber`]: https://docs.rs/tracing/0.1.11/tracing/subscriber/index.html
+//! [span]: https://docs.rs/tracing/0.1.12/tracing/span/index.html
+//! [`Subscriber`]: https://docs.rs/tracing/0.1.12/tracing/subscriber/index.html
 //! [`Instrument`]: trait.Instrument.html
 //! [`WithSubscriber`]: trait.WithSubscriber.html
 //! [`futures`]: https://crates.io/crates/futures
-#![doc(html_root_url = "https://docs.rs/tracing-futures/0.2.1")]
+#![doc(html_root_url = "https://docs.rs/tracing-futures/0.2.2")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
### Added

- Support for `futures` 0.3 `Stream`s and `Sink`s (#544)

### Fixed

- Compilation errors when using the `futures-03` feature (#576)

Thanks to @obergner and @najamelan for their contributions to this
release!

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
