### PR TITLE
Add conversion between `span::Id` and `NonZeroU64`

### DIFF
--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -68,11 +68,27 @@ impl Id {
         Id(NonZeroU64::new(u).expect("span IDs must be > 0"))
     }
 
+    /// Constructs a new span ID from the given `NonZeroU64`.
+    ///
+    /// Unlike [`Id::from_u64`](#method.from_u64), this will never panic.
+    #[inline]
+    pub const fn from_non_zero_u64(id: NonZeroU64) -> Self {
+        Id(id)
+    }
+
     // Allow `into` by-ref since we don't want to impl Copy for Id
     #[allow(clippy::wrong_self_convention)]
     /// Returns the span's ID as a `u64`.
     pub fn into_u64(&self) -> u64 {
         self.0.get()
+    }
+
+    // Allow `into` by-ref since we don't want to impl Copy for Id
+    #[allow(clippy::wrong_self_convention)]
+    /// Returns the span's ID as a `NonZeroU64`.
+    #[inline]
+    pub const fn into_non_zero_u64(&self) -> NonZeroU64 {
+        self.0
     }
 }
 


### PR DESCRIPTION
## Motivation

Consumers of the crate should be able to handle the 0 case separately and avoiding panicking within `Id::from_u64`.

## Solution

Expose direct conversion between the inner type.