### PR TITLE
do not add parent context if the context is invalid

### DIFF
--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -90,6 +90,7 @@ pub(crate) fn build_span_context(
     let (trace_id, trace_flags) = builder
         .parent_context
         .as_ref()
+        .filter(|parent_context| parent_context.is_valid())
         .map(|parent_context| (parent_context.trace_id(), parent_context.trace_flags()))
         .unwrap_or_else(|| {
             let trace_id = builder.trace_id.expect("trace_id should exist");


### PR DESCRIPTION
## Motivation
I use B3Propagator with opentelemetry and when there isn't any headers for B3 propagation it return an empty context and then the `set_parent` method doesn't really check if the context is valid or not. 

## Solution
I just check if the context is valid. If not I don't put it as parent context for the current span.