### PR TITLE
subscriber: prepare to release 0.2.8

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,7 @@ tracing-core = { path = "../tracing-core", version = "0.1"}
 tracing-error = { path = "../tracing-error" }
 tracing-flame = { path = "../tracing-flame" }
 tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.7", features = ["json", "chrono"] }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.8", features = ["json", "chrono"] }
 tracing-futures = { version = "0.2.1", path = "../tracing-futures", features = ["futures-01"] }
 tracing-attributes =  { path = "../tracing-attributes", version = "0.1.2"}
 tracing-log = { path = "../tracing-log", version = "0.1.1", features = ["env_logger"] }

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,28 @@
+# 0.2.8 (July 17, 2020)
+
+### Changed
+
+- **fmt**: When the `chrono` dependency is enabled, the `SystemTime` timestamp
+  formatter now emits human-readable timestamps rather than using `SystemTime`'s
+  `fmt::Debug`implementation (`chrono` is still required for customized
+  timestamp formatting) (#807)
+- **ansi**: Updated `ansi_term` dependency to 0.12 (#816)
+
+### Added
+
+- **json**: `with_span_list` method to configure the JSON formatter to include a
+  list of all spans in the current trace in formatting events (similarly to the
+  text formatter) (#741) 
+- **json**: `with_current_span` method to configure the JSON formatter to include
+  a field for the _current_ span (the leaf of the trace) in formatted events
+  (#741)
+- **fmt**: `with_thread_names` and `with_thread_ids` methods to configure
+  `fmt::Subscriber`s and `fmt::Layer`s to include the thread name and/or thread ID
+  of the current thread when formatting events (#818)
+  
+Thanks to new contributors @mockersf, @keetonian, and @Pothulapati for
+contributing to this release!
+
 # 0.2.7 (July 1, 2020)
 
 ### Changed

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.7"
+version = "0.2.8"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -17,7 +17,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.2.7
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.8
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -49,7 +49,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.7")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.8")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(
     missing_debug_implementations,


### PR DESCRIPTION
### Changed

- **fmt**: When the `chrono` dependency is enabled, the `SystemTime`
  timestamp now emits human-readable timestamps rather than using
  `SystemTime`'s fmt::Debug`implementation (`chrono` is still required
  for customized timestamp formatting) (#807)
- **ansi**: Updated `ansi_term` dependency to 0.12 (#816)

### Added

- **json**: `with_span_list` method to configure the JSON formatter to
  include a list of all spans in the current trace in formatting events
  (similarly to the text formatter) (#741)
- **json**: `with_current_span` method to configure the JSON formatter
  to include a field for the _current_ span (the leaf of the trace) in
  formatted events (#741)
- **fmt**: `with_thread_names` and `with_thread_ids` methods to
  configure `fmt::Subscriber`s and `fmt::Layer`s to include the thread
  name and/or thread ID of the current thread when formatting events
  (#818)

Thanks to new contributors @mockersf, @keetonian, and @Pothulapati for
contributing to this release!