### PR TITLE
docs: fix "sploded" formatting

### DIFF
--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -113,7 +113,7 @@
 //! </div>
 //! <div class="example-wrap" style="display:inline-block">
 //! <pre class="ignore" style="white-space:normal;font:inherit;">
-//! <strong>Note</strong>:the thread-local scoped dispatcher <code>with_default</code>
+//! <strong>Note</strong>:the thread-local scoped dispatcher (<code>with_default</code>)
 //! requires the Rust standard library. <code>no_std</code> users should use
 //! <a href="#fn.set_global_default"><code>set_global_default</code></a>
 //! instead.

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -113,8 +113,9 @@
 //! </div>
 //! <div class="example-wrap" style="display:inline-block">
 //! <pre class="ignore" style="white-space:normal;font:inherit;">
-//! <strong>Note</strong>:the thread-local scoped dispatcher (<code>with_default</code>)
-//! requires the Rust standard library. <code>no_std</code> users should use
+//! <strong>Note</strong>:the thread-local scoped dispatcher
+//! (<code>with_default</code>) requires the Rust standard library.
+//! <code>no_std</code> users should use
 //! <a href="#fn.set_global_default"><code>set_global_default</code></a>
 //! instead.
 //! </pre></div>

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -114,8 +114,8 @@
 //! <div class="example-wrap" style="display:inline-block">
 //! <pre class="ignore" style="white-space:normal;font:inherit;">
 //! <strong>Note</strong>:the thread-local scoped dispatcher
