### PR TITLE
subscriber: fix `Span::record` resulting in malformed JSON

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -445,10 +445,7 @@ where
         if let Some(FormattedFields { ref mut fields, .. }) =
             extensions.get_mut::<FormattedFields<N>>()
         {
-            if !values.is_empty() {
-                fields.push(' ');
-            }
-            let _ = self.fmt_fields.format_fields(fields, values);
+            let _ = self.fmt_fields.add_fields(fields, values);
         } else {
             let mut buf = String::new();
             if self.fmt_fields.format_fields(&mut buf, values).is_ok() {

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 use std::fmt::{self, Write};
 use tracing_core::{
     field::{self, Field, Visit},
-    Event, Level, Subscriber,
+    span, Event, Level, Subscriber,
 };
 
 #[cfg(feature = "tracing-log")]
@@ -80,6 +80,18 @@ pub trait FormatFields<'writer> {
         writer: &'writer mut dyn fmt::Write,
         fields: R,
     ) -> fmt::Result;
+
+    /// Record additional field(s) on an existing span.
+    ///
+    /// By default, this appends a space to the current set of fields if it is
+    /// non-empty, and then calls `self.format_fields`. If different behavior is
+    /// required, the default implementation of this method can be overridden.
+    fn add_fields(&self, current: &'writer mut String, fields: &span::Record<'_>) -> fmt::Result {
+        if !current.is_empty() {
+            current.push(' ');
+        }
+        self.format_fields(current, fields)
+    }
 }
 
 /// Returns the default configuration for an [event formatter].


### PR DESCRIPTION
## Motivation

An issue (#707) currently exists where calling `record` on a span will cause the
JSON formatter in `tracing_subscriber::fmt` to not log any further events that
occur within that span.

This issue results from a combination of two factors:

*  Currently, when formatting the fields on a parent span as JSON, we
  return a `fmt::Error`. In this case, we bail from the `format_event`
  function, causing us to skip formatting that event entirely. We
  don't print anything or panic when this occurs.

* The implementation of `on_record` for `fmt::Layer` simply formats the
  new fields and appends them to the previous fields. This doesn't work 
  with JSON! The  previous fields will have been recorded as a JSON 
  object, like:

  ```json 
  { "field_1": "value_1" }
  ```

  Appending the new fields will result in a string like:
  ```json 
  { "field_1": "value_1" } { "field_2": "value_2" }
  ```
  This is not valid JSON! Thus, serializing the event will fail with a
  `fmt::Error`, as discussed previously, and we'll skip formatting that
  event entirely.

## Solution

This PR does the following:

* Add a test reproducing #707, which fails on master.

* Update the behavior when encountering fields that are not valid JSON.
  We will now panic in debug mode with a message clearly indicating
  that this is a bug, or continue serializing the event with a message
  indicating that the parent span was malformed in release mode. This
  lets us avoid potentially crashing the application while still 
  indicating to sthe user that something is wrong internally.

* Actually fixed the bug.

  I did this by adding a new trait method to `FormatFields` to allow
  overriding how fields are appended to existing fields. This method
  has a default implementation that does the existing behavior of
  adding a space, but can be overridden by formatters that need 
  different behavior. In this case, the JSON formatter overrides this 
  method to re-parse the existing fields as a JSON object, add the new
  fields, and serialize the new JSON.

  Note that the above approach (parsing & re-serializing) kinda...sucks
  a lot. This is unfortunately what we get for implementing the JSON
  formatter on top of the `fmt` machinery. In a future release we will
  probably want to replace the JSON formatter with a totally separate 
  JSON layer. Then, we can store the fields as JSON objects rather than
  as strings, and add new fields without having to parse and 
  re-serialize. For now, though, the current approach does achieve the
  goal of "not being broken", which is better than can be said for what
  we did previously.

Fixes #707

Signed-off-by: Eliza Weisman <eliza@buoyant.io>