### PR TITLE
subscriber: add more ergonomic subscriber configuration APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,16 @@ The simplest way to use a subscriber is to call the `set_global_default` functio
 
 ```rust
 use tracing::{info, Level};
-use tracing_subscriber::FmtSubscriber;
+use tracing_subscriber;
 
 fn main() {
     // a builder for `FmtSubscriber`.
-    let subscriber = FmtSubscriber::builder()
+    let subscriber = tracing_subscriber::fmt()
         // all spans/events with a level higher than TRACE (e.g, debug, info, warn, etc.)
         // will be written to stdout.
         .with_max_level(Level::TRACE)
-        // completes the builder.
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber)
-        .expect("setting default subscriber failed");
+        // completes the builder and sets the constructed `Subscriber` as the default.
+        .init();
 
     let number_of_yaks = 3;
     // this creates a new event, outside of any spans.
@@ -88,10 +85,10 @@ In addition, you can locally override the default subscriber. For example:
 
 ```rust
 use tracing::{info, Level};
-use tracing_subscriber::FmtSubscriber;
+use tracing_subscriber;
 
 fn main() {
-    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+    let subscriber = tracing_subscriber::fmt()
         // all spans/events with a level higher than TRACE (e.g, debug, info, warn, etc.)
         // will be written to stdout.
         .with_max_level(Level::TRACE)

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,10 @@ This directory contains a collection of examples that demonstrate the use of the
     which provides a subscriber implementation that logs traces to the console.
   + `fmt-stderr`: Demonstrates overriding the output stream used by the `fmt`
     subscriber.
+  + `fmt-custom-field`: Demonstrates overriding how the `fmt` subscriber formats
+    fields on spans and events.
+  + `fmt-custom-event`: Demonstrates overriding how the `fmt` subscriber formats
+    events.
   + `subscriber-filter`: Demonstrates the `tracing-subscriber::filter` module,
     which provides a layer which adds configurable filtering to a subscriber
     implementation.

--- a/examples/examples/all-levels.rs
+++ b/examples/examples/all-levels.rs
@@ -2,7 +2,7 @@ use tracing::Level;
 use tracing_subscriber;
 
 fn main() {
-    tracing_subscriber::FmtSubscriber::builder()
+    tracing_subscriber::fmt()
         // all spans/events with a level higher than TRACE (e.g, info, warn, etc.)
         // will be written to stdout.
         .with_max_level(Level::TRACE)

--- a/examples/examples/async_fn.rs
+++ b/examples/examples/async_fn.rs
@@ -43,10 +43,9 @@ async fn write(stream: &mut TcpStream) -> io::Result<usize> {
 pub async fn main() -> Result<(), Box<dyn Error>> {
     let addr = "127.0.0.1:6142".parse()?;
 
-    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
+    tracing_subscriber::fmt()
         .with_env_filter("async_fn=trace")
-        .finish();
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+        .try_init()?;
 
     // Open a TCP stream to the socket address.
     //

--- a/examples/examples/async_fn.rs
+++ b/examples/examples/async_fn.rs
@@ -40,12 +40,12 @@ async fn write(stream: &mut TcpStream) -> io::Result<usize> {
 }
 
 #[tokio::main]
-pub async fn main() -> Result<(), Box<dyn Error>> {
+pub async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let addr = "127.0.0.1:6142".parse()?;
 
     tracing_subscriber::fmt()
         .with_env_filter("async_fn=trace")
-        .init();
+        .try_init()?;
 
     // Open a TCP stream to the socket address.
     //

--- a/examples/examples/async_fn.rs
+++ b/examples/examples/async_fn.rs
@@ -45,7 +45,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
 
     tracing_subscriber::fmt()
         .with_env_filter("async_fn=trace")
-        .try_init()?;
+        .init();
 
     // Open a TCP stream to the socket address.
     //

--- a/examples/examples/attrs-args.rs
+++ b/examples/examples/attrs-args.rs
@@ -27,8 +27,7 @@ fn fibonacci_seq(to: u64) -> Vec<u64> {
 }
 
 fn main() {
-    use tracing_subscriber::fmt;
-    let subscriber = fmt::Subscriber::builder()
+    let subscriber = tracing_subscriber::fmt()
         .with_env_filter("attrs_args=trace")
         .finish();
 

--- a/examples/examples/attrs-basic.rs
+++ b/examples/examples/attrs-basic.rs
@@ -11,7 +11,7 @@ fn suggest_band() -> String {
 }
 
 fn main() {
-    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
+    let subscriber = tracing_subscriber::fmt()
         .with_env_filter("attrs_basic=trace")
         .finish();
     tracing::subscriber::with_default(subscriber, || {

--- a/examples/examples/custom_error.rs
+++ b/examples/examples/custom_error.rs
@@ -4,7 +4,7 @@
 use std::error::Error;
 use std::fmt;
 use tracing_error::{ErrorLayer, SpanTrace};
-use tracing_subscriber::{fmt::Layer as FmtLayer, prelude::*, registry::Registry};
+use tracing_subscriber::prelude::*;
 #[derive(Debug)]
 struct FooError {
     message: &'static str,
@@ -50,11 +50,11 @@ fn do_another_thing(
 
 #[tracing::instrument]
 fn main() {
-    let subscriber = Registry::default()
-        .with(FmtLayer::default())
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
         // The `ErrorLayer` subscriber layer enables the use of `SpanTrace`.
-        .with(ErrorLayer::default());
-    tracing::subscriber::set_global_default(subscriber).expect("Could not set global default");
+        .with(ErrorLayer::default())
+        .init();
     match do_something("hello world") {
         Ok(result) => println!("did something successfully: {}", result),
         Err(e) => eprintln!("error: {}", e),

--- a/examples/examples/echo.rs
+++ b/examples/examples/echo.rs
@@ -36,13 +36,12 @@ use tracing::{debug, info, info_span, trace_span, warn};
 use tracing_futures::Instrument;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
-    use tracing_subscriber::{EnvFilter, FmtSubscriber};
+async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    use tracing_subscriber::EnvFilter;
 
-    let subscriber = FmtSubscriber::builder()
+    tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env().add_directive("echo=trace".parse()?))
-        .finish();
-    tracing::subscriber::set_global_default(subscriber)?;
+        .try_init()?;
 
     // Allow passing an address to listen on as the first argument of this
     // program, but otherwise we'll just set up our TCP listener on

--- a/examples/examples/fmt-custom-event.rs
+++ b/examples/examples/fmt-custom-event.rs
@@ -1,0 +1,29 @@
+#![deny(rust_2018_idioms)]
+use tracing_subscriber;
+#[path = "fmt/yak_shave.rs"]
+mod yak_shave;
+
+fn main() {
+    use tracing_subscriber::fmt;
+
+    // Configure a custom event formatter
+    let format = fmt::format()
+        .compact() // use an abbreviated format for logging spans
+        .with_level(false) // don't include levels in formatted output
+        .with_target(false); // don't include targets
+
+    // Create a `fmt` subscriber that uses our custom event format, and set it
+    // as the default.
+    fmt().event_format(format).init();
+
+    // Shave some yaks!
+    let number_of_yaks = 3;
+    // this creates a new event, outside of any spans.
+    tracing::info!(number_of_yaks, "preparing to shave yaks");
+
+    let number_shaved = yak_shave::shave_all(number_of_yaks);
+    tracing::info!(
+        all_yaks_shaved = number_shaved == number_of_yaks,
+        "yak shaving completed."
+    );
+}

--- a/examples/examples/fmt-custom-event.rs
+++ b/examples/examples/fmt-custom-event.rs
@@ -14,7 +14,7 @@ fn main() {
 
     // Create a `fmt` subscriber that uses our custom event format, and set it
     // as the default.
-    fmt().event_format(format).init();
+    tracing_subscriber::fmt().event_format(format).init();
 
     // Shave some yaks!
     let number_of_yaks = 3;

--- a/examples/examples/fmt-custom-field.rs
+++ b/examples/examples/fmt-custom-field.rs
@@ -1,5 +1,22 @@
 //! This example demonstrates overriding the way `tracing-subscriber`'s
 //! `FmtSubscriber` formats fields on spans and events, using a closure.
+//!
+//! We'll create a custom format that prints key-value pairs separated by
+//! colons rather than equals signs, and separates fields with commas.
+//!
+//! For an event like
+//! ```rust
+//! tracing::info!(hello = "world", answer = 42);
+//! ```
+//!
+//! the default formatter will format the fields like this:
+//! ```not_rust
+//! hello="world" answer=42
+//! ```
+//! while our custom formatter will output
+//! ```not_rust
+//! hello: "world", answer: 42
+//! ```
 #![deny(rust_2018_idioms)]
 use tracing_subscriber;
 
@@ -10,9 +27,9 @@ fn main() {
     use tracing_subscriber::{fmt::format, prelude::*};
 
     // Format fields using the provided closure.
-    let format = format::debug_fn(|writer, _field, value| {
-        // We'll format _just_ the value of each field, ignoring the field name.
-        write!(writer, "{:?}", value)
+    let format = format::debug_fn(|writer, field, value| {
+        // We'll format the field name and value separated with a colon.
+        write!(writer, "{}: {:?}", field, value)
     })
     // Separate each field with a comma.
     // This method is provided by an extension trait in the

--- a/examples/examples/fmt-custom-field.rs
+++ b/examples/examples/fmt-custom-field.rs
@@ -1,7 +1,6 @@
 //! This example demonstrates overriding the way `tracing-subscriber`'s
 //! `FmtSubscriber` formats fields on spans and events, using a closure.
 #![deny(rust_2018_idioms)]
-use tracing::Level;
 use tracing_subscriber;
 
 #[path = "fmt/yak_shave.rs"]

--- a/examples/examples/fmt-custom-field.rs
+++ b/examples/examples/fmt-custom-field.rs
@@ -1,0 +1,37 @@
+//! This example demonstrates overriding the way `tracing-subscriber`'s
+//! `FmtSubscriber` formats fields on spans and events, using a closure.
+#![deny(rust_2018_idioms)]
+use tracing::Level;
+use tracing_subscriber;
+
+#[path = "fmt/yak_shave.rs"]
+mod yak_shave;
+
+fn main() {
+    use tracing_subscriber::{fmt::format, prelude::*};
+
+    // Format fields using the provided closure.
+    let format = format::debug_fn(|writer, _field, value| {
+        // We'll format _just_ the value of each field, ignoring the field name.
+        write!(writer, "{:?}", value)
+    })
+    // Separate each field with a comma.
+    // This method is provided by an extension trait in the
+    // `tracing-subscriber` prelude.
+    .delimited(", ");
+
+    // Create a `fmt` subscriber that uses our custom event format, and set it
+    // as the default.
+    tracing_subscriber::fmt().fmt_fields(format).init();
+
+    // Shave some yaks!
+    let number_of_yaks = 3;
+    // this creates a new event, outside of any spans.
+    tracing::info!(number_of_yaks, "preparing to shave yaks");
+
+    let number_shaved = yak_shave::shave_all(number_of_yaks);
+    tracing::info!(
+        all_yaks_shaved = number_shaved == number_of_yaks,
+        "yak shaving completed."
+    );
+}

--- a/examples/examples/fmt-stderr.rs
+++ b/examples/examples/fmt-stderr.rs
@@ -3,9 +3,7 @@ use std::io;
 use tracing::error;
 
 fn main() {
-    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
-        .with_writer(io::stderr)
-        .finish();
+    let subscriber = tracing_subscriber::fmt().with_writer(io::stderr).finish();
 
     tracing::subscriber::with_default(subscriber, || {
         error!("This event will be printed to `stderr`.");

--- a/examples/examples/fmt.rs
+++ b/examples/examples/fmt.rs
@@ -6,7 +6,7 @@ use tracing_subscriber;
 mod yak_shave;
 
 fn main() {
-    tracing_subscriber::fmt::Subscriber::builder()
+    tracing_subscriber::fmt()
         // all spans/events with a level higher than DEBUG (e.g, info, warn, etc.)
         // will be written to stdout.
         .with_max_level(Level::DEBUG)

--- a/examples/examples/hyper-echo.rs
+++ b/examples/examples/hyper-echo.rs
@@ -95,7 +95,7 @@ async fn echo(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     use tracing_log::env_logger::BuilderExt;
 
-    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+    let subscriber = tracing_subscriber::fmt()
         .with_max_level(Level::TRACE)
         .finish();
     let mut builder = env_logger::Builder::new();

--- a/examples/examples/instrumented_error.rs
+++ b/examples/examples/instrumented_error.rs
@@ -4,7 +4,7 @@
 use std::error::Error;
 use std::fmt;
 use tracing_error::{prelude::*, ErrorLayer};
-use tracing_subscriber::{prelude::*, registry::Registry};
+use tracing_subscriber::prelude::*;
 
 #[derive(Debug)]
 struct FooError {
@@ -43,11 +43,12 @@ fn do_another_thing(
 
 #[tracing::instrument]
 fn main() {
-    let subscriber = Registry::default()
-        .with(tracing_subscriber::fmt::Layer::default())
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
         // The `ErrorLayer` subscriber layer enables the use of `SpanTrace`.
-        .with(ErrorLayer::default());
-    tracing::subscriber::set_global_default(subscriber).expect("Could not set global default");
+        .with(ErrorLayer::default())
+        .init();
+
     match do_something("hello world") {
         Ok(result) => println!("did something successfully: {}", result),
         Err(e) => {

--- a/examples/examples/log.rs
+++ b/examples/examples/log.rs
@@ -1,5 +1,5 @@
 fn main() {
-    tracing_subscriber::fmt::Subscriber::builder()
+    tracing_subscriber::fmt()
         .with_max_level(tracing::Level::TRACE)
         .init();
 

--- a/examples/examples/spawny_thing.rs
+++ b/examples/examples/spawny_thing.rs
@@ -10,6 +10,7 @@
 use tokio;
 
 use futures::future::join_all;
+use std::error::Error;
 use tracing::{debug, info};
 use tracing_attributes::instrument;
 
@@ -37,11 +38,10 @@ async fn subtask(number: usize) -> usize {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
+async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    tracing_subscriber::fmt()
         .with_max_level(tracing::Level::DEBUG)
-        .finish();
-    tracing::subscriber::set_global_default(subscriber)?;
+        .try_init()?;
     parent_task(10).await;
     Ok(())
 }

--- a/examples/examples/tower-client.rs
+++ b/examples/examples/tower-client.rs
@@ -26,10 +26,9 @@ fn req_span<A>(req: &Request<A>) -> tracing::Span {
 
 #[tokio::main]
 async fn main() -> Result<(), Err> {
-    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
+    tracing_subscriber::fmt()
         .with_env_filter("tower=trace")
-        .finish();
-    tracing::subscriber::set_global_default(subscriber)?;
+        .try_init()?;
 
     let mut svc = ServiceBuilder::new()
         .timeout(Duration::from_millis(250))

--- a/examples/examples/tower-load.rs
+++ b/examples/examples/tower-load.rs
@@ -44,19 +44,18 @@ use tokio::{time, try_join};
 use tower::{Service, ServiceBuilder, ServiceExt};
 use tracing::{self, debug, error, info, span, trace, warn, Level, Span};
 use tracing_futures::Instrument;
-use tracing_subscriber::{filter::EnvFilter, reload::Handle, FmtSubscriber};
+use tracing_subscriber::{filter::EnvFilter, reload::Handle};
 use tracing_tower::{request_span, request_span::make};
 
 type Err = Box<dyn Error + Send + Sync + 'static>;
 
 #[tokio::main]
 async fn main() -> Result<(), Err> {
-    let builder = FmtSubscriber::builder()
+    let builder = tracing_subscriber::fmt()
         .with_env_filter("info,tower_load=debug")
         .with_filter_reloading();
     let handle = builder.reload_handle();
-
-    let _ = tracing::subscriber::set_global_default(builder.finish());
+    builder.try_init()?;
 
     let addr = "[::1]:3000".parse::<SocketAddr>()?;
     let admin_addr = "[::1]:3001".parse::<SocketAddr>()?;

--- a/examples/examples/tower-server.rs
+++ b/examples/examples/tower-server.rs
@@ -88,10 +88,9 @@ impl<T> Service<T> for MakeSvc {
 
 #[tokio::main]
 async fn main() -> Result<(), Err> {
-    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
+    tracing_subscriber::fmt()
         .with_env_filter("tower=trace")
-        .finish();
-    tracing::subscriber::set_global_default(subscriber)?;
+        .try_init()?;
 
     let svc = ServiceBuilder::new()
         .timeout(Duration::from_millis(250))

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -32,7 +32,7 @@ use tracing_core::{
 /// use tracing_subscriber::{fmt, Registry};
 /// use tracing_subscriber::prelude::*;
 ///
-/// let fmt_layer = fmt::Layer::default()
+/// let fmt_layer = fmt::layer()
 ///    .with_target(false) // don't include event targets when logging
 ///    .with_level(false); // don't include event levels when logging
 ///
@@ -43,11 +43,11 @@ use tracing_core::{
 /// Setting a custom  event formatter:
 ///
 /// ```rust
-/// use tracing_subscriber::fmt::{self, format::Format, time};
+/// use tracing_subscriber::fmt::{self, format, time};
 /// use tracing_subscriber::prelude::*;
 ///
-/// let fmt = Format::default().with_timer(time::Uptime::default());
-/// let fmt_layer = fmt::Layer::default()
+/// let fmt = format().with_timer(time::Uptime::default());
+/// let fmt_layer = fmt::layer()
 ///     .event_format(fmt)
 ///     .with_target(false);
 /// # let subscriber = fmt_layer.with_subscriber(tracing_subscriber::registry::Registry::default());
@@ -122,8 +122,8 @@ where
     /// ```rust
     /// use tracing_subscriber::fmt::{self, format};
     ///
-    /// let layer = fmt::Layer::default()
-    ///     .event_format(format::Format::default().compact());
+    /// let layer = fmt::layer()
+    ///     .event_format(format().compact());
     /// # // this is necessary for type inference.
     /// # use tracing_subscriber::Layer as _;
     /// # let _ = layer.with_subscriber(tracing_subscriber::registry::Registry::default());
@@ -156,7 +156,7 @@ impl<S, N, E, W> Layer<S, N, E, W> {
     /// use std::io;
     /// use tracing_subscriber::fmt;
     ///
-    /// let layer = fmt::Layer::default()
+    /// let layer = fmt::layer()
     ///     .with_writer(io::stderr);
     /// # // this is necessary for type inference.
     /// # use tracing_subscriber::Layer as _;

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -90,13 +90,13 @@ pub trait FormatFields<'writer> {
 /// ```rust
 /// let format = tracing_subscriber::fmt::format()
 ///     .without_time()         // Don't include timestamps
-///     .with_targets(false)    // Don't include event targets.
+///     .with_target(false)     // Don't include event targets.
 ///     .with_level(false)      // Don't include event levels.
 ///     .compact();             // Use a more compact, abbreviated format.
 ///
 /// // Use the configured formatter when building a new subscriber.
 /// tracing_subscriber::fmt()
-///     .format_event(format)
+///     .event_format(format)
 ///     .init();
 /// ```
 pub fn format() -> Format {

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -82,6 +82,34 @@ pub trait FormatFields<'writer> {
     ) -> fmt::Result;
 }
 
+/// Returns the default configuration for an [event formatter].
+///
+/// Methods on the returned event formatter can be used for further
+/// configuration. For example:
+///
+/// ```rust
+/// let format = tracing_subscriber::fmt::format()
+///     .without_time()         // Don't include timestamps
+///     .with_targets(false)    // Don't include event targets.
+///     .with_level(false)      // Don't include event levels.
+///     .compact();             // Use a more compact, abbreviated format.
+///
+/// // Use the configured formatter when building a new subscriber.
+/// tracing_subscriber::fmt()
+///     .format_event(format)
+///     .init();
+/// ```
+pub fn format() -> Format {
+    Format::default()
+}
+
+/// Returns the default configuration for a JSON [event formatter].
+#[cfg(feature = "json")]
+#[cfg_attr(docsrs, doc(cfg(feature = "json")))]
+pub fn json() -> Format<Json> {
+    format().json()
+}
+
 /// Returns a [`FormatFields`] implementation that formats fields using the
 /// provided function or closure.
 ///

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -52,9 +52,7 @@
 //! You can create one by calling:
 //!
 //! ```rust
-//! use tracing_subscriber::FmtSubscriber;
-//!
-//! let subscriber = FmtSubscriber::builder()
+//! let subscriber = tracing_subscriber::fmt()
 //!     // ... add configuration
 //!     .finish();
 //! ```
@@ -200,7 +198,7 @@ pub struct SubscriberBuilder<
 /// tracing_subscriber::fmt()
 ///     // Configure formatting settings.
 ///     .with_target(false)
-///     .with_timer(fmt::time::uptime())
+///     .with_timer(tracing_subscriber::fmt::time::uptime())
 ///     .with_level(true)
 ///     // Set the subscriber as the default.
 ///     .init();
@@ -211,12 +209,12 @@ pub struct SubscriberBuilder<
 /// ```rust
 /// use std::error::Error;
 ///
-/// fn init_subscriber() -> Result<(), Box<dyn Error>> {
+/// fn init_subscriber() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 ///     tracing_subscriber::fmt()
 ///         // Configure the subscriber to emit logs in JSON format.
 ///         .json()
 ///         // Configure the subscriber to flatten event fields in the output JSON objects.
-///         .flatten_event()
+///         .flatten_event(true)
 ///         // Set the subscriber as the default, returning an error if this fails.
 ///         .try_init()?;
 ///
@@ -598,7 +596,7 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
     ///
     /// For example:
     /// ```rust
-    /// use tracing_subscriber::fmt::{Subscriber, format};
+    /// use tracing_subscriber::fmt::format;
     /// use tracing_subscriber::prelude::*;
     ///
     /// let formatter =
@@ -608,7 +606,7 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
     ///         // formatter so that a delimiter is added between fields.
     ///         .delimited(", ");
     ///
-    /// let subscriber = Subscriber::builder()
+    /// let subscriber = tracing_subscriber::fmt()
     ///     .fmt_fields(formatter)
     ///     .finish();
     /// # drop(subscriber)
@@ -656,7 +654,7 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
     /// ```rust
     /// use tracing_subscriber::{fmt, filter::{EnvFilter, LevelFilter}};
     ///
-    /// # fn filter() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn filter() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let filter = EnvFilter::try_from_env("MY_CUSTOM_FILTER_ENV_VAR")?
     ///     // Set the base level when not matched by other directives to WARN.
     ///     .add_directive(LevelFilter::WARN.into())
@@ -707,7 +705,7 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
     /// ```
     /// This subscriber won't record any spans or events!
     /// ```rust
-    /// use tracing_subscriber::{FmtSubscriber, filter::LevelFilter};
+    /// use tracing_subscriber::{fmt, filter::LevelFilter};
     ///
     /// let subscriber = fmt()
     ///     .with_max_level(LevelFilter::OFF)
@@ -798,7 +796,9 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
 /// This is shorthand for
 ///
 /// ```rust
+/// # fn doc() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 /// tracing_subscriber::fmt().try_init()
+/// # }
 /// ```
 ///
 ///

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -143,7 +143,8 @@ use crate::{
 
 #[doc(inline)]
 pub use self::{
-    format::{FormatEvent, FormatFields},
+    format::{format, FormatEvent, FormatFields},
+    time::time,
     writer::MakeWriter,
 };
 
@@ -199,7 +200,7 @@ pub struct SubscriberBuilder<
 /// tracing_subscriber::fmt()
 ///     // Configure formatting settings.
 ///     .with_target(false)
-///     .with_timer(fmt::time::Uptime::default())
+///     .with_timer(fmt::time::uptime())
 ///     .with_level(true)
 ///     // Set the subscriber as the default.
 ///     .init();

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -182,6 +182,84 @@ pub struct SubscriberBuilder<
     inner: Layer<Registry, N, E, W>,
 }
 
+/// Returns a new [`SubscriberBuilder`] for configuring a [formatting subscriber].
+///
+/// This is essentially shorthand for [`SubscriberBuilder::default()]`.
+///
+/// # Examples
+///
+/// Using [`init`] to set the default subscriber:
+///
+/// ```rust
+/// tracing_subscriber::fmt::subscriber().init();
+/// ```
+///
+/// Configuring the output format:
+///
+/// ```rust
+/// use tracing_subscriber::fmt;
+///
+/// fmt::subscriber()
+///     // Configure formatting settings.
+///     .with_target(false)
+///     .with_timer(fmt::time::Uptime::default())
+///     .with_level(true)
+///     // Set the subscriber as the default.
+///     .init();
+/// ```
+///
+/// [`try_init`] returns an error if the default subscriber could not be set:
+///
+/// ```rust
+/// use std::error::Error;
+///
+/// fn init_subscriber() -> Result<(), Box<dyn Error>> {
+///     tracing_subscriber::fmt::subscriber()
+///         // Configure the subscriber to emit logs in JSON format.
+///         .json()
+///         // Configure the subscriber to flatten event fields in the output JSON objects.
+///         .flatten_event()
+///         // Set the subscriber as the default, returning an error if this fails.
+///         .try_init()?;
+///
+///     Ok(())
+/// }
+/// ```
+///
+/// Rather than setting the subscriber as the default, [`finish`] _returns_ the
+/// constructed subscriber, which may then be passed to other functions:
+///
+/// ```rust
+/// let subscriber = tracing_subscriber::fmt::subscriber()
+///     .with_max_level(tracing::Level::DEBUG)
+///     .compact()
+///     .finish();
+///
+/// tracing::subscriber::with_default(subscriber, || {
+///     // the subscriber will only be set as the default
+///     // inside this closure...
+/// })
+/// ```
+///
+/// [`SubscriberBuilder`]: struct.SubscriberBuilder.html
+/// [formatting subscriber]: struct.Subscriber.html
+/// [`SubscriberBuilder::default()`]: struct.SubscriberBuilder.html#method.default
+/// [`init`]: struct.SubscriberBuilder.html#method.init
+/// [`try_init`]: struct.SubscriberBuilder.html#method.try_init
+/// [`finish`]: struct.SubscriberBuilder.html#method.finish
+pub fn subscriber() -> SubscriberBuilder {
+    SubscriberBuilder::default()
+}
+
+/// Returns a new [`LayerBuilder`] for configuring a [formatting layer].
+///
+/// [`LayerBuilder`]: struct.LayerBuilder.html
+/// [formatting layer]: struct.Layer.html
+/// [`LayerBuilder::default()`]: struct.LayerBuilder.html#method.default
+pub fn layer<S>() -> LayerBuilder<S> {
+    LayerBuilder::default()
+}
+
 impl Subscriber {
     /// The maximum [verbosity level] that is enabled by a `Subscriber` by
     /// default.

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -100,21 +100,19 @@
 //! Composing an [`EnvFilter`] `Layer` and a [format `Layer`](../fmt/struct.Layer.html):
 //!
 //! ```rust
-//! use tracing_subscriber::{fmt, Layer, registry::Registry, EnvFilter};
+//! use tracing_subscriber::{fmt, EnvFilter};
 //! use tracing_subscriber::prelude::*;
 //!
-//! let fmt_layer = fmt::Layer::builder()
-//!     .with_target(false)
-//!     .finish();
+//! let fmt_layer = fmt::layer()
+//!     .with_target(false);
 //! let filter_layer = EnvFilter::try_from_default_env()
 //!     .or_else(|_| EnvFilter::try_new("info"))
 //!     .unwrap();
 //!
-//! let subscriber = Registry::default()
+//! tracing_subscriber::registry()
 //!     .with(filter_layer)
-//!     .with(fmt_layer);
-//!
-//! tracing::subscriber::set_global_default(subscriber).unwrap();
+//!     .with(fmt_layer)
+//!     .init();
 //! ```
 //!
 //! [`EnvFilter`]: ../filter/struct.EnvFilter.html
@@ -250,13 +248,16 @@ pub fn fmt() -> SubscriberBuilder {
     SubscriberBuilder::default()
 }
 
-/// Returns a new [`LayerBuilder`] for configuring a [formatting layer].
+/// Returns a new [formatting layer] that can be [composed] with other layers to
+/// construct a [`Subscriber`].
 ///
-/// [`LayerBuilder`]: struct.LayerBuilder.html
+/// This is a shorthand for the equivalent [`Layer::default`] function.
+///
 /// [formatting layer]: struct.Layer.html
-/// [`LayerBuilder::default()`]: struct.LayerBuilder.html#method.default
-pub fn layer<S>() -> LayerBuilder<S> {
-    LayerBuilder::default()
+/// [composed]: ../layer/index.html
+/// [`Layer::default`]: struct.Layer.html#method.default
+pub fn layer<S>() -> Layer<S> {
+    Layer::default()
 }
 
 impl Subscriber {

--- a/tracing-subscriber/src/fmt/time.rs
+++ b/tracing-subscriber/src/fmt/time.rs
@@ -37,7 +37,9 @@ pub trait FormatTime {
 ///
 /// This is equivalent to calling
 /// ```rust
+/// # fn timer() -> tracing_subscriber::fmt::time::SystemTime {
 /// tracing_subscriber::fmt::time::SystemTime::default()
+/// # }
 /// ```
 pub fn time() -> SystemTime {
     SystemTime::default()
@@ -53,7 +55,9 @@ pub fn time() -> SystemTime {
 ///
 /// This is equivalent to calling
 /// ```rust
+/// # fn timer() -> tracing_subscriber::fmt::time::Uptime {
 /// tracing_subscriber::fmt::time::Uptime::default()
+/// # }
 /// ```
 pub fn uptime() -> Uptime {
     Uptime::default()

--- a/tracing-subscriber/src/fmt/time.rs
+++ b/tracing-subscriber/src/fmt/time.rs
@@ -30,6 +30,35 @@ pub trait FormatTime {
     fn format_time(&self, w: &mut dyn fmt::Write) -> fmt::Result;
 }
 
+/// Returns a new `SystemTime` timestamp provider.
+///
+/// This can then be configured further to determine how timestamps should be
+/// configured.
+///
+/// This is equivalent to calling
+/// ```rust
+/// tracing_subscriber::fmt::time::SystemTime::default()
+/// ```
+pub fn time() -> SystemTime {
+    SystemTime::default()
+}
+
+/// Returns a new `Uptime` timestamp provider.
+///
+/// With this timer, timestamps will be formatted with the amount of time
+/// elapsed since the timestamp provider was constructed.
+///
+/// This can then be configured further to determine how timestamps should be
+/// configured.
+///
+/// This is equivalent to calling
+/// ```rust
+/// tracing_subscriber::fmt::time::Uptime::default()
+/// ```
+pub fn uptime() -> Uptime {
+    Uptime::default()
+}
+
 impl<'a, F> FormatTime for &'a F
 where
     F: FormatTime,

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -102,6 +102,7 @@ pub mod registry;
 pub mod reload;
 pub(crate) mod sync;
 pub(crate) mod thread;
+pub mod util;
 
 #[cfg(feature = "env-filter")]
 #[cfg_attr(docsrs, doc(cfg(feature = "env-filter")))]
@@ -113,9 +114,20 @@ pub use layer::Layer;
 #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
 pub use registry::Registry;
 
+///
+#[cfg(feature = "registry")]
+#[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
+pub fn registry() -> Registry {
+    Registry::default()
+}
+
 #[cfg(feature = "fmt")]
 #[cfg_attr(docsrs, doc(cfg(feature = "fmt")))]
 pub use fmt::Subscriber as FmtSubscriber;
+
+#[cfg(feature = "fmt")]
+#[cfg_attr(docsrs, doc(cfg(feature = "fmt")))]
+pub use fmt::fmt;
 
 use std::default::Default;
 /// Tracks the currently executing span on a per-thread basis.

--- a/tracing-subscriber/src/prelude.rs
+++ b/tracing-subscriber/src/prelude.rs
@@ -10,3 +10,5 @@ pub use crate::field::{
 pub use crate::layer::{
     Layer as __tracing_subscriber_Layer, SubscriberExt as __tracing_subscriber_SubscriberExt,
 };
+
+pub use crate::util::SubscriberInitExt as _;

--- a/tracing-subscriber/src/util.rs
+++ b/tracing-subscriber/src/util.rs
@@ -1,0 +1,28 @@
+use tracing_core::dispatcher::{self, Dispatch};
+pub trait SubscriberInitExt
+where
+    Self: Into<Dispatch>,
+{
+    fn set_default(self) -> dispatcher::DefaultGuard {
+        #[cfg(feature = "tracing-log")]
+        let _ = tracing_log::LogTracer::init();
+
+        dispatcher::set_default(&self.into())
+    }
+
+    fn try_init(self) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+        #[cfg(feature = "tracing-log")]
+        tracing_log::LogTracer::init().map_err(Box::new)?;
+
+        dispatcher::set_global_default(self.into())?;
+
+        Ok(())
+    }
+
+    fn init(self) {
+        self.try_init()
+            .expect("failed to set global default subscriber")
+    }
+}
+
+impl<T> SubscriberInitExt for T where T: Into<Dispatch> {}

--- a/tracing-subscriber/src/util.rs
+++ b/tracing-subscriber/src/util.rs
@@ -1,8 +1,33 @@
+//! Extension traits and other utilities to make working with subscribers more
+//! ergonomic.
 use tracing_core::dispatcher::{self, Dispatch};
+
+/// Extension trait adding utility methods for subscriber initialization.
+///
+/// This trait provides extension methods to make configuring and setting a
+/// [default subscriber] more ergonomic. It is automatically implemented for all
+/// types that can be converted into a [trace dispatcher]. Since `Dispatch`
+/// implements `From<T>` for all `T: Subscriber`, all `Subscriber`
+/// implementations will implement this extension trait as well. Types which
+/// can be converted into `Subscriber`s, such as builders that construct a
+/// `Subscriber`, may implement `Into<Dispatch>`, and will also receive an
+/// implementation of this trait.
+///
+/// [default subscriber]: https://docs.rs/tracing/0.1.13/tracing/dispatcher/index.html#setting-the-default-subscriber
+/// [trace dispatcher]:  https://docs.rs/tracing/0.1.13/tracing/dispatcher/index.html
 pub trait SubscriberInitExt
 where
     Self: Into<Dispatch>,
 {
+    /// Sets `self` as the [default subscriber] in the current scope, returning a
+    /// guard that will unset it when dropped.
+    ///
+    /// If the "tracing-log" feature flag is enabled, this will also initialize
+    /// a [`log`] compatibility layer. This allows the subscriber to consume
+    /// `log::Record`s as though they were `tracing` `Event`s.
+    ///
+    /// [default subscriber]: https://docs.rs/tracing/0.1.13/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [`log`]: https://crates.io/log
     fn set_default(self) -> dispatcher::DefaultGuard {
         #[cfg(feature = "tracing-log")]
         let _ = tracing_log::LogTracer::init();
@@ -10,6 +35,19 @@ where
         dispatcher::set_default(&self.into())
     }
 
+    /// Attempts to set `self` as the [global default subscriber] in the current
+    /// scope, returning an error if one is already set.
+    ///
+    /// If the "tracing-log" feature flag is enabled, this will also attempt to
+    /// initialize a [`log`] compatibility layer. This allows the subscriber to
+    /// consume `log::Record`s as though they were `tracing` `Event`s.
+    ///
+    /// This method returns an error if a global default subscriber has already
+    /// been set, or if a `log` logger has already been set (when the
+    /// "tracing-log" feature is enabled).
+    ///
+    /// [global default subscriber]: https://docs.rs/tracing/0.1.13/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [`log`]: https://crates.io/log
     fn try_init(self) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         #[cfg(feature = "tracing-log")]
         tracing_log::LogTracer::init().map_err(Box::new)?;
@@ -19,6 +57,19 @@ where
         Ok(())
     }
 
+    /// Attempts to set `self` as the [global default subscriber] in the current
+    /// scope, panicking if this fails.
+    ///
+    /// If the "tracing-log" feature flag is enabled, this will also attempt to
+    /// initialize a [`log`] compatibility layer. This allows the subscriber to
+    /// consume `log::Record`s as though they were `tracing` `Event`s.
+    ///
+    /// This method panics if a global default subscriber has already been set,
+    /// or if a `log` logger has already been set (when the "tracing-log"
+    /// feature is enabled).
+    ///
+    /// [global default subscriber]: https://docs.rs/tracing/0.1.13/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [`log`]: https://crates.io/log
     fn init(self) {
         self.try_init()
             .expect("failed to set global default subscriber")

--- a/tracing-subscriber/tests/utils.rs
+++ b/tracing-subscriber/tests/utils.rs
@@ -30,7 +30,7 @@ fn builders_are_init_ext() {
 #[test]
 fn layered_is_init_ext() {
     tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer().finish())
+        .with(tracing_subscriber::fmt::layer())
         .with(tracing_subscriber::EnvFilter::new("foo=info"))
         .set_default();
 }

--- a/tracing-subscriber/tests/utils.rs
+++ b/tracing-subscriber/tests/utils.rs
@@ -1,0 +1,36 @@
+mod support;
+use self::support::*;
+use tracing_subscriber::prelude::*;
+
+#[test]
+fn init_ext_works() {
+    let (subscriber, finished) = subscriber::mock()
+        .event(
+            event::mock()
+                .at_level(tracing::Level::INFO)
+                .with_target("init_works"),
+        )
+        .done()
+        .run_with_handle();
+
+    let _guard = subscriber.set_default();
+    tracing::info!(target: "init_works", "it worked!");
+    finished.assert_finished();
+}
+
+#[test]
+fn builders_are_init_ext() {
+    tracing_subscriber::fmt().set_default();
+    let _ = tracing_subscriber::fmt()
+        .with_target(false)
+        .compact()
+        .try_init();
+}
+
+#[test]
+fn layered_is_init_ext() {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().finish())
+        .with(tracing_subscriber::EnvFilter::new("foo=info"))
+        .set_default();
+}


### PR DESCRIPTION
## Motivation

Users have said fairly frequently that configuring new subscribers in an
application is unnecessarily verbose and confusing. We should try to
make this nicer, especially as it's a common "on ramp" for new `tracing`
users.

## Solution 

This branch adds new APIs, inspired by `tonic` and `warp`, that should
make setting up a subscriber a little less verbose. This includes:

- Many modules in `tracing-subscriber` now expose free functions 
  that construct default instances of various types. This makes 
  configuring subscribers using these types more concise, a la `warp`.
- An extension trait for adding `.set_default`, `.init`, and `.try_init` 
  methods to subscribers. This generalizes the similar functions on
  `fmt`'s `SubscriberBuilder` to work with other subscribers.

All the old APIs are still left as they were previously. The new APIs
just provide shorthand for them.