### PR TITLE
futures: prepare to release 0.2.3

### DIFF
--- a/tracing-futures/CHANGELOG.md
+++ b/tracing-futures/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.2.3 (Feb 26, 2020)
+
+### Added
+
+- `WithDispatch::inner` and `WithDispatch::inner_mut` methods to allow borrowing
+  the wrapped type (#589)
+- `WithDispatch::with_dispatch` method, to propagate the subscriber to another
+  type (#589)
+- `inner_pin_ref` and `inner_pin_mut` methods to `Instrumented` and
+  `WithDispatch` to project to the inner future when pinned (#590)
+
 # 0.2.2 (Feb 14, 2020)
 
 ### Added

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-futures"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"

--- a/tracing-futures/README.md
+++ b/tracing-futures/README.md
@@ -13,9 +13,9 @@ Utilities for instrumenting futures-based code with [`tracing`].
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-futures.svg
-[crates-url]: https://crates.io/crates/tracing-futures/0.2.0
+[crates-url]: https://crates.io/crates/tracing-futures/0.2.3
 [docs-badge]: https://docs.rs/tracing-futures/badge.svg
-[docs-url]: https://docs.rs/tracing-futures/0.2.0/tracing_futures
+[docs-url]: https://docs.rs/tracing-futures/0.2.3/tracing_futures
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_futures
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -41,10 +41,10 @@ The crate provides the following traits:
 * [`WithSubscriber`] allows a `tracing` [`Subscriber`] to be attached to a
   future, sink, stream, or executor.
 
-[`Instrument`]: https://docs.rs/tracing-futures/0.2.0/tracing_futures/trait.Instrument.html
-[`WithSubscriber`]: https://docs.rs/tracing-futures/0.2.0/tracing_futures/trait.WithSubscriber.html
-[span]: https://docs.rs/tracing/0.1.9/tracing/span/index.html
-[`Subscriber`]: https://docs.rs/tracing/0.1.9/tracing/subscriber/index.html
+[`Instrument`]: https://docs.rs/tracing-futures/0.2.3/tracing_futures/trait.Instrument.html
+[`WithSubscriber`]: https://docs.rs/tracing-futures/0.2.3/tracing_futures/trait.WithSubscriber.html
+[span]: https://docs.rs/tracing/latest/tracing/span/index.html
+[`Subscriber`]: https://docs.rs/tracing/latest/tracing/subscriber/index.html
 [`tracing`]: https://crates.io/tracing
 
 ## License

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -43,18 +43,18 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing-futures = { version = "0.2", default-features = false }
+//!   tracing-futures = { version = "0.2.3", default-features = false }
 //!   ```
 //!
 //! The `tokio`, `std-future` and `std` features are enabled by default.
 //!
 //! [`tracing`]: https://crates.io/crates/tracing
-//! [span]: https://docs.rs/tracing/0.1.12/tracing/span/index.html
-//! [`Subscriber`]: https://docs.rs/tracing/0.1.12/tracing/subscriber/index.html
+//! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
+//! [`Subscriber`]: https://docs.rs/tracing/latest/tracing/subscriber/index.html
 //! [`Instrument`]: trait.Instrument.html
 //! [`WithSubscriber`]: trait.WithSubscriber.html
 //! [`futures`]: https://crates.io/crates/futures
-#![doc(html_root_url = "https://docs.rs/tracing-futures/0.2.2")]
+#![doc(html_root_url = "https://docs.rs/tracing-futures/0.2.3")]
 #![warn(
     missing_debug_implementations,
     missing_docs,
@@ -96,7 +96,7 @@ pub mod executor;
 /// Extension trait allowing futures, streams, sinks, and executors to be
 /// instrumented with a `tracing` [span].
 ///
-/// [span]: https://docs.rs/tracing/0.1.9/tracing/span/index.html
+/// [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 pub trait Instrument: Sized {
     /// Instruments this type with the provided `Span`, returning an
     /// `Instrumented` wrapper.
@@ -125,7 +125,7 @@ pub trait Instrument: Sized {
     /// # }
     /// ```
     ///
-    /// [entered]: https://docs.rs/tracing/0.1.9/tracing/span/struct.Span.html#method.enter
+    /// [entered]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.enter
     fn instrument(self, span: Span) -> Instrumented<Self> {
         Instrumented { inner: self, span }
     }
@@ -160,8 +160,8 @@ pub trait Instrument: Sized {
     /// # }
     /// ```
     ///
-    /// [current]: https://docs.rs/tracing/0.1.9/tracing/span/struct.Span.html#method.current
-    /// [entered]: https://docs.rs/tracing/0.1.9/tracing/span/struct.Span.html#method.enter
+    /// [current]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.current
+    /// [entered]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.enter
     #[inline]
     fn in_current_span(self) -> Instrumented<Self> {
         self.instrument(Span::current())
@@ -171,7 +171,7 @@ pub trait Instrument: Sized {
 /// Extension trait allowing futures, streams, and skins to be instrumented with
 /// a `tracing` [`Subscriber`].
 ///
-/// [`Subscriber`]: https://docs.rs/tracing/0.1.9/tracing/subscriber/trait.Subscriber.html
+/// [`Subscriber`]: https://docs.rs/tracing/latest/tracing/subscriber/trait.Subscriber.html
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub trait WithSubscriber: Sized {
@@ -183,8 +183,8 @@ pub trait WithSubscriber: Sized {
     /// When the wrapped type is an executor, the subscriber will be set as the
     /// default for any futures spawned on that executor.
     ///
-    /// [`Subscriber`]: https://docs.rs/tracing/0.1.9/tracing/subscriber/trait.Subscriber.html
-    /// [default]: https://docs.rs/tracing/0.1.9/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [`Subscriber`]: https://docs.rs/tracing/latest/tracing/subscriber/trait.Subscriber.html
+    /// [default]: https://docs.rs/tracing/latest/tracing/dispatcher/index.html#setting-the-default-subscriber
     fn with_subscriber<S>(self, subscriber: S) -> WithDispatch<Self>
     where
         S: Into<Dispatch>,
@@ -206,8 +206,8 @@ pub trait WithSubscriber: Sized {
     /// This can be used to propagate the current dispatcher context when
     /// spawning a new future.
     ///
-    /// [`Subscriber`]: https://docs.rs/tracing/0.1.9/tracing/subscriber/trait.Subscriber.html
-    /// [default]: https://docs.rs/tracing/0.1.9/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [`Subscriber`]: https://docs.rs/tracing/latest/tracing/subscriber/trait.Subscriber.html
+    /// [default]: https://docs.rs/tracing/latest/tracing/dispatcher/index.html#setting-the-default-subscriber
     #[inline]
     fn with_current_subscriber(self) -> WithDispatch<Self> {
         WithDispatch {


### PR DESCRIPTION
### Added

- `WithDispatch::inner` and `WithDispatch::inner_mut` methods to allow
  borrowing the wrapped type (#589)
- `WithDispatch::with_dispatch` method, to propagate the subscriber to
  another type (#589)
- `inner_pin_ref` and `inner_pin_mut` methods to `Instrumented` and
  `WithDispatch` to project to the inner future when pinned (#590)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>