### PR TITLE
error: Bump minimum version for tracing dep

### DIFF
--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -39,7 +39,7 @@ traced-error = []
 
 [dependencies]
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.2", default-features = false, features = ["registry", "fmt"] }
-tracing = { path = "../tracing", version = "0.1"}
+tracing = { path = "../tracing", version = "0.1.12"}
 
 [badges]
 maintenance = { status = "experimental" }


### PR DESCRIPTION
## Motivation

tracing-error's ErrorLayer depends upon subscriber changes that were introduced in tracing "0.1.12" and depending on tracing = "0.1" allows it to select versions that will not compile.