### PR TITLE
futures: Add Instrumented and WithDispatch ::{inner_pin_ref, inner_pin_mut}

### DIFF
--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -459,7 +459,7 @@ impl<T> WithDispatch<T> {
     pub fn inner_pin_mut(self: Pin<&mut Self>) -> Pin<&mut T> {
         self.project().inner
     }
-  
+
     /// Borrows the wrapped type.
     pub fn inner(&self) -> &T {
         &self.inner

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -381,6 +381,20 @@ impl<T> Instrumented<T> {
         &mut self.inner
     }
 
+    /// Get a pinned reference to the wrapped type.
+    #[cfg(feature = "std-future")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std-future")))]
+    pub fn inner_pin_ref(self: Pin<&Self>) -> Pin<&T> {
+        self.project_ref().inner
+    }
+
+    /// Get a pinned mutable reference to the wrapped type.
+    #[cfg(feature = "std-future")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std-future")))]
+    pub fn inner_pin_mut(self: Pin<&mut Self>) -> Pin<&mut T> {
+        self.project().inner
+    }
+
     /// Consumes the `Instrumented`, returning the wrapped type.
     ///
     /// Note that this drops the span.
@@ -434,6 +448,20 @@ impl<T> WithDispatch<T> {
     /// Borrows the `Dispatch` that this type is instrumented by.
     pub fn dispatch(&self) -> &Dispatch {
         &self.dispatch
+    }
+
+    /// Get a pinned reference to the wrapped type.
+    #[cfg(feature = "std-future")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std-future")))]
+    pub fn inner_pin_ref(self: Pin<&Self>) -> Pin<&T> {
+        self.project_ref().inner
+    }
+
+    /// Get a pinned mutable reference to the wrapped type.
+    #[cfg(feature = "std-future")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std-future")))]
+    pub fn inner_pin_mut(self: Pin<&mut Self>) -> Pin<&mut T> {
+        self.project().inner
     }
 
     /// Consumes the `WithDispatch`, returning the wrapped type.


### PR DESCRIPTION
Adds the possibility for the client code to access a pinned projection of the wrapped types in `Instrumented` and `WithDispatch`. As suggested in #386.

I added this after seeing the suggestion, it compiles fine, but be warned I have not actually tried to use this for anything. Let me know if you want to see any tests added.

The main thing I see this enabling is calling `poll` directly on a wrapped future, which would disable the functionality from the wrappers. I'm not sure of the use case, but that's not a reason to make it impossible I suppose.

I got stuck a bit wondering how sound it is to give access to both a `&mut` and a `Pin<&mut>` for the same field, but haven't been able to find any way to break anything without unsafe code. 