### PR TITLE
Fix example of using TracedError with error kind pattern

### DIFF
--- a/tracing-error/src/error.rs
+++ b/tracing-error/src/error.rs
@@ -17,9 +17,24 @@ struct Erased;
 ///
 /// ```rust,compile_fail
 /// #[derive(Debug, thiserror::Error)]
+/// enum Kind {
+///     // ...
+/// }
+///
+/// #[derive(Debug)]
 /// pub struct Error {
 ///     source: TracedError<Kind>,
 ///     backtrace: Backtrace,
+/// }
+///
+/// impl std::error::Error for Error {
+///     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+///         self.source.source()
+///     }
+///
+///     fn backtrace(&self) -> Option<&Backtrace> {
+///         Some(&self.backtrace)
+///     }
 /// }
 ///
 /// impl fmt::Display for Error {


### PR DESCRIPTION
The originally given example for how to use TracedError along side the Error Kind pattern was subtly incorrect. You cannot use a derive macro on the error itself because it needs to forward all implementation other than `backtrace()` to its inner error type, which is not supported by the existing `transparent` attribute of thiserror.