### PR TITLE
tracing_opentelemetry: Switch to `Context` propagation

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -53,5 +53,5 @@ indenter = "0.1.3"
 tempdir = "0.3.7"
 
 # opentelemetry example
-opentelemetry = "0.4"
-opentelemetry-jaeger = "0.3"
+opentelemetry = "0.5"
+opentelemetry-jaeger = "0.4"

--- a/examples/examples/opentelemetry.rs
+++ b/examples/examples/opentelemetry.rs
@@ -36,10 +36,9 @@ fn init_tracer() -> Result<(), Box<dyn std::error::Error>> {
     let tracer = provider.get_tracer("tracing");
 
     let opentelemetry = tracing_opentelemetry::layer().with_tracer(tracer);
-    let subscriber = Registry::default().with(opentelemetry);
-    tracing::subscriber::set_global_default(subscriber)?;
-
-    Ok(())
+    tracing_subscriber::registry()
+        .with(opentelemetry)
+        .try_init()
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/examples/opentelemetry.rs
+++ b/examples/examples/opentelemetry.rs
@@ -1,8 +1,8 @@
-use opentelemetry::{api::Provider, global, sdk};
+use opentelemetry::api::Provider;
+use opentelemetry::sdk;
 use std::{io, thread, time::Duration};
 use tracing::{span, trace, warn};
 use tracing_attributes::instrument;
-use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Registry;
 
@@ -17,7 +17,7 @@ fn expensive_work() -> &'static str {
     "success"
 }
 
-fn init_tracer() -> io::Result<()> {
+fn init_tracer() -> Result<(), Box<dyn std::error::Error>> {
     let exporter = opentelemetry_jaeger::Exporter::builder()
         .with_agent_endpoint("127.0.0.1:6831".parse().unwrap())
         .with_process(opentelemetry_jaeger::Process {
@@ -33,29 +33,28 @@ fn init_tracer() -> io::Result<()> {
             ..Default::default()
         })
         .build();
-    global::set_provider(provider);
+    let tracer = provider.get_tracer("tracing");
+
+    let opentelemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+    let subscriber = Registry::default().with(opentelemetry);
+    tracing::subscriber::set_global_default(subscriber)?;
 
     Ok(())
 }
 
-fn main() -> io::Result<()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     init_tracer()?;
-    let tracer = global::trace_provider().get_tracer("tracing");
-    let opentelemetry = OpenTelemetryLayer::with_tracer(tracer);
-    let subscriber = Registry::default().with(opentelemetry);
 
-    tracing::subscriber::with_default(subscriber, || {
-        let root = span!(tracing::Level::INFO, "app_start", work_units = 2);
-        let _enter = root.enter();
+    let root = span!(tracing::Level::INFO, "app_start", work_units = 2);
+    let _enter = root.enter();
 
-        let work_result = expensive_work();
+    let work_result = expensive_work();
 
-        span!(tracing::Level::INFO, "faster_work")
-            .in_scope(|| thread::sleep(Duration::from_millis(10)));
+    span!(tracing::Level::INFO, "faster_work")
+        .in_scope(|| thread::sleep(Duration::from_millis(10)));
 
-        warn!("About to exit!");
-        trace!("status: {}", work_result);
-    });
+    warn!("About to exit!");
+    trace!("status: {}", work_result);
 
     Ok(())
 }

--- a/examples/examples/opentelemetry.rs
+++ b/examples/examples/opentelemetry.rs
@@ -1,10 +1,9 @@
 use opentelemetry::api::Provider;
 use opentelemetry::sdk;
-use std::{io, thread, time::Duration};
+use std::{thread, time::Duration};
 use tracing::{span, trace, warn};
 use tracing_attributes::instrument;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::Registry;
+use tracing_subscriber::prelude::*;
 
 #[instrument]
 #[inline]
@@ -24,8 +23,7 @@ fn init_tracer() -> Result<(), Box<dyn std::error::Error>> {
             service_name: "report_example".to_string(),
             tags: Vec::new(),
         })
