### PR TITLE
Re-export the log crate from tracing-log

### DIFF
--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -151,6 +151,8 @@ pub use self::trace_logger::TraceLogger;
 #[cfg_attr(docsrs, doc(cfg(feature = "env_logger")))]
 pub mod env_logger;
 
+pub use log;
+
 /// Format a log record as a trace event in the current span.
 pub fn format_trace(record: &log::Record<'_>) -> io::Result<()> {
     let filter_meta = record.as_trace();

--- a/tracing-log/tests/reexport_log_crate.rs
+++ b/tracing-log/tests/reexport_log_crate.rs
@@ -1,0 +1,10 @@
+use tracing_log::{log::LevelFilter, LogTracer};
+
+/// This test makes sure we can access `log::LevelFilter` through the `tracing_log` crate and don't
+/// have to depend on `log` separately.
+///
+/// See https://github.com/tokio-rs/tracing/issues/552.
+#[test]
+fn can_initialize_log_tracer_with_level() {
+    LogTracer::init_with_filter(LevelFilter::Error).unwrap();
+}


### PR DESCRIPTION
## Motivation

Resolves #552.

## Solution

Re-export the whole log crate.