### PR TITLE
Add documentation to tracing appender crate

### DIFF
--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -3,7 +3,9 @@ use crate::non_blocking::{NonBlocking, WorkerGuard};
 use std::io::Write;
 
 mod inner;
+/// Non blocking, off-thread writer
 pub mod non_blocking;
+/// Rolling file appender
 pub mod rolling;
 mod worker;
 
@@ -19,8 +21,8 @@ mod worker;
 /// occur if logs are consistently produced faster than the worker thread can
 /// output them. The queue capacity and behavior when full (i.e., whether to
 /// drop logs or to exert backpressure to slow down senders) can be configured
-/// using [`NonBlockingBuilder::default()`]. This function simply returns the default
-/// configuration &mdash; it is equivalent to
+/// using [`NonBlockingBuilder::default()`]: /non_blocking/struct.NonBlockingBuilder.html#method.default
+/// This function simply returns the default configuration &mdash; it is equivalent to
 ///
 /// ```rust
 /// # use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
@@ -30,8 +32,13 @@ mod worker;
 /// ```
 /// [`NonBlocking::builder()`]: /non_blocking/struct.NonBlocking.html#method.builder
 ///
+/// Also creates a `WorkerGuard` which is responsible for ensuring logs are flushed once the
+/// guard is dropped. The struct contains a reference to an `AtomicBool` which notifies the
+/// worker thread to stop and flush logs.
+///
 /// Note that the `WorkerGuard` returned by `non_blocking` _must_ be assigned to a binding that
-/// is not `_`, as `_` will result in the `WorkerGuard` being dropped immediately.
+/// is not `_`, as `_` will result in the `WorkerGuard` being dropped immediately. It should also
+/// not be dropped accidently if you want to ensure logs are flushed during panics.
 ///
 /// # Examples
 /// ``` rust

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -32,7 +32,7 @@ mod worker;
 /// ```
 /// [builder]: non_blocking/struct.NonBlockingBuilder.html#method.default
 ///
-/// <br/> This function returns a tuple of `NonBlocking` and `WorkerGuard`. 
+/// <br/> This function returns a tuple of `NonBlocking` and `WorkerGuard`.
 /// `NonBlocking` implements [`MakeWriter`] which integrates with `tracing_subscriber`.
 /// `WorkerGuard` is a drop guard that is responsible for flushing any remaining logs when
 /// the program terminates.

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -21,7 +21,7 @@ mod worker;
 /// occur if logs are consistently produced faster than the worker thread can
 /// output them. The queue capacity and behavior when full (i.e., whether to
 /// drop logs or to exert backpressure to slow down senders) can be configured
-/// using [`NonBlockingBuilder::default()`]: /non_blocking/struct.NonBlockingBuilder.html#method.default
+/// using [`NonBlockingBuilder::default()`][builder].
 /// This function simply returns the default configuration &mdash; it is equivalent to
 ///
 /// ```rust
@@ -30,11 +30,11 @@ mod worker;
 /// tracing_appender::non_blocking::NonBlocking::new(std::io::stdout())
 /// # }
 /// ```
-/// [`NonBlocking::builder()`]: /non_blocking/struct.NonBlocking.html#method.builder
+/// [builder]: non_blocking/struct.NonBlockingBuilder.html#method.default
 ///
-/// Also creates a `WorkerGuard` which is responsible for ensuring logs are flushed once the
-/// guard is dropped. The struct contains a reference to an `AtomicBool` which notifies the
-/// worker thread to stop and flush logs.
+/// <br/> This function returns a tuple containing a `NonBlocking` struct and a `WorkerGuard`. The
+/// NonBlocking` struct implements [`MakeWriter`], while the `WorkerGuard` is a drop guard which
+/// is responsible for ensuring any buffered logs are flushed when the program terminates.
 ///
 /// Note that the `WorkerGuard` returned by `non_blocking` _must_ be assigned to a binding that
 /// is not `_`, as `_` will result in the `WorkerGuard` being dropped immediately. It should also
@@ -42,7 +42,6 @@ mod worker;
 ///
 /// # Examples
 /// ``` rust
-///
 /// # fn docs() {
 /// let (non_blocking, _guard) = tracing_appender::non_blocking(std::io::stdout());
 /// let subscriber = tracing_subscriber::fmt().with_writer(non_blocking);

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -3,9 +3,9 @@ use crate::non_blocking::{NonBlocking, WorkerGuard};
 use std::io::Write;
 
 mod inner;
-/// Non blocking, off-thread writer
+/// A non-blocking, off-thread writer.
 pub mod non_blocking;
-/// Rolling file appender
+/// A rolling file appender.
 pub mod rolling;
 mod worker;
 
