### PR TITLE
tracing: prepare to release 0.1.15

### DIFF
--- a/tracing-subscriber/src/util.rs
+++ b/tracing-subscriber/src/util.rs
@@ -14,8 +14,8 @@ use tracing_core::dispatcher::{self, Dispatch};
 /// `Subscriber`, may implement `Into<Dispatch>`, and will also receive an
 /// implementation of this trait.
 ///
-/// [default subscriber]: https://docs.rs/tracing/0.1.14/tracing/dispatcher/index.html#setting-the-default-subscriber
-/// [trace dispatcher]: https://docs.rs/tracing/0.1.14/tracing/dispatcher/index.html
+/// [default subscriber]: https://docs.rs/tracing/0.1.15/tracing/dispatcher/index.html#setting-the-default-subscriber
+/// [trace dispatcher]: https://docs.rs/tracing/0.1.15/tracing/dispatcher/index.html
 pub trait SubscriberInitExt
 where
     Self: Into<Dispatch>,
@@ -27,7 +27,7 @@ where
     /// a [`log`] compatibility layer. This allows the subscriber to consume
     /// `log::Record`s as though they were `tracing` `Event`s.
     ///
-    /// [default subscriber]: https://docs.rs/tracing/0.1.14/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [default subscriber]: https://docs.rs/tracing/0.1.15/tracing/dispatcher/index.html#setting-the-default-subscriber
     /// [`log`]: https://crates.io/log
     fn set_default(self) -> dispatcher::DefaultGuard {
         #[cfg(feature = "tracing-log")]
@@ -47,7 +47,7 @@ where
     /// been set, or if a `log` logger has already been set (when the
     /// "tracing-log" feature is enabled).
     ///
-    /// [global default subscriber]: https://docs.rs/tracing/0.1.14/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [global default subscriber]: https://docs.rs/tracing/0.1.15/tracing/dispatcher/index.html#setting-the-default-subscriber
     /// [`log`]: https://crates.io/log
     fn try_init(self) -> Result<(), TryInitError> {
         #[cfg(feature = "tracing-log")]
@@ -69,7 +69,7 @@ where
     /// or if a `log` logger has already been set (when the "tracing-log"
     /// feature is enabled).
     ///
-    /// [global default subscriber]: https://docs.rs/tracing/0.1.14/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [global default subscriber]: https://docs.rs/tracing/0.1.15/tracing/dispatcher/index.html#setting-the-default-subscriber
     /// [`log`]: https://crates.io/log
     fn init(self) {
         self.try_init()

--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.1.15 (June 2, 2020)
+
+### Changed
+
+- **macros**: Replaced use of legacy `local_inner_macros` with `$crate::` (#740)
+
+### Added
+
+- Docs fixes and improvements (#742, #731, #730)
+
+Thanks to @bnjjj, @blaenk, and @LukeMathWalker for contributing to this release!
+
 # 0.1.14 (May 14, 2020)
 
 ### Added

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.14"
+version = "0.1.15"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -12,9 +12,9 @@ Application-level tracing for Rust.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.14
+[crates-url]: https://crates.io/crates/tracing/0.1.15
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.14
+[docs-url]: https://docs.rs/tracing/0.1.15
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -241,7 +241,7 @@ my_future
 is as long as the future's.
 
 The second, and preferred, option is through the
-[`#[instrument]`](https://docs.rs/tracing/0.1.14/tracing/attr.instrument.html)
+[`#[instrument]`](https://docs.rs/tracing/0.1.15/tracing/attr.instrument.html)
 attribute:
 
 ```rust
@@ -288,7 +288,7 @@ span.in_scope(|| {
 // Dropping the span will close it, indicating that it has ended.
 ```
 
-The [`#[instrument]`](https://docs.rs/tracing/0.1.14/tracing/attr.instrument.html) attribute macro
+The [`#[instrument]`](https://docs.rs/tracing/0.1.15/tracing/attr.instrument.html) attribute macro
 can reduce some of this boilerplate:
 
 ```rust

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -724,7 +724,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing = { version = "0.1.14", default-features = false }
+//!   tracing = { version = "0.1.15", default-features = false }
 //!   ```
 //!
 //!   *Compiler support: requires rustc 1.39+*
@@ -760,7 +760,7 @@
 //! [flags]: #crate-feature-flags
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.14")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.15")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
# 0.1.15 (June 2, 2020)

### Changed

- **macros**: Replaced use of legacy `local_inner_macros` with
  `$crate::` (#740)

### Added

- Docs fixes and improvements (#742, #731, #730)

Thanks to @bnjjj, @blaenk, and @LukeMathWalker for contributing to this
release!

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