-        .init()
-        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        .init()?;
     let provider = sdk::Provider::builder()
         .with_simple_exporter(exporter)
         .with_config(sdk::Config {
@@ -38,7 +36,9 @@ fn init_tracer() -> Result<(), Box<dyn std::error::Error>> {
     let opentelemetry = tracing_opentelemetry::layer().with_tracer(tracer);
     tracing_subscriber::registry()
         .with(opentelemetry)
-        .try_init()
+        .try_init()?;
+
+    Ok(())
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/tracing-opentelemetry/CHANGELOG.md
+++ b/tracing-opentelemetry/CHANGELOG.md
@@ -1,0 +1,45 @@
+# 0.4.0 (May 12, 2020)
+
+### Added
+
+- `tracing_opentelemetry::layer()` method to construct a default layer.
+- `OpenTelemetryLayer::with_sampler` method to configure the opentelemetry
+  sampling behavior.
+- `OpenTelemetryLayer::new` method to configure both the tracer and sampler.
+
+### Changed
+
+- `OpenTelemetrySpanExt::set_parent` now accepts a reference to an extracted
+  parent `Context` instead of a `SpanContext` to match propagators.
+- `OpenTelemetrySpanExt::context` now returns a `Context` instead of a
+  `SpanContext` to match propagators.
+- `OpenTelemetryLayer::with_tracer` now takes `&self` as a parameter
+- Upgrade to `v0.5.0` of `opentelemetry`.
+
+### Fixed
+
+- Fixes bug where child spans were always marked as sampled
+
+# 0.3.1 (April 19, 2020)
+
+### Added
+
+- Change span status code to unknown on error event
+
+# 0.3.0 (April 5, 2020)
+
+### Added
+
+- Span extension for injecting and extracting `opentelemetry` span contexts
+  into `tracing` spans
+
+### Removed
+
+- Disabled the `metrics` feature of the opentelemetry as it is unused.
+
+# 0.2.0 (February 7, 2020)
+
+### Changed
+
+- Update `tracing-subscriber` to 0.2.0 stable
+- Update to `opentelemetry` 0.2.0

--- a/tracing-opentelemetry/CHANGELOG.md
+++ b/tracing-opentelemetry/CHANGELOG.md
@@ -7,7 +7,7 @@
   sampling behavior.
 - `OpenTelemetryLayer::new` method to configure both the tracer and sampler.
 
-### Changed
+### Breaking Changes
 
 - `OpenTelemetrySpanExt::set_parent` now accepts a reference to an extracted
   parent `Context` instead of a `SpanContext` to match propagators.

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -19,13 +19,11 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-opentelemetry = { version = "0.4", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.5", default-features = false, features = ["trace"] }
 rand = "0.7"
 tracing = { path = "../tracing", version = "0.1" }
 tracing-core = { path = "../tracing-core", version = "0.1" }
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.2", default-features = false, features = ["registry"] }
 
 [dev-dependencies]
-opentelemetry-jaeger = "0.3.0"
-thrift = "0.13.0"
-tracing-attributes =  { path = "../tracing-attributes", version = "0.1.7"}
+opentelemetry-jaeger = "0.4"

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-opentelemetry"
-version = "0.3.1"
+version = "0.4.0"
 authors = [
     "Julian Tescher <julian@tescher.me>",
     "Tokio Contributors <team@tokio.rs>"

--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -53,7 +53,6 @@ The crate provides the following types:
 ```rust
 use opentelemetry::{api::Provider, sdk};
 use tracing::{error, span};
-use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Registry;
 
@@ -62,7 +61,7 @@ fn main() {
     let tracer = sdk::Provider::default().get_tracer("component_name");
 
     // Create a new OpenTelemetry tracing layer
-    let telemetry = OpenTelemetryLayer::with_tracer(tracer);
+    let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
 
     let subscriber = Registry::default().with(telemetry);
 

--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -218,7 +218,7 @@ where
             tracer,
             sampler: self.sampler,
             id_generator: self.id_generator,
-            get_context: self.get_context,
+            get_context: WithContext(OpenTelemetryLayer::<S, Tracer>::get_context),
             _registry: self._registry,
         }
     }

--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -1,4 +1,5 @@
-use opentelemetry::api;
+use opentelemetry::api::IdGenerator;
+use opentelemetry::{api, sdk};
 use std::any::TypeId;
 use std::fmt;
 use std::marker;
@@ -16,9 +17,43 @@ use tracing_subscriber::Layer;
 /// [tracing]: https://github.com/tokio-rs/tracing
 pub struct OpenTelemetryLayer<S, T: api::Tracer> {
     tracer: T,
+    sampler: Box<dyn api::Sampler>,
+    id_generator: sdk::IdGenerator,
 
     get_context: WithContext,
     _registry: marker::PhantomData<S>,
+}
+
+impl<S> Default for OpenTelemetryLayer<S, api::NoopTracer>
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    fn default() -> Self {
+        OpenTelemetryLayer::new(api::NoopTracer {}, sdk::Sampler::Always)
+    }
+}
+
+/// Construct a layer to track spans via [OpenTelemetry].
+///
+/// [OpenTelemetry]: https://opentelemetry.io
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use tracing_subscriber::layer::SubscriberExt;
+/// use tracing_subscriber::Registry;
+///
+/// // Use the tracing subscriber `Registry`, or any other subscriber
+/// // that impls `LookupSpan`
+/// let subscriber = Registry::default()
+///     .with(tracing_opentelemetry::layer());
+/// # drop(subscriber);
+/// ```
+pub fn layer<S>() -> OpenTelemetryLayer<S, api::NoopTracer>
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    OpenTelemetryLayer::default()
 }
 
 // this function "remembers" the types of the subscriber so that we
@@ -27,7 +62,7 @@ pub struct OpenTelemetryLayer<S, T: api::Tracer> {
 //
 // See https://github.com/tokio-rs/tracing/blob/4dad420ee1d4607bad79270c1520673fa6266a3d/tracing-error/src/layer.rs
 pub(crate) struct WithContext(
-    fn(&tracing::Dispatch, &span::Id, f: &mut dyn FnMut(&mut api::SpanBuilder)),
+    fn(&tracing::Dispatch, &span::Id, f: &mut dyn FnMut(&mut api::SpanBuilder, &dyn api::Sampler)),
 );
 
 impl WithContext {
@@ -37,23 +72,58 @@ impl WithContext {
         &self,
         dispatch: &'a tracing::Dispatch,
         id: &span::Id,
-        mut f: impl FnMut(&mut api::SpanBuilder),
+        mut f: impl FnMut(&mut api::SpanBuilder, &dyn api::Sampler),
     ) {
         (self.0)(dispatch, id, &mut f)
     }
 }
 
-pub(crate) fn build_context(builder: &mut api::SpanBuilder) -> api::SpanContext {
+pub(crate) fn build_span_context(
+    builder: &mut api::SpanBuilder,
+    sampler: &dyn api::Sampler,
+) -> api::SpanContext {
     let span_id = builder.span_id.expect("Builders must have id");
     let (trace_id, trace_flags) = builder
         .parent_context
         .as_ref()
         .map(|parent_context| (parent_context.trace_id(), parent_context.trace_flags()))
         .unwrap_or_else(|| {
-            (
-                builder.trace_id.expect("trace_id should exist"),
-                api::TRACE_FLAG_SAMPLED,
-            )
+            let trace_id = builder.trace_id.expect("trace_id should exist");
+
+            // ensure sampling decision is recorded so all span contexts have consistent flags
+            let sampling_decision = if let Some(result) = builder.sampling_result.as_ref() {
+                result.decision.clone()
+            } else {
+                let mut result = sampler.should_sample(
+                    builder.parent_context.as_ref(),
+                    trace_id,
+                    span_id.clone(),
+                    &builder.name,
+                    builder
+                        .span_kind
+                        .as_ref()
+                        .unwrap_or(&api::SpanKind::Internal),
+                    builder.attributes.as_ref().unwrap_or(&Vec::new()),
+                    builder.links.as_ref().unwrap_or(&Vec::new()),
+                );
+
+                // Record additional attributes resulting from sampling
+                if let Some(attributes) = &mut builder.attributes {
+                    attributes.append(&mut result.attributes)
+                } else {
+                    builder.attributes = Some(result.attributes);
+                }
+
+                result.decision
+            };
+
+            let trace_flags = if sampling_decision == api::SamplingDecision::RecordAndSampled {
+                api::TRACE_FLAG_SAMPLED
+            } else {
+                0
+            };
+
+            (trace_id, trace_flags)
         });
 
     api::SpanContext::new(trace_id, span_id, trace_flags, false)
@@ -97,36 +167,6 @@ where
     S: Subscriber + for<'span> LookupSpan<'span>,
     T: api::Tracer + 'static,
 {
-    /// Retrieve the parent OpenTelemetry [`SpanContext`] from the current
-    /// tracing [`span`] through the [`Registry`]. This [`SpanContext`]
-    /// links spans to their parent for proper hierarchical visualization.
-    ///
-    /// [`SpanContext`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span_context/struct.SpanContext.html
-    /// [`span`]: https://docs.rs/tracing/latest/tracing/struct.Span.html
-    /// [`Registry`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.Registry.html
-    fn parent_context(
-        &self,
-        attrs: &Attributes<'_>,
-        ctx: &Context<'_, S>,
-    ) -> Option<api::SpanContext> {
-        // If a span is specified, it _should_ exist in the underlying `Registry`.
-        if let Some(parent) = attrs.parent() {
-            let span = ctx.span(parent).expect("Span not found, this is a bug");
-            let mut extensions = span.extensions_mut();
-            extensions.get_mut::<api::SpanBuilder>().map(build_context)
-        // Else if the span is inferred from context, look up any available current span.
-        } else if attrs.is_contextual() {
-            ctx.current_span().id().and_then(|span_id| {
-                let span = ctx.span(span_id).expect("Span not found, this is a bug");
-                let mut extensions = span.extensions_mut();
-                extensions.get_mut::<api::SpanBuilder>().map(build_context)
-            })
-        // Explicit root spans should have no parent context.
-        } else {
-            None
-        }
-    }
-
     /// Set the [`Tracer`] that this layer will use to produce and track
     /// OpenTelemetry [`Span`]s.
     ///
@@ -136,8 +176,7 @@ where
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use opentelemetry::{api::Provider, global, sdk};
-    /// use tracing_opentelemetry::OpenTelemetryLayer;
+    /// use opentelemetry::{api::Provider, sdk};
     /// use tracing_subscriber::layer::SubscriberExt;
     /// use tracing_subscriber::Registry;
     ///
@@ -163,7 +202,7 @@ where
     /// let tracer = provider.get_tracer("component-name");
     ///
     /// // Create a layer with the configured tracer
-    /// let otel_layer = OpenTelemetryLayer::with_tracer(tracer);
+    /// let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
     ///
     /// // Use the tracing subscriber `Registry`, or any other subscriber
     /// // that impls `LookupSpan`
@@ -171,18 +210,109 @@ where
     ///     .with(otel_layer);
     /// # drop(subscriber);
     /// ```
-    pub fn with_tracer(tracer: T) -> Self {
+    pub fn with_tracer<Tracer>(self, tracer: Tracer) -> OpenTelemetryLayer<S, Tracer>
+    where
+        Tracer: api::Tracer + 'static,
+    {
         OpenTelemetryLayer {
             tracer,
+            sampler: self.sampler,
+            id_generator: self.id_generator,
+            get_context: self.get_context,
+            _registry: self._registry,
+        }
+    }
+
+    /// Set the [`Sampler`] to configure the logic around which [`Span`]s are
+    /// exported.
+    ///
+    /// [`Sampler`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/sampler/trait.Sampler.html
+    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use opentelemetry::sdk;
+    /// use tracing_subscriber::layer::SubscriberExt;
+    /// use tracing_subscriber::Registry;
+    ///
+    /// // The probability sampler can be used to export a percentage of spans
+    /// let sampler = sdk::Sampler::Probability(0.33);
+    ///
+    /// // Create a layer with the configured sampler
+    /// let otel_layer = tracing_opentelemetry::layer().with_sampler(sampler);
+    ///
+    /// // Use the tracing subscriber `Registry`, or any other subscriber
+    /// // that impls `LookupSpan`
+    /// let subscriber = Registry::default()
+    ///     .with(otel_layer);
+    /// # drop(subscriber);
+    /// ```
+    pub fn with_sampler<Sampler>(self, sampler: Sampler) -> Self
+    where
+        Sampler: api::Sampler + 'static,
+    {
+        OpenTelemetryLayer {
+            sampler: Box::new(sampler),
+            ..self
+        }
+    }
+
+    /// Construct a new layer with the specified [`Tracer`] and [`Sampler`].
+    ///
+    /// [`Tracer`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/tracer/trait.Tracer.html
+    /// [`Sampler`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/sampler/trait.Sampler.html
+    fn new<Sampler>(tracer: T, sampler: Sampler) -> Self
+    where
+        Sampler: api::Sampler + 'static,
+    {
+        OpenTelemetryLayer {
+            tracer,
+            sampler: Box::new(sampler),
+            id_generator: sdk::IdGenerator::default(),
             get_context: WithContext(Self::get_context),
             _registry: marker::PhantomData,
+        }
+    }
+
+    /// Retrieve the parent OpenTelemetry [`SpanContext`] from the current
+    /// tracing [`span`] through the [`Registry`]. This [`SpanContext`]
+    /// links spans to their parent for proper hierarchical visualization.
+    ///
+    /// [`SpanContext`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span_context/struct.SpanContext.html
+    /// [`span`]: https://docs.rs/tracing/latest/tracing/struct.Span.html
+    /// [`Registry`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.Registry.html
+    fn parent_span_context(
+        &self,
+        attrs: &Attributes<'_>,
+        ctx: &Context<'_, S>,
+    ) -> Option<api::SpanContext> {
+        // If a span is specified, it _should_ exist in the underlying `Registry`.
+        if let Some(parent) = attrs.parent() {
+            let span = ctx.span(parent).expect("Span not found, this is a bug");
+            let mut extensions = span.extensions_mut();
+            extensions
+                .get_mut::<api::SpanBuilder>()
+                .map(|builder| build_span_context(builder, self.sampler.as_ref()))
+        // Else if the span is inferred from context, look up any available current span.
+        } else if attrs.is_contextual() {
+            ctx.current_span().id().and_then(|span_id| {
+                let span = ctx.span(span_id).expect("Span not found, this is a bug");
+                let mut extensions = span.extensions_mut();
+                extensions
+                    .get_mut::<api::SpanBuilder>()
+                    .map(|builder| build_span_context(builder, self.sampler.as_ref()))
+            })
+        // Explicit root spans should have no parent context.
+        } else {
+            None
         }
     }
 
     fn get_context(
         dispatch: &tracing::Dispatch,
         id: &span::Id,
-        f: &mut dyn FnMut(&mut api::SpanBuilder),
+        f: &mut dyn FnMut(&mut api::SpanBuilder, &dyn api::Sampler),
     ) {
         let subscriber = dispatch
             .downcast_ref::<S>()
@@ -190,10 +320,13 @@ where
         let span = subscriber
             .span(id)
             .expect("registry should have a span for the current ID");
+        let layer = dispatch
+            .downcast_ref::<OpenTelemetryLayer<S, T>>()
+            .expect("layer should downcast to expected type; this is a bug!");
 
         let mut extensions = span.extensions_mut();
         if let Some(builder) = extensions.get_mut::<api::SpanBuilder>() {
-            f(builder);
+            f(builder, layer.sampler.as_ref());
         }
     }
 }
@@ -216,12 +349,12 @@ where
             .span_builder(attrs.metadata().name())
             .with_start_time(SystemTime::now())
             // Eagerly assign span id so children have stable parent id
-            .with_span_id(api::SpanId::from_u64(rand::random()));
-        builder.parent_context = self.parent_context(attrs, &ctx);
+            .with_span_id(self.id_generator.new_span_id());
+        builder.parent_context = self.parent_span_context(attrs, &ctx);
 
         // Ensure trace id exists so children are matched properly.
         if builder.parent_context.is_none() {
-            builder.trace_id = Some(api::TraceId::from_u128(rand::random()));
+            builder.trace_id = Some(self.id_generator.new_trace_id());
         }
 
         attrs.record(&mut SpanAttributeVisitor(&mut builder));

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -14,7 +14,6 @@
 //! ```
 //! use opentelemetry::{api::Provider, sdk};
 //! use tracing::{error, span};
-//! use tracing_opentelemetry::OpenTelemetryLayer;
 //! use tracing_subscriber::layer::SubscriberExt;
 //! use tracing_subscriber::Registry;
 //!
@@ -22,7 +21,7 @@
 //! let tracer = sdk::Provider::default().get_tracer("service_name");
 //!
 //! // Create a new OpenTelemetry tracing layer
-//! let telemetry = OpenTelemetryLayer::with_tracer(tracer);
+//! let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
 //!
 //! let subscriber = Registry::default().with(telemetry);
 //!
@@ -39,8 +38,8 @@
 
 /// Implementation of the trace::Layer as a source of OpenTelemetry data.
 mod layer;
-/// Span extension which enables OpenTelemetry span context management.
+/// Span extension which enables OpenTelemetry context management.
 mod span_ext;
 
-pub use layer::OpenTelemetryLayer;
+pub use layer::{layer, OpenTelemetryLayer};
 pub use span_ext::OpenTelemetrySpanExt;

--- a/tracing-opentelemetry/src/span_ext.rs
+++ b/tracing-opentelemetry/src/span_ext.rs
@@ -1,21 +1,23 @@
-use crate::layer::{build_context, WithContext};
+use crate::layer::{build_span_context, WithContext};
 use opentelemetry::api;
+use opentelemetry::api::TraceContextExt;
 
-/// Utility functions to allow tracing [`Span`]s to accept and return OpenTelemetry
-/// [`SpanContext`]s.
+/// Utility functions to allow tracing [`Span`]s to accept and return
+/// [OpenTelemetry] [`Context`]s.
 ///
 /// [`Span`]: https://docs.rs/tracing/latest/tracing/struct.Span.html
-/// [`SpanContext`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span_context/struct.SpanContext.html
+/// [OpenTelemetry]: https://opentelemetry.io
+/// [`Context`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/context/struct.Context.html
 pub trait OpenTelemetrySpanExt {
     /// Associates `self` with a given OpenTelemetry trace, using the provided
-    /// parent [`SpanContext`].
+    /// parent [`Context`].
     ///
-    /// [`SpanContext`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span_context/struct.SpanContext.html
+    /// [`Context`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/context/struct.Context.html
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use opentelemetry::api::{self, HttpTextFormat};
+    /// use opentelemetry::api::{self, HttpTextFormat, TraceContextExt};
     /// use tracing_opentelemetry::OpenTelemetrySpanExt;
     /// use std::collections::HashMap;
     /// use tracing::Span;
@@ -26,23 +28,23 @@ pub trait OpenTelemetrySpanExt {
     /// // Propagator can be swapped with trace context propagator binary propagator, etc.
     /// let propagator = api::B3Propagator::new(true);
     ///
-    /// // Extract otel parent span context via the chosen propagator
+    /// // Extract otel parent context via the chosen propagator
     /// let parent_context = propagator.extract(&carrier);
     ///
     /// // Generate a tracing span as usual
     /// let app_root = tracing::span!(tracing::Level::INFO, "app_start");
     ///
     /// // Assign parent trace from external context
-    /// app_root.set_parent(parent_context);
+    /// app_root.set_parent(&parent_context);
     ///
     /// // Or if the current span has been created elsewhere:
-    /// Span::current().set_parent(propagator.extract(&carrier));
+    /// Span::current().set_parent(&parent_context);
     /// ```
-    fn set_parent(&self, span_context: api::SpanContext);
+    fn set_parent(&self, span_context: &api::Context);
 
-    /// Extracts an OpenTelemetry [`SpanContext`] from `self`.
+    /// Extracts an OpenTelemetry [`Context`] from `self`.
     ///
-    /// [`SpanContext`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span_context/struct.SpanContext.html
+    /// [`Context`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/context/struct.Context.html
     ///
     /// # Examples
     ///
@@ -51,47 +53,95 @@ pub trait OpenTelemetrySpanExt {
     /// use tracing_opentelemetry::OpenTelemetrySpanExt;
     /// use tracing::Span;
     ///
-    /// fn make_request(span_context: api::SpanContext) {
+    /// fn make_request(cx: api::Context) {
     ///     // perform external request after injecting context
     ///     // e.g. if there are request headers that impl `opentelemetry::api::Carrier`
-    ///     // then `propagator.inject(span_context, request.headers_mut())`
+    ///     // then `propagator.inject_context(cx, request.headers_mut())`
     /// }
     ///
     /// // Generate a tracing span as usual
     /// let app_root = tracing::span!(tracing::Level::INFO, "app_start");
     ///
-    /// // To include tracing span context in client requests from _this_ app,
-    /// // extract the current OpenTelemetry span context.
+    /// // To include tracing context in client requests from _this_ app,
+    /// // extract the current OpenTelemetry context.
     /// make_request(app_root.context());
     ///
     /// // Or if the current span has been created elsewhere:
     /// make_request(Span::current().context())
     /// ```
-    fn context(&self) -> api::SpanContext;
+    fn context(&self) -> api::Context;
 }
 
 impl OpenTelemetrySpanExt for tracing::Span {
-    fn set_parent(&self, parent_context: api::SpanContext) {
+    fn set_parent(&self, parent_context: &api::Context) {
         self.with_subscriber(move |(id, subscriber)| {
-            let mut parent_context = Some(parent_context);
             if let Some(get_context) = subscriber.downcast_ref::<WithContext>() {
-                get_context.with_context(subscriber, id, move |builder| {
-                    builder.parent_context = parent_context.take()
+                get_context.with_context(subscriber, id, move |builder, _sampler| {
+                    builder.parent_context = parent_context.remote_span_context().cloned()
                 });
             }
         });
     }
 
-    fn context(&self) -> api::SpanContext {
+    fn context(&self) -> api::Context {
         let mut span_context = None;
         self.with_subscriber(|(id, subscriber)| {
             if let Some(get_context) = subscriber.downcast_ref::<WithContext>() {
-                get_context.with_context(subscriber, id, |builder| {
-                    span_context = Some(build_context(builder));
+                get_context.with_context(subscriber, id, |builder, sampler| {
+                    span_context = Some(build_span_context(builder, sampler));
                 })
             }
         });
 
-        span_context.unwrap_or_else(api::SpanContext::empty_context)
+        let compat_span = CompatSpan(span_context.unwrap_or_else(api::SpanContext::empty_context));
+        api::Context::current_with_span(compat_span)
+    }
+}
+
+/// A compatibility wrapper for an injectable OpenTelemetry span context.
+#[derive(Debug)]
+struct CompatSpan(api::SpanContext);
+impl api::Span for CompatSpan {
+    fn add_event_with_timestamp(
+        &self,
+        _name: String,
+        _timestamp: std::time::SystemTime,
+        _attributes: Vec<api::KeyValue>,
+    ) {
+        // OpenTelemetry and tracing APIs cannot be mixed, use `tracing::event!`
+        // macro instead.
+    }
+
+    /// This method is used by OpenTelemetry propagators to inject span context
+    /// information into [`Carrier`]s.
+    ///
+    /// [`Carrier`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/context/propagation/trait.Carrier.html
+    fn span_context(&self) -> api::SpanContext {
+        self.0.clone()
+    }
+
+    fn is_recording(&self) -> bool {
+        // cannot record via OpenTelemetry API when using extracted span in tracing
+        false
+    }
+
+    fn set_attribute(&self, _attribute: api::KeyValue) {
+        // OpenTelemetry and tracing APIs cannot be mixed, use `tracing::span!`
+        // macro or `span.record()` instead.
+    }
+
+    fn set_status(&self, _code: api::StatusCode, _message: String) {
+        // OpenTelemetry and tracing apis cannot be mixed, use `tracing::span!`
+        // macro or `span.record()` instead.
+    }
+
+    fn update_name(&self, _new_name: String) {
+        // OpenTelemetry and tracing APIs cannot be mixed, span names are not
+        // mutable.
+    }
+
+    fn end(&self) {
+        // OpenTelemetry and tracing APIs cannot be mixed, span end times are set
+        // when the underlying tracing span closes.
     }
 }

--- a/tracing-opentelemetry/src/span_ext.rs
+++ b/tracing-opentelemetry/src/span_ext.rs
@@ -108,8 +108,10 @@ impl api::Span for CompatSpan {
         _timestamp: std::time::SystemTime,
         _attributes: Vec<api::KeyValue>,
     ) {
-        // OpenTelemetry and tracing APIs cannot be mixed, use `tracing::event!`
-        // macro instead.
+        debug_assert!(
+            false,
+            "OpenTelemetry and tracing APIs cannot be mixed, use `tracing::event!` macro instead."
+        );
     }
 
     /// This method is used by OpenTelemetry propagators to inject span context
@@ -121,27 +123,39 @@ impl api::Span for CompatSpan {
     }
 
     fn is_recording(&self) -> bool {
-        // cannot record via OpenTelemetry API when using extracted span in tracing
+        debug_assert!(
+            false,
+            "cannot record via OpenTelemetry API when using extracted span in tracing"
+        );
+
         false
     }
 
     fn set_attribute(&self, _attribute: api::KeyValue) {
-        // OpenTelemetry and tracing APIs cannot be mixed, use `tracing::span!`
-        // macro or `span.record()` instead.
+        debug_assert!(
+            false,
+            "OpenTelemetry and tracing APIs cannot be mixed, use `tracing::span!` macro or `span.record()` instead."
+        );
     }
 
     fn set_status(&self, _code: api::StatusCode, _message: String) {
-        // OpenTelemetry and tracing apis cannot be mixed, use `tracing::span!`
-        // macro or `span.record()` instead.
+        debug_assert!(
+            false,
+            "OpenTelemetry and tracing APIs cannot be mixed, use `tracing::span!` macro or `span.record()` instead."
+        );
     }
 
     fn update_name(&self, _new_name: String) {
-        // OpenTelemetry and tracing APIs cannot be mixed, span names are not
-        // mutable.
+        debug_assert!(
+            false,
+            "OpenTelemetry and tracing APIs cannot be mixed, span names are not  mutable."
+        );
     }
 
     fn end(&self) {
-        // OpenTelemetry and tracing APIs cannot be mixed, span end times are set
-        // when the underlying tracing span closes.
+        debug_assert!(
+            false,
+            "OpenTelemetry and tracing APIs cannot be mixed, span end times are set when the underlying tracing span closes."
+        );
     }
 }

--- a/tracing-opentelemetry/src/span_ext.rs
+++ b/tracing-opentelemetry/src/span_ext.rs
@@ -108,8 +108,8 @@ impl api::Span for CompatSpan {
         _timestamp: std::time::SystemTime,
         _attributes: Vec<api::KeyValue>,
     ) {
-        debug_assert!(
-            false,
+        #[cfg(debug_assertions)]
+        panic!(
             "OpenTelemetry and tracing APIs cannot be mixed, use `tracing::event!` macro instead."
         );
     }
@@ -123,39 +123,30 @@ impl api::Span for CompatSpan {
     }
 
     fn is_recording(&self) -> bool {
-        debug_assert!(
-            false,
-            "cannot record via OpenTelemetry API when using extracted span in tracing"
-        );
+        #[cfg(debug_assertions)]
+        panic!("cannot record via OpenTelemetry API when using extracted span in tracing");
 
+        #[cfg(not(debug_assertions))]
         false
     }
 
     fn set_attribute(&self, _attribute: api::KeyValue) {
-        debug_assert!(
-            false,
-            "OpenTelemetry and tracing APIs cannot be mixed, use `tracing::span!` macro or `span.record()` instead."
-        );
+        #[cfg(debug_assertions)]
+        panic!("OpenTelemetry and tracing APIs cannot be mixed, use `tracing::span!` macro or `span.record()` instead.");
     }
 
     fn set_status(&self, _code: api::StatusCode, _message: String) {
-        debug_assert!(
-            false,
-            "OpenTelemetry and tracing APIs cannot be mixed, use `tracing::span!` macro or `span.record()` instead."
-        );
+        #[cfg(debug_assertions)]
+        panic!("OpenTelemetry and tracing APIs cannot be mixed, use `tracing::span!` macro or `span.record()` instead.");
     }
 
     fn update_name(&self, _new_name: String) {
-        debug_assert!(
-            false,
-            "OpenTelemetry and tracing APIs cannot be mixed, span names are not  mutable."
-        );
+        #[cfg(debug_assertions)]
+        panic!("OpenTelemetry and tracing APIs cannot be mixed, span names are not mutable.");
     }
 
     fn end(&self) {
-        debug_assert!(
-            false,
-            "OpenTelemetry and tracing APIs cannot be mixed, span end times are set when the underlying tracing span closes."
-        );
+        #[cfg(debug_assertions)]
+        panic!("OpenTelemetry and tracing APIs cannot be mixed, span end times are set when the underlying tracing span closes.");
     }
 }


### PR DESCRIPTION
## Motivation 

The [OpenTelemetry Propagation Spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md) has been changed from operating primarily on `SpanContext`s to a more generic `Context` struct which is a propagation mechanism that carries execution-scoped values across API boundaries and between logically associated execution units.

## Breaking Changes

The following APIs are updated to facilitate this change:

* OpenTelemetrySpanExt's `set_parent` now accepts a reference to an  extracted parent context.
* OpenTelemetrySpanExt's `context` now returns a context.

Additionally the need to sample spans before their context can be injected into `Carrier`s necessitates that a `Sampler` is stored in the `OpenTelemetryLayer`. Accordingly:

* `OpenTelemetryLayer::with_tracer(tracer)` has been removed in favor of `tracing_opentelemetry::layer().with_tracer(tracer).with_sampler(sampler)`