@@ -22,7 +22,7 @@ mod worker;
 /// output them. The queue capacity and behavior when full (i.e., whether to
 /// drop logs or to exert backpressure to slow down senders) can be configured
 /// using [`NonBlockingBuilder::default()`][builder].
-/// This function simply returns the default configuration &mdash; it is equivalent to
+/// This function returns the default configuration. It is equivalent to:
 ///
 /// ```rust
 /// # use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
@@ -32,13 +32,15 @@ mod worker;
 /// ```
 /// [builder]: non_blocking/struct.NonBlockingBuilder.html#method.default
 ///
-/// <br/> This function returns a tuple containing a `NonBlocking` struct and a `WorkerGuard`. The
-/// NonBlocking` struct implements [`MakeWriter`], while the `WorkerGuard` is a drop guard which
-/// is responsible for ensuring any buffered logs are flushed when the program terminates.
+/// <br/> This function returns a tuple of `NonBlocking` and `WorkerGuard`. 
+/// `NonBlocking` implements [`MakeWriter`] which integrates with `tracing_subscriber`.
+/// `WorkerGuard` is a drop guard that is responsible for flushing any remaining logs when
+/// the program terminates.
 ///
 /// Note that the `WorkerGuard` returned by `non_blocking` _must_ be assigned to a binding that
-/// is not `_`, as `_` will result in the `WorkerGuard` being dropped immediately. It should also
-/// not be dropped accidently if you want to ensure logs are flushed during panics.
+/// is not `_`, as `_` will result in the `WorkerGuard` being dropped immediately.
+/// Unintentional drops of `WorkerGuard` remove the guarantee that logs will be flushed
+/// during a program's termination, in a panic or otherwise.
 ///
 /// # Examples
 /// ``` rust

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -39,7 +39,7 @@ pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 ///
 /// ``` rust
 /// # #[clippy::allow(needless_doctest_main)]
-/// fn main() {
+/// fn main () {
 /// # fn doc() {
 ///     let (non_blocking, _guard) = tracing_appender::non_blocking(std::io::stdout());
 ///     let subscriber = tracing_subscriber::fmt().with_writer(non_blocking);

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -19,7 +19,7 @@ use tracing_subscriber::fmt::MakeWriter;
 /// Recommended to be a power of 2.
 pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 
-/// A guard that flushes an associated [`NonBlocking`] of spans/events on drop.
+/// A guard that flushes spans/events associated to a [`NonBlocking`] on a drop
 ///
 /// Writing to a [`NonBlocking`] writer will **not** immediately write a span or event to the underlying
 /// output. Instead, the span or event will be written by a dedicated logging thread at some later point.
@@ -34,6 +34,19 @@ pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 /// `WorkerGuard` should be assigned in the `main` function or whatever the entrypoint of the program is.
 /// This will ensure that the guard will be dropped during an unwinding or when `main` exits
 /// successfully.
