### PR TITLE
style: fix warning in examples

### DIFF
--- a/examples/examples/tower-load.rs
+++ b/examples/examples/tower-load.rs
@@ -318,8 +318,8 @@ async fn load_gen(addr: SocketAddr) -> Result<(), Err> {
         .layer(request_span::layer(req_span))
         .timeout(Duration::from_millis(200))
         .service(Client::new());
-
-    while let Some(_) = time::interval(Duration::from_millis(50)).next().await {
+    let mut interval = time::interval(Duration::from_millis(50));
+    while interval.next().await.is_some() {
         let authority = format!("{}", addr);
         let mut svc = svc.clone().ready_oneshot().await?;
 


### PR DESCRIPTION
This fixes a new compiler warning in the `tower-load` example.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>