### PR TITLE
chore: Add preliminary CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Eliza should review everything unassigned.
+*                               @hawkw @tokio-rs/tracing
+
+# tracing-error and tracing-flame were contributed by Jane.
+/tracing-error/                 @yaahc @tokio-rs/tracing
+/tracing-flame/                 @yaahc @tokio-rs/tracing
+
+# David contributed the Registry implementation.
+/tracing-subscriber/registry    @davidbarsky @hawkw @tokio-rs/tracing


### PR DESCRIPTION
This branch adds a CODEOWNERS file to configure Github to automatically
assign reviewers for pull requests. In general, when a crate or large
subsystem of a crate was contributed by an individual person, we should
use this file to ensure that that person is assigned to review future
changes to that code.

The @tokio-rs/tracing team should still be tagged to approve all pull
requests, in addition to the person who originally contributed the code,
so the CODEOWNERS file ensures this as well.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>