### PR TITLE
appender: reduce tracing-subscriber's required features to `fmt`

### DIFF
--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -20,9 +20,14 @@ keywords = ["logging", "tracing", "file-appender", "non-blocking-writer"]
 edition = "2018"
 
 [dependencies]
-tracing-subscriber = {path = "../tracing-subscriber", version = "0.2.7"}
 crossbeam-channel = "0.4.2"
 chrono = "0.4.11"
+
+[dependencies.tracing-subscriber]
+path = "../tracing-subscriber"
+version = "0.2.7"
+default-features = false
+features = ["fmt"]
 
 [dev-dependencies]
 tracing = { path = "../tracing", version = "0.1" }


### PR DESCRIPTION
This resolves https://github.com/tokio-rs/tracing/issues/777.