### PR TITLE
error: prepare to release 0.1.2

### DIFF
--- a/tracing-error/CHANGELOG.md
+++ b/tracing-error/CHANGELOG.md
@@ -1,7 +1,26 @@
+# 0.1.2 (March 3, 2020)
+
+### Added
+
+- **TracedError**: `TracedError`, an error type wrapper that annotates an error
+  with the current span.
+- **SpanTrace**:`SpanTrace::status` method and `SpanTraceStatus` type for
+  determing whether a `SpanTrace` was successfully captured (#614)
+
+### Changed
+
+- **SpanTrace**: Made backtrace formatting more consistent with upstream changes
+  to `std::backtrace` (#584)
+
 # 0.1.1 (February 5, 2020)
 
+### Fixed
+
 - Fixed a typo in the crate description
-- Changed the maintenance badge from active to experimental
+
+### Changed
+
+- the maintenance badge from active to experimental
 
 # 0.1.0 (February 5, 2020)
 

--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-error"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "Jane Lusby <jlusby@yaah.dev>",

--- a/tracing-error/README.md
+++ b/tracing-error/README.md
@@ -13,9 +13,9 @@ Utilities for instrumenting errors with [`tracing`].
 [Documentation (release)][docs-url] | [Documentation (master)][docs-master-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-error.svg
-[crates-url]: https://crates.io/crates/tracing-error/0.1.0
+[crates-url]: https://crates.io/crates/tracing-error/0.1.2
 [docs-badge]: https://docs.rs/tracing-error/badge.svg
-[docs-url]: https://docs.rs/tracing-error/0.1.0/tracing_error
+[docs-url]: https://docs.rs/tracing-error/0.1.2/tracing_error
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_error
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -108,8 +108,8 @@ fn main() {
 }
 ```
 
-[`SpanTrace`]: https://docs.rs/tracing-error/0.1.0/tracing_error/struct.SpanTrace.html
-[`ErrorLayer`]: https://docs.rs/tracing-error/0.1.0/tracing_error/struct.ErrorLayer.html
+[`SpanTrace`]: https://docs.rs/tracing-error/0.1.2/tracing_error/struct.SpanTrace.html
+[`ErrorLayer`]: https://docs.rs/tracing-error/0.1.2/tracing_error/struct.ErrorLayer.html
 [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 [event]: https://docs.rs/tracing/latest/tracing/struct.Event.html
 [subscriber layer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/trait.Layer.html

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -168,7 +168,7 @@
 //! [`tracing`]: https://docs.rs/tracing
 //! [`std::error::Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/tracing-error/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/tracing-error/0.1.2")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
### Added

- **TracedError**: `TracedError`, an error type wrapper that annotates
  an error with the current span.
- **SpanTrace**:`SpanTrace::status` method and `SpanTraceStatus` type
  for determing whether a `SpanTrace` was successfully captured (#614)

### Changed

- **SpanTrace**: Made backtrace formatting more consistent with upstream
  changes to `std::backtrace` (#584)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
