### PR TITLE
appender: Add appender to write same log line to multiple outputs in a loop.

### DIFF
--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -139,6 +139,8 @@ pub mod rolling;
 
 mod worker;
 
+pub mod multi;
+
 /// Convenience function for creating a non-blocking, off-thread writer.
 ///
 /// See the [`non_blocking` module's docs][non_blocking]'s for more details.

--- a/tracing-appender/src/multi.rs
+++ b/tracing-appender/src/multi.rs
@@ -1,0 +1,77 @@
+//! An appender that writes the same log line to multiple writers at once.
+//!
+//! This appender wraps other writers and writes out the same log line to each
+//! wrapped writer in a loop. This appender can only accept writers of the same
+//! concrete type.
+//!
+//! `MultiAppender` implements [`MakeWriter`][make_writer], which integrates with `tracing_subscriber`.
+//!
+//! [make_writer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/trait.MakeWriter.html
+use std::io::Result as IOResult;
+use std::io::Write;
+use std::sync::Arc;
+use tracing_subscriber::fmt::MakeWriter;
+
+/// A writer that wraps other writers and writes log lines to all wrapped writers at the
+/// same time.
+///
+/// This struct will wrap multiple other writers of the same type (ie, a group of
+/// [`NonBlocking`][non_blocking] or a group of [`RollingFileAppender`][rolling]) and write the log line to all the writers in
+/// in a loop. It is the spiritual equivalent of using `tee(1)` to have your log output printed
+/// to both stdout and a file at the same time.
+///
+/// [non_blocking]: https://docs.rs/tracing-appender/latest/tracing_appender/non_blocking/struct.NonBlocking.html
+/// [rolling]: https://docs.rs/tracing-appender/latest/tracing_appender/rolling/struct.RollingFileAppender.html
+#[derive(Debug, Clone)]
+pub struct MultiAppender<S> {
+    writers: Arc<Vec<S>>,
+}
+
+impl<S> MultiAppender<S>
+where
+    S: MakeWriter + std::io::Write + Send + Sync,
+{
+    /// Returns a new `MultiAppender` wrapping a provided `Vec` of [`MakeWriter`][make_writer].
+    ///
+    /// [make_writer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/trait.MakeWriter.html
+    pub fn from(writers: Vec<S>) -> Self {
+        MultiAppender {
+            writers: Arc::new(writers),
+        }
+    }
+}
+
+impl<S> Write for MultiAppender<S>
+where
+    S: MakeWriter + std::io::Write + Send + Sync,
+{
+    fn write(&mut self, buf: &[u8]) -> IOResult<usize> {
+        let size = buf.len();
+        for writer in &*self.writers {
+            let _ = writer.make_writer().write(buf)?;
+        }
+
+        Ok(size)
+    }
+
+    fn flush(&mut self) -> IOResult<()> {
+        for writer in &*self.writers {
+            writer.make_writer().flush()?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<S> MakeWriter for MultiAppender<S>
+where
+    S: MakeWriter + std::io::Write + Send + Sync,
+{
+    type Writer = MultiAppender<S>;
+
+    fn make_writer(&self) -> Self::Writer {
+        MultiAppender {
+            writers: self.writers.clone(),
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

tracing currently doesn't have a way to send the same log line to multiple appenders at the same time.

## Solution

This is a very quick implementation of an appender that wraps an arbitrary number of other appenders and writes the same log line to all of them in a loop. 

I didn't write any tests for this module because it legitimately doesn't do anything except call the implementations of its inner writers, so there's really nothing testable here. 
