### PR TITLE
attributes: check if a skipped parameter exists

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -215,12 +215,16 @@ pub fn instrument(args: TokenStream, item: TokenStream) -> TokenStream {
     for skip in &skips {
         if !param_names.contains(skip) {
             return quote_spanned!(skip.span()=>
-                compile_error!("attempting to skip non-existing parameter")
-            ).into();
+                compile_error!("attempting to skip non-existent parameter")
+            )
+            .into();
         }
     }
 
-    let param_names: Vec<Ident> = param_names.into_iter().filter(|ident| !skips.contains(ident)).collect();
+    let param_names: Vec<Ident> = param_names
+        .into_iter()
+        .filter(|ident| !skips.contains(ident))
+        .collect();
 
     let fields = match fields(&args, &param_names) {
         Ok(fields) => fields,


### PR DESCRIPTION
This PR adds a check to the `#[instrument]` macro to emit a compiler error if the user tries to skip non-existing parameters.

Fixes: https://github.com/tokio-rs/tracing/issues/562