### PR TITLE
opentelemetry: support `tracing-log` special values

### DIFF
--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -18,12 +18,16 @@ keywords = ["tracing", "opentelemetry", "jaeger", "zipkin", "async"]
 license = "MIT"
 edition = "2018"
 
+[features]
+default = ["tracing-log"]
+
 [dependencies]
 opentelemetry = { version = "0.5", default-features = false, features = ["trace"] }
 rand = "0.7"
 tracing = { path = "../tracing", version = "0.1" }
 tracing-core = { path = "../tracing-core", version = "0.1" }
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.2", default-features = false, features = ["registry"] }
+tracing-log = { path = "../tracing-log", version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
 opentelemetry-jaeger = "0.4"


### PR DESCRIPTION
## Motivation

Currently, when converting `log::Record`s to `tracing::Event`s using `tracing-log`, data from `log`'s metadata is converted to special fields prefixed with `log.`, rather than being recorded as `tracing` metadata. In order to properly display this data from `log`, the `tracing-log` crate provides the [`NormalizeMetadata` trait](https://docs.rs/tracing-log/0.1.1/tracing_log/trait.NormalizeEvent.html). `tracing-opentelemetry` does not currently use this, however, and location data from `log` events is treated as a regular field rather than a source code location in OpenTelemetry logs.

## Solution

Update `tracing-opentelemetry`'s `on_event` implementation to format recorded logs similarly to how `tracing-subscriber::fmt` does. Event metadata is normalized and intermediate `log.` prefixed values are properly ignored. This is flagged under a new `tracing-log` feature that is enabled by default but allows for opting-out.

Fixes #733 