### PR TITLE
Add `must_use` attribute to `set_default`

### DIFF
--- a/tracing/src/subscriber.rs
+++ b/tracing/src/subscriber.rs
@@ -57,6 +57,7 @@ where
 /// [`DefaultGuard`]: ../dispatcher/struct.DefaultGuard.html
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[must_use = "Dropping the guard unregisters the subscriber."]
 pub fn set_default<S>(subscriber: S) -> DefaultGuard
 where
     S: Subscriber + Send + Sync + 'static,


### PR DESCRIPTION
This makes the user aware of if the guard is dropped immediately and
thus, the tracing does not work.

