### PR TITLE
Add clear_global_default function

### DIFF
--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -361,8 +361,8 @@ pub fn get_default<T, F>(mut f: F) -> T
 where
     F: FnMut(&Dispatch) -> T,
 {
-    if let Some(d) = get_global() {
-        f(d)
+    if let Some(d) = unsafe { get_global() } {
+        f(unsafe { &*d })
     } else {
         f(&Dispatch::none())
     }

--- a/tracing/src/dispatcher.rs
+++ b/tracing/src/dispatcher.rs
@@ -141,7 +141,7 @@ pub use tracing_core::dispatcher::with_default;
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use tracing_core::dispatcher::DefaultGuard;
 pub use tracing_core::dispatcher::{
-    get_default, set_global_default, Dispatch, SetGlobalDefaultError,
+    clear_global_default, get_default, set_global_default, Dispatch, SetGlobalDefaultError,
 };
 
 /// Private API for internal use by tracing's macros.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

In a `Subscriber` I've written the `Span` is sent to Google StackDriver. It's undesirable to block on this, so the `Span`s are sent to an internal engine to be uploaded. However the program may exit before this upload completes. I want to block the exit of the program until the upload is complete, or a timeout is elapsed. I cannot do that with `tracing` as is.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The crux of the issue is that `static` variables in Rust are never dropped. There are [good reasons](https://stackoverflow.com/a/48733480/2125788) for this, but it still removes my only vector for detecting when the program is about to end, and injecting behavior at that point. So, this PR gives me the ability to call an `unsafe` function that invokes `Drop::drop` on the global default exporter.