### PR TITLE
Remove trailing space in ChronoUtc format_time

### DIFF
--- a/tracing-subscriber/src/fmt/time.rs
+++ b/tracing-subscriber/src/fmt/time.rs
@@ -192,8 +192,8 @@ impl FormatTime for ChronoUtc {
     fn format_time(&self, w: &mut dyn fmt::Write) -> fmt::Result {
         let time = chrono::Utc::now();
         match self.format {
-            ChronoFmtType::Rfc3339 => write!(w, "{} ", time.to_rfc3339()),
-            ChronoFmtType::Custom(ref format_str) => write!(w, "{} ", time.format(format_str)),
+            ChronoFmtType::Rfc3339 => write!(w, "{}", time.to_rfc3339()),
+            ChronoFmtType::Custom(ref format_str) => write!(w, "{}", time.format(format_str)),
         }
     }
 }


### PR DESCRIPTION
This removes the trailing space from the end of the ChronoUtc FormatTime impl.

I'm pretty sure this is accidental? None of the other FormatTime impls have this there. Not sure if this is considered a breaking change. Hopefully not.