### PR TITLE
opentelemetry: Fix crate url metadata

### DIFF
--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -6,8 +6,8 @@ authors = [
     "Tokio Contributors <team@tokio.rs>"
 ]
 description = "OpenTelemetry integration for tracing"
-homepage = "https://github.com/tokio-rs/tracing/tracing-opentelemetry"
-repository = "https://github.com/tokio-rs/tracing/tracing-opentelemetry"
+homepage = "https://github.com/tokio-rs/tracing/tree/master/tracing-opentelemetry"
+repository = "https://github.com/tokio-rs/tracing/tree/master/tracing-opentelemetry"
 readme = "README.md"
 categories = [
     "development-tools::debugging",

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 description = "OpenTelemetry integration for tracing"
 homepage = "https://github.com/tokio-rs/tracing/tree/master/tracing-opentelemetry"
-repository = "https://github.com/tokio-rs/tracing/tree/master/tracing-opentelemetry"
+repository = "https://github.com/tokio-rs/tracing"
 readme = "README.md"
 categories = [
     "development-tools::debugging",


### PR DESCRIPTION
Fix broken `homepage` and `repository` links.