### PR TITLE
Fix typo in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ In addition, you can locally override the default subscriber. For example:
 
 ```rust
 use tracing::{info, Level};
-use tracing_subscruber::FmtSubscriber;
+use tracing_subscriber::FmtSubscriber;
 
 fn main() {
     let subscriber = tracing_subscriber::FmtSubscriber::builder()


### PR DESCRIPTION
Hi, I noticed a small typo while checking out the README 🙂 