### PR TITLE
Fix receiver type to avoid a reborrow

### DIFF
--- a/tracing-error/src/heap_error.rs
+++ b/tracing-error/src/heap_error.rs
@@ -76,7 +76,7 @@ where
     }
 }
 
-impl ExtractSpanTrace for &(dyn Error + 'static) {
+impl ExtractSpanTrace for dyn Error + 'static {
     fn span_trace(&self) -> Option<&SpanTrace> {
         self.downcast_ref::<ErrorImpl>().map(|e| &e.span_trace)
     }

--- a/tracing-error/src/stack_error.rs
+++ b/tracing-error/src/stack_error.rs
@@ -151,7 +151,7 @@ where
     }
 }
 
-impl ExtractSpanTrace for &(dyn Error + 'static) {
+impl ExtractSpanTrace for dyn Error + 'static {
     fn span_trace(&self) -> Option<&SpanTrace> {
         self.downcast_ref::<ErrorImpl<Erased>>()
             .map(|inner| &inner.span_trace)


### PR DESCRIPTION
## Motivation

The current impl for `ExtractSpanTrace` is implemented for references and takes &self as its receiver type, which causes it to reborrow the error and the lifetime of the returned SpanTrace is tied to this new borrow. This prevents the SpanTrace from outliving the borrow created from the `span_trace` call which functionally means you cannot return references to the borrowed `SpanTrace`s

## Solution

This changes the receiver type from `&dyn Error` to `dyn Error` so that the `&` in the `&self` pattern ends up matching against the original borrow, which could be a borrow that was passed in from another function, which lets us use the longer lifetime as the lifetime for the reference to the SpanTrace.