### PR TITLE
[Documentation] Clarify `record` behaviour for new fields

### DIFF
--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -680,8 +680,7 @@ impl Span {
     /// }
     /// ```
     ///
-    /// Beware though!
-    /// The fields associated with a span are part of its [`Metadata`].
+    /// **Note**: The fields associated with a span are part of its [`Metadata`].
     /// The [`Metadata`] describing a particular span is constructed statically when the span is
     /// created and cannot be extended later to add new fields.
     /// Therefore, you cannot record a value for a field that was not specified when the span

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -698,6 +698,11 @@ impl Span {
     /// // declared as `Empty` or populated when you created `span`.
     /// // You won't get any error, but the assignment will have no effect!
     /// span.record("new_field", &"interesting_value_you_really_need");
+    ///
+    /// // Instead, all fields that may be recorded after span creation should be declared up front,
+    /// // using field::Empty when a value is not known, as we did for `parting`.
+    /// // This `record` call will indeed replace field::Empty with "you will be remembered".
+    /// span.record("parting", &"you will be remembered");
     /// ```
     /// [`field::Empty`]: ../field/struct.Empty.html
     /// [`Metadata`]: ../struct.Metadata.html

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -684,8 +684,8 @@ impl Span {
     /// The fields associated with a span are part of its [`Metadata`].
     /// The [`Metadata`] describing a particular span is constructed statically when the span is
     /// created and cannot be extended later to add new fields.
-    /// Hence you cannot record a value for a field that was not specified at the moment
-    /// of span creation:
+    /// Therefore, you cannot record a value for a field that was not specified when the span
+    /// was created:
     /// ```
     /// use tracing::{trace_span, field};
     ///

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -679,7 +679,29 @@ impl Span {
     ///     }
     /// }
     /// ```
+    ///
+    /// Beware though!
+    /// The fields associated with a span are part of its [`Metadata`].
+    /// The [`Metadata`] describing a particular span is constructed statically when the span is
+    /// created and cannot be extended later to add new fields.
+    /// Hence you cannot record a value for a field that was not specified at the moment
+    /// of span creation:
+    /// ```
+    /// use tracing::{trace_span, field};
+    ///
+    /// // Create a span with two fields: `greeting`, with the value "hello world", and
+    /// // `parting`, without a value.
+    /// let span = trace_span!("my_span", greeting = "hello world", parting = field::Empty);
+    ///
+    /// // ...
+    ///
+    /// // Now, you try to record a value for a new field, `new_field`, which was not
+    /// // declared as `Empty` or populated when you created `span`.
+    /// // You won't get any error, but the assignment will have no effect!
+    /// span.record("new_field", &"interesting_value_you_really_need");
+    /// ```
     /// [`field::Empty`]: ../field/struct.Empty.html
+    /// [`Metadata`]: ../struct.Metadata.html
     pub fn record<Q: ?Sized, V>(&self, field: &Q, value: &V) -> &Self
     where
         Q: field::AsField,


### PR DESCRIPTION
## Motivation

When working with `tracing` I was caught by surprise when trying to record a new field on a span to later find out that the field was completely ignored.

## Solution

Add a more explicit reference to this behaviour in the documentation of `Span::record` as well as an example. 