### PR TITLE
subscriber: prepare to release 0.2.7 (July 1, 2020)

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,7 @@ tracing-core = { path = "../tracing-core", version = "0.1"}
 tracing-error = { path = "../tracing-error" }
 tracing-flame = { path = "../tracing-flame" }
 tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.6", features = ["json", "chrono"] }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.7", features = ["json", "chrono"] }
 tracing-futures = { version = "0.2.1", path = "../tracing-futures", features = ["futures-01"] }
 tracing-attributes =  { path = "../tracing-attributes", version = "0.1.2"}
 tracing-log = { path = "../tracing-log", version = "0.1.1", features = ["env_logger"] }

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -20,7 +20,7 @@ keywords = ["logging", "tracing", "file-appender", "non-blocking-writer"]
 edition = "2018"
 
 [dependencies]
-tracing-subscriber = {path = "../tracing-subscriber", version = "0.2.6"}
+tracing-subscriber = {path = "../tracing-subscriber", version = "0.2.7"}
 crossbeam-channel = "0.4.2"
 chrono = "0.4.11"
 

--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -38,7 +38,7 @@ default = ["traced-error"]
 traced-error = []
 
 [dependencies]
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.6", default-features = false, features = ["registry", "fmt"] }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.7", default-features = false, features = ["registry", "fmt"] }
 tracing = { path = "../tracing", version = "0.1.12"}
 
 [badges]

--- a/tracing-error/src/layer.rs
+++ b/tracing-error/src/layer.rs
@@ -15,10 +15,10 @@ use tracing_subscriber::{
 /// when formatting the fields of each span in a trace. When no formatter is
 /// provided, the [default format] is used instead.
 ///
-/// [`Layer`]: https://docs.rs/tracing-subscriber/0.2.6/tracing_subscriber/layer/trait.Layer.html
+/// [`Layer`]: https://docs.rs/tracing-subscriber/0.2.7/tracing_subscriber/layer/trait.Layer.html
 /// [`SpanTrace`]: ../struct.SpanTrace.html
-/// [field formatter]: https://docs.rs/tracing-subscriber/0.2.6/tracing_subscriber/fmt/trait.FormatFields.html
-/// [default format]: https://docs.rs/tracing-subscriber/0.2.6/tracing_subscriber/fmt/format/struct.DefaultFields.html
+/// [field formatter]: https://docs.rs/tracing-subscriber/0.2.7/tracing_subscriber/fmt/trait.FormatFields.html
+/// [default format]: https://docs.rs/tracing-subscriber/0.2.7/tracing_subscriber/fmt/format/struct.DefaultFields.html
 pub struct ErrorLayer<S, F = DefaultFields> {
     format: F,
 
@@ -70,7 +70,7 @@ where
 {
     /// Returns a new `ErrorLayer` with the provided [field formatter].
     ///
-    /// [field formatter]: https://docs.rs/tracing-subscriber/0.2.6/tracing_subscriber/fmt/trait.FormatFields.html
+    /// [field formatter]: https://docs.rs/tracing-subscriber/0.2.7/tracing_subscriber/fmt/trait.FormatFields.html
     pub fn new(format: F) -> Self {
         Self {
             format,

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 0.2.7 (July 1, 2020)
+
+### Changed
+
+- **parking_lot**: Updated the optional `parking_lot` dependency to accept the
+  latest `parking_lot` version (#774)
+
+### Fixed
+
+- **fmt**: Fixed events with explicitly overridden parent spans being formatted
+  as though they were children of the current span (#767)
+
+### Added
+
+- **fmt**: Added the option to print synthesized events when spans are created,
+  entered, exited, and closed, including span durations (#761)
+- Documentation clarification and improvement (#762, #769)
+
+Thanks to @rkuhn, @greenwoodcm, and @Ralith for contributing to this release!
+
 # 0.2.6 (June 19, 2020)
 
 ### Fixed

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.6"
+version = "0.2.7"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -17,7 +17,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.2.6
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.7
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -49,7 +49,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.6")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.7")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(
     missing_debug_implementations,


### PR DESCRIPTION
### Changed

- **parking_lot**: Updated the optional `parking_lot` dependency to
  accept the latest `parking_lot` version (#774)

### Fixed

- **fmt**: Fixed events with explicitly overridden parent spans being
  formatted  as though they were children of the current span (#767)

### Added

- **fmt**: Added the option to print synthesized events when spans are
  created, entered, exited, and closed, including span durations (#761)
- Documentation clarification and improvement (#762, #769)

Thanks to @rkuhn, @greenwoodcm, and @Ralith for contributing to this
release!

Signed-off-by: Eliza Weisman <eliza@buoyant.io>