### PR TITLE
tracing: prepare to release 0.1.13

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,9 +1,26 @@
-# Unreleased
+# 0.1.13 (February 26, 2019)
+
+### Added
+
+- **field**: `field::Empty` type for declaring empty fields whose values will be
+  recorded later (#548)
+- **field**: `field::Value` implementations for `Wrapping` and `NonZero*`
+  numbers (#538)
+- **attributes**: Support for adding arbitrary literal fields to spans generated
+  by `#[instrument]` (#569)
+- **attributes**: `#[instrument]` now emits a helpful compiler error when
+  attempting to skip a function parameter (#600)
 
 ### Changed
 
-- The `instrument` attribute was placed under an on-by-default feature
-  flag (#603)
+- **attributes**: The `#[instrument]` attribute was placed under an on-by-default
+  feature flag "attributes" (#603)
+
+### Fixed
+
+- Broken and unresolvable links in RustDoc (#595)
+
+Thanks to @oli-cosmian and @Kobzol for contributing to this release!
 
 # 0.1.12 (January 11, 2019)
 

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -12,9 +12,9 @@ Application-level tracing for Rust.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.12
+[crates-url]: https://crates.io/crates/tracing/0.1.13
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.12
+[docs-url]: https://docs.rs/tracing/0.1.13
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -241,7 +241,7 @@ my_future
 is as long as the future's.
 
 The second, and preferred, option is through the
-[`#[instrument]`](https://docs.rs/tracing/0.1.12/tracing/attr.instrument.html)
+[`#[instrument]`](https://docs.rs/tracing/0.1.13/tracing/attr.instrument.html)
 attribute:
 
 ```rust
@@ -290,7 +290,7 @@ span.in_scope(|| {
 // Dropping the span will close it, indicating that it has ended.
 ```
 
-The [`#[instrument]`](https://docs.rs/tracing/0.1.12/tracing/attr.instrument.html) attribute macro
+The [`#[instrument]`](https://docs.rs/tracing/0.1.13/tracing/attr.instrument.html) attribute macro
 can reduce some of this boilerplate:
 
 ```rust

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -665,7 +665,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing = { version = "0.1.12", default-features = false }
+//!   tracing = { version = "0.1.13", default-features = false }
 //!   ```
 //!
 //!   *Compiler support: requires rustc 1.39+*
@@ -698,7 +698,7 @@
 //! [instrument]: https://docs.rs/tracing-attributes/latest/tracing_attributes/attr.instrument.html
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.12")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.13")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
### Added

- **field**: `field::Empty` type for declaring empty fields whose values
  will be recorded later (#548)
- **field**: `field::Value` implementations for `Wrapping` and `NonZero*`
  numbers (#538)
- **attributes**: Support for adding arbitrary literal fields to spans
  generated by `#[instrument]` (#569)
- **attributes**: `#[instrument]` now emits a helpful compiler error when
  attempting to skip a function parameter (#600)

### Changed

- **attributes**: The `#[instrument]` attribute was placed under an
  on-by-default  feature flag "attributes" (#603)

### Fixed

- Broken and unresolvable links in RustDoc (#595)

Thanks to @oli-cosmian and @Kobzol for contributing to this release!

Signed-off-by: Eliza Weisman <eliza@buoyant.io>