### PR TITLE
examples: await inner future

### DIFF
--- a/examples/examples/tower-load.rs
+++ b/examples/examples/tower-load.rs
@@ -368,6 +368,7 @@ async fn load_gen(addr: SocketAddr) -> Result<(), Err> {
                 Ok(())
             }
             .instrument(span)
+            .await
         }
         .instrument(span!(target: "gen", Level::INFO, "generated_request", remote.addr=%addr));
         tokio::spawn(f);


### PR DESCRIPTION
I forgot to await the inner future in the `tower-load` which led to the example _not doing anything_. Whoops!