### PR TITLE
Add a prelude

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -825,6 +825,8 @@ pub mod span;
 pub(crate) mod stdlib;
 pub mod subscriber;
 
+pub mod prelude;
+
 #[doc(hidden)]
 pub mod __macro_support {
     pub use crate::stdlib::sync::atomic::{AtomicUsize, Ordering};

--- a/tracing/src/prelude.rs
+++ b/tracing/src/prelude.rs
@@ -1,0 +1,14 @@
+//! The `tracing` prelude.
+//!
+//! This brings into scope the most commonly used `tracing` macros and structs.
+//! You'll almost always want to import the prelude's entire contents:
+//!
+//! ```
+//! # #![allow(warnings)]
+//! use tracing::prelude::*;
+//! ```
+
+pub use crate::{
+    debug, debug_span, error, error_span, event, info, info_span, span, trace, trace_span, warn,
+    warn_span, Level,
+};


### PR DESCRIPTION
## Motivation

A prelude will make it a tiny bit easier to use `tracing`. Having the right elements in scope reduces friction and avoids churn in the using section.

## Solution

Add a prelude (from https://github.com/tokio-rs/tracing/issues/167).

## Design

This PR takes a minimalist approach: only the bare minimum of `span!`, `event!`, level specific equivalents, and the `Level` type are included. TBD on design questions in #167.