### PR TITLE
print spans on close

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -36,7 +36,7 @@ tracing-core = { path = "../tracing-core", version = "0.1.2" }
 # only required by the filter feature
 matchers = { optional = true, version = "0.0.1" }
 regex = { optional = true, version = "1" }
-smallvec = { optional = true, version = "1", features = ["write"] }
+smallvec = { optional = true, version = "1" }
 lazy_static = { optional = true, version = "1" }
 
 # fmt

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -36,7 +36,7 @@ tracing-core = { path = "../tracing-core", version = "0.1.2" }
 # only required by the filter feature
 matchers = { optional = true, version = "0.0.1" }
 regex = { optional = true, version = "1" }
-smallvec = { optional = true, version = "1"}
+smallvec = { optional = true, version = "1", features = ["write"] }
 lazy_static = { optional = true, version = "1" }
 
 # fmt
@@ -60,6 +60,7 @@ tracing = { path = "../tracing", version = "0.1"}
 log = "0.4"
 tracing-log = { path = "../tracing-log", version = "0.1" }
 criterion = { version = "0.3", default_features = false }
+regex = "1"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -770,7 +770,7 @@ mod test {
             .with_level(false)
             .with_ansi(false)
             .with_timer(MockTime)
-            // check that FmtSpan::None is the default
+            // check that FmtSpan::NONE is the default
             .finish();
 
         with_default(subscriber, || {
@@ -793,7 +793,7 @@ mod test {
             .with_level(false)
             .with_ansi(false)
             .with_timer(MockTime)
-            .with_spans(FmtSpan::Active)
+            .with_spans(FmtSpan::ACTIVE)
             .finish();
 
         with_default(subscriber, || {
@@ -820,7 +820,7 @@ mod test {
             .with_level(false)
             .with_ansi(false)
             .with_timer(MockTime)
-            .with_spans(FmtSpan::Close)
+            .with_spans(FmtSpan::CLOSE)
             .finish();
 
         with_default(subscriber, || {
@@ -847,7 +847,7 @@ mod test {
             .with_ansi(false)
             .with_timer(MockTime)
             .without_time()
-            .with_spans(FmtSpan::Close)
+            .with_spans(FmtSpan::CLOSE)
             .finish();
 
         with_default(subscriber, || {
@@ -873,7 +873,7 @@ mod test {
             .with_level(false)
             .with_ansi(false)
             .with_timer(MockTime)
-            .with_spans(FmtSpan::Full)
+            .with_spans(FmtSpan::FULL)
             .finish();
 
         with_default(subscriber, || {

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -468,7 +468,7 @@ impl<E> Deref for FormattedFields<E> {
 // === impl FmtLayer ===
 
 macro_rules! with_event_from_span {
-    ($id:ident, $span:ident, $($field:literal = $value:expr),*, |$event:ident| $code:tt) => {
+    ($id:ident, $span:ident, $($field:literal = $value:expr),*, |$event:ident| $code:block) => {
         let meta = $span.metadata();
         let cs = meta.callsite();
         let fs = field::FieldSet::new(&[$($field),*], cs);

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -941,23 +941,19 @@ impl Default for FmtSpanConfig {
 pub(super) struct TimingDisplay(pub(super) u64);
 impl Display for TimingDisplay {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt_nanos(self.0, f)
-    }
-}
-
-fn fmt_nanos(t: u64, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    let mut t = t as f64;
-    for unit in ["ns", "µs", "ms", "s"].iter() {
-        if t < 10.0 {
-            return write!(f, "{:.2}{}", t, unit);
-        } else if t < 100.0 {
-            return write!(f, "{:.1}{}", t, unit);
-        } else if t < 1000.0 {
-            return write!(f, "{:.0}{}", t, unit);
+        let mut t = self.0 as f64;
+        for unit in ["ns", "µs", "ms", "s"].iter() {
+            if t < 10.0 {
+                return write!(f, "{:.2}{}", t, unit);
+            } else if t < 100.0 {
+                return write!(f, "{:.1}{}", t, unit);
+            } else if t < 1000.0 {
+                return write!(f, "{:.0}{}", t, unit);
+            }
+            t /= 1000.0;
         }
-        t /= 1000.0;
+        write!(f, "{:.0}s", t * 1000.0)
     }
-    write!(f, "{:.0}s", t * 1000.0)
 }
 
 #[cfg(test)]

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -857,7 +857,9 @@ impl<'a, F> fmt::Debug for FieldFnVisitor<'a, F> {
 
 // === printing synthetic Span events ===
 
-/// Select the degree to which tracing spans are logged as events
+/// Configures what points in the span lifecycle are logged as events.
+///
+/// see also [`with_span_events`](../struct.SubscriberBuilder.html#method.with_span_events)
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct FmtSpan(FmtSpanInner);
 
@@ -915,34 +917,20 @@ impl FmtSpanConfig {
     }
     pub(super) fn trace_new(&self) -> bool {
         match self.kind {
-            FmtSpan::NONE => false,
-            FmtSpan::ACTIVE => false,
-            FmtSpan::CLOSE => false,
             FmtSpan::FULL => true,
+            _ => false,
         }
     }
-    pub(super) fn trace_enter(&self) -> bool {
+    pub(super) fn trace_active(&self) -> bool {
         match self.kind {
-            FmtSpan::NONE => false,
-            FmtSpan::ACTIVE => true,
-            FmtSpan::CLOSE => false,
-            FmtSpan::FULL => true,
-        }
-    }
-    pub(super) fn trace_exit(&self) -> bool {
-        match self.kind {
-            FmtSpan::NONE => false,
-            FmtSpan::ACTIVE => true,
-            FmtSpan::CLOSE => false,
-            FmtSpan::FULL => true,
+            FmtSpan::ACTIVE | FmtSpan::FULL => true,
+            _ => false,
         }
     }
     pub(super) fn trace_close(&self) -> bool {
         match self.kind {
-            FmtSpan::NONE => false,
-            FmtSpan::ACTIVE => false,
-            FmtSpan::CLOSE => true,
-            FmtSpan::FULL => true,
+            FmtSpan::CLOSE | FmtSpan::FULL => true,
+            _ => false,
         }
     }
 }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -859,7 +859,7 @@ impl<'a, F> fmt::Debug for FieldFnVisitor<'a, F> {
 
 /// Configures what points in the span lifecycle are logged as events.
 ///
-/// see also [`with_span_events`](../struct.SubscriberBuilder.html#method.with_span_events)
+/// See also [`with_span_events`](../struct.SubscriberBuilder.html#method.with_span_events).
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct FmtSpan(FmtSpanInner);
 

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -477,6 +477,14 @@ where
         }
     }
 
+    /// Select which span usage shall be logged as events
+    pub fn with_spans(self, kind: format::FmtSpan) -> Self {
+        SubscriberBuilder {
+            filter: self.filter,
+            inner: self.inner.with_spans(kind),
+        }
+    }
+
     /// Enable ANSI encoding for formatted events.
     #[cfg(feature = "ansi")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -477,7 +477,32 @@ where
         }
     }
 
-    /// Select which span usage shall be logged as events
+    /// Configures how synthesized events are emitted at points in the [span
+    /// lifecycle][lifecycle].
+    ///
+    /// The following options are available:
+    ///
+    /// - `FmtSpan::NONE`: No events will be synthesized when spans are
+    ///    created, entered, exited, or closed. Data from spans will still be
+    ///    included as the context for formatted events. This is the default.
+    /// - `FmtSpan::ACTIVE`: Events will be synthesized when spans are entered
+    ///    or exited. 
+    /// - `FmtSpan::CLOSE`: An event will be synthesized when a span closes. If
+    ///    [timestamps are enabled][time] for this formatter, the generated
+    ///    event will contain fields with the span's _active time_ (the total
+    ///    time for which it was entered) and _idle time_ (the total time that
+    ///    the span existed but was not entered).
+    /// - `FmtSpan::FULL`: Events will be synthesized whenever a span is 
+    ///    created, entered, exited, or closed. If timestamps are enabled, the
+    ///    close event will contain the span's active and idle time, as 
+    ///    described above.
+    /// 
+    /// Note that the generated events will only be part of the log output by
+    /// this formatter; they will not be recorded by other `Subscriber`s or by
+    /// `Layer`s added to this subscriber.
+    ///
+    /// [lifecycle]: https://docs.rs/tracing/latest/tracing/span/index.html#the-span-lifecycle
+    /// [time]: #method.without_time
     pub fn with_spans(self, kind: format::FmtSpan) -> Self {
         SubscriberBuilder {
             filter: self.filter,

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -486,27 +486,27 @@ where
     ///    created, entered, exited, or closed. Data from spans will still be
     ///    included as the context for formatted events. This is the default.
     /// - `FmtSpan::ACTIVE`: Events will be synthesized when spans are entered
-    ///    or exited. 
+    ///    or exited.
     /// - `FmtSpan::CLOSE`: An event will be synthesized when a span closes. If
     ///    [timestamps are enabled][time] for this formatter, the generated
-    ///    event will contain fields with the span's _active time_ (the total
+    ///    event will contain fields with the span's _busy time_ (the total
     ///    time for which it was entered) and _idle time_ (the total time that
     ///    the span existed but was not entered).
-    /// - `FmtSpan::FULL`: Events will be synthesized whenever a span is 
+    /// - `FmtSpan::FULL`: Events will be synthesized whenever a span is
     ///    created, entered, exited, or closed. If timestamps are enabled, the
-    ///    close event will contain the span's active and idle time, as 
+    ///    close event will contain the span's busy and idle time, as
     ///    described above.
-    /// 
+    ///
     /// Note that the generated events will only be part of the log output by
     /// this formatter; they will not be recorded by other `Subscriber`s or by
     /// `Layer`s added to this subscriber.
     ///
     /// [lifecycle]: https://docs.rs/tracing/latest/tracing/span/index.html#the-span-lifecycle
     /// [time]: #method.without_time
-    pub fn with_spans(self, kind: format::FmtSpan) -> Self {
+    pub fn with_span_events(self, kind: format::FmtSpan) -> Self {
         SubscriberBuilder {
             filter: self.filter,
-            inner: self.inner.with_spans(kind),
+            inner: self.inner.with_span_events(kind),
         }
     }
 


### PR DESCRIPTION
EDIT: thanks to @hawkw’s help this now actually is a pull request :-)

This is not really a pull request, more a hack that demonstrates the question I’d like to ask. Currently there is no subscriber that comes out of the box that will print information about spans. I find the concept quite useful and instrumented some code that does database queries in order to print out how long things take as well as tracing the execution (i.e. each span is doubling as a log statement of the same level). Example output looks like the following:

![image](https://user-images.githubusercontent.com/470469/85235218-9e36ef00-b413-11ea-9aa7-e6439bc2f604.png)

There is an ugly hack in the code to get the fields of the recently closed span into the output, and the output is generated using an even uglier hack by faking an event, but I hope that this still makes it sufficiently clear what I am trying to do.

There has been some discussion about “printing spans” in the past, but they did not quite target the same thing. I am after the timings and I want one line per span, just like an event, so I think the argument that “spans are too noisy” does not apply (otherwise events were too noisy as well).

Do you think it might make sense to implement this in a better way and offer it under a feature flag? This would be particularly useful for enabling test logging with a crate like `test-env-log`, where manual layer configuration is not suitable. I can also see myself using this to get nice and useful log output from production applications as well in several cases.