### PR TITLE
core: prepare to release 0.1.11

### DIFF
--- a/tracing-core/CHANGELOG.md
+++ b/tracing-core/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Clippy warning on vtable address comparison in `callsite::Identifier` (#749)
 - Documentation formatting issues (#715, #771)
 
-Thanks to @bkchr, @majecty, @taiki-e, @nagisa, and @nqvz for contributing to
+Thanks to @bkchr, @majecty, @taiki-e, @nagisa, and @nvzqz for contributing to
 this release!
 
 # 0.1.10 (January 24, 2020)

--- a/tracing-core/CHANGELOG.md
+++ b/tracing-core/CHANGELOG.md
@@ -1,3 +1,26 @@
+# 0.1.11 (June 8, 2020)
+
+## Changed
+
+- Replaced use of `inner_local_macros` with `$crate::` (#729)
+
+## Added
+
+- `must_use` warning to guards returned by `dispatcher::set_default` (#686)
+- `fmt::Debug` impl to `dyn Value`s (#696) 
+- Functions to convert between `span::Id` and `NonZeroU64` (#770)
+- More obvious warnings in documentation (#769)
+
+## Fixed
+
+- Compiler error when `tracing-core/std` feature is enabled but `tracing/std` is
+  not (#760)
+- Clippy warning on vtable address comparison in `callsite::Identifier` (#749)
+- Documentation formatting issues (#715, #771)
+
+Thanks to @bkchr, @majecty, @taiki-e, @nagisa, and @nqvz for contributing to
+this release!
+
 # 0.1.10 (January 24, 2020)
 
 ### Added

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-core"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -12,9 +12,9 @@ Core primitives for application-level tracing.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-core.svg
-[crates-url]: https://crates.io/crates/tracing-core/0.1.10
+[crates-url]: https://crates.io/crates/tracing-core/0.1.11
 [docs-badge]: https://docs.rs/tracing-core/badge.svg
-[docs-url]: https://docs.rs/tracing-core/0.1.10
+[docs-url]: https://docs.rs/tracing-core/0.1.11
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_core
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -71,7 +71,7 @@ The following crate feature flags are available:
 
   ```toml
   [dependencies]
-  tracing-core = { version = "0.1.10", default-features = false }
+  tracing-core = { version = "0.1.11", default-features = false }
   ```
 
   *Compiler support: requires rustc 1.39+*
@@ -79,16 +79,16 @@ The following crate feature flags are available:
   **Note**:`tracing-core`'s `no_std` support requires `liballoc`.
 
 [`tracing`]: ../tracing
-[`span::Id`]: https://docs.rs/tracing-core/0.1.10/tracing_core/span/struct.Id.html
-[`Event`]: https://docs.rs/tracing-core/0.1.10/tracing_core/event/struct.Event.html
-[`Subscriber`]: https://docs.rs/tracing-core/0.1.10/tracing_core/subscriber/trait.Subscriber.html
-[`Metadata`]: https://docs.rs/tracing-core/0.1.10/tracing_core/metadata/struct.Metadata.html
-[`Callsite`]: https://docs.rs/tracing-core/0.1.10/tracing_core/callsite/trait.Callsite.html
-[`Field`]: https://docs.rs/tracing-core/0.1.10/tracing_core/field/struct.Field.html
-[`FieldSet`]: https://docs.rs/tracing-core/0.1.10/tracing_core/field/struct.FieldSet.html
-[`Value`]: https://docs.rs/tracing-core/0.1.10/tracing_core/field/trait.Value.html
-[`ValueSet`]: https://docs.rs/tracing-core/0.1.10/tracing_core/field/struct.ValueSet.html
-[`Dispatch`]: https://docs.rs/tracing-core/0.1.10/tracing_core/dispatcher/struct.Dispatch.html
+[`span::Id`]: https://docs.rs/tracing-core/0.1.11/tracing_core/span/struct.Id.html
+[`Event`]: https://docs.rs/tracing-core/0.1.11/tracing_core/event/struct.Event.html
+[`Subscriber`]: https://docs.rs/tracing-core/0.1.11/tracing_core/subscriber/trait.Subscriber.html
+[`Metadata`]: https://docs.rs/tracing-core/0.1.11/tracing_core/metadata/struct.Metadata.html
+[`Callsite`]: https://docs.rs/tracing-core/0.1.11/tracing_core/callsite/trait.Callsite.html
+[`Field`]: https://docs.rs/tracing-core/0.1.11/tracing_core/field/struct.Field.html
+[`FieldSet`]: https://docs.rs/tracing-core/0.1.11/tracing_core/field/struct.FieldSet.html
+[`Value`]: https://docs.rs/tracing-core/0.1.11/tracing_core/field/trait.Value.html
+[`ValueSet`]: https://docs.rs/tracing-core/0.1.11/tracing_core/field/struct.ValueSet.html
+[`Dispatch`]: https://docs.rs/tracing-core/0.1.11/tracing_core/dispatcher/struct.Dispatch.html
 
 ## License
 

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -49,7 +49,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing-core = { version = "0.1.10", default-features = false }
+//!   tracing-core = { version = "0.1.11", default-features = false }
 //!   ```
 //!
 //!   *Compiler support: requires rustc 1.39+*
@@ -68,7 +68,7 @@
 //! [`Dispatch`]: dispatcher/struct.Dispatch.html
 //! [`tokio-rs/tracing`]: https://github.com/tokio-rs/tracing
 //! [`tracing`]: https://crates.io/crates/tracing
-#![doc(html_root_url = "https://docs.rs/tracing-core/0.1.10")]
+#![doc(html_root_url = "https://docs.rs/tracing-core/0.1.11")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -27,7 +27,7 @@ keywords = ["logging", "tracing", "metrics", "async"]
 edition = "2018"
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.10", default-features = false }
+tracing-core = { path = "../tracing-core", version = "0.1.11", default-features = false }
 log = { version = "0.4", optional = true }
 tracing-attributes = { path = "../tracing-attributes", version = "0.1.8", optional = true }
 cfg-if = "0.1.10"


### PR DESCRIPTION
### Changed

- Replaced use of `inner_local_macros` with `$crate::` (#729)

### Added

- `must_use` warning to guards returned by `dispatcher::set_default`
  (#686)
- `fmt::Debug` impl to `dyn Value`s (#696)
- Functions to convert between `span::Id` and `NonZeroU64` (#770)
- More obvious warnings in documentation (#769)

### Fixed

- Compiler error when `tracing-core/std` feature is enabled but
  `tracing/std` is not (#760)
- Clippy warning on vtable address comparison in `callsite::Identifier`
  (#749)
- Documentation formatting issues (#715, #771)

Thanks to @bkchr, @majecty, @taiki-e, @nagisa, and @nvzqz for
contributing to this release!
