### PR TITLE
subscriber: fix clippy lints

### DIFF
--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -83,6 +83,8 @@ macro_rules! try_lock {
         try_lock!($lock, else return)
     };
     ($lock:expr, else $els:expr) => {
+        // see: https://github.com/rust-lang/rust-clippy/issues/3688
+        #[allow(clippy::match_wild_err_arm)]
         match $lock {
             Ok(l) => l,
             Err(_err) if std::thread::panicking() => $els,

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -83,12 +83,12 @@ macro_rules! try_lock {
         try_lock!($lock, else return)
     };
     ($lock:expr, else $els:expr) => {
-        // see: https://github.com/rust-lang/rust-clippy/issues/3688
-        #[allow(clippy::match_wild_err_arm)]
-        match $lock {
-            Ok(l) => l,
-            Err(_err) if std::thread::panicking() => $els,
-            Err(_err) => panic!("lock poisoned"),
+        if let Ok(l) = $lock {
+            l
+        } else if std::thread::panicking() {
+            $els
+        } else {
+            panic!("lock poisoned")
         }
     };
 }


### PR DESCRIPTION
## Motivation

Looks like Clippy is once again complaining about the
`match_wild_err_arm` lint, presumably as a result of the Rust 1.42
release. This lint triggers on the `try_lock!` macro that
`tracing-subscriber` uses to avoid double panics when a mutex is
poisoned. In this case, the lint is something of a false positive here,
since we _do_ actually have two different `Err(...)` arms; the
differentiation between the two arms is not in the match pattern but in
a guard. See https://github.com/rust-lang/rust-clippy/issues/3688 for
details on the lint.

## Solution

I've refactored the code in question to use `if`/`else`, avoiding the
lint.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
