### PR TITLE
Adjust Once to not violate feature additivity principle

### DIFF
--- a/tracing-core/src/lazy_static/core_lazy.rs
+++ b/tracing-core/src/lazy_static/core_lazy.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::Once;
+use crate::spin::Once;
 
 pub(crate) struct Lazy<T: Sync>(Once<T>);
 

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -226,7 +226,10 @@ pub(crate) mod spin;
 
 #[cfg(not(feature = "std"))]
 #[doc(hidden)]
-pub use self::spin::Once;
+pub type Once = self::spin::Once<()>;
+
+#[cfg(feature = "std")]
+pub use stdlib::sync::Once;
 
 pub mod callsite;
 pub mod dispatcher;

--- a/tracing-core/src/spin/mod.rs
+++ b/tracing-core/src/spin/mod.rs
@@ -1,7 +1,7 @@
 //! Synchronization primitives based on spinning
 
 pub(crate) use mutex::*;
-pub use once::Once;
+pub(crate) use once::Once;
 
 mod mutex;
 mod once;

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -832,12 +832,7 @@ pub mod subscriber;
 #[doc(hidden)]
 pub mod __macro_support {
     pub use crate::stdlib::sync::atomic::{AtomicUsize, Ordering};
-
-    #[cfg(feature = "std")]
-    pub use crate::stdlib::sync::Once;
-
-    #[cfg(not(feature = "std"))]
-    pub type Once = tracing_core::Once<()>;
+    pub type Once = tracing_core::Once;
 }
 
 mod sealed {


### PR DESCRIPTION
When the following dependencies and their features were specified:

```toml
tracing-core = { version = "0.1", default-features = false, features = ["std"] }
tracing = { version = "0.1", default-features = false }
```

The build would fail with the following error:

```
error[E0412]: cannot find type `Once` in crate `tracing_core`
   --> tracing/src/lib.rs:840:35
    |
840 |     pub type Once = tracing_core::Once<()>;
    |                                   ^^^^ not found in `tracing_core`
    |
```

This happened because `tracing-core` exports `Once` only if its `std`
feature is disabled. And the depending `tracing` crate assumed that if
its `std` feature was disabled, so would be the `std` feature in
`tracing-core`.

This is a violation of the [undocumented "features must be additive"
guideline][ag]. In this commit tracing-core is adjusted to export `Once`
regardless of whether `std` is disabled or not.

[ag]: https://github.com/rust-lang/cargo/issues/4328