### PR TITLE
attributes: prepare to release 0.1.9

### DIFF
--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.1.9 (June 30, 2020)
+
+### Added
+
+- Support for arbitrary expressions as fields in `#[instrument]` (#672)
+
+### Changed
+
+- `#[instrument]` now emits a helpful error for unrecognized input, rather than
+  ignoring it (#672)
+
 # 0.1.8 (May 13, 2020)
 
 ### Added

--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.1.9 (June 30, 2020)
+# 0.1.9 (July 8, 2020)
 
 ### Added
 
@@ -6,8 +6,8 @@
 
 ### Changed
 
-- `#[instrument]` now emits a helpful error for unrecognized input, rather than
-  ignoring it (#672)
+- `#[instrument]` now emits a compiler warning when ignoring unrecognized
+  input (#672, #786)
 
 # 0.1.8 (May 13, 2020)
 

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-attributes"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.8"
+version = "0.1.9"
 authors = [
     "Tokio Contributors <team@tokio.rs>",
     "Eliza Weisman <eliza@buoyant.io>",

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -14,7 +14,7 @@ Macro attributes for application-level tracing.
 [crates-badge]: https://img.shields.io/crates/v/tracing-attributes.svg
 [crates-url]: https://crates.io/crates/tracing-attributes
 [docs-badge]: https://docs.rs/tracing-attributes/badge.svg
-[docs-url]: https://docs.rs/tracing-attributes/0.1.8
+[docs-url]: https://docs.rs/tracing-attributes/0.1.9
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_attributes
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -39,7 +39,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing-attributes = "0.1.8"
+tracing-attributes = "0.1.9"
 ```
 
 *Compiler support: requires rustc 1.39+*
@@ -58,7 +58,7 @@ pub fn my_function(my_arg: usize) {
 
 
 [`tracing`]: https://crates.io/crates/tracing
-[span]: https://docs.rs/tracing/0.1.8/tracing/span/index.html
+[span]: https://docs.rs/tracing/latest/tracing/span/index.html
 
 ## License
 

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tracing-attributes = "0.1.8"
+//! tracing-attributes = "0.1.9"
 //! ```
 //!
 //! *Compiler support: requires rustc 1.39+*
@@ -35,7 +35,7 @@
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 //! [instrument]: attr.instrument.html
-#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.8")]
+#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.9")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
# 0.1.9 (July 8, 2020)

### Added

- Support for arbitrary expressions as fields in `#[instrument]` (#672)

### Changed

- `#[instrument]` now emits a compiler warning when ignoring 
  unrecognized input (#672, #786)

Fixes #785 