### PR TITLE
attributes: instrument Err

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -146,8 +146,8 @@ use syn::{
 /// }
 /// ```
 ///
-/// If the function returns a `Result<T, E>`, you can add `err` to emit error events when the
-/// function returns `Err`:
+/// If the function returns a `Result<T, E>` and `E` implements `std::fmt::Display`, you can add
+/// `err` to emit error events when the function returns `Err`:
 ///
 /// ```
 /// # use tracing_attributes::instrument;

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -281,7 +281,7 @@ pub fn instrument(args: TokenStream, item: TokenStream) -> TokenStream {
                     match async move { #block }.await {
                         Ok(x) => Ok(x),
                         Err(e) => {
-                            tracing::error!("{}", e);
+                            tracing::error!(error = %e);
                             Err(e)
                         }
                     }
@@ -302,7 +302,7 @@ pub fn instrument(args: TokenStream, item: TokenStream) -> TokenStream {
             match { #block } {
                 Ok(x) => Ok(x),
                 Err(e) => {
-                    tracing::error!("{}", e);
+                    tracing::error!(error = %e);
                     Err(e)
                 }
             }

--- a/tracing-attributes/tests/err.rs
+++ b/tracing-attributes/tests/err.rs
@@ -1,0 +1,64 @@
+#[path = "../../tracing-futures/tests/support.rs"]
+// we don't use some of the test support functions, but `tracing-futures` does.
+#[allow(dead_code)]
+mod support;
+use support::*;
+
+use tracing::subscriber::with_default;
+use tracing::Level;
+use tracing_attributes::instrument;
+
+use std::convert::TryFrom;
+use std::num::TryFromIntError;
+
+#[instrument(err)]
+fn err() -> Result<u8, TryFromIntError> {
+    u8::try_from(1234)
+}
+
+#[test]
+fn test() {
+    let span = span::mock().named("err");
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(span.clone())
+        .enter(span.clone())
+        .event(event::mock().at_level(Level::ERROR))
+        .exit(span.clone())
+        .drop_span(span)
+        .done()
+        .run_with_handle();
+    with_default(subscriber, || err().ok());
+    handle.assert_finished();
+}
+
+#[instrument(err)]
+async fn err_async(polls: usize) -> Result<u8, TryFromIntError> {
+    let future = PollN::new_ok(polls);
+    tracing::trace!(awaiting = true);
+    future.await.ok();
+    u8::try_from(1234)
+}
+
+#[test]
+fn test_async() {
+    let span = span::mock().named("err_async");
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(span.clone())
+        .enter(span.clone())
+        .event(
+            event::mock()
+                .with_fields(field::mock("awaiting").with_value(&true))
+                .at_level(Level::TRACE),
+        )
+        .exit(span.clone())
+        .enter(span.clone())
+        .event(event::mock().at_level(Level::ERROR))
+        .exit(span.clone())
+        .drop_span(span)
+        .done()
+        .run_with_handle();
+    with_default(subscriber, || {
+        block_on_future(async { err_async(2).await }).ok();
+    });
+    handle.assert_finished();
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

From #545:

> When using `?` for error handling, trace events on returning an Err need to be handled in the caller explicitly. In a lot of cases I'd rather be lazy and instrument any returned Errs implicitly, in the same span that encompasses the function the Err was returned from.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

This adds `#[instrument(err)]`, which instruments returned Errs implicitly. Fixes #545.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
