### PR TITLE
attributes: prepare to release v0.1.8

### DIFF
--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.1.8 (May 13, 2020)
+
+### Added
+
+- Support for using `#[instrument]` on methods that are part of [`async-trait`]
+  trait implementations (#711)
+- Optional `#[instrument(err)]` argument to automatically emit an event if an
+  instrumented function returns `Err` (#637) 
+
+Thanks to @ilana and @nightmared for contributing to this release!
+
+[`async-trait`]: https://crates.io/crates/async-trait
+
 # 0.1.7 (February 26, 2020)
 
 ### Added

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-attributes"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.7"
+version = "0.1.8"
 authors = [
     "Tokio Contributors <team@tokio.rs>",
     "Eliza Weisman <eliza@buoyant.io>",

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -14,7 +14,7 @@ Macro attributes for application-level tracing.
 [crates-badge]: https://img.shields.io/crates/v/tracing-attributes.svg
 [crates-url]: https://crates.io/crates/tracing-attributes
 [docs-badge]: https://docs.rs/tracing-attributes/badge.svg
-[docs-url]: https://docs.rs/tracing-attributes/0.1.7
+[docs-url]: https://docs.rs/tracing-attributes/0.1.8
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_attributes
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -39,7 +39,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing-attributes = "0.1.7"
+tracing-attributes = "0.1.8"
 ```
 
 *Compiler support: requires rustc 1.39+*
@@ -58,7 +58,7 @@ pub fn my_function(my_arg: usize) {
 
 
 [`tracing`]: https://crates.io/crates/tracing
-[span]: https://docs.rs/tracing/0.1.7/tracing/span/index.html
+[span]: https://docs.rs/tracing/0.1.8/tracing/span/index.html
 
 ## License
 

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tracing-attributes = "0.1.7"
+//! tracing-attributes = "0.1.8"
 //! ```
 //!
 //! *Compiler support: requires rustc 1.39+*
@@ -35,7 +35,7 @@
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 //! [instrument]: attr.instrument.html
-#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.7")]
+#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.8")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
## 0.1.8 (May 13, 2020)

### Added:

- Support for using `#[instrument]` on methods that are part of
  [`async-trait`] trait implementations (#711)
- Optional `#[instrument(err)]` argument to automatically emit an event
  if an instrumented function returns `Err` (#637)

Thanks to @ilana and @nightmared for contributing to this release!

[`async-trait`]: https://crates.io/crates/async-trait

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
