### PR TITLE
subscriber: handle explicit event parents properly in formatters

### DIFF
--- a/examples/examples/tower-client.rs
+++ b/examples/examples/tower-client.rs
@@ -15,12 +15,7 @@ fn req_span<A>(req: &Request<A>) -> tracing::Span {
         req.version = ?req.version(),
         headers = ?req.headers()
     );
-    {
-        // TODO: this is a workaround because tracing_subscriber::fmt::Layer doesn't honor
-        // overridden span parents.
-        let _enter = span.enter();
-        tracing::info!(parent: &span, "sending request");
-    }
+    tracing::info!(parent: &span, "sending request");
     span
 }
 

--- a/examples/examples/tower-load.rs
+++ b/examples/examples/tower-load.rs
@@ -383,6 +383,11 @@ fn req_span<A>(req: &Request<A>) -> Span {
         req.method = ?req.method(),
         req.path = ?req.uri().path(),
     );
-    debug!(message = "received request.", req.headers = ?req.headers(), req.version = ?req.version());
+    debug!(
+        parent: &span,
+        message = "received request.",
+        req.headers = ?req.headers(),
+        req.version = ?req.version(),
+    );
     span
 }

--- a/examples/examples/tower-server.rs
+++ b/examples/examples/tower-server.rs
@@ -18,11 +18,7 @@ fn req_span<A>(req: &Request<A>) -> tracing::Span {
         req.version = ?req.version(),
         req.headers = ?req.headers()
     );
-    {
-        // TODO: this is a workaround because tracing_subscriber::fmt::Layer doesn't honor
-        // overridden span parents.
-        let _enter = span.enter();
-    }
+    tracing::info!(parent: &span, "received request");
     span
 }
 

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -351,7 +351,7 @@ where
             }
             #[cfg(not(feature = "ansi"))]
             {
-                FullCtx::new(&ctx)
+                FullCtx::new(ctx, event.parent())
             }
         };
 

--- a/tracing-subscriber/src/fmt/time.rs
+++ b/tracing-subscriber/src/fmt/time.rs
@@ -118,7 +118,7 @@ impl FormatTime for SystemTime {
 
 #[cfg(not(feature = "chrono"))]
 impl FormatTime for SystemTime {
-    fn format_time(&self, w: &mut fmt::Write) -> fmt::Result {
+    fn format_time(&self, w: &mut dyn fmt::Write) -> fmt::Result {
         write!(w, "{:?}", std::time::SystemTime::now())
     }
 }


### PR DESCRIPTION
## Motivation

Currently, the default formatter implementations in
`tracing-subscriber`'s `fmt` module do not handle explicitly set parent
spans for events, such as

```rust
let span = tracing::info_span!("some_interesting_span");
tracing::info!(parent: &span, "something is happening!");
```

Instead, when formatting the span context of an event, the context is
_always_ generated from the current span, even when the event has an
overridden parent. This is not correct.

## Solution

This branch changes the default context formatters to use the explicit
parent ID, if it is present. Otherwise, the contexual parent is used, as
it was previously.

I've also added tests ensuring that this works correctly, and removed
some workarounds for the previous incorrect behavior from the examples.

Fixes #766

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
