### PR TITLE
Prepare tracing-appender for release

### DIFF
--- a/tracing-appender/CHANGELOG.md
+++ b/tracing-appender/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0 (May 4, 2020)
+
+- Initial release

--- a/tracing-appender/CHANGELOG.md
+++ b/tracing-appender/CHANGELOG.md
@@ -1,3 +1,3 @@
-# 0.1.0 (May 4, 2020)
+# 0.1.0 (May 5, 2020)
 
 - Initial release

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "tracing-appender"
 version = "0.1.0"
-authors = ["Zeki Sherif <zekshi@amazon.com>"]
+authors = [
+    "Zeki Sherif <zekshi@amazon.com>",
+    "Tokio Contributors <team@tokio.rs>"
+]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -2,12 +2,20 @@
 name = "tracing-appender"
 version = "0.1.0"
 authors = ["Zeki Sherif <zekshi@amazon.com>"]
-edition = "2018"
+license = "MIT"
+readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
 description = """
-Provides an `appender` that writes to a file
+Application-level tracing for Rust.
 """
+categories = [
+    "development-tools::debugging",
+    "development-tools::profiling",
+    "asynchronous",
+]
+keywords = ["logging", "tracing", "file-appender", "non-blocking-writer"]
+edition = "2018"
 
 [dependencies]
 tracing-subscriber = {path = "../tracing-subscriber", version = "0.2.4"}

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
 description = """
-Application-level tracing for Rust.
+Provides an `appender` that writes to a file
 """
 categories = [
     "development-tools::debugging",

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -10,11 +10,10 @@ readme = "README.md"
 repository = "https://github.com/tokio-rs/tracing"
 homepage = "https://tokio.rs"
 description = """
-Provides an `appender` that writes to a file
+Provides utilities for file appenders and making non-blocking writers.
 """
 categories = [
     "development-tools::debugging",
-    "development-tools::profiling",
     "asynchronous",
 ]
 keywords = ["logging", "tracing", "file-appender", "non-blocking-writer"]

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -104,6 +104,29 @@
 //!     .init();
 //! # }
 //! ```
+#![doc(html_root_url = "https://docs.rs/tracing-appender/0.1.0")]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub,
+    bad_style,
+    const_err,
+    dead_code,
+    improper_ctypes,
+    non_shorthand_field_patterns,
+    no_mangle_generic_items,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    private_in_public,
+    unconditional_recursion,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true
+)]
 use crate::non_blocking::{NonBlocking, WorkerGuard};
 
 use std::io::Write;


### PR DESCRIPTION
Following the release process for https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md and these changes are the only things left to commit before release.

I'd like to hopefully get this released today so we can start using this crate internally.

Note:
I need to get PR #703 and PR #678 merged before release.