### PR TITLE
ci: add possible workaround for missing cargo-hack

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,6 +81,9 @@ jobs:
         path: ${{ runner.tool_cache }}/cargo-hack/bin
         key: cargo-hack-bin-${{ hashFiles('.github/caching/cargo-hack.lock') }}
     - run: echo "::add-path::${{ runner.tool_cache }}/cargo-hack/bin"
+    # if `cargo-hack` somehow doesn't exist after loading it from the cache,
+    # make *sure* it's there.
+    - run: cargo hack --help || { cargo install --force cargo-hack; }
     - name: cargo hack check
       working-directory: ${{ matrix.subcrate }}
       run: cargo hack check --feature-powerset --no-dev-deps


### PR DESCRIPTION
## Motivation

Our CI builds currently have an issue where `cargo hack` doesn't work
after loading a cached build of the tool. This causes builds to fail.
See #648.

## Solution

This is an admittedly hacky workaround: I've added a step to check if
`cargo hack` exists by running `cargo hack --help`. If this doesn't
succeed, we assume it doesn't exist and forcibly install it from
crates.io.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
