### PR TITLE
chore: remove redundant imports

### DIFF
--- a/examples/examples/all-levels.rs
+++ b/examples/examples/all-levels.rs
@@ -1,5 +1,4 @@
 use tracing::Level;
-use tracing_subscriber;
 
 fn main() {
     tracing_subscriber::fmt()

--- a/examples/examples/async_fn.rs
+++ b/examples/examples/async_fn.rs
@@ -16,7 +16,6 @@
 //! [`hello_world`]: https://github.com/tokio-rs/tokio/blob/132e9f1da5965530b63554d7a1c59824c3de4e30/tokio/examples/hello_world.rs
 #![deny(rust_2018_idioms)]
 
-use tokio;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 

--- a/examples/examples/echo.rs
+++ b/examples/examples/echo.rs
@@ -24,7 +24,6 @@
 #![warn(rust_2018_idioms)]
 
 use futures::future::{FutureExt, TryFutureExt};
-use tokio;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 

--- a/examples/examples/fmt-custom-event.rs
+++ b/examples/examples/fmt-custom-event.rs
@@ -1,5 +1,4 @@
 #![deny(rust_2018_idioms)]
-use tracing_subscriber;
 #[path = "fmt/yak_shave.rs"]
 mod yak_shave;
 

--- a/examples/examples/fmt-custom-field.rs
+++ b/examples/examples/fmt-custom-field.rs
@@ -18,7 +18,6 @@
 //! hello: "world", answer: 42
 //! ```
 #![deny(rust_2018_idioms)]
-use tracing_subscriber;
 
 #[path = "fmt/yak_shave.rs"]
 mod yak_shave;

--- a/examples/examples/fmt.rs
+++ b/examples/examples/fmt.rs
@@ -1,6 +1,5 @@
 #![deny(rust_2018_idioms)]
 use tracing::{info, Level};
-use tracing_subscriber;
 
 #[path = "fmt/yak_shave.rs"]
 mod yak_shave;

--- a/examples/examples/sloggish/sloggish_subscriber.rs
+++ b/examples/examples/sloggish/sloggish_subscriber.rs
@@ -10,11 +10,8 @@
 //!
 //! [`slog-term`]: https://docs.rs/slog-term/2.4.0/slog_term/
 //! [`slog` README]: https://github.com/slog-rs/slog#terminal-output-example
-use self::ansi_term::{Color, Style};
-use ansi_term;
-use humantime;
+use ansi_term::{Color, Style};
 use tracing::{
-    self,
     field::{Field, Visit},
     Id, Level, Subscriber,
 };

--- a/examples/examples/spawny_thing.rs
+++ b/examples/examples/spawny_thing.rs
@@ -7,8 +7,6 @@
 /// ```
 /// cargo +nightly run --example spawny_thing
 /// ```
-use tokio;
-
 use futures::future::join_all;
 use std::error::Error;
 use tracing::{debug, info};

--- a/tracing-log/src/env_logger.rs
+++ b/tracing-log/src/env_logger.rs
@@ -1,6 +1,4 @@
 //! Utilities for configuring the `env_logger` crate to emit `tracing` events.
-use env_logger;
-use log;
 
 /// Extension trait to configure an `env_logger::Builder` to emit traces.
 pub trait BuilderExt: crate::sealed::Sealed {

--- a/tracing-log/src/log_tracer.rs
+++ b/tracing-log/src/log_tracer.rs
@@ -27,7 +27,6 @@
 //! [builder]: struct.LogTracer.html#method.builder
 //! [ignore]: struct.Builder.html#method.ignore_crate
 use crate::{format_trace, AsTrace};
-use log;
 pub use log::SetLoggerError;
 use tracing_core::dispatcher;
 

--- a/tracing-macros/examples/factorial.rs
+++ b/tracing-macros/examples/factorial.rs
@@ -5,8 +5,6 @@
 extern crate tracing;
 #[macro_use]
 extern crate tracing_macros;
-use env_logger;
-use tracing_log;
 
 fn factorial(n: u32) -> u32 {
     if dbg!(n <= 1) {

--- a/tracing-subscriber/benches/fmt.rs
+++ b/tracing-subscriber/benches/fmt.rs
@@ -1,6 +1,5 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use std::{io, time::Duration};
-use tracing_subscriber;
 
 mod support;
 use support::MultithreadedBench;

--- a/tracing-subscriber/src/fmt/time.rs
+++ b/tracing-subscriber/src/fmt/time.rs
@@ -1,8 +1,4 @@
 //! Formatters for event timestamps.
-
-#[cfg(feature = "chrono")]
-use chrono;
-
 #[cfg(feature = "ansi")]
 use ansi_term::Style;
 

--- a/tracing-tower/src/http.rs
+++ b/tracing-tower/src/http.rs
@@ -1,6 +1,3 @@
-use http;
-use tracing;
-
 macro_rules! make_req_fns {
     ($($name:ident, $level:expr),+) => {
         $(

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -781,11 +781,10 @@ extern crate alloc;
 
 #[macro_use]
 extern crate cfg_if;
-use tracing_core;
 
 #[cfg(feature = "log")]
 #[doc(hidden)]
-pub extern crate log;
+pub use log;
 
 // Somehow this `use` statement is necessary for us to re-export the `core`
 // macros on Rust 1.26.0. I'm not sure how this makes it work, but it does.
@@ -793,22 +792,17 @@ pub extern crate log;
 #[doc(hidden)]
 use tracing_core::*;
 
-pub use self::{
-    dispatcher::Dispatch,
-    event::Event,
-    field::Value,
-    subscriber::Subscriber,
-    tracing_core::{event, Level, Metadata},
-};
+pub use self::{dispatcher::Dispatch, event::Event, field::Value, subscriber::Subscriber};
 
 #[doc(hidden)]
-pub use self::{
-    span::Id,
-    tracing_core::{
-        callsite::{self, Callsite},
-        metadata,
-    },
+pub use self::span::Id;
+
+#[doc(hidden)]
+pub use tracing_core::{
+    callsite::{self, Callsite},
+    metadata,
 };
+pub use tracing_core::{event, Level, Metadata};
 
 #[doc(inline)]
 pub use self::span::Span;


### PR DESCRIPTION
## Motivation

It looks like Rust 1.43's version of clippy added a new lint for
redundant `use` statements with just a crate name. These are unnecessary
because the root module of an external crate is always available without
imports. Apparently, `tracing-log`, `tracing-subscriber`, `tracing`, and 
`tracing-tower` all had some redundant `use` statements, which clippy now 
warns us about.

## Solution

This PR removes them.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>