### PR TITLE
futures: prepare to release 0.2.4

### DIFF
--- a/tracing-futures/CHANGELOG.md
+++ b/tracing-futures/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Fixed
 
 - docs.rs build failures (#618)
-- Fixing spelling in documentation skins -> sinks (#643)
+- Spelling in documentation skins -> sinks (#643)
 
 # 0.2.3 (Feb 26, 2020)
 

--- a/tracing-futures/CHANGELOG.md
+++ b/tracing-futures/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.4 (April 21, 2020)
+
+### Fixed
+
+- docs.rs build failures (#618)
+- Fixing spelling in documentation skins -> sinks (#643)
+
 # 0.2.3 (Feb 26, 2020)
 
 ### Added

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-futures"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"


### PR DESCRIPTION
With any luck, this should resolve the docs.rs build failures.