### PR TITLE
Fix races in tracing-appender unit tests

### DIFF
--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -355,7 +355,9 @@ mod test {
         write_non_blocking(&mut non_blocking, b"Hello");
         assert_eq!(0, error_count.load(Ordering::Acquire));
 
-        // Second write will not block as Worker will have called `recv` on channel. "Hello" not yet consumed. MockWriter call to write_all will block until "Hello" is consumed.
+        // Second write will not block as Worker will have called `recv` on channel.
+        // "Hello" is not yet consumed. MockWriter call to write_all will block until
+        // "Hello" is consumed.
         write_non_blocking(&mut non_blocking, b", World");
         assert_eq!(0, error_count.load(Ordering::Acquire));
 
@@ -363,7 +365,8 @@ mod test {
         write_non_blocking(&mut non_blocking, b"Test");
         assert_eq!(0, error_count.load(Ordering::Acquire));
 
-        // Allow a line to be written. "Hello" message will be consumed. ", World" will be able to write to MockWriter.
+        // Allow a line to be written. "Hello" message will be consumed.
+        // ", World" will be able to write to MockWriter.
         // "Test" will block on call to MockWriter's `write_all`
         let line = rx.recv().unwrap();
         assert_eq!(line, "Hello");


### PR DESCRIPTION
I was able to reproduce the failures for `logs_dropped_if_lossy` on my machine when usnig loom.

Realized that the Worker calls `recv` and the only time we actually will increment the error_counter is when we have a write blocking on the call to `write_all` (called by the worker) and a messege buffered in NonBlocking crossbeam sender.

I added some sleeps after writes to avoid some races I saw.

For `multi_threaded_writes`, what likely is happening is that sometimes the last thread hasn't had a chance write to the queue, hence we now use recv_timeout instead of try_recv, to ensure  there's more than enough time for the a message to be visible in the channel.