### PR TITLE
attributes: fix compile error generation

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -197,41 +197,67 @@ pub fn instrument(args: TokenStream, item: TokenStream) -> TokenStream {
     // function name
     let ident_str = ident.to_string();
 
-    // Pull out the arguments-to-be-skipped first, so we can filter results below.
-    let skips = match skips(&args) {
-        Ok(skips) => skips,
-        Err(err) => return quote!(#err).into(),
-    };
+    // generate this inside a closure, so we can return early on errors.
+    let span = (|| {
+        // Pull out the arguments-to-be-skipped first, so we can filter results below.
+        let skips = match skips(&args) {
+            Ok(skips) => skips,
+            Err(err) => return quote!(#err).into(),
+        };
 
-    let param_names: Vec<Ident> = params
-        .clone()
-        .into_iter()
-        .flat_map(|param| match param {
-            FnArg::Typed(PatType { pat, .. }) => param_names(*pat),
-            FnArg::Receiver(_) => Box::new(iter::once(Ident::new("self", param.span()))),
-        })
-        .collect();
+        let param_names: Vec<Ident> = params
+            .clone()
+            .into_iter()
+            .flat_map(|param| match param {
+                FnArg::Typed(PatType { pat, .. }) => param_names(*pat),
+                FnArg::Receiver(_) => Box::new(iter::once(Ident::new("self", param.span()))),
+            })
+            .collect();
 
-    for skip in &skips {
-        if !param_names.contains(skip) {
-            return quote_spanned!(skip.span()=>
-                compile_error!("attempting to skip non-existent parameter")
-            )
-            .into();
+        for skip in &skips {
+            if !param_names.contains(skip) {
+                return quote_spanned! {skip.span()=>
+                    compile_error!("attempting to skip non-existent parameter")
+                }
+                .into();
+            }
         }
-    }
 
-    let param_names: Vec<Ident> = param_names
-        .into_iter()
-        .filter(|ident| !skips.contains(ident))
-        .collect();
+        let param_names: Vec<Ident> = param_names
+            .into_iter()
+            .filter(|ident| !skips.contains(ident))
+            .collect();
 
-    let fields = match fields(&args, &param_names) {
-        Ok(fields) => fields,
-        Err(err) => return quote!(#err).into(),
-    };
+        let fields = match fields(&args, &param_names) {
+            Ok(fields) => fields,
+            Err(err) => return quote!(#err).into(),
+        };
 
-    let param_names_clone = param_names.clone();
+        let param_names_clone = param_names.clone();
+
+        let level = level(&args);
+        let target = target(&args);
+        let span_name = name(&args, ident_str);
+
+        let mut quoted_fields: Vec<_> = param_names
+            .into_iter()
+            .map(|i| quote!(#i = tracing::field::debug(&#i)))
+            .collect();
+        quoted_fields.extend(fields.into_iter().map(|(key, value)| {
+            let value = match value {
+                Some(value) => quote!(#value),
+                None => quote!(tracing::field::Empty),
+            };
+
+            quote!(#key = #value)
+        }));
+        quote!(tracing::span!(
+            target: #target,
+            #level,
+            #span_name,
+            #(#quoted_fields),*
+        ))
+    })();
 
     // Generate the instrumented function body.
     // If the function is an `async fn`, this will wrap it in an async block,
@@ -259,34 +285,12 @@ pub fn instrument(args: TokenStream, item: TokenStream) -> TokenStream {
         )
     };
 
-    let level = level(&args);
-    let target = target(&args);
-    let span_name = name(&args, ident_str);
-
-    let mut quoted_fields: Vec<_> = param_names
-        .into_iter()
-        .map(|i| quote!(#i = tracing::field::debug(&#i)))
-        .collect();
-    quoted_fields.extend(fields.into_iter().map(|(key, value)| {
-        let value = match value {
-            Some(value) => quote!(#value),
-            None => quote!(tracing::field::Empty),
-        };
-
-        quote!(#key = #value)
-    }));
-
     quote!(
         #(#attrs) *
         #vis #constness #unsafety #asyncness #abi fn #ident<#gen_params>(#params) #return_type
         #where_clause
         {
-            let __tracing_attr_span = tracing::span!(
-                target: #target,
-                #level,
-                #span_name,
-                #(#quoted_fields),*
-            );
+            let __tracing_attr_span = #span;
             #body
         }
     )

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -202,7 +202,7 @@ pub fn instrument(args: TokenStream, item: TokenStream) -> TokenStream {
         // Pull out the arguments-to-be-skipped first, so we can filter results below.
         let skips = match skips(&args) {
             Ok(skips) => skips,
-            Err(err) => return quote!(#err).into(),
+            Err(err) => return quote!(#err),
         };
 
         let param_names: Vec<Ident> = params
@@ -218,8 +218,7 @@ pub fn instrument(args: TokenStream, item: TokenStream) -> TokenStream {
             if !param_names.contains(skip) {
                 return quote_spanned! {skip.span()=>
                     compile_error!("attempting to skip non-existent parameter")
-                }
-                .into();
+                };
             }
         }
 
@@ -230,7 +229,7 @@ pub fn instrument(args: TokenStream, item: TokenStream) -> TokenStream {
 
         let fields = match fields(&args, &param_names) {
             Ok(fields) => fields,
-            Err(err) => return quote!(#err).into(),
+            Err(err) => return quote!(#err),
         };
 
         let param_names_clone = param_names.clone();


### PR DESCRIPTION
## Motivation

Previously, some compile errors generated by `tracing-attributes` on bad
inputs, such as for an invalid `skip` arg, would be generated as the
_entire_ output of the attribute. Since the attribute is invoked in item
position (to generate a function), this would result in invalid code,
and the compiler would emit a much more cryptic parse error rather than
the intended helpful error.

For example, this code

```rust
    #[instrument(skip(baz))]
    fn bad_skip(foo: usize) {}
```

would result in the compiler outputting this error:

```
error: macros that expand to items must be delimited with braces or followed by a semicolon
 --> tracing-attributes/tests/bad_skip.rs:3:19
  |
3 | #[instrument(skip(baz))]
  |                   ^^^
  |
help: change the delimiters to curly braces
  |
3 | #[instrument(skip( {a}))]
  |                    ^ ^
help: add a semicolon
  |
3 | #[instrument(skip(baz;))]
  |                      ^
```

which doesn't make a lot of sense.

## Solution

This branch changes the `instrument` attribute so that a function
definition is always generated, and any compile errors due to bad input
are generated _inside_ that function definition. This means that the
compiler won't complain at us for generating a bad function definition
before it sees our `compile_error` macros.

For example, the code I showed above now results in this error:

```
error: attempting to skip non-existent parameter
 --> tracing-attributes/tests/bad_skip.rs:3:19
  |
3 | #[instrument(skip(baz))]
  |
```

Fixes #612

Signed-off-by: Eliza Weisman <eliza@buoyant.io>