### PR TITLE
subscriber: prepare to release 0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ idiomatic `tracing`.)
 In order to record trace events, executables have to use a `Subscriber`
 implementation compatible with `tracing`. A `Subscriber` implements a way of
 collecting trace data, such as by logging it to standard output. [`tracing_subscriber`](https://docs.rs/tracing-subscriber/)'s
-[`fmt` module](https://docs.rs/tracing-subscriber/0.2.2/tracing_subscriber/fmt/index.html) provides reasonable defaults.
+[`fmt` module](https://docs.rs/tracing-subscriber/0.2.3/tracing_subscriber/fmt/index.html) provides reasonable defaults.
 Additionally, `tracing-subscriber` is able to consume messages emitted by `log`-instrumented libraries and modules.
 
 The simplest way to use a subscriber is to call the `set_global_default` function.
@@ -78,7 +78,7 @@ fn main() {
 ```toml
 [dependencies]
 tracing = "0.1"
-tracing-subscriber = "0.2.2"
+tracing-subscriber = "0.2.3"
 ```
 
 This subscriber will be used as the default in all threads for the remainder of the duration

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,7 +19,7 @@ tracing = { path = "../tracing", version = "0.1"}
 tracing-core = { path = "../tracing-core", version = "0.1"}
 tracing-error = { path = "../tracing-error" }
 tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.2", features = ["json", "chrono"] }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.3", features = ["json", "chrono"] }
 tracing-futures = { version = "0.2.1", path = "../tracing-futures", features = ["futures-01"] }
 tracing-attributes =  { path = "../tracing-attributes", version = "0.1.2"}
 tracing-log = { path = "../tracing-log", version = "0.1.1", features = ["env_logger"] }

--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -38,7 +38,7 @@ default = ["traced-error"]
 traced-error = []
 
 [dependencies]
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.2", default-features = false, features = ["registry", "fmt"] }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.3", default-features = false, features = ["registry", "fmt"] }
 tracing = { path = "../tracing", version = "0.1"}
 
 [badges]

--- a/tracing-error/src/layer.rs
+++ b/tracing-error/src/layer.rs
@@ -15,10 +15,10 @@ use tracing_subscriber::{
 /// when formatting the fields of each span in a trace. When no formatter is
 /// provided, the [default format] is used instead.
 ///
-/// [`Layer`]: https://docs.rs/tracing-subscriber/0.2.2/tracing_subscriber/layer/trait.Layer.html
+/// [`Layer`]: https://docs.rs/tracing-subscriber/0.2.3/tracing_subscriber/layer/trait.Layer.html
 /// [`SpanTrace`]: ../struct.SpanTrace.html
-/// [field formatter]: https://docs.rs/tracing-subscriber/0.2.2/tracing_subscriber/fmt/trait.FormatFields.html
-/// [default format]: https://docs.rs/tracing-subscriber/0.2.2/tracing_subscriber/fmt/format/struct.DefaultFields.html
+/// [field formatter]: https://docs.rs/tracing-subscriber/0.2.3/tracing_subscriber/fmt/trait.FormatFields.html
+/// [default format]: https://docs.rs/tracing-subscriber/0.2.3/tracing_subscriber/fmt/format/struct.DefaultFields.html
 pub struct ErrorLayer<S, F = DefaultFields> {
     format: F,
 
@@ -70,7 +70,7 @@ where
 {
     /// Returns a new `ErrorLayer` with the provided [field formatter].
     ///
-    /// [field formatter]: https://docs.rs/tracing-subscriber/0.2.2/tracing_subscriber/fmt/trait.FormatFields.html
+    /// [field formatter]: https://docs.rs/tracing-subscriber/0.2.3/tracing_subscriber/fmt/trait.FormatFields.html
     pub fn new(format: F) -> Self {
         Self {
             format,

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.3 (March 5, 2020)
+
+### Fixed
+
+- **env-filter**: Regression where filter directives were selected in the order
+  they were listed, rather than most specific first (#624)
+
 # 0.2.2 (February 27, 2020)
 
 ### Added

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.2"
+version = "0.2.3"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -17,7 +17,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.2.2
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.3
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -51,7 +51,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.2")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.3")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(
     missing_debug_implementations,


### PR DESCRIPTION
# 0.2.3 (March 5, 2020)

### Fixed

- **env-filter**: Regression where filter directives were selected in the order
  they were listed, rather than most specific first (#624)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>