### PR TITLE
refactor(subsriber): rename Layer::new_span method to Layer::on_new_span for consistency

### DIFF
--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -310,7 +310,7 @@ impl<S: Subscriber> Layer<S> for EnvFilter {
         false
     }
 
-    fn new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, _: Context<'_, S>) {
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, _: Context<'_, S>) {
         let by_cs = try_lock!(self.by_cs.read());
         if let Some(cs) = by_cs.get(&attrs.metadata().callsite()) {
             let span = cs.to_span_match(attrs);

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -423,7 +423,7 @@ where
     E: FormatEvent<S, N> + 'static,
     W: MakeWriter + 'static,
 {
-    fn new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         let span = ctx.span(id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
 

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -281,7 +281,14 @@ where
 
     /// Notifies this layer that a new span was constructed with the given
     /// `Attributes` and `Id`.
+    #[deprecated(since = "0.3.0", note = "Please use the on_new_span method instead")]
     fn new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        self.on_new_span(attrs, id, ctx)
+    }
+
+    /// Notifies this layer that a new span was constructed with the given
+    /// `Attributes` and `Id`.
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
         let _ = (attrs, id, ctx);
     }
 
@@ -580,7 +587,7 @@ where
 
     fn new_span(&self, span: &span::Attributes<'_>) -> span::Id {
         let id = self.inner.new_span(span);
-        self.layer.new_span(span, &id, self.ctx());
+        self.layer.on_new_span(span, &id, self.ctx());
         id
     }
 
@@ -698,9 +705,9 @@ where
     }
 
     #[inline]
-    fn new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
-        self.inner.new_span(attrs, id, ctx.clone());
-        self.layer.new_span(attrs, id, ctx);
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        self.inner.on_new_span(attrs, id, ctx.clone());
+        self.layer.on_new_span(attrs, id, ctx);
     }
 
     #[inline]

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -422,7 +422,7 @@ mod tests {
     where
         S: Subscriber + for<'a> LookupSpan<'a>,
     {
-        fn new_span(&self, _: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        fn on_new_span(&self, _: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
             let span = ctx.span(id).expect("Missing span; this is a bug");
             let mut lock = self.inner.lock().unwrap();
             let is_removed = Arc::new(());

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -73,8 +73,8 @@ where
     }
 
     #[inline]
-    fn new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: layer::Context<'_, S>) {
-        try_lock!(self.inner.read()).new_span(attrs, id, ctx)
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: layer::Context<'_, S>) {
+        try_lock!(self.inner.read()).on_new_span(attrs, id, ctx)
     }
 
     #[inline]


### PR DESCRIPTION
##  Motivation

close #630

## Solution

Deprecate the previous method.