-//! (<code>with_default</code>) requires the Rust standard library.
-//! <code>no_std</code> users should use
+//! (<a href="#fn.with_default"><code>with_default</code></a>) requires the
+//! Rust standard library. <code>no_std</code> users should use
 //! <a href="#fn.set_global_default"><code>set_global_default</code></a>
 //! instead.
 //! </pre></div>

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -559,7 +559,7 @@ impl Dispatch {
     /// <strong>Deprecated</strong>: The <a href="#method.try_close"><code>try_close</code></a>
     /// method is functionally identical, but returns <code>true</code> if the span is now closed.
     /// It should be used instead of this method.
-    /// </pre>
+    /// </pre></div>
     ///
     /// [span ID]: ../span/struct.Id.html
     /// [`Subscriber`]: ../subscriber/trait.Subscriber.html

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -175,7 +175,7 @@ pub struct Iter {
 /// <div class="example-wrap" style="display:inline-block">
 /// <pre class="ignore" style="white-space:normal;font:inherit;">
 /// <strong>Note</strong>: The <code>record_error</code> trait method is only
-/// available when the Rust standard library is present, as it requires the `
+/// available when the Rust standard library is present, as it requires the
 /// <code>std::error::Error</code> trait.
 /// </pre></div>
 ///
@@ -212,7 +212,6 @@ pub trait Visit {
     /// <div class="information">
     ///     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>
     /// </div>
-    /// <div class="example-wrap" style="display:inline-block">
     /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: This is only enabled when the Rust standard library is
@@ -622,7 +621,6 @@ impl FieldSet {
     ///     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>
     /// </div>
     /// <div class="example-wrap" style="display:inline-block">
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: If <code>field</code> shares a name with a field
     /// in this <code>FieldSet</code>, but was created by a <code>FieldSet</code>
@@ -631,7 +629,6 @@ impl FieldSet {
     /// named "foo", the <code>Field</code> corresponding to "foo" for each
     /// of those callsites are not equivalent.
     /// </pre></div>
-    /// </div>
     pub fn contains(&self, field: &Field) -> bool {
         field.callsite() == self.callsite() && field.i <= self.len()
     }

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -630,7 +630,7 @@ impl FieldSet {
     /// contain it. This is so that if two separate span callsites define a field
     /// named "foo", the <code>Field</code> corresponding to "foo" for each
     /// of those callsites are not equivalent.
-    /// </pre>
+    /// </pre></div>
     /// </div>
     pub fn contains(&self, field: &Field) -> bool {
         field.callsite() == self.callsite() && field.i <= self.len()

--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -64,7 +64,6 @@ impl Id {
     ///     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>
     /// </div>
     /// <div class="example-wrap" style="display:inline-block">
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: Span IDs must be greater than zero.</pre></div>
     ///

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -216,7 +216,6 @@ where
     ///     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>
     /// </div>
     /// <div class="example-wrap" style="display:inline-block">
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: This method (and <a href="#method.enabled">
     /// <code>Layer::enabled</code></a>) determine whether a span or event is
@@ -229,8 +228,8 @@ where
     /// <a href="#method.on_enter"><code>on_enter</code></a>,
     /// <a href="#method.on_exit"><code>on_exit<code></a>, and other notification
     /// methods.
-     /// </pre></div>
-     ///
+    /// </pre></div>
+    ///
     /// See [the trait-level documentation] for more information on filtering
     /// with `Layer`s.
     ///
@@ -269,7 +268,6 @@ where
     ///     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>
     /// </div>
     /// <div class="example-wrap" style="display:inline-block">
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: This method (and <a href="#method.register_callsite">
     /// <code>Layer::register_callsite</code></a>) determine whether a span or event is
@@ -282,8 +280,8 @@ where
     /// <a href="#method.on_enter"><code>on_enter</code></a>,
     /// <a href="#method.on_exit"><code>on_exit<code></a>, and other notification
     /// methods.
-     /// </pre></div>
-     ///
+    /// </pre></div>
+    ///
     ///
     /// See [the trait-level documentation] for more information on filtering
     /// with `Layer`s.
@@ -874,14 +872,13 @@ impl<'a, S: Subscriber> Context<'a, S> {
     ///     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>
     /// </div>
     /// <div class="example-wrap" style="display:inline-block">
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: This requires the wrapped subscriber to implement the
     /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
     /// <code>Layer</code> implementations that wish to use this
     /// function can bound their <code>Subscriber</code> type parameter with:
-     /// </pre></div>
-     /// ```rust,ignore
+    /// </pre></div>
+    /// ```rust,ignore
     /// where S: Subscriber + for<'a> LookupSpan<'a>,`
     /// ```
     #[inline]
@@ -904,14 +901,13 @@ impl<'a, S: Subscriber> Context<'a, S> {
     ///     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>
     /// </div>
     /// <div class="example-wrap" style="display:inline-block">
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: This requires the wrapped subscriber to implement the
     /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
     /// <code>Layer</code> implementations that wish to use this
     /// function can bound their <code>Subscriber</code> type parameter with:
-     /// </pre></div>
-     /// ```rust,ignore
+    /// </pre></div>
+    /// ```rust,ignore
     /// where S: Subscriber + for<'a> LookupSpan<'a>,`
     /// ```
     ///
@@ -933,14 +929,13 @@ impl<'a, S: Subscriber> Context<'a, S> {
     ///     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>
     /// </div>
     /// <div class="example-wrap" style="display:inline-block">
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: This requires the wrapped subscriber to implement the
     /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
     /// <code>Layer</code> implementations that wish to use this
     /// function can bound their <code>Subscriber</code> type parameter with:
-     /// </pre></div>
-     /// ```rust,ignore
+    /// </pre></div>
+    /// ```rust,ignore
     /// where S: Subscriber + for<'a> LookupSpan<'a>,`
     /// ```
     ///
@@ -964,14 +959,13 @@ impl<'a, S: Subscriber> Context<'a, S> {
     ///     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>
     /// </div>
     /// <div class="example-wrap" style="display:inline-block">
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: This requires the wrapped subscriber to implement the
     /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
     /// <code>Layer</code> implementations that wish to use this
     /// function can bound their <code>Subscriber</code> type parameter with:
-     /// </pre></div>
-     /// ```rust,ignore
+    /// </pre></div>
+    /// ```rust,ignore
     /// where S: Subscriber + for<'a> LookupSpan<'a>,`
     /// ```
     ///
@@ -1006,14 +1000,13 @@ impl<'a, S: Subscriber> Context<'a, S> {
     ///     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>
     /// </div>
     /// <div class="example-wrap" style="display:inline-block">
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: This requires the wrapped subscriber to implement the
     /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
     /// <code>Layer</code> implementations that wish to use this
     /// function can bound their <code>Subscriber</code> type parameter with:
-     /// </pre></div>
-     /// ```rust,ignore
+    /// </pre></div>
+    /// ```rust,ignore
     /// where S: Subscriber + for<'a> LookupSpan<'a>,`
     /// ```
     ///

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -229,8 +229,8 @@ where
     /// <a href="#method.on_enter"><code>on_enter</code></a>,
     /// <a href="#method.on_exit"><code>on_exit<code></a>, and other notification
     /// methods.
-    /// </pre>
-    ///
+     /// </pre></div>
+     ///
     /// See [the trait-level documentation] for more information on filtering
     /// with `Layer`s.
     ///
@@ -282,8 +282,8 @@ where
     /// <a href="#method.on_enter"><code>on_enter</code></a>,
     /// <a href="#method.on_exit"><code>on_exit<code></a>, and other notification
     /// methods.
-    /// </pre>
-    ///
+     /// </pre></div>
+     ///
     ///
     /// See [the trait-level documentation] for more information on filtering
     /// with `Layer`s.
@@ -880,8 +880,8 @@ impl<'a, S: Subscriber> Context<'a, S> {
     /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
     /// <code>Layer</code> implementations that wish to use this
     /// function can bound their <code>Subscriber</code> type parameter with:
-    /// </pre>
-    /// ```rust,ignore
+     /// </pre></div>
+     /// ```rust,ignore
     /// where S: Subscriber + for<'a> LookupSpan<'a>,`
     /// ```
     #[inline]
@@ -910,8 +910,8 @@ impl<'a, S: Subscriber> Context<'a, S> {
     /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
     /// <code>Layer</code> implementations that wish to use this
     /// function can bound their <code>Subscriber</code> type parameter with:
-    /// </pre>
-    /// ```rust,ignore
+     /// </pre></div>
+     /// ```rust,ignore
     /// where S: Subscriber + for<'a> LookupSpan<'a>,`
     /// ```
     ///
@@ -939,8 +939,8 @@ impl<'a, S: Subscriber> Context<'a, S> {
     /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
     /// <code>Layer</code> implementations that wish to use this
     /// function can bound their <code>Subscriber</code> type parameter with:
-    /// </pre>
-    /// ```rust,ignore
+     /// </pre></div>
+     /// ```rust,ignore
     /// where S: Subscriber + for<'a> LookupSpan<'a>,`
     /// ```
     ///
@@ -970,8 +970,8 @@ impl<'a, S: Subscriber> Context<'a, S> {
     /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
     /// <code>Layer</code> implementations that wish to use this
     /// function can bound their <code>Subscriber</code> type parameter with:
-    /// </pre>
-    /// ```rust,ignore
+     /// </pre></div>
+     /// ```rust,ignore
     /// where S: Subscriber + for<'a> LookupSpan<'a>,`
     /// ```
     ///
@@ -1012,8 +1012,8 @@ impl<'a, S: Subscriber> Context<'a, S> {
     /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
     /// <code>Layer</code> implementations that wish to use this
     /// function can bound their <code>Subscriber</code> type parameter with:
-    /// </pre>
-    /// ```rust,ignore
+     /// </pre></div>
+     /// ```rust,ignore
     /// where S: Subscriber + for<'a> LookupSpan<'a>,`
     /// ```
     ///

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -98,15 +98,14 @@ pub trait LookupSpan<'a> {
     ///     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>
     /// </div>
     /// <div class="example-wrap" style="display:inline-block">
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: users of the <code>LookupSpan<code> trait should
     /// typically call the <a href="#method.span"><code>span</code> method rather
     /// than this method. The <code>span</code> method is implemented by
     /// <em>calling</em> <code>span_data</code>, but returns a reference which is
     /// capable of performing more sophisiticated queries.
-     /// </pre></div>
-     ///
+    /// </pre></div>
+    ///
     /// [`SpanData`]: trait.SpanData.html
     fn span_data(&'a self, id: &Id) -> Option<Self::Data>;
 

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -105,8 +105,8 @@ pub trait LookupSpan<'a> {
     /// than this method. The <code>span</code> method is implemented by
     /// <em>calling</em> <code>span_data</code>, but returns a reference which is
     /// capable of performing more sophisiticated queries.
-    /// </pre>
-    ///
+     /// </pre></div>
+     ///
     /// [`SpanData`]: trait.SpanData.html
     fn span_data(&'a self, id: &Id) -> Option<Self::Data>;
 


### PR DESCRIPTION

## Motivation

PR #769 was merged with some incorrect docs formatting due to
incorrect HTML that resulted from overzealous find-and-replace
misuse. See https://github.com/tokio-rs/tracing/pull/769#pullrequestreview-439416330

## Solution

This PR un-splodes it.
