### PR TITLE
[tracing-subscriber] remove the duplicated test 'field_filter_events'

### DIFF
--- a/tracing-subscriber/tests/filter.rs
+++ b/tracing-subscriber/tests/filter.rs
@@ -183,32 +183,3 @@ fn span_name_filter_is_dynamic() {
 
     finished.assert_finished();
 }
-
-#[test]
-fn field_filter_events() {
-    let filter: EnvFilter = "[{thing}]=debug".parse().expect("filter should parse");
-    let (subscriber, finished) = subscriber::mock()
-        .event(
-            event::mock()
-                .at_level(Level::INFO)
-                .with_fields(field::mock("thing")),
-        )
-        .event(
-            event::mock()
-                .at_level(Level::DEBUG)
-                .with_fields(field::mock("thing")),
-        )
-        .done()
-        .run_with_handle();
-    let subscriber = subscriber.with(filter);
-
-    with_default(subscriber, || {
-        tracing::trace!(disabled = true);
-        tracing::info!("also disabled");
-        tracing::info!(thing = 1);
-        tracing::debug!(thing = 2);
-        tracing::trace!(thing = 3);
-    });
-
-    finished.assert_finished();
-}


### PR DESCRIPTION
This removes the test `field_filter_events` in `tracing-subscriber/tests/filter.rs` as it appears to be a duplicate of `field_filter_events` in `tracing-subscriber/tests/field_filter.rs` (see discussion at https://github.com/tokio-rs/tracing/pull/711#issuecomment-626365124).
