### PR TITLE
appender: prepare to release 0.1.1

### DIFF
--- a/tracing-appender/CHANGELOG.md
+++ b/tracing-appender/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.1.1 (July 20, 2020)
+
+### Added
+
+- **rolling**: `minutely` rotation schedule to rotate the log file once every
+  minute (#748)
+
+### Fixed
+
+- Fixed broken links in docs (#718)
+- `tracing-appender` now only enables the necessary `tracing-subscriber`'s
+  feature flags, rather than all of them (#779) 
+
+Thanks to new contributors @ericjheinz and @sourcefrog for contributing
+to this release!
+
 # 0.1.0 (May 5, 2020)
 
 - Initial release

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-appender"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "Zeki Sherif <zekshi@amazon.com>",
     "Tokio Contributors <team@tokio.rs>"

--- a/tracing-appender/README.md
+++ b/tracing-appender/README.md
@@ -12,9 +12,9 @@ Writers for logging events and spans
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-appender.svg
-[crates-url]: https://crates.io/crates/tracing-appender/0.1.0
+[crates-url]: https://crates.io/crates/tracing-appender/0.1.1
 [docs-badge]: https://docs.rs/tracing-appender/badge.svg
-[docs-url]: https://docs.rs/tracing-appender/0.1.0
+[docs-url]: https://docs.rs/tracing-appender/0.1.1
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing.rs/tracing-appender
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -104,7 +104,7 @@
 //!     .init();
 //! # }
 //! ```
-#![doc(html_root_url = "https://docs.rs/tracing-appender/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-appender/0.1.1")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
### Added

- **rolling**: `minutely` rotation schedule to rotate the log file once
  every minute (#748)

### Fixed

- Fixed broken links in docs (#718)
- `tracing-appender` now only enables the necessary
  `tracing-subscriber`'s feature flags, rather than all of them (#779)

Thanks to new contributors @ericjheinz and @sourcefrog for contributing
to this release!

Signed-off-by: Eliza Weisman <eliza@buoyant.io>