### PR TITLE
opentelemetry: Add dynamic span name field

### DIFF
--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -41,10 +41,6 @@
 //!     let root = span!(tracing::Level::TRACE, "app_start", work_units = 2);
 //!     let _enter = root.enter();
 //!
-//!     // Optionally set a dynamic span name for otel to export
-//!     let operation = "GET http://example.com".to_string();
-//!     span!(tracing::Level::TRACE, "http_request", otel.name=operation.as_str());
-//!
 //!     error!("This event will be logged in the root span.");
 //! });
 //! ```

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -30,6 +30,10 @@
 //!     let root = span!(tracing::Level::TRACE, "app_start", work_units = 2);
 //!     let _enter = root.enter();
 //!
+//!     // Optionally set a dynamic span name for otel to export
+//!     let operation = "GET http://example.com".to_string();
+//!     span!(tracing::Level::TRACE, "http_request", otel.name=operation.as_str());
+//!
 //!     error!("This event will be logged in the root span.");
 //! });
 //! ```

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -9,6 +9,15 @@
 //! [OpenTelemetry]: https://opentelemetry.io
 //! [`tracing`]: https://github.com/tokio-rs/tracing
 //!
+//! ### Special Fields
+//!
+//! These fields have specific meaning for `tracing-opentelemetry` and will be
+//! treated as ordinary fields by other layers:
+//!
+//! * `otel.name`: Override the span name sent to OpenTelemetry exporters.
+//! Setting this field is useful if you want to display non-static information
+//! in your span name.
+//!
 //! ## Examples
 //!
 //! ```

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -11,8 +11,9 @@
 //!
 //! ### Special Fields
 //!
-//! These fields have specific meaning for `tracing-opentelemetry` and will be
-//! treated as ordinary fields by other layers:
+//! Fields with an `otel.` prefix are reserved for this crate and have specific
+//! meaning. They are treated as ordinary fields by other layers. The current
+//! special fields are:
 //!
 //! * `otel.name`: Override the span name sent to OpenTelemetry exporters.
 //! Setting this field is useful if you want to display non-static information
@@ -36,6 +37,7 @@
 //!
 //! // Trace executed code
 //! tracing::subscriber::with_default(subscriber, || {
+//!     // Spans will be sent to the configured OpenTelemetry exporter
 //!     let root = span!(tracing::Level::TRACE, "app_start", work_units = 2);
 //!     let _enter = root.enter();
 //!


### PR DESCRIPTION
## Motivation

The OpenTelemetry [spec for HTTP server request](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md#http-server-semantic-conventions) span names states that:

> Given an inbound request for a route (e.g. "/users/:userID?") the name
> attribute of the span SHOULD be set to this route. If the route does not
> include the application root, it SHOULD be prepended to the span name.

However, `tracing` span names must be `'static`, so it is currently not always possible to add this dynamic information.

## Solution

This patch adds support for setting OpenTelemetry span names by specifying a field named `otel.name` for a given span.

Resolves #720