### PR TITLE
Add a status fn to SpanTrace

### DIFF
--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -247,16 +247,14 @@ impl fmt::Debug for SpanTrace {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tracing_subscriber::{prelude::*, registry::Registry};
+    use crate::ErrorLayer;
     use tracing::subscriber::with_default;
     use tracing::{span, Level};
-    use crate::ErrorLayer;
-
+    use tracing_subscriber::{prelude::*, registry::Registry};
 
     #[test]
     fn capture_supported() {
-        let subscriber = Registry::default()
-            .with(ErrorLayer::default());
+        let subscriber = Registry::default().with(ErrorLayer::default());
 
         with_default(subscriber, || {
             let span = span!(Level::ERROR, "test span");
@@ -268,13 +266,11 @@ mod tests {
 
             assert_eq!(SpanTraceStatus::Captured, span_trace.status())
         });
-
     }
 
     #[test]
     fn capture_empty() {
-        let subscriber = Registry::default()
-            .with(ErrorLayer::default());
+        let subscriber = Registry::default().with(ErrorLayer::default());
 
         with_default(subscriber, || {
             let span_trace = SpanTrace::capture();

--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -121,7 +121,12 @@ impl SpanTrace {
         });
     }
 
-    /// Returns the status of this SpanTrace, indicating whether this backtrace request was unsupported, empty, or a span trace was actually captured.
+    /// Returns the status of this `SpanTrace`.
+    ///
+    /// The status indicates one of the following:
+    /// * the current subscriber does not support capturing `SpanTrace`s
+    /// * there was no current span, so a trace was not captured
+    /// * a span trace was successfully captured
     pub fn status(&self) -> SpanTraceStatus {
         SpanTraceStatus(if self.span.is_none() {
             SpanTraceStatusInner::Empty

--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -128,7 +128,7 @@ impl SpanTrace {
     /// * there was no current span, so a trace was not captured
     /// * a span trace was successfully captured
     pub fn status(&self) -> SpanTraceStatus {
-        SpanTraceStatus(if self.span.is_none() {
+        let inner = if self.span.is_none() {
             SpanTraceStatusInner::Empty
         } else {
             let mut status = None;
@@ -139,25 +139,29 @@ impl SpanTrace {
             });
 
             status.unwrap_or(SpanTraceStatusInner::Unsupported)
-        })
+        };
+
+        SpanTraceStatus(inner)
     }
 }
 
-/// The current status of a SpanTrace, indicating whether it was captured or whether it is empty
-/// for some other reason.
+/// The current status of a SpanTrace, indicating whether it was captured or
+/// whether it is empty for some other reason.
 #[derive(Debug, PartialEq, Eq)]
 pub struct SpanTraceStatus(SpanTraceStatusInner);
 
 impl SpanTraceStatus {
-    /// Formatting a SpanTrace is not supported, likely because there is no ErrorLayer or the
-    /// ErrorLayer is from a different version of tracing_error
+    /// Formatting a SpanTrace is not supported, likely because there is no
+    /// ErrorLayer or the ErrorLayer is from a different version of
+    /// tracing_error
     pub const UNSUPPORTED: SpanTraceStatus = SpanTraceStatus(SpanTraceStatusInner::Unsupported);
 
-    /// The SpanTrace is empty, likely because it was captured outside of any `span`s
+    /// The SpanTrace is empty, likely because it was captured outside of any
+    /// `span`s
     pub const EMPTY: SpanTraceStatus = SpanTraceStatus(SpanTraceStatusInner::Empty);
 
-    /// A span trace has been captured and the `SpanTrace` should print reasonable information when
-    /// rendered.
+    /// A span trace has been captured and the `SpanTrace` should print
+    /// reasonable information when rendered.
     pub const CAPTURED: SpanTraceStatus = SpanTraceStatus(SpanTraceStatusInner::Captured);
 }
 

--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -123,7 +123,7 @@ impl SpanTrace {
 
     /// Returns the status of this SpanTrace, indicating whether this backtrace request was unsupported, empty, or a span trace was actually captured.
     pub fn status(&self) -> SpanTraceStatus {
-        if self.span == Span::none() {
+        if self.span.is_none() {
             SpanTraceStatus::Empty
         } else {
             let mut status = None;

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -202,7 +202,7 @@ mod layer;
 #[cfg(feature = "stack-error")]
 mod stack_error;
 
-pub use self::backtrace::SpanTrace;
+pub use self::backtrace::{SpanTrace, SpanTraceStatus};
 #[cfg(not(feature = "stack-error"))]
 pub use self::heap_error::TracedError;
 pub use self::layer::ErrorLayer;


### PR DESCRIPTION
## Motivation

Because `SpanTrace` does not have a header, implementations that wish to print a `SpanTrace` must print their own header before printing the `SpanTrace` itself. When the `SpanTrace` is empty this ends up inserting a header with no content after it, and the only way to avoid this via the current API is to `to_string` the `SpanTrace` prior to printing the header to check if `SpanTrace` would print any content.

## Solution

This change adds a `SpanTrace::status()` fn and accompanying `SpanTraceStatus` enum type to indicate to the user what will be printed if anything when the user attempts to display/debug print the `SpanTrace`.