### PR TITLE
Replace local_inner_macros with $crate

### DIFF
--- a/tracing-core/src/lazy_static/mod.rs
+++ b/tracing-core/src/lazy_static/mod.rs
@@ -19,15 +19,15 @@ pub(crate) mod lazy;
 #[doc(hidden)]
 pub(crate) use core::ops::Deref as __Deref;
 
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 macro_rules! __lazy_static_internal {
     // optional visibility restrictions are wrapped in `()` to allow for
     // explicitly passing otherwise implicit information about private items
     ($(#[$attr:meta])* ($($vis:tt)*) static ref $N:ident : $T:ty = $e:expr; $($t:tt)*) => {
-        __lazy_static_internal!(@MAKE TY, $(#[$attr])*, ($($vis)*), $N);
-        __lazy_static_internal!(@TAIL, $N : $T = $e);
-        lazy_static!($($t)*);
+        $crate::__lazy_static_internal!(@MAKE TY, $(#[$attr])*, ($($vis)*), $N);
+        $crate::__lazy_static_internal!(@TAIL, $N : $T = $e);
+        $crate::lazy_static!($($t)*);
     };
     (@TAIL, $N:ident : $T:ty = $e:expr) => {
         impl $crate::lazy_static::__Deref for $N {
@@ -38,7 +38,7 @@ macro_rules! __lazy_static_internal {
 
                 #[inline(always)]
                 fn __stability() -> &'static $T {
-                    __lazy_static_create!(LAZY, $T);
+                    $crate::__lazy_static_create!(LAZY, $T);
                     LAZY.get(__static_ref_initialize)
                 }
                 __stability()
@@ -63,18 +63,18 @@ macro_rules! __lazy_static_internal {
     () => ()
 }
 
-#[macro_export(local_inner_macros)]
-/// lazy_static (suppress docs_missing warning)
+#[macro_export]
+#[doc(hidden)]
 macro_rules! lazy_static {
     ($(#[$attr:meta])* static ref $N:ident : $T:ty = $e:expr; $($t:tt)*) => {
         // use `()` to explicitly forward the information about private items
-        __lazy_static_internal!($(#[$attr])* () static ref $N : $T = $e; $($t)*);
+        $crate::__lazy_static_internal!($(#[$attr])* () static ref $N : $T = $e; $($t)*);
     };
     ($(#[$attr:meta])* pub static ref $N:ident : $T:ty = $e:expr; $($t:tt)*) => {
-        __lazy_static_internal!($(#[$attr])* (pub) static ref $N : $T = $e; $($t)*);
+        $crate::__lazy_static_internal!($(#[$attr])* (pub) static ref $N : $T = $e; $($t)*);
     };
     ($(#[$attr:meta])* pub ($($vis:tt)+) static ref $N:ident : $T:ty = $e:expr; $($t:tt)*) => {
-        __lazy_static_internal!($(#[$attr])* (pub ($($vis)+)) static ref $N : $T = $e; $($t)*);
+        $crate::__lazy_static_internal!($(#[$attr])* (pub ($($vis)+)) static ref $N : $T = $e; $($t)*);
     };
     () => ()
 }

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -177,7 +177,7 @@ macro_rules! metadata {
         callsite: $callsite:expr,
         kind: $kind:expr
     ) => {
-        metadata! {
+        $crate::metadata! {
             name: $name,
             target: $target,
             level: $level,

--- a/tracing-macros/examples/factorial.rs
+++ b/tracing-macros/examples/factorial.rs
@@ -1,10 +1,7 @@
 //! Compare to the example given in the documentation for the `std::dbg` macro.
 #![deny(rust_2018_idioms)]
 
-#[macro_use]
-extern crate tracing;
-#[macro_use]
-extern crate tracing_macros;
+use tracing_macros::dbg;
 
 fn factorial(n: u32) -> u32 {
     if dbg!(n <= 1) {

--- a/tracing-macros/src/lib.rs
+++ b/tracing-macros/src/lib.rs
@@ -1,19 +1,17 @@
-extern crate tracing;
-
 /// Alias of `dbg!` for avoiding conflicts with the `std::dbg!` macro.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! trace_dbg {
     (target: $target:expr, level: $level:expr, $ex:expr) => {
-        dbg!(target: $target, level: $level, $ex)
+        $crate::dbg!(target: $target, level: $level, $ex)
     };
     (level: $level:expr, $ex:expr) => {
-        dbg!(target: module_path!(), level: $level, $ex)
+        $crate::dbg!(target: module_path!(), level: $level, $ex)
     };
     (target: $target:expr, $ex:expr) => {
-        dbg!(target: $target, level: tracing::Level::DEBUG, $ex)
+        $crate::dbg!(target: $target, level: tracing::Level::DEBUG, $ex)
     };
     ($ex:expr) => {
-        dbg!(level: tracing::Level::DEBUG, $ex)
+        $crate::dbg!(level: tracing::Level::DEBUG, $ex)
     };
 }
 
@@ -31,7 +29,7 @@ macro_rules! dbg {
             field::{debug, Value},
             Event, Id, Subscriber,
         };
-        let callsite = callsite! {
+        let callsite = tracing::callsite! {
             name: concat!("event:trace_dbg(", stringify!($ex), ")"),
             kind: tracing::metadata::Kind::EVENT,
             target: $target,
@@ -39,7 +37,7 @@ macro_rules! dbg {
             fields: value,
         };
         let val = $ex;
-        if is_enabled!(callsite) {
+        if tracing::is_enabled!(callsite) {
             let meta = callsite.metadata();
             let fields = meta.fields();
             let key = meta
@@ -55,12 +53,12 @@ macro_rules! dbg {
         val
     }};
     (level: $level:expr, $ex:expr) => {
-        dbg!(target: module_path!(), level: $level, $ex)
+        $crate::dbg!(target: module_path!(), level: $level, $ex)
     };
     (target: $target:expr, $ex:expr) => {
-        dbg!(target: $target, level: tracing::Level::DEBUG, $ex)
+        $crate::dbg!(target: $target, level: tracing::Level::DEBUG, $ex)
     };
     ($ex:expr) => {
-        dbg!(level: tracing::Level::DEBUG, $ex)
+        $crate::dbg!(level: tracing::Level::DEBUG, $ex)
     };
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

If it doesn't support pre-1.30 compilers, it's preferable to use `$crate` (it's more simple and powerful): https://doc.rust-lang.org/edition-guide/rust-2018/macros/macro-changes.html#macros-with-crate-prefix
