### PR TITLE
Allow thread name and id to be displayed in traces

### DIFF
--- a/examples/examples/thread-info.rs
+++ b/examples/examples/thread-info.rs
@@ -1,5 +1,5 @@
 #![deny(rust_2018_idioms)]
-/// This is a example showing how thread info can be enabled 
+/// This is a example showing how thread info can be enabled
 /// to be attached with events
 ///
 /// You can run this example by running the following command in a terminal
@@ -35,7 +35,9 @@ fn main() {
         .spawn(do_work)
         .expect("could not spawn a new thread");
 
-    thread_with_no_name.join().expect("could not wait for a thread");
+    thread_with_no_name
+        .join()
+        .expect("could not wait for a thread");
     thread_one.join().expect("could not wait for a thread");
     thread_two.join().expect("could not wait for a thread");
 }

--- a/examples/examples/thread-info.rs
+++ b/examples/examples/thread-info.rs
@@ -1,6 +1,8 @@
 #![deny(rust_2018_idioms)]
 /// This is a example showing how thread info can be displayed when
-/// formatting events with `tracing_subscriber::fmt`.
+/// formatting events with `tracing_subscriber::fmt`. This is useful
+/// as `tracing` spans can be entered by multicple threads concurrently,
+/// or move across threads freely.
 ///
 /// You can run this example by running the following command in a terminal
 ///
@@ -22,7 +24,9 @@ use tracing::info;
 fn main() {
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::DEBUG)
+        // enable thread id to be emitted
         .with_thread_ids(true)
+        // enabled thread name to be emitted
         .with_thread_names(true)
         .init();
 

--- a/examples/examples/thread-info.rs
+++ b/examples/examples/thread-info.rs
@@ -5,7 +5,7 @@
 /// You can run this example by running the following command in a terminal
 ///
 /// ```
-/// cargo run --example tokio-spawny-thing
+/// cargo run --example thread-info
 /// ```
 use std::thread;
 use std::time::Duration;

--- a/examples/examples/thread-info.rs
+++ b/examples/examples/thread-info.rs
@@ -13,9 +13,9 @@
 /// Example output:
 ///
 /// ```not_rust
-/// Jul 17 00:38:07.177  INFO ThreadId( 2) thread_info: i=9
-/// Jul 17 00:38:07.177  INFO            thread 1 ThreadId( 3) thread_info: i=9
-/// Jul 17 00:38:07.177  INFO large name thread 2 ThreadId( 4) thread_info: i=9
+/// Jul 17 00:38:07.177  INFO ThreadId(02) thread_info: i=9
+/// Jul 17 00:38:07.177  INFO            thread 1 ThreadId(03) thread_info: i=9
+/// Jul 17 00:38:07.177  INFO large name thread 2 ThreadId(04) thread_info: i=9
 /// ```
 use std::thread;
 use std::time::Duration;

--- a/examples/examples/thread-info.rs
+++ b/examples/examples/thread-info.rs
@@ -20,7 +20,7 @@ fn main() {
 
     let do_work = || {
         for i in 1..10 {
-            info!("number {}", i);
+            info!(i);
             thread::sleep(Duration::from_millis(1));
         }
     };

--- a/examples/examples/thread-info.rs
+++ b/examples/examples/thread-info.rs
@@ -1,11 +1,19 @@
 #![deny(rust_2018_idioms)]
-/// This is a example showing how thread info can be enabled
-/// to be attached with events
+/// This is a example showing how thread info can be displayed when
+/// formatting events with `tracing_subscriber::fmt`.
 ///
 /// You can run this example by running the following command in a terminal
 ///
 /// ```
 /// cargo run --example thread-info
+/// ```
+///
+/// Example output:
+///
+/// ```not_rust
+/// Jul 17 00:38:07.177  INFO ThreadId( 2) thread_info: i=9
+/// Jul 17 00:38:07.177  INFO            thread 1 ThreadId( 3) thread_info: i=9
+/// Jul 17 00:38:07.177  INFO large name thread 2 ThreadId( 4) thread_info: i=9
 /// ```
 use std::thread;
 use std::time::Duration;

--- a/examples/examples/thread_info.rs
+++ b/examples/examples/thread_info.rs
@@ -1,0 +1,41 @@
+#![deny(rust_2018_idioms)]
+/// This is a example showing how thread info can be enabled 
+/// to be attached with events
+///
+/// You can run this example by running the following command in a terminal
+///
+/// ```
+/// cargo run --example tokio-spawny-thing
+/// ```
+use std::thread;
+use std::time::Duration;
+use tracing::info;
+
+fn main() {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_thread_ids(true)
+        .with_thread_names(true)
+        .init();
+
+    let do_work = || {
+        for i in 1..10 {
+            info!("number {}", i);
+            thread::sleep(Duration::from_millis(1));
+        }
+    };
+
+    let thread_with_no_name = thread::spawn(do_work);
+    let thread_one = thread::Builder::new()
+        .name("thread 1".to_string())
+        .spawn(do_work)
+        .expect("could not spawn a new thread");
+    let thread_two = thread::Builder::new()
+        .name("large name thread 2".to_string())
+        .spawn(do_work)
+        .expect("could not spawn a new thread");
+
+    thread_with_no_name.join().expect("could not wait for a thread");
+    thread_one.join().expect("could not wait for a thread");
+    thread_two.join().expect("could not wait for a thread");
+}

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -290,6 +290,31 @@ where
         }
     }
 
