### PR TITLE
opentelemetry: Upgrade to opentelemetry v0.6.0

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -53,5 +53,5 @@ indenter = "0.1.3"
 tempdir = "0.3.7"
 
 # opentelemetry example
-opentelemetry = "0.5"
-opentelemetry-jaeger = "0.4"
+opentelemetry = "0.6"
+opentelemetry-jaeger = "0.5"

--- a/examples/examples/opentelemetry_remote_context.rs
+++ b/examples/examples/opentelemetry_remote_context.rs
@@ -11,10 +11,10 @@ fn make_request(_cx: api::Context) {
     // then `propagator.inject_context(cx, request.headers_mut())`
 }
 
-fn build_example_carrier() -> HashMap<&'static str, String> {
+fn build_example_carrier() -> HashMap<String, String> {
     let mut carrier = HashMap::new();
     carrier.insert(
-        "X-B3",
+        "X-B3".to_string(),
         "4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-1".to_string(),
     );
 

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2018"
 default = ["tracing-log"]
 
 [dependencies]
-opentelemetry = { version = "0.5", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.6", default-features = false, features = ["trace"] }
 rand = "0.7"
 tracing = { path = "../tracing", version = "0.1" }
 tracing-core = { path = "../tracing-core", version = "0.1" }
@@ -30,4 +30,4 @@ tracing-subscriber = { path = "../tracing-subscriber", version = "0.2", default-
 tracing-log = { path = "../tracing-log", version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
-opentelemetry-jaeger = "0.4"
+opentelemetry-jaeger = "0.5"

--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -102,7 +102,6 @@ pub(crate) fn build_span_context(
                 let mut result = sampler.should_sample(
                     builder.parent_context.as_ref(),
                     trace_id,
-                    span_id.clone(),
                     &builder.name,
                     builder
                         .span_kind


### PR DESCRIPTION
Upgrade `opentelemetry` to latest release version
