### PR TITLE
Fix but in new_span for fmt layer

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -445,7 +445,7 @@ where
             let mut buf = String::new();
             if self.fmt_fields.format_fields(&mut buf, attrs).is_ok() {
                 let fmt_fields = FormattedFields {
-                     fields: buf,
+                    fields: buf,
                     _format_event: PhantomData::<fn(N)>,
                 };
                 extensions.insert(fmt_fields);

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -440,19 +440,18 @@ where
     fn new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         let span = ctx.span(id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
-        if let Some(FormattedFields { ref mut fields, .. }) =
-            extensions.get_mut::<FormattedFields<N>>()
-        {
-            let _ = self.fmt_fields.format_fields(fields, attrs);
-        } else {
-            let mut buf = String::new();
-            if self.fmt_fields.format_fields(&mut buf, attrs).is_ok() {
-                let fmt_fields = FormattedFields {
-                    fields: buf,
-                    _format_event: PhantomData::<fn(N)>,
-                };
-                extensions.insert(fmt_fields);
-            }
+
+        if extensions.get_mut::<FormattedFields<N>>().is_some() {
+            return;
+        }
+
+        let mut buf = String::new();
+        if self.fmt_fields.format_fields(&mut buf, attrs).is_ok() {
+            let fmt_fields = FormattedFields {
+                fields: buf,
+                _format_event: PhantomData::<fn(N)>,
+            };
+            extensions.insert(fmt_fields);
         }
     }
 

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -441,17 +441,15 @@ where
         let span = ctx.span(id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
 
-        if extensions.get_mut::<FormattedFields<N>>().is_some() {
-            return;
-        }
-
-        let mut buf = String::new();
-        if self.fmt_fields.format_fields(&mut buf, attrs).is_ok() {
-            let fmt_fields = FormattedFields {
-                fields: buf,
-                _format_event: PhantomData::<fn(N)>,
-            };
-            extensions.insert(fmt_fields);
+        if extensions.get_mut::<FormattedFields<N>>().is_none() {
+            let mut buf = String::new();
+            if self.fmt_fields.format_fields(&mut buf, attrs).is_ok() {
+                let fmt_fields = FormattedFields {
+                     fields: buf,
+                    _format_event: PhantomData::<fn(N)>,
+                };
+                extensions.insert(fmt_fields);
+            }
         }
     }
 


### PR DESCRIPTION
Right now theres a bug where if you have an error layer and a fmt layer, and the error layer is first, the fmt layer will still fmt the args and will end up duplicating the output in the formatted fields.

This change correctly skips formatting fields if the fields already exist in the registry.