+    /// Sets whether or not an event's thread id is displayed.
+    pub fn with_thread_ids(self, display_thread_ids: bool) -> Layer<S, N, format::Format<L, T>, W> {
+        Layer {
+            fmt_event: self.fmt_event.with_thread_id(display_thread_ids),
+            fmt_fields: self.fmt_fields,
+            fmt_span: self.fmt_span,
+            make_writer: self.make_writer,
+            _inner: self._inner,
+        }
+    }
+
+    /// Sets whether or not an event's thread name is displayed.
+    pub fn with_thread_names(
+        self,
+        display_thread_names: bool,
+    ) -> Layer<S, N, format::Format<L, T>, W> {
+        Layer {
+            fmt_event: self.fmt_event.with_thread_name(display_thread_names),
+            fmt_fields: self.fmt_fields,
+            fmt_span: self.fmt_span,
+            make_writer: self.make_writer,
+            _inner: self._inner,
+        }
+    }
+
     /// Sets the layer being built to use a [less verbose formatter](../fmt/format/struct.Compact.html).
     pub fn compact(self) -> Layer<S, N, format::Format<format::Compact, T>, W>
     where

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -296,7 +296,7 @@ where
     /// [thread ID]: https://doc.rust-lang.org/stable/std/thread/struct.ThreadId.html
     pub fn with_thread_ids(self, display_thread_ids: bool) -> Layer<S, N, format::Format<L, T>, W> {
         Layer {
-            fmt_event: self.fmt_event.with_thread_id(display_thread_ids),
+            fmt_event: self.fmt_event.with_thread_ids(display_thread_ids),
             fmt_fields: self.fmt_fields,
             fmt_span: self.fmt_span,
             make_writer: self.make_writer,
@@ -313,7 +313,7 @@ where
         display_thread_names: bool,
     ) -> Layer<S, N, format::Format<L, T>, W> {
         Layer {
-            fmt_event: self.fmt_event.with_thread_name(display_thread_names),
+            fmt_event: self.fmt_event.with_thread_names(display_thread_names),
             fmt_fields: self.fmt_fields,
             fmt_span: self.fmt_span,
             make_writer: self.make_writer,

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -290,7 +290,10 @@ where
         }
     }
 
-    /// Sets whether or not an event's thread id is displayed.
+    /// Sets whether or not the [thread ID] of the current thread is displayed
+    /// when formatting events
+    ///
+    /// [thread ID]: https://doc.rust-lang.org/stable/std/thread/struct.ThreadId.html
     pub fn with_thread_ids(self, display_thread_ids: bool) -> Layer<S, N, format::Format<L, T>, W> {
         Layer {
             fmt_event: self.fmt_event.with_thread_id(display_thread_ids),
@@ -301,7 +304,10 @@ where
         }
     }
 
-    /// Sets whether or not an event's thread name is displayed.
+    /// Sets whether or not the [name] of the current thread is displayed
+    /// when formatting events
+    ///
+    /// [name]: https://doc.rust-lang.org/stable/std/thread/index.html#naming-threads
     pub fn with_thread_names(
         self,
         display_thread_names: bool,

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -236,6 +236,28 @@ where
                 serializer.serialize_entry("target", meta.target())?;
             }
 
+            if self.display_thread_name {
+                match std::thread::current().name() {
+                    Some(name) => {
+                        serializer.serialize_entry("threadName", name)?;
+                    }
+                    None => {
+                        // fall-back to thread id when name is absent and id's are not enabled
+                        if !self.display_thread_id {
+                            serializer.serialize_entry(
+                                "threadId",
+                                &format!("{:?}", std::thread::current().id()),
+                            )?;
+                        }
+                    }
+                }
+            }
+
+            if self.display_thread_id {
+                serializer
+                    .serialize_entry("threadId", &format!("{:?}", std::thread::current().id()))?;
+            }
+
             if !self.format.flatten_event {
                 use tracing_serde::fields::AsMap;
                 serializer.serialize_entry("fields", &event.field_map())?;

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -237,16 +237,15 @@ where
             }
 
             if self.display_thread_name {
-                match std::thread::current().name() {
+                let current_thread = std::thread::current();
+                match current_thread.name() {
                     Some(name) => {
                         serializer.serialize_entry("threadName", name)?;
                     }
                     // fall-back to thread id when name is absent and ids are not enabled
                     None if !self.display_thread_id => {
-                        serializer.serialize_entry(
-                            "threadName",
-                            &format!("{:?}", std::thread::current().id()),
-                        )?;
+                        serializer
+                            .serialize_entry("threadName", &format!("{:?}", current_thread.id()))?;
                     }
                     _ => {}
                 }

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -241,15 +241,14 @@ where
                     Some(name) => {
                         serializer.serialize_entry("threadName", name)?;
                     }
-                    None => {
-                        // fall-back to thread id when name is absent and id's are not enabled
-                        if !self.display_thread_id {
-                            serializer.serialize_entry(
-                                "threadId",
-                                &format!("{:?}", std::thread::current().id()),
-                            )?;
-                        }
+                    // fall-back to thread id when name is absent and ids are not enabled
+                    None if !self.display_thread_id => {
+                        serializer.serialize_entry(
+                            "threadId",
+                            &format!("{:?}", std::thread::current().id()),
+                        )?;
                     }
+                    _ => {}
                 }
             }
 

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -244,7 +244,7 @@ where
                     // fall-back to thread id when name is absent and ids are not enabled
                     None if !self.display_thread_id => {
                         serializer.serialize_entry(
-                            "threadId",
+                            "threadName",
                             &format!("{:?}", std::thread::current().id()),
                         )?;
                     }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -848,6 +848,9 @@ impl<'a> fmt::Display for FmtThreadName<'a> {
             Ordering::{AcqRel, Acquire, Relaxed},
         };
 
+        // MAX_LEN stores the length of the longest thread name that we've seen
+        // so far and is persistent across fmt executions being a static field
+        // thread names are padded with this field to get formatted outputs.
         static MAX_LEN: AtomicUsize = AtomicUsize::new(0);
         let len = self.name.len();
         let mut max_len = MAX_LEN.load(Relaxed);

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -300,7 +300,10 @@ impl<F, T> Format<F, T> {
         }
     }
 
-    /// Sets whether or not an event's thread id is displayed.
+    /// Sets whether or not the [thread ID] of the current thread is displayed
+    /// when formatting events
+    ///
+    /// [thread ID]: https://doc.rust-lang.org/stable/std/thread/struct.ThreadId.html
     pub fn with_thread_id(self, display_thread_id: bool) -> Format<F, T> {
         Format {
             display_thread_id,
@@ -308,7 +311,10 @@ impl<F, T> Format<F, T> {
         }
     }
 
-    /// Sets whether or not an event's thread name is displayed.
+    /// Sets whether or not the [name] of the current thread is displayed
+    /// when formatting events
+    ///
+    /// [name]: https://doc.rust-lang.org/stable/std/thread/index.html#naming-threads
     pub fn with_thread_name(self, display_thread_name: bool) -> Format<F, T> {
         Format {
             display_thread_name,

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -402,13 +402,14 @@ where
         }
 
         if self.display_thread_name {
-            match std::thread::current().name() {
+            let current_thread = std::thread::current();
+            match current_thread.name() {
                 Some(name) => {
                     write!(writer, "{} ", FmtThreadName::new(name))?;
                 }
                 // fall-back to thread id when name is absent and ids are not enabled
                 None if !self.display_thread_id => {
-                    write!(writer, "{:>2?} ", std::thread::current().id())?;
+                    write!(writer, "{:>2?} ", current_thread.id())?;
                 }
                 _ => {}
             }
@@ -476,13 +477,14 @@ where
         }
 
         if self.display_thread_name {
-            match std::thread::current().name() {
+            let current_thread = std::thread::current();
+            match current_thread.name() {
                 Some(name) => {
                     write!(writer, "{} ", FmtThreadName::new(name))?;
                 }
                 // fall-back to thread id when name is absent and ids are not enabled
                 None if !self.display_thread_id => {
-                    write!(writer, "{:>2?} ", std::thread::current().id())?;
+                    write!(writer, "{:>2?} ", current_thread.id())?;
                 }
                 _ => {}
             }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -304,7 +304,7 @@ impl<F, T> Format<F, T> {
     /// when formatting events
     ///
     /// [thread ID]: https://doc.rust-lang.org/stable/std/thread/struct.ThreadId.html
-    pub fn with_thread_id(self, display_thread_id: bool) -> Format<F, T> {
+    pub fn with_thread_ids(self, display_thread_id: bool) -> Format<F, T> {
         Format {
             display_thread_id,
             ..self
@@ -315,7 +315,7 @@ impl<F, T> Format<F, T> {
     /// when formatting events
     ///
     /// [name]: https://doc.rust-lang.org/stable/std/thread/index.html#naming-threads
-    pub fn with_thread_name(self, display_thread_name: bool) -> Format<F, T> {
+    pub fn with_thread_names(self, display_thread_name: bool) -> Format<F, T> {
         Format {
             display_thread_name,
             ..self

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -848,20 +848,28 @@ impl<'a> fmt::Display for FmtThreadName<'a> {
             Ordering::{AcqRel, Acquire, Relaxed},
         };
 
-        // MAX_LEN stores the length of the longest thread name that we've seen
-        // so far and is persistent across fmt executions being a static field
-        // thread names are padded with this field to get formatted outputs.
+        // Track the longest thread name length we've seen so far in an atomic,
+        // so that it can be updated by any thread.
         static MAX_LEN: AtomicUsize = AtomicUsize::new(0);
         let len = self.name.len();
+        // Snapshot the current max thread name length.
         let mut max_len = MAX_LEN.load(Relaxed);
 
         while len > max_len {
+            // Try to set a new max length, if it is still the value we took a
+            // snapshot of.
             match MAX_LEN.compare_exchange(max_len, len, AcqRel, Acquire) {
+                // We successfully set the new max value
                 Ok(_) => break,
+                // Another thread set a new max value since we last observed
+                // it! It's possible that the new length is actually longer than
+                // ours, so we'll loop again and check whether our length is
+                // still the longest. If not, we'll just use the newer value.
                 Err(actual) => max_len = actual,
             }
         }
 
+        // pad thread name using `max_len`
         write!(f, "{:>width$}", self.name, width = max_len)
     }
 }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -402,14 +402,13 @@ where
                 }
                 // fall-back to thread id when name is absent and ids are not enabled
                 None if !self.display_thread_id => {
-                    write!(writer, "{} ", FmtThreadId::new(std::thread::current().id()))?;
-                }
+                    write!(writer, "{:>2?} ", std::thread::current().id())?;                }
                 _ => {}
             }
         }
 
         if self.display_thread_id {
-            write!(writer, "{} ", FmtThreadId::new(std::thread::current().id()))?;
+            write!(writer, "{:>2?} ", std::thread::current().id())?;
         }
 
         let full_ctx = {
@@ -476,14 +475,14 @@ where
                 }
                 // fall-back to thread id when name is absent and ids are not enabled
                 None if !self.display_thread_id => {
-                    write!(writer, "{} ", FmtThreadId::new(std::thread::current().id()))?;
+                    write!(writer, "{:>2?} ", std::thread::current().id())?;
                 }
                 _ => {}
             }
         }
 
         if self.display_thread_id {
-            write!(writer, "{} ", FmtThreadId::new(std::thread::current().id()))?;
+            write!(writer, "{:>2?} ", std::thread::current().id())?;
         }
 
         let fmt_ctx = {
@@ -852,22 +851,6 @@ impl<'a> fmt::Display for FmtThreadName<'a> {
         }
 
         write!(f, "{:>width$}", self.name, width = max_len)
-    }
-}
-
-struct FmtThreadId {
-    thread_id: std::thread::ThreadId,
-}
-
-impl FmtThreadId {
-    pub(crate) fn new(thread_id: std::thread::ThreadId) -> Self {
-        Self { thread_id }
-    }
-}
-
-impl fmt::Display for FmtThreadId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:>2?}", self.thread_id)
     }
 }
 

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -400,12 +400,11 @@ where
                 Some(name) => {
                     write!(writer, "{} ", FmtThreadName::new(name))?;
                 }
-                None => {
-                    // fall-back to thread id when name is absent and id's are not enabled
-                    if !self.display_thread_id {
-                        write!(writer, "{} ", FmtThreadId::new(std::thread::current().id()))?;
-                    }
+                // fall-back to thread id when name is absent and ids are not enabled
+                None if !self.display_thread_id => {
+                    write!(writer, "{} ", FmtThreadId::new(std::thread::current().id()))?;
                 }
+                _ => {}
             }
         }
 
@@ -475,12 +474,11 @@ where
                 Some(name) => {
                     write!(writer, "{} ", FmtThreadName::new(name))?;
                 }
-                None => {
-                    // fall-back to thread id when name is absent and id's are not enabled
-                    if !self.display_thread_id {
-                        write!(writer, "{} ", FmtThreadId::new(std::thread::current().id()))?;
-                    }
+                // fall-back to thread id when name is absent and ids are not enabled
+                None if !self.display_thread_id => {
+                    write!(writer, "{} ", FmtThreadId::new(std::thread::current().id()))?;
                 }
+                _ => {}
             }
         }
 

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -402,7 +402,8 @@ where
                 }
                 // fall-back to thread id when name is absent and ids are not enabled
                 None if !self.display_thread_id => {
-                    write!(writer, "{:>2?} ", std::thread::current().id())?;                }
+                    write!(writer, "{:>2?} ", std::thread::current().id())?;
+                }
                 _ => {}
             }
         }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -409,14 +409,14 @@ where
                 }
                 // fall-back to thread id when name is absent and ids are not enabled
                 None if !self.display_thread_id => {
-                    write!(writer, "{:>2?} ", current_thread.id())?;
+                    write!(writer, "{:0>2?} ", current_thread.id())?;
                 }
                 _ => {}
             }
         }
 
         if self.display_thread_id {
-            write!(writer, "{:>2?} ", std::thread::current().id())?;
+            write!(writer, "{:0>2?} ", std::thread::current().id())?;
         }
 
         let full_ctx = {
@@ -484,14 +484,14 @@ where
                 }
                 // fall-back to thread id when name is absent and ids are not enabled
                 None if !self.display_thread_id => {
-                    write!(writer, "{:>2?} ", current_thread.id())?;
+                    write!(writer, "{:0>2?} ", current_thread.id())?;
                 }
                 _ => {}
             }
         }
 
         if self.display_thread_id {
-            write!(writer, "{:>2?} ", std::thread::current().id())?;
+            write!(writer, "{:0>2?} ", std::thread::current().id())?;
         }
 
         let fmt_ctx = {

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -542,7 +542,10 @@ where
         }
     }
 
