### PR TITLE
subscriber: add nested spans in json formatter

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -352,30 +352,30 @@ impl<S, T, W> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
         }
     }
 
-    /// Sets the JSON layer being built to not contain the current span.
+    /// Sets whether or not the JSON layer being built will include the current span in the `span` field.
     ///
     /// See [`format::Json`](../fmt/format/struct.Json.html)
-    pub fn disable_current_span(
+    pub fn with_current_span(
         self,
-        disable_current_span: bool,
+        display_current_span: bool,
     ) -> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
         Layer {
-            fmt_event: self.fmt_event.disable_current_span(disable_current_span),
+            fmt_event: self.fmt_event.with_current_span(display_current_span),
             fmt_fields: format::JsonFields::new(),
             make_writer: self.make_writer,
             _inner: self._inner,
         }
     }
 
-    /// Sets the JSON layer being built to not contain the span list.
+    /// Sets whether or not the JSON layer being built will include a span list in the `spans` field.
     ///
     /// See [`format::Json`](../fmt/format/struct.Json.html)
-    pub fn disable_span_list(
+    pub fn with_span_list(
         self,
-        disable_span_list: bool,
+        display_span_list: bool,
     ) -> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
         Layer {
-            fmt_event: self.fmt_event.disable_span_list(disable_span_list),
+            fmt_event: self.fmt_event.with_span_list(display_span_list),
             fmt_fields: format::JsonFields::new(),
             make_writer: self.make_writer,
             _inner: self._inner,

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -363,6 +363,7 @@ impl<S, T, W> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
         Layer {
             fmt_event: self.fmt_event.with_current_span(display_current_span),
             fmt_fields: format::JsonFields::new(),
+            fmt_span: self.fmt_span,
             make_writer: self.make_writer,
             _inner: self._inner,
         }
@@ -379,6 +380,7 @@ impl<S, T, W> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
         Layer {
             fmt_event: self.fmt_event.with_span_list(display_span_list),
             fmt_fields: format::JsonFields::new(),
+            fmt_span: self.fmt_span,
             make_writer: self.make_writer,
             _inner: self._inner,
         }

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -368,8 +368,8 @@ impl<S, T, W> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
         }
     }
 
-    /// Sets whether or not the formatter will include a list of all currently
-    /// entered spans in formatted events.
+    /// Sets whether or not the formatter will include a list (from root to leaf)
+    /// of all currently entered spans in formatted events.
     ///
     /// See [`format::Json`](../fmt/format/struct.Json.html)
     pub fn with_span_list(

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -351,6 +351,36 @@ impl<S, T, W> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
             _inner: self._inner,
         }
     }
+
+    /// Sets the JSON layer being built to not contain the current span.
+    ///
+    /// See [`format::Json`](../fmt/format/struct.Json.html)
+    pub fn disable_current_span(
+        self,
+        disable_current_span: bool,
+    ) -> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
+        Layer {
+            fmt_event: self.fmt_event.disable_current_span(disable_current_span),
+            fmt_fields: format::JsonFields::new(),
+            make_writer: self.make_writer,
+            _inner: self._inner,
+        }
+    }
+
+    /// Sets the JSON layer being built to not contain the span list.
+    ///
+    /// See [`format::Json`](../fmt/format/struct.Json.html)
+    pub fn disable_span_list(
+        self,
+        disable_span_list: bool,
+    ) -> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
+        Layer {
+            fmt_event: self.fmt_event.disable_span_list(disable_span_list),
+            fmt_fields: format::JsonFields::new(),
+            make_writer: self.make_writer,
+            _inner: self._inner,
+        }
+    }
 }
 
 impl<S, N, E, W> Layer<S, N, E, W> {

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -352,7 +352,8 @@ impl<S, T, W> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
         }
     }
 
-    /// Sets whether or not the JSON layer being built will include the current span in the `span` field.
+    /// Sets whether or not the formatter will include the current span in
+    /// formatted events.
     ///
     /// See [`format::Json`](../fmt/format/struct.Json.html)
     pub fn with_current_span(
@@ -367,7 +368,8 @@ impl<S, T, W> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
         }
     }
 
