### PR TITLE
chore(crates): rename examples crate

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "examples"
+name = "tracing-examples"
 version = "0.0.0"
 publish = false
 edition = "2018"


### PR DESCRIPTION
`examples` is actually not a valid crate identifier. This prevents dependabot from working correctly.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
