### PR TITLE
Add Layer::visit_spans

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -542,15 +542,11 @@ where
     /// The provided closure will be called first with the current span,
     /// and then with that span's parent, and then that span's parent,
     /// and so on until a root span is reached.
-    pub fn visit_spans<E, F>(&self, mut f: F) -> Result<(), E>
+    pub fn visit_spans<E, F>(&self, f: F) -> Result<(), E>
     where
         F: FnMut(&SpanRef<'_, S>) -> Result<(), E>,
     {
-        // visit all the current spans
-        for span in self.ctx.scope() {
-            f(&span)?;
-        }
-        Ok(())
+        self.ctx.visit_spans(f)
     }
 }
 

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -976,6 +976,25 @@ impl<'a, S: Subscriber> Context<'a, S> {
         });
         Scope(scope)
     }
+
+    /// Visits every span in the current context with a closure.
+    ///
+    /// The provided closure will be called first with the current span,
+    /// and then with that span's parent, and then that span's parent,
+    /// and so on until a root span is reached.
+    #[cfg(feature = "registry")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
+    pub fn visit_spans<E, F>(&self, mut f: F) -> Result<(), E>
+    where
+        S: for<'lookup> LookupSpan<'lookup>,
+        F: FnMut(&SpanRef<'_, S>) -> Result<(), E>,
+    {
+        // visit all the current spans
+        for span in self.scope() {
+            f(&span)?;
+        }
+        Ok(())
+    }
 }
 
 impl<'a, S> Context<'a, S> {


### PR DESCRIPTION
Add `Layer::visit_spans`, which is exactly the same implementation as `FmtContext::visit_spans`.

## Motivation

Very simple addition, but I found it convenient to visit the parent spans directly within the layer's Context. It so happens that it was defined on FmtContext, but not on Context.

## Solution

Move the code from FmtContext to Context, and preserve the same public API exposed on FmtContext.