-    /// Sets whether or not the JSON layer being built will include a span list in the `spans` field.
+    /// Sets whether or not the formatter will include a list of all currently
+    /// entered spans in formatted events.
     ///
     /// See [`format::Json`](../fmt/format/struct.Json.html)
     pub fn with_span_list(

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -46,7 +46,7 @@ use tracing_log::NormalizeEvent;
 /// span
 /// - [`Json::with_span_list`] can be used to control logging of the span list
 /// object.
-/// 
+///
 /// By default, event fields are not flattened, and both current span and span
 /// list are logged.
 ///

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -54,7 +54,6 @@ impl Json {
         self.flatten_event = flatten_event;
     }
 
-    
     /// If set to `false`, formatted events won't contain a field for the current span.
     pub fn with_current_span(&mut self, display_current_span: bool) {
         self.display_current_span = display_current_span;

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -28,15 +28,27 @@ use tracing_log::NormalizeEvent;
 /// # Example Output
 ///
 /// ```ignore,json
-/// {"timestamp":"Feb 20 11:28:15.096","level":"INFO","target":"mycrate","fields":{"message":"some message", "key": "value"}}
+/// {
+///     "timestamp":"Feb 20 11:28:15.096",
+///     "level":"INFO",
+///     "spans":[{"name":"root"},{"name":"leaf"}],
+///     "span":{name":"leaf"},
+///     "target":"mycrate",
+///     "fields":{"message":"some message","key":"value"}
+/// }
 /// ```
 ///
 /// # Options
 ///
-/// - [`Json::flatten_event`] can be used to enable flattening event fields into the root
-/// - [`Json::with_current_span`] can be used to control logging of the current span
+/// - [`Json::flatten_event`] can be used to enable flattening event fields into
+/// the root
+/// - [`Json::with_current_span`] can be used to control logging of the current
+/// span
 /// - [`Json::with_span_list`] can be used to control logging of the span list
 /// object.
+/// 
+/// By default, event fields are not flattened, and both current span and span
+/// list are logged.
 ///
 /// [`Json::flatten_event`]: #method.flatten_event
 /// [`Json::with_current_span`]: #method.with_current_span
@@ -59,7 +71,8 @@ impl Json {
         self.display_current_span = display_current_span;
     }
 
-    /// If set to `false`, formatted events won't contain a list of all currently entered spans.
+    /// If set to `false`, formatted events won't contain a list of all currently
+    /// entered spans. Spans are logged in a list from root to leaf.
     pub fn with_span_list(&mut self, display_span_list: bool) {
         self.display_span_list = display_span_list;
     }

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -54,12 +54,13 @@ impl Json {
         self.flatten_event = flatten_event;
     }
 
-    /// If set to `false` event won't contain current span.
+    
+    /// If set to `false`, formatted events won't contain a field for the current span.
     pub fn with_current_span(&mut self, display_current_span: bool) {
         self.display_current_span = display_current_span;
     }
 
-    /// If set to `false` event won't contain spans.
+    /// If set to `false`, formatted events won't contain a list of all currently entered spans.
     pub fn with_span_list(&mut self, display_span_list: bool) {
         self.display_span_list = display_span_list;
     }
@@ -204,13 +205,11 @@ where
                 None
             };
 
-            if self.format.display_span_list {
-                if current_span.is_some() {
-                    serializer.serialize_entry(
-                        "spans",
-                        &SerializableContext(&ctx.ctx, format_field_marker),
-                    )?;
-                }
+            if self.format.display_span_list && current_span.is_some() {
+                serializer.serialize_entry(
+                    "spans",
+                    &SerializableContext(&ctx.ctx, format_field_marker),
+                )?;
             }
 
             if self.format.display_current_span {

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -307,7 +307,8 @@ impl<T> Format<Json, T> {
         self
     }
 
-    /// Use the full JSON format and sets whether or not it will include the current span.
+    /// Sets whether or not the formatter will include the current span in
+    /// formatted events.
     ///
     /// See [`format::Json`](../fmt/format/struct.Json.html)
     #[cfg(feature = "json")]
@@ -317,7 +318,8 @@ impl<T> Format<Json, T> {
         self
     }
 
-    /// Use the full JSON format sets whether or not it will include the span list.
+    /// Sets whether or not the formatter will include a list of all currently
+    /// entered spans in formatted events.
     ///
     /// See [`format::Json`](../fmt/format/struct.Json.html)
     #[cfg(feature = "json")]

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -307,23 +307,23 @@ impl<T> Format<Json, T> {
         self
     }
 
-    /// Use the full JSON format without the current span.
+    /// Use the full JSON format and sets whether or not it will include the current span.
     ///
     /// See [`format::Json`](../fmt/format/struct.Json.html)
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
-    pub fn disable_current_span(mut self, disable_current_span: bool) -> Format<Json, T> {
-        self.format.disable_current_span(disable_current_span);
+    pub fn with_current_span(mut self, display_current_span: bool) -> Format<Json, T> {
+        self.format.with_current_span(display_current_span);
         self
     }
 
-    /// Use the full JSON format without the span list.
+    /// Use the full JSON format sets whether or not it will include the span list.
     ///
     /// See [`format::Json`](../fmt/format/struct.Json.html)
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
-    pub fn disable_span_list(mut self, disable_span_list: bool) -> Format<Json, T> {
-        self.format.disable_span_list(disable_span_list);
+    pub fn with_span_list(mut self, display_span_list: bool) -> Format<Json, T> {
+        self.format.with_span_list(display_span_list);
         self
     }
 }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -306,6 +306,26 @@ impl<T> Format<Json, T> {
         self.format.flatten_event(flatten_event);
         self
     }
+
+    /// Use the full JSON format without the current span.
+    ///
+    /// See [`format::Json`](../fmt/format/struct.Json.html)
+    #[cfg(feature = "json")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
+    pub fn disable_current_span(mut self, disable_current_span: bool) -> Format<Json, T> {
+        self.format.disable_current_span(disable_current_span);
+        self
+    }
+
+    /// Use the full JSON format without the span list.
+    ///
+    /// See [`format::Json`](../fmt/format/struct.Json.html)
+    #[cfg(feature = "json")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
+    pub fn disable_span_list(mut self, disable_span_list: bool) -> Format<Json, T> {
+        self.format.disable_span_list(disable_span_list);
+        self
+    }
 }
 
 impl<S, N, T> FormatEvent<S, N> for Format<Full, T>

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -318,8 +318,8 @@ impl<T> Format<Json, T> {
         self
     }
 
-    /// Sets whether or not the formatter will include a list of all currently
-    /// entered spans in formatted events.
+    /// Sets whether or not the formatter will include a list (from root to
+    /// leaf) of all currently entered spans in formatted events.
     ///
     /// See [`format::Json`](../fmt/format/struct.Json.html)
     #[cfg(feature = "json")]

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -588,6 +588,32 @@ impl<T, F, W> SubscriberBuilder<format::JsonFields, format::Format<format::Json,
             inner: self.inner.flatten_event(flatten_event),
         }
     }
+
+    /// Sets the json subscriber being built to not contain the current span.
+    ///
+    /// See [`format::Json`](../fmt/format/struct.Json.html)
+    pub fn disable_current_span(
+        self,
+        disable_current_span: bool,
+    ) -> SubscriberBuilder<format::JsonFields, format::Format<format::Json, T>, F, W> {
+        SubscriberBuilder {
+            filter: self.filter,
+            inner: self.inner.disable_current_span(disable_current_span),
+        }
+    }
+
+    /// Sets the json subscriber being built to not contain the span list.
+    ///
+    /// See [`format::Json`](../fmt/format/struct.Json.html)
+    pub fn disable_span_list(
+        self,
+        disable_span_list: bool,
+    ) -> SubscriberBuilder<format::JsonFields, format::Format<format::Json, T>, F, W> {
+        SubscriberBuilder {
+            filter: self.filter,
+            inner: self.inner.disable_span_list(disable_span_list),
+        }
+    }
 }
 
 #[cfg(feature = "env-filter")]

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -603,8 +603,8 @@ impl<T, F, W> SubscriberBuilder<format::JsonFields, format::Format<format::Json,
         }
     }
 
