### PR TITLE
tracing: prepare to release 0.1.16

### DIFF
--- a/tracing-subscriber/src/util.rs
+++ b/tracing-subscriber/src/util.rs
@@ -14,8 +14,8 @@ use tracing_core::dispatcher::{self, Dispatch};
 /// `Subscriber`, may implement `Into<Dispatch>`, and will also receive an
 /// implementation of this trait.
 ///
-/// [default subscriber]: https://docs.rs/tracing/0.1.15/tracing/dispatcher/index.html#setting-the-default-subscriber
-/// [trace dispatcher]: https://docs.rs/tracing/0.1.15/tracing/dispatcher/index.html
+/// [default subscriber]: https://docs.rs/tracing/0.1.16/tracing/dispatcher/index.html#setting-the-default-subscriber
+/// [trace dispatcher]: https://docs.rs/tracing/0.1.16/tracing/dispatcher/index.html
 pub trait SubscriberInitExt
 where
     Self: Into<Dispatch>,
@@ -27,7 +27,7 @@ where
     /// a [`log`] compatibility layer. This allows the subscriber to consume
     /// `log::Record`s as though they were `tracing` `Event`s.
     ///
-    /// [default subscriber]: https://docs.rs/tracing/0.1.15/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [default subscriber]: https://docs.rs/tracing/0.1.16/tracing/dispatcher/index.html#setting-the-default-subscriber
     /// [`log`]: https://crates.io/log
     fn set_default(self) -> dispatcher::DefaultGuard {
         #[cfg(feature = "tracing-log")]
@@ -47,7 +47,7 @@ where
     /// been set, or if a `log` logger has already been set (when the
     /// "tracing-log" feature is enabled).
     ///
-    /// [global default subscriber]: https://docs.rs/tracing/0.1.15/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [global default subscriber]: https://docs.rs/tracing/0.1.16/tracing/dispatcher/index.html#setting-the-default-subscriber
     /// [`log`]: https://crates.io/log
     fn try_init(self) -> Result<(), TryInitError> {
         #[cfg(feature = "tracing-log")]
@@ -69,7 +69,7 @@ where
     /// or if a `log` logger has already been set (when the "tracing-log"
     /// feature is enabled).
     ///
-    /// [global default subscriber]: https://docs.rs/tracing/0.1.15/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [global default subscriber]: https://docs.rs/tracing/0.1.16/tracing/dispatcher/index.html#setting-the-default-subscriber
     /// [`log`]: https://crates.io/log
     fn init(self) {
         self.try_init()

--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 0.1.16 (July 8, 2020)
+
+### Added
+
+- **attributes**: Support for arbitrary expressions as fields in `#[instrument]` (#672)
+- **attributes**: `#[instrument]` now emits a compiler warning when ignoring unrecognized
+  input (#672, #786)
+- Improved documentation on using `tracing` in async code (#769)
+
+### Changed
+
+- Updated `tracing-core` dependency to 0.1.11
+
+### Fixed
+
+- **macros**: Excessive monomorphization in macros, which could lead to
+  longer compilation times (#787) 
+- **log**: Compiler warnings in macros when `log` or `log-always` features
+  are enabled (#753)
+- Compiler error when `tracing-core/std` feature is enabled but `tracing/std` is
+  not (#760)
+
+Thanks to @nagisa for contributing to this release!
+
 # 0.1.15 (June 2, 2020)
 
 ### Changed

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.15"
+version = "0.1.16"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
@@ -29,7 +29,7 @@ edition = "2018"
 [dependencies]
 tracing-core = { path = "../tracing-core", version = "0.1.11", default-features = false }
 log = { version = "0.4", optional = true }
-tracing-attributes = { path = "../tracing-attributes", version = "0.1.8", optional = true }
+tracing-attributes = { path = "../tracing-attributes", version = "0.1.9", optional = true }
 cfg-if = "0.1.10"
 
 [dev-dependencies]

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -12,9 +12,9 @@ Application-level tracing for Rust.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.15
+[crates-url]: https://crates.io/crates/tracing/0.1.16
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.15
+[docs-url]: https://docs.rs/tracing/0.1.16
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -241,7 +241,7 @@ my_future
 is as long as the future's.
 
 The second, and preferred, option is through the
-[`#[instrument]`](https://docs.rs/tracing/0.1.15/tracing/attr.instrument.html)
+[`#[instrument]`](https://docs.rs/tracing/0.1.16/tracing/attr.instrument.html)
 attribute:
 
 ```rust
@@ -288,7 +288,7 @@ span.in_scope(|| {
 // Dropping the span will close it, indicating that it has ended.
 ```
 
-The [`#[instrument]`](https://docs.rs/tracing/0.1.15/tracing/attr.instrument.html) attribute macro
+The [`#[instrument]`](https://docs.rs/tracing/0.1.16/tracing/attr.instrument.html) attribute macro
 can reduce some of this boilerplate:
 
 ```rust

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -750,7 +750,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing = { version = "0.1.15", default-features = false }
+//!   tracing = { version = "0.1.16", default-features = false }
 //!   ```
 //!
 //!   *Compiler support: requires rustc 1.39+*
@@ -794,7 +794,7 @@
 //! [flags]: #crate-feature-flags
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.15")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.16")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
### Added

- **attributes**: Support for arbitrary expressions as fields in
  `#[instrument]` (#672)
- **attributes**: `#[instrument]` now emits a compiler warning when
  ignoring unrecognized input (#672, #786)
- Improved documentation on using `tracing` in async code (#769)

### Changed

- Updated `tracing-core` dependency to 0.1.11

### Fixed

- **macros**: Excessive monomorphization in macros, which could lead to
  longer compilation times (#787)
- **log**: Compiler warnings in macros when `log` or `log-always` features
  are enabled (#753)
- Compiler error when `tracing-core/std` feature is enabled but
  `tracing/std` is not (#760)

Thanks to @nagisa, and everyone who contributed to the new `tracing-core`
and `tracing-attributes` versions, for contributing to this release!
