### PR TITLE
tracing: Make tracing-attributes (and syn) optional

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Changed
 
 - The `instrument` attribute was placed under an on-by-default feature
-  flag.
+  flag (#603)
 
 # 0.1.12 (January 11, 2019)
 

--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+### Changed
+
+- The `instrument` attribute was placed under an on-by-default feature
+  flag.
+
 # 0.1.12 (January 11, 2019)
 
 ### Added

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -29,7 +29,7 @@ edition = "2018"
 [dependencies]
 tracing-core = { path = "../tracing-core", version = "0.1.10", default-features = false }
 log = { version = "0.4", optional = true }
-tracing-attributes = { path = "../tracing-attributes", version = "0.1.6"}
+tracing-attributes = { path = "../tracing-attributes", version = "0.1.6", optional = true }
 cfg-if = "0.1.10"
 
 [dev-dependencies]
@@ -38,7 +38,7 @@ criterion = { version = "0.3", default_features = false }
 log = "0.4"
 
 [features]
-default = ["std"]
+default = ["std", "attributes"]
 
 max_level_off   = []
 max_level_error = []
@@ -59,6 +59,7 @@ async-await = []
 
 std = ["tracing-core/std"]
 log-always = ["log"]
+attributes = ["tracing-attributes"]
 
 [[bench]]
 name = "subscriber"

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -654,6 +654,9 @@
 //!   applications which intend to collect traces and logs separately; if an
 //!   adapter is used to convert `log` records into `tracing` events, this will
 //!   cause duplicate events to occur.
+//! * `attributes`: Includes support for the `#[instrument]` attribute.
+//!   This is on by default, but does bring in the `syn` crate as a dependency,
+//!   which may add to the compile time of crates that do not already use it.
 //! * `std`: Depend on the Rust standard library (enabled by default).
 //!
 //!   `no_std` users may disable this feature with `default-features = false`:
@@ -753,6 +756,7 @@ pub use self::{
 
 #[doc(inline)]
 pub use self::span::Span;
+#[cfg(feature = "attributes")]
 #[doc(inline)]
 pub use tracing_attributes::instrument;
 

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -146,6 +146,8 @@
 //!
 //! For example:
 //! ```
+//! # #[cfg(feature = "attributes")]
+//! # {
 //! use tracing::{Level, event, instrument};
 //!
 //! #[instrument]
@@ -155,6 +157,7 @@
 //!     event!(Level::INFO, "inside my_function!");
 //!     // ...
 //! }
+//! # }
 //! # fn main() {}
 //! ```
 //!

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -145,9 +145,9 @@
 //! fields using `fmt::Debug`.
 //!
 //! For example:
-//! ```
-//! # #[cfg(feature = "attributes")]
-//! # {
+//! ```ignore
+//! # // this doctest is ignored because we don't have a way to say
+//! # // that it should only be run with cfg(feature = "attributes")
 //! use tracing::{Level, event, instrument};
 //!
 //! #[instrument]
@@ -157,7 +157,6 @@
 //!     event!(Level::INFO, "inside my_function!");
 //!     // ...
 //! }
-//! # }
 //! # fn main() {}
 //! ```
 //!

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -757,6 +757,7 @@ pub use self::{
 #[doc(inline)]
 pub use self::span::Span;
 #[cfg(feature = "attributes")]
+#[cfg_attr(docsrs, doc(cfg(feature = "attributes")))]
 #[doc(inline)]
 pub use tracing_attributes::instrument;
 


### PR DESCRIPTION
This allows consumers to use the convenience of `tracing` without having to pull in the `syn` crate.