-    /// Sets whether or not the JSON layer being built will include a list of all
-    /// currently entered spans in formatted events.
+    /// Sets whether or not the JSON layer being built will include a list (from
+    /// root to leaf) of all currently entered spans in formatted events.
     ///
     /// See [`format::Json`](../fmt/format/struct.Json.html)
     pub fn with_span_list(

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -589,7 +589,8 @@ impl<T, F, W> SubscriberBuilder<format::JsonFields, format::Format<format::Json,
         }
     }
 
-    /// Sets whether or not the JSON layer being built will include the current span.
+    /// Sets whether or not the JSON layer being built will include the current span
+    /// in formatted events.
     ///
     /// See [`format::Json`](../fmt/format/struct.Json.html)
     pub fn with_current_span(
@@ -602,7 +603,8 @@ impl<T, F, W> SubscriberBuilder<format::JsonFields, format::Format<format::Json,
         }
     }
 
-    /// Sets whether or not the JSON layer being built will include a list.
+    /// Sets whether or not the JSON layer being built will include a list of all
+    /// currently entered spans in formatted events.
     ///
     /// See [`format::Json`](../fmt/format/struct.Json.html)
     pub fn with_span_list(

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -589,29 +589,29 @@ impl<T, F, W> SubscriberBuilder<format::JsonFields, format::Format<format::Json,
         }
     }
 
-    /// Sets the json subscriber being built to not contain the current span.
+    /// Sets whether or not the JSON layer being built will include the current span.
     ///
     /// See [`format::Json`](../fmt/format/struct.Json.html)
-    pub fn disable_current_span(
+    pub fn with_current_span(
         self,
-        disable_current_span: bool,
+        display_current_span: bool,
     ) -> SubscriberBuilder<format::JsonFields, format::Format<format::Json, T>, F, W> {
         SubscriberBuilder {
             filter: self.filter,
-            inner: self.inner.disable_current_span(disable_current_span),
+            inner: self.inner.with_current_span(display_current_span),
         }
     }
 
-    /// Sets the json subscriber being built to not contain the span list.
+    /// Sets whether or not the JSON layer being built will include a list.
     ///
     /// See [`format::Json`](../fmt/format/struct.Json.html)
-    pub fn disable_span_list(
+    pub fn with_span_list(
         self,
-        disable_span_list: bool,
+        display_span_list: bool,
     ) -> SubscriberBuilder<format::JsonFields, format::Format<format::Json, T>, F, W> {
         SubscriberBuilder {
             filter: self.filter,
-            inner: self.inner.disable_span_list(disable_span_list),
+            inner: self.inner.with_span_list(display_span_list),
         }
     }
 }


### PR DESCRIPTION
Fixes: #704

## Motivation

Nested spans are not available in json formatter

## Solution

I added a field `spans` in the json, with an array of the nested spans. I reused the span representation from the existing `span`, and pushed all the span representation in a `vec` using `ctx.visit_spans`. I didn't remove the `span` field as it can be useful to have direct access to the current span