### PR TITLE
docs: update top-level documentation of crate features

### DIFF
--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -25,7 +25,7 @@
 //!   Enabled by default.
 //! - `ansi`: Enables `fmt` support for ANSI terminal colors. Enabled by
 //!   default.
-//! - `registry`: enables the experimental [`registry`] module. Enabled by default.
+//! - `registry`: enables the [`registry`] module. Enabled by default.
 //! - `json`: Enables `fmt` support for JSON output. In JSON output, the ANSI feature does nothing.
 //!
 //! ### Optional Dependencies

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -25,7 +25,7 @@
 //!   Enabled by default.
 //! - `ansi`: Enables `fmt` support for ANSI terminal colors. Enabled by
 //!   default.
-//! - `registry`: enables the experimental [`registry`] module.
+//! - `registry`: enables the experimental [`registry`] module. Enabled by default.
 //! - `json`: Enables `fmt` support for JSON output. In JSON output, the ANSI feature does nothing.
 //!
 //! ### Optional Dependencies


### PR DESCRIPTION
The "registry" crate feature is enabled by default but the top-level
documentation implies that it is not.

## Motivation

Minor docs fix to clarify that the registry feature is enabled by default.  The docs are not "wrong" per se, but other crate features indicate that they are enabled by default and the registry feature does not say that, which may lead to confusion (it did for me).

## Solution

Fix the docs