+///
+/// # Examples
+/// ``` rust
+/// fn main() {
+///     let (non_blocking, _guard) = tracing_appender::non_blocking(std::io::stdout());
+///     let subscriber = tracing_subscriber::fmt().with_writer(non_blocking);
+///     tracing::subscriber::with_default(subscriber.finish(), || {
+///         // Emit some tracing events within context of the non_blocking `_guard` and tracing subscriber
+///         tracing::event!(tracing::Level::INFO, "Hello");
+///     });
+/// // Exiting the context of `main` will drop the `_guard` and any remaining logs should get flushed
+/// }
+/// ```
 #[must_use]
 #[derive(Debug)]
 pub struct WorkerGuard {

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -36,8 +36,11 @@ pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 /// successfully.
 ///
 /// # Examples
+///
 /// ``` rust
+/// # #[clippy::allow(needless_doctest_main)]
 /// fn main() {
+/// # fn doc() {
 ///     let (non_blocking, _guard) = tracing_appender::non_blocking(std::io::stdout());
 ///     let subscriber = tracing_subscriber::fmt().with_writer(non_blocking);
 ///     tracing::subscriber::with_default(subscriber.finish(), || {
@@ -45,6 +48,7 @@ pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 ///         tracing::event!(tracing::Level::INFO, "Hello");
 ///     });
 /// // Exiting the context of `main` will drop the `_guard` and any remaining logs should get flushed
+/// # }
 /// }
 /// ```
 #[must_use]

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -18,16 +18,16 @@ use tracing_subscriber::fmt::MakeWriter;
 /// Recommended to be a power of 2.
 pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 
-/// A guard which triggers an associated [`NonBlocking`][non-blocking] writer to flush logs when dropped.
+/// A guard which triggers an associated [`NonBlocking`] writer to flush logs when dropped.
 ///
-/// Writing to a [`NonBlocking`][non-blocking] writer will **not** immediately write a log line to the underlying
+/// Writing to a [`NonBlocking`] writer will **not** immediately write a log line to the underlying
 /// output. Instead, the log line will be enqueued to be written by the logging worker thread. In
 /// addition, to improve throughput, the non-blocking writer flushes the underlying output
 /// periodically, rather than every time a line is written. This means that if the program
 /// terminates abruptly (such as by panicking, or by calling `std::process::exit`), some log lines
 /// may not be written.
 ///
-/// [non-blocking]: ./struct.NonBlocking.html
+/// [`NonBlocking`]: ./struct.NonBlocking.html
 /// Since logs recorded near a crash are often necessary for diagnosing the failure, this type
 /// provides a mechanism to ensure that all buffered logs are written to the output, and that the
 /// output is flushed prior to terminating. In order for this to work, this guard should generally
@@ -117,14 +117,18 @@ impl NonBlockingBuilder {
         self
     }
 
-    /// Sets whether `NonBlocking` should be lossy or not. If set to `True`, logs will be dropped
-    /// if buffered limit is reached. If `False`, backpressure will be exerted on senders.
+    /// Sets whether `NonBlocking` should be lossy or not.
+    ///
+    /// If set to `true`, logs will be dropped when the buffered limit is reached. If `false`, backpressure
+    /// will be exerted on senders, blocking them until the buffer has capacity again.
+    ///
+    /// By default, the built `NonBlocking` will be lossy.
     pub fn lossy(mut self, is_lossy: bool) -> NonBlockingBuilder {
         self.is_lossy = is_lossy;
         self
     }
 
-    /// Call to finish creation of `NonBlocking`
+    /// Completes the builder, returning the configured `NonBlocking`.
     pub fn finish<T: Write + Send + Sync + 'static>(self, writer: T) -> (NonBlocking, WorkerGuard) {
         NonBlocking::create(writer, self.buffered_lines_limit, self.is_lossy)
     }

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -23,13 +23,13 @@ pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 ///
 /// Writing to a [`NonBlocking`] writer will **not** immediately write a span or event to the underlying
 /// output. Instead, the span or event will be written by a dedicated logging thread at some later point.
-/// To increase throughput, the non-blocking writer will flush to the underlying output on 
+/// To increase throughput, the non-blocking writer will flush to the underlying output on
 /// a periodic basis rather than every time a span or event is written. This means that if the program
 /// terminates abruptly (such as through an uncaught `panic` or a `std::process::exit`), some spans
 /// or events may not be written.
 ///
 /// [`NonBlocking`]: ./struct.NonBlocking.html
-/// Since spans/events and events recorded near a crash are often necessary for diagnosing the failure, 
+/// Since spans/events and events recorded near a crash are often necessary for diagnosing the failure,
 /// `WorkerGuard` provides a mechanism to ensure that _all_ buffered logs are flushed to their output.
 /// `WorkerGuard` should be assigned in the `main` function or whatever the entrypoint of the program is.
 /// This will ensure that the guard will be dropped during an unwinding or when `main` exits
