### PR TITLE
subscriber: Bump sharded-slab dependency

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -53,7 +53,7 @@ tracing-serde = { path = "../tracing-serde", version = "0.1.1", optional = true 
 parking_lot = { version = ">= 0.7, < 0.10", optional = true }
 
 # registry
-sharded-slab = { version = "0.0.8", optional = true }
+sharded-slab = { version = "^0.0.9", optional = true }
 
 [dev-dependencies]
 tracing = { path = "../tracing", version = "0.1"}


### PR DESCRIPTION
Cargo doesn't want to resolve 0.0.9 for tracing-subscriber :(