### PR TITLE
docs: fix broken and unresolvable links

### DIFF
--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -477,7 +477,7 @@ impl Dispatch {
     /// `Dispatch` forwards to.
     ///
     /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`event`]: ../subscriber/trait.Subscriber.html#method.event
+    /// [`enter`]: ../subscriber/trait.Subscriber.html#method.enter
     #[inline]
     pub fn enter(&self, span: &span::Id) {
         self.subscriber.enter(span);
@@ -485,8 +485,11 @@ impl Dispatch {
 
     /// Records that a span has been exited.
     ///
-    /// This calls the [`exit`](::Subscriber::exit) function on the `Subscriber`
-    /// that this `Dispatch` forwards to.
+    /// This calls the [`exit`] function on the [`Subscriber`] that this
+    /// `Dispatch` forwards to.
+    ///
+    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
+    /// [`exit`]: ../subscriber/trait.Subscriber.html#method.exit
     #[inline]
     pub fn exit(&self, span: &span::Id) {
         self.subscriber.exit(span);
@@ -526,7 +529,7 @@ impl Dispatch {
     ///
     /// [span ID]: ../span/struct.Id.html
     /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`clone_span`]: ../subscriber/trait.Subscriber.html#method.clone_span
+    /// [`drop_span`]: ../subscriber/trait.Subscriber.html#method.drop_span
     /// [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
     /// [`try_close`]: #method.try_close
     #[inline]

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -127,7 +127,7 @@ extern crate alloc;
 ///
 /// [`Identifier`]: callsite/struct.Identifier.html
 /// [`Callsite`]: callsite/trait.Callsite.html
-/// [`Callsite`]: callsite/trait.Callsite.html#method.id
+/// [`Callsite::id`]: callsite/trait.Callsite.html#method.id
 #[macro_export]
 macro_rules! identify_callsite {
     ($callsite:expr) => {

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -452,8 +452,8 @@ impl dyn Subscriber {
 /// `Subscriber`s return an `Interest` from their [`register_callsite`] methods
 /// in order to determine whether that span should be enabled or disabled.
 ///
-/// [`Subscriber`] ../trait.Subscriber.html
-/// [clone_span]: ../trait.Subscriber.html#method.register_callsite
+/// [`Subscriber`]: ../trait.Subscriber.html
+/// [`register_callsite`]: ../trait.Subscriber.html#method.register_callsite
 #[derive(Clone, Debug)]
 pub struct Interest(InterestKind);
 

--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -61,7 +61,7 @@ use tracing::{Metadata, Span};
 /// [fields]: https://docs.rs/tracing/latest/tracing/field/index.html
 /// [futures]: https://doc.rust-lang.org/std/future/trait.Future.html
 /// [`tracing-futures`]: https://docs.rs/tracing-futures/
-/// [`with_spans`] method: #method.with_spans.html
+/// [`with_spans`]: #method.with_spans
 #[derive(Clone)]
 pub struct SpanTrace {
     span: Span,

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -90,7 +90,8 @@
 //! [`SpanTrace`]: struct.SpanTrace.html
 //! [`ErrorLayer`]: struct.ErrorLayer.html
 //! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
-//! [event]: https://docs.rs/tracing/latest/tracing/struct.Event.html
+//! [events]: https://docs.rs/tracing/latest/tracing/struct.Event.html
+//! [`Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
 //! [subscriber layer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/trait.Layer.html
 //! [`tracing`]: https://docs.rs/tracing
 #![doc(html_root_url = "https://docs.rs/tracing-error/0.1.1")]

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -86,6 +86,7 @@
 //! [`tracing::Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
 //! [`Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
 //! [`tracing::Event`]: https://docs.rs/tracing/latest/tracing/struct.Event.html
+//! [flags]: https://docs.rs/tracing/latest/tracing/#crate-feature-flags
 #![doc(html_root_url = "https://docs.rs/tracing-log/0.1.1")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(

--- a/tracing-log/src/trace_logger.rs
+++ b/tracing-log/src/trace_logger.rs
@@ -12,8 +12,11 @@
 //! [`Subscriber`]: https://docs.rs/tracing/0.1.7/tracing/subscriber/trait.Subscriber.html
 //! [`TraceLogger`]: struct.TraceLogger.html
 //! [`log::Record`]: https://docs.rs/log/0.4.8/log/struct.Record.html
-//! [flags]: https://docs.rs/tracing/0.1.10/tracing/#crate-feature-flags
-#![deprecated(since = "0.1.1", note = "use the `tracing` crate's \"log\" feature flag instead")]
+//! [flags]: https://docs.rs/tracing/latest/tracing/#crate-feature-flags
+#![deprecated(
+    since = "0.1.1",
+    note = "use the `tracing` crate's \"log\" feature flag instead"
+)]
 use crate::AsLog;
 use std::{
     cell::RefCell,
@@ -38,6 +41,7 @@ use tracing_core::{
 /// flags][flags] on the `tracing` crate should be used instead.
 ///
 /// [`Subscriber`]: https://docs.rs/tracing/0.1.7/tracing/subscriber/trait.Subscriber.html
+/// [flags]: https://docs.rs/tracing/latest/tracing/#crate-feature-flags
 pub struct TraceLogger {
     settings: Builder,
     spans: Mutex<HashMap<Id, SpanLineBuilder>>,

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -132,8 +132,11 @@ impl CurrentSpan {
         }
     }
 
-    /// Returns the [`Id`](::Id) of the span in which the current thread is
+    /// Returns the [`Id`] of the span in which the current thread is
     /// executing, or `None` if it is not inside of a span.
+    ///
+    ///
+    /// [`Id`]: https://docs.rs/tracing/latest/tracing/span/struct.Id.html
     pub fn id(&self) -> Option<Id> {
         self.current.with(|current| current.last().cloned())?
     }

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -179,7 +179,9 @@ pub struct Parents<'a, R> {
 /// An iterator over a span's parents, starting with the root of the trace
 /// tree.
 ///
-/// For additonal details, see [`Context::scope`].
+/// For additonal details, see [`SpanRef::from_root`].
+///
+/// [`Span::from_root`]: struct.SpanRef.html#method.from_root
 pub struct FromRoot<'a, R: LookupSpan<'a>> {
     #[cfg(feature = "smallvec")]
     inner: std::iter::Rev<smallvec::IntoIter<SpanRefVecArray<'a, R>>>,

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -18,13 +18,12 @@
 //! Spans are created using the [`span!`] macro. This macro is invoked with the
 //! following arguments, in order:
 //!
-//! - The [`target`] and/or [`parent`](parent) attributes, if the user wishes to override
-//!   their default values.
+//! - The [`target`] and/or [`parent`][parent] attributes, if the user wishes to
+//!   override their default values.
 //! - The span's [verbosity level]
 //! - A string literal providing the span's name.
 //! - Finally, between zero and 32 arbitrary key/value fields.
 //!
-//! [parent]: #span-relationships
 //! [`target`]: ../struct.Metadata.html#method.target
 //!
 //! For example:
@@ -47,12 +46,10 @@
 //!
 //! The [`Attributes`] type contains data associated with a span, and is
 //! provided to the [`Subscriber`] when a new span is created. It contains
-//! the span's metadata, the ID of [the span's parent] if one was explicitly set,
-//! and any fields whose values were recorded when the span was constructed.
-//! The subscriber, which is responsible for recording `tracing` data, can then
-//! store or record these values.
-//!
-//! [the span's parent]: #span-relationships
+//! the span's metadata, the ID of [the span's parent][parent] if one was
+//! explicitly set, and any fields whose values were recorded when the span was
+//! constructed. The subscriber, which is responsible for recording `tracing`
+//! data, can then store or record these values.
 //!
 //! # The Span Lifecycle
 //!
@@ -298,6 +295,7 @@
 //! [`in_scope`]: struct.Span.html#method.in_scope
 //! [`follows_from`]: struct.Span.html#method.follows_from
 //! [guard]: struct.Entered.html
+//! [parent]: #span-relationships
 pub use tracing_core::span::{Attributes, Id, Record};
 
 use crate::stdlib::{


### PR DESCRIPTION
This commit fixes several RustDoc links which were either broken
(without references) or had unresolvable references.

It looks like nightly RustDoc has recently gotten much smarter about
finding links that were unresolvable. These had always been broken, but
they used to silently 404. Now, the nightly build of RustDoc will emit a
warning, which we deny, causing the build to fail. This should fix CI
(as well as actually fixing the wrong links).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>