@@ -43,7 +43,7 @@ pub struct WorkerGuard {
 
 /// A non-blocking writer.
 ///
-/// While the line between "blocking" and "non-blocking" IO is fuzzy, writing to a file is typically 
+/// While the line between "blocking" and "non-blocking" IO is fuzzy, writing to a file is typically
 /// to be a _blocking_ operation. For an application whose `Subscriber` writes spans and events
 /// as they are emitted, an application might find the latency profile to be unacceptable.
 /// `NonBlocking` moves the writing out of an application's data path by sending spans and events

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -47,7 +47,7 @@ pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 ///         // Emit some tracing events within context of the non_blocking `_guard` and tracing subscriber
 ///         tracing::event!(tracing::Level::INFO, "Hello");
 ///     });
-/// // Exiting the context of `main` will drop the `_guard` and any remaining logs should get flushed
+///     // Exiting the context of `main` will drop the `_guard` and any remaining logs should get flushed
 /// # }
 /// }
 /// ```

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -44,7 +44,7 @@ pub struct WorkerGuard {
 /// A non-blocking writer.
 ///
 /// While the line between "blocking" and "non-blocking" IO is fuzzy, writing to a file is typically
-/// to be a _blocking_ operation. For an application whose `Subscriber` writes spans and events
+/// considered to be a _blocking_ operation. For an application whose `Subscriber` writes spans and events
 /// as they are emitted, an application might find the latency profile to be unacceptable.
 /// `NonBlocking` moves the writing out of an application's data path by sending spans and events
 /// to a dedicated logging thread.

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -37,7 +37,7 @@ impl RollingFileAppender {
     /// defined by [`Rotation`](struct.Rotation.html). The `directory` and
     /// `file_name_prefix` arguments determine the location and file name's _prefix_
     /// of the log file. `RollingFileAppender` will automatically append the current date
-    /// and hour to the file name.
+    /// and hour (UTC format) to the file name.
     ///
     /// An alternative way to construct a `RollingFileAppender` is to use one of the helpers:
     ///
@@ -88,15 +88,14 @@ impl io::Write for RollingFileAppender {
 /// a non-blocking, hourly file appender.
 ///
 /// The directory of the log file is specified with the `directory` argument.
-/// `file_name_prefix` specifies the _prefix_ of the log file. `RollingFileAppender` 
-/// adds the current date and hour to the log file.
+/// `file_name_prefix` specifies the _prefix_ of the log file. `RollingFileAppender`
+/// adds the current date and hour to the log file in UTC.
 ///
 /// # Examples
 ///
 /// ``` rust
 /// # #[clippy::allow(needless_doctest_main)]
 /// fn main () {
-///
 /// # fn doc() {
 ///     let appender = tracing_appender::rolling::hourly("/some/path", "rolling.log");
 ///     let (non_blocking_appender, _guard) = tracing_appender::non_blocking(appender);
@@ -109,6 +108,8 @@ impl io::Write for RollingFileAppender {
 /// # }
 /// }
 /// ```
+///
+/// This will result in a log file located at `/some/path/rolling.log.YYYY-MM-DD-HH`.
 pub fn hourly(
     directory: impl AsRef<Path>,
     file_name_prefix: impl AsRef<Path>,
@@ -124,14 +125,13 @@ pub fn hourly(
 /// A `RollingFileAppender` will have a fixed rotation whose frequency is
 /// defined by [`Rotation`](struct.Rotation.html). The `directory` and
 /// `file_name_prefix` arguments determine the location and file name's _prefix_
-/// of the log file. `RollingFileAppender` will automatically append the current date.
+/// of the log file. `RollingFileAppender` will automatically append the current date in UTC.
 ///
 /// # Examples
 ///
 /// ``` rust
 /// # #[clippy::allow(needless_doctest_main)]
 /// fn main () {
-///
 /// # fn doc() {
 ///     let appender = tracing_appender::rolling::daily("/some/path", "rolling.log");
 ///     let (non_blocking_appender, _guard) = tracing_appender::non_blocking(appender);
@@ -144,6 +144,8 @@ pub fn hourly(
 /// # }
 /// }
 /// ```
+///
+/// This will result in a log file located at `/some/path/rolling.log.YYYY-MM-DD`.
 pub fn daily(
     directory: impl AsRef<Path>,
     file_name_prefix: impl AsRef<Path>,
@@ -157,14 +159,13 @@ pub fn daily(
 /// a non-blocking, appender that never rotates.
 ///
 /// The location of the log file will be specified the `directory` passed in.
-/// `file_name_prefix` specifies the prefix of the log file. No date is appended to it.
+/// `file_name` specifies the prefix of the log file. No date is appended to it.
 ///
 /// # Examples
 ///
 /// ``` rust
 /// # #[clippy::allow(needless_doctest_main)]
 /// fn main () {
-///
 /// # fn doc() {
 ///     let appender = tracing_appender::rolling::never("/some/path", "non-rolling.log");
 ///     let (non_blocking_appender, _guard) = tracing_appender::non_blocking(appender);
@@ -177,11 +178,10 @@ pub fn daily(
 /// # }
 /// }
 /// ```
-pub fn never(
-    directory: impl AsRef<Path>,
-    file_name_prefix: impl AsRef<Path>,
-) -> RollingFileAppender {
-    RollingFileAppender::new(Rotation::NEVER, directory, file_name_prefix)
+///
+/// This will result in a log file located at `/some/path/non-rolling.log`.
+pub fn never(directory: impl AsRef<Path>, file_name: impl AsRef<Path>) -> RollingFileAppender {
+    RollingFileAppender::new(Rotation::NEVER, directory, file_name)
 }
 
 /// Defines a fixed period for rolling of a log file.

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -31,11 +31,13 @@ pub struct RollingFileAppender {
 }
 
 impl RollingFileAppender {
-    /// Returns a new `RollingFileAppender`
+    /// Creates a new `RollingFileAppender`.
     ///
-    /// The returned `RollingFileAppender` will have a fixed rotation whose behavior is
-    /// defined by [`Rotation`](struct.Rotation.html). The provided `directory` and
-    /// `file_name_prefix`, will determine the location and file name prefix of the log file.
+    /// A `RollingFileAppender` will have a fixed rotation whose frequency is
+    /// defined by [`Rotation`](struct.Rotation.html). The `directory` and
+    /// `file_name_prefix` arguments determine the location and file name's _prefix_
+    /// of the log file. `RollingFileAppender` will automatically append the current date
+    /// and hour to the file name.
     ///
     /// An alternative way to construct a `RollingFileAppender` is to use one of the helpers:
     ///
@@ -85,9 +87,9 @@ impl io::Write for RollingFileAppender {
 /// The appender returned by `rolling::hourly` can be used with `non_blocking` to create
 /// a non-blocking, hourly file appender.
 ///
-/// The location of the log file will be specified the `directory` passed in.
-/// `file_name_prefix` specifies the prefix of the log file. It is appended by the
-/// current date and hour.
+/// The directory of the log file is specified with the `directory` argument.
+/// `file_name_prefix` specifies the _prefix_ of the log file. `RollingFileAppender` 
+/// adds the current date and hour to the log file.
 ///
 /// # Examples
 ///
@@ -119,8 +121,10 @@ pub fn hourly(
 /// The appender returned by `rolling::daily` can be used with `non_blocking` to create
 /// a non-blocking, daily file appender.
 ///
-/// The location of the log file will be specified the `directory` passed in.
-/// `file_name_prefix` specifies the prefix of the log file. It is appended by the current date.
+/// A `RollingFileAppender` will have a fixed rotation whose frequency is
+/// defined by [`Rotation`](struct.Rotation.html). The `directory` and
+/// `file_name_prefix` arguments determine the location and file name's _prefix_
+/// of the log file. `RollingFileAppender` will automatically append the current date.
 ///
 /// # Examples
 ///
@@ -182,9 +186,9 @@ pub fn never(
 
 /// Defines a fixed period for rolling of a log file.
 ///
-/// To use a `Rotation`, you can do the following:
+/// To use a `Rotation`, pick one of the following options:
 ///
-/// To get an hourly rotation:
+/// ### Hourly Rotation
 /// ```rust
 /// # fn docs() {
 /// use tracing_appender::rolling::Rotation;
@@ -192,7 +196,7 @@ pub fn never(
 /// # }
 /// ```
 ///
-/// To get an daily rotation:
+/// ### Daily Rotation
 /// ```rust
 /// # fn docs() {
 /// use tracing_appender::rolling::Rotation;
@@ -200,7 +204,7 @@ pub fn never(
 /// # }
 /// ```
 ///
-/// To never rotate:
+/// ### No Rotation
 /// ```rust
 /// # fn docs() {
 /// use tracing_appender::rolling::Rotation;

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 
 /// A file appender with the ability to rotate log files at a fixed schedule.
 ///
-/// This struct implements [`std:io::Write` trait][write] and will block on any write operation.
-/// It can be used in conjunction with [`NonBlocking`][non-blocking] to perform writes without
+/// `RollingFileAppender` implements [`std:io::Write` trait][write] and will block on write operations.
+/// It is intended to be used with [`NonBlocking`][non-blocking] to perform writes without
 /// blocking the current thread.
 ///
 /// [write]: https://doc.rust-lang.org/nightly/std/io/trait.Write.html
@@ -35,9 +35,11 @@ impl RollingFileAppender {
     /// of the log file. `RollingFileAppender` will automatically append the current date
     /// and hour (UTC format) to the file name.
     ///
-    /// An alternative way to construct a `RollingFileAppender` is to use one of the helpers:
+    /// Alternatively, a `RollingFileAppender` can be constructed using one of the following helpers:
     ///
-    /// [`Rotation::hourly()`][hourly],[`Rotation::daily()`][daily],[`Rotation::never()`][never]
+    /// - [`Rotation::hourly()`][hourly],
+    /// - [`Rotation::daily()`][daily],
+    /// - [`Rotation::never()`][never]
     ///
     /// [hourly]: fn.hourly.html
     /// [daily]: fn.daily.html
@@ -113,15 +115,15 @@ pub fn hourly(
     RollingFileAppender::new(Rotation::HOURLY, directory, file_name_prefix)
 }
 
-/// Creates an daily, rolling file appender.
+/// Creates a file appender that rotates daily.
 ///
 /// The appender returned by `rolling::daily` can be used with `non_blocking` to create
 /// a non-blocking, daily file appender.
 ///
-/// A `RollingFileAppender` will have a fixed rotation whose frequency is
+/// A `RollingFileAppender` has a fixed rotation whose frequency is
 /// defined by [`Rotation`](struct.Rotation.html). The `directory` and
 /// `file_name_prefix` arguments determine the location and file name's _prefix_
-/// of the log file. `RollingFileAppender` will automatically append the current date in UTC.
+/// of the log file. `RollingFileAppender` automatically appends the current date in UTC.
 ///
 /// # Examples
 ///
@@ -152,10 +154,10 @@ pub fn daily(
 /// Creates a non-rolling, file appender
 ///
 /// The appender returned by `rolling::never` can be used with `non_blocking` to create
-/// a non-blocking, appender that never rotates.
+/// a non-blocking, non-rotating appender.
 ///
 /// The location of the log file will be specified the `directory` passed in.
-/// `file_name` specifies the prefix of the log file. No date is appended to it.
+/// `file_name` specifies the prefix of the log file. No date or time is appended.
 ///
 /// # Examples
 ///

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 ///
 /// This struct implements [`std:io::Write` trait][write] and will block on any write operation.
 /// It can be used in conjunction with [`NonBlocking`][non-blocking] to perform writes without
-/// blocking the main thread.
+/// blocking the current thread.
 ///
 /// [write]: https://doc.rust-lang.org/nightly/std/io/trait.Write.html
 /// [non-blocking]: ../non_blocking/struct.NonBlocking.html
@@ -17,12 +17,8 @@ use std::path::Path;
 ///
 /// ```rust
 /// # fn docs() {
-/// use tracing_appender::rolling::RollingFileAppender;
-/// use tracing_appender::rolling::Rotation;
-/// use tracing_appender::non_blocking::NonBlocking;
-///
-/// let file_appender = RollingFileAppender::new(Rotation::HOURLY, "/some/directory", "prefix.log");
-/// let (non_blocking, _guard) = NonBlocking::new(file_appender);
+/// let file_appender = tracing_appender::rolling::hourly("/some/directory", "prefix.log");
+/// let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
 /// # }
 /// ```
 #[derive(Debug)]

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -6,18 +6,17 @@ use std::path::Path;
 
 /// A file appender with the ability to rotate log files at a fixed schedule.
 ///
-/// The file appender has a fixed rotation, which is defined by
-/// [`Rotation`]: tracing_appender/rolling/struct.Rotation.html
+/// The file appender has a fixed rotation, which is defined by [`Rotation`](struct.Rotation.html)
 ///
 /// The log file output is determined by providing a directory and log file name prefix.
 ///
 /// To construct a rolling file appender, use
-/// [`RollingFileAppender::new()`]: tracing_appender/rolling/struct.RollingFileAppender.html#method.new
+/// [`RollingFileAppender::new()`](struct.RollingFileAppender.html#method.new) or use one of
+/// the provided helpers:
 ///
-/// or use the provided helpers:
-/// [`Rotation::hourly()`]: tracing_appender/rolling/fn.hourly.html
-/// [`Rotation::daily()`]: tracing_appender/rolling/fn.daily.html
-/// [`Rotation::never()`]: tracing_appender/rolling/fn.never.html
+/// [`Rotation::hourly()`](fn.hourly.html)<br/>
+/// [`Rotation::daily()`](fn.daily.html)<br/>
+/// [`Rotation::never()`](fn.never.html)<br/>
 ///
 /// # Examples
 ///
@@ -163,7 +162,7 @@ pub fn never(
     RollingFileAppender::new(Rotation::NEVER, directory, file_name_prefix)
 }
 
-/// `Rotation`s defines a fixed period for rolling of a log file.
+/// Defines a fixed period for rolling of a log file.
 ///
 /// To use a `Rotation`, you can do the following:
 ///

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -6,17 +6,12 @@ use std::path::Path;
 
 /// A file appender with the ability to rotate log files at a fixed schedule.
 ///
-/// The file appender has a fixed rotation, which is defined by [`Rotation`](struct.Rotation.html)
+/// This struct implements [`std:io::Write` trait][write] and will block on any write operation.
+/// It can be used in conjunction with [`NonBlocking`][non-blocking] to perform writes without
+/// blocking the main thread.
 ///
-/// The log file output is determined by providing a directory and log file name prefix.
-///
-/// To construct a rolling file appender, use
-/// [`RollingFileAppender::new()`](struct.RollingFileAppender.html#method.new) or use one of
-/// the provided helpers:
-///
-/// [`Rotation::hourly()`](fn.hourly.html)<br/>
-/// [`Rotation::daily()`](fn.daily.html)<br/>
-/// [`Rotation::never()`](fn.never.html)<br/>
+/// [write]: https://doc.rust-lang.org/nightly/std/io/trait.Write.html
+/// [non-blocking]: ../non_blocking/struct.NonBlocking.html
 ///
 /// # Examples
 ///
@@ -24,7 +19,10 @@ use std::path::Path;
 /// # fn docs() {
 /// use tracing_appender::rolling::RollingFileAppender;
 /// use tracing_appender::rolling::Rotation;
+/// use tracing_appender::non_blocking::NonBlocking;
+///
 /// let file_appender = RollingFileAppender::new(Rotation::HOURLY, "/some/directory", "prefix.log");
+/// let (non_blocking, _guard) = NonBlocking::new(file_appender);
 /// # }
 /// ```
 #[derive(Debug)]
@@ -33,8 +31,28 @@ pub struct RollingFileAppender {
 }
 
 impl RollingFileAppender {
-    /// Returns a `RollingFileAppender` that writes to a rolling log file in a provided `directory`
-    /// and with a file name prefix.
+    /// Returns a new `RollingFileAppender`
+    ///
+    /// The returned `RollingFileAppender` will have a fixed rotation whose behavior is
+    /// defined by [`Rotation`](struct.Rotation.html). The provided `directory` and
+    /// `file_name_prefix`, will determine the location and file name prefix of the log file.
+    ///
+    /// An alternative way to construct a `RollingFileAppender` is to use one of the helpers:
+    ///
+    /// [`Rotation::hourly()`][hourly],[`Rotation::daily()`][daily],[`Rotation::never()`][never]
+    ///
+    /// [hourly]: fn.hourly.html
+    /// [daily]: fn.daily.html
+    /// [never]: fn.never.html
+    ///
+    /// # Examples
+    /// ```rust
+    /// # fn docs() {
+    /// use tracing_appender::rolling::RollingFileAppender;
+    /// use tracing_appender::rolling::Rotation;
+    /// let file_appender = RollingFileAppender::new(Rotation::HOURLY, "/some/directory", "prefix.log");
+    /// # }
+    /// ```
     pub fn new(
         rotation: Rotation,
         directory: impl AsRef<Path>,

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -4,12 +4,38 @@ use std::fmt::Debug;
 use std::io;
 use std::path::Path;
 
+/// A file appender with the ability to rotate log files at a fixed schedule.
+///
+/// The file appender has a fixed rotation, which is defined by
+/// [`Rotation`]: tracing_appender/rolling/struct.Rotation.html
+///
+/// The log file output is determined by providing a directory and log file name prefix.
+///
+/// To construct a rolling file appender, use
+/// [`RollingFileAppender::new()`]: tracing_appender/rolling/struct.RollingFileAppender.html#method.new
+///
+/// or use the provided helpers:
+/// [`Rotation::hourly()`]: tracing_appender/rolling/fn.hourly.html
+/// [`Rotation::daily()`]: tracing_appender/rolling/fn.daily.html
+/// [`Rotation::never()`]: tracing_appender/rolling/fn.never.html
+///
+/// # Examples
+///
+/// ```rust
+/// # fn docs() {
+/// use tracing_appender::rolling::RollingFileAppender;
+/// use tracing_appender::rolling::Rotation;
+/// let file_appender = RollingFileAppender::new(Rotation::HOURLY, "/some/directory", "prefix.log");
+/// # }
+/// ```
 #[derive(Debug)]
 pub struct RollingFileAppender {
     inner: InnerAppender,
 }
 
 impl RollingFileAppender {
+    /// Returns a `RollingFileAppender` that writes to a rolling log file in a provided `directory`
+    /// and with a file name prefix.
     pub fn new(
         rotation: Rotation,
         directory: impl AsRef<Path>,
@@ -42,6 +68,10 @@ impl io::Write for RollingFileAppender {
 /// The appender returned by `rolling::hourly` can be used with `non_blocking` to create
 /// a non-blocking, hourly file appender.
 ///
+/// The location of the log file will be specified the `directory` passed in.
+/// `file_name_prefix` specifies the prefix of the log file. It is appended by the
+/// current date and hour.
+///
 /// # Examples
 ///
 /// ``` rust
@@ -67,6 +97,32 @@ pub fn hourly(
     RollingFileAppender::new(Rotation::HOURLY, directory, file_name_prefix)
 }
 
+/// Creates an daily, rolling file appender.
+///
+/// The appender returned by `rolling::daily` can be used with `non_blocking` to create
+/// a non-blocking, daily file appender.
+///
+/// The location of the log file will be specified the `directory` passed in.
+/// `file_name_prefix` specifies the prefix of the log file. It is appended by the current date.
+///
+/// # Examples
+///
+/// ``` rust
+/// # #[clippy::allow(needless_doctest_main)]
+/// fn main () {
+///
+/// # fn doc() {
+///     let appender = tracing_appender::rolling::daily("/some/path", "rolling.log");
+///     let (non_blocking_appender, _guard) = tracing_appender::non_blocking(appender);
+///
+///     let subscriber = tracing_subscriber::fmt().with_writer(non_blocking_appender);
+///
+///     tracing::subscriber::with_default(subscriber.finish(), || {
+///         tracing::event!(tracing::Level::INFO, "Hello");
+///     });
+/// # }
+/// }
+/// ```
 pub fn daily(
     directory: impl AsRef<Path>,
     file_name_prefix: impl AsRef<Path>,
@@ -74,6 +130,32 @@ pub fn daily(
     RollingFileAppender::new(Rotation::DAILY, directory, file_name_prefix)
 }
 
+/// Creates a non-rolling, file appender
+///
+/// The appender returned by `rolling::never` can be used with `non_blocking` to create
+/// a non-blocking, appender that never rotates.
+///
+/// The location of the log file will be specified the `directory` passed in.
+/// `file_name_prefix` specifies the prefix of the log file. No date is appended to it.
+///
+/// # Examples
+///
+/// ``` rust
+/// # #[clippy::allow(needless_doctest_main)]
+/// fn main () {
+///
+/// # fn doc() {
+///     let appender = tracing_appender::rolling::never("/some/path", "non-rolling.log");
+///     let (non_blocking_appender, _guard) = tracing_appender::non_blocking(appender);
+///
+///     let subscriber = tracing_subscriber::fmt().with_writer(non_blocking_appender);
+///
+///     tracing::subscriber::with_default(subscriber.finish(), || {
+///         tracing::event!(tracing::Level::INFO, "Hello");
+///     });
+/// # }
+/// }
+/// ```
 pub fn never(
     directory: impl AsRef<Path>,
     file_name_prefix: impl AsRef<Path>,
@@ -81,6 +163,33 @@ pub fn never(
     RollingFileAppender::new(Rotation::NEVER, directory, file_name_prefix)
 }
 
+/// `Rotation`s defines a fixed period for rolling of a log file.
+///
+/// To use a `Rotation`, you can do the following:
+///
+/// To get an hourly rotation:
+/// ```rust
+/// # fn docs() {
+/// use tracing_appender::rolling::Rotation;
+/// let rotation = tracing_appender::rolling::Rotation::HOURLY;
+/// # }
+/// ```
+///
+/// To get an daily rotation:
+/// ```rust
+/// # fn docs() {
+/// use tracing_appender::rolling::Rotation;
+/// let rotation = tracing_appender::rolling::Rotation::DAILY;
+/// # }
+/// ```
+///
+/// To never rotate:
+/// ```rust
+/// # fn docs() {
+/// use tracing_appender::rolling::Rotation;
+/// let rotation = tracing_appender::rolling::Rotation::NEVER;
+/// # }
+/// ```
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct Rotation(RotationKind);
 
@@ -92,8 +201,11 @@ enum RotationKind {
 }
 
 impl Rotation {
+    /// Provides an hourly rotation
     pub const HOURLY: Self = Self(RotationKind::Hourly);
+    /// Provides a daily rotation
     pub const DAILY: Self = Self(RotationKind::Daily);
+    /// Provides a rotation that never rotates.
     pub const NEVER: Self = Self(RotationKind::Never);
 
     pub(crate) fn next_date(&self, current_date: &DateTime<Utc>) -> DateTime<Utc> {

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 /// A file appender with the ability to rotate log files at a fixed schedule.
 ///
 /// `RollingFileAppender` implements [`std:io::Write` trait][write] and will block on write operations.
-/// It is intended to be used with [`NonBlocking`][non-blocking] to perform writes without
+/// It may be used with [`NonBlocking`][non-blocking] to perform writes without
 /// blocking the current thread.
 ///
 /// [write]: https://doc.rust-lang.org/nightly/std/io/trait.Write.html
@@ -18,7 +18,6 @@ use std::path::Path;
 /// ```rust
 /// # fn docs() {
 /// let file_appender = tracing_appender::rolling::hourly("/some/directory", "prefix.log");
-/// let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
 /// # }
 /// ```
 #[derive(Debug)]
@@ -48,8 +47,7 @@ impl RollingFileAppender {
     /// # Examples
     /// ```rust
     /// # fn docs() {
-    /// use tracing_appender::rolling::RollingFileAppender;
-    /// use tracing_appender::rolling::Rotation;
+    /// use tracing_appender::rolling::{RollingFileAppender, Rotation};
     /// let file_appender = RollingFileAppender::new(Rotation::HOURLY, "/some/directory", "prefix.log");
     /// # }
     /// ```


### PR DESCRIPTION
## Motivation

Adds documentation for tracing-appender that was added in PR #673 

I still need to fix the way links to structs/methods looks. But the rest of the content is reviewable.