-    /// Sets whether or not an event's thread name is displayed.
+    /// Sets whether or not the [name] of the current thread is displayed
+    /// when formatting events
+    ///
+    /// [name]: https://doc.rust-lang.org/stable/std/thread/index.html#naming-threads
     pub fn with_thread_names(
         self,
         display_thread_names: bool,
@@ -553,7 +556,10 @@ where
         }
     }
 
-    /// Sets whether or not an event's thread id is displayed.
+    /// Sets whether or not the [thread ID] of the current thread is displayed
+    /// when formatting events
+    ///
+    /// [thread ID]: https://doc.rust-lang.org/stable/std/thread/struct.ThreadId.html
     pub fn with_thread_ids(
         self,
         display_thread_ids: bool,

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -542,6 +542,28 @@ where
         }
     }
 
+    /// Sets whether or not an event's thread name is displayed.
+    pub fn with_thread_names(
+        self,
+        display_thread_names: bool,
+    ) -> SubscriberBuilder<N, format::Format<L, T>, F, W> {
+        SubscriberBuilder {
+            filter: self.filter,
+            inner: self.inner.with_thread_names(display_thread_names),
+        }
+    }
+
+    /// Sets whether or not an event's thread id is displayed.
+    pub fn with_thread_ids(
+        self,
+        display_thread_ids: bool,
+    ) -> SubscriberBuilder<N, format::Format<L, T>, F, W> {
+        SubscriberBuilder {
+            filter: self.filter,
+            inner: self.inner.with_thread_ids(display_thread_ids),
+        }
+    }
+
     /// Sets the subscriber being built to use a less verbose formatter.
     ///
     /// See [`format::Compact`](../fmt/format/struct.Compact.html).


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

Fixes #809 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

This PR adds two new methods i.e `with_thread_ids` and
`with_thread_names` to the fmt Layer which passed till
the pre-configured Format type, where the check is performed
and these the above values are formatted based on the flags.

The formatting is done by creating to new Types that impl Display
for Id and Name. For Thread Name, we keep track of the max length
of the thread name that occured till now using a thread safe static
type and pad accordingly. For Thread Id, we pad directly with 2
as in most cases we would see a double digit number of threads.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
