### PR TITLE
tracing: Revert "tracing: fix name clash inside of tracing macros (#806)"

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -1883,91 +1883,92 @@ macro_rules! valueset {
     // };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&$crate::field::debug(&$val) as &$crate::field::Value)) },
+            @ { $($out),*, (&$next, Some(&debug(&$val) as &Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&$crate::field::display(&$val) as &$crate::field::Value)) },
+            @ { $($out),*, (&$next, Some(&display(&$val) as &Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = $val:expr, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&$val as &$crate::field::Value)) },
+            @ { $($out),*, (&$next, Some(&$val as &Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&$($k).+ as &$crate::field::Value)) },
+            @ { $($out),*, (&$next, Some(&$($k).+ as &Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, ?$($k:ident).+, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&$crate::field::debug(&$($k).+) as &$crate::field::Value)) },
+            @ { $($out),*, (&$next, Some(&debug(&$($k).+) as &Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, %$($k:ident).+, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&$crate::field::display(&$($k).+) as &$crate::field::Value)) },
+            @ { $($out),*, (&$next, Some(&display(&$($k).+) as &Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = ?$val:expr) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&$crate::field::debug(&$val) as &$crate::field::Value)) },
+            @ { $($out),*, (&$next, Some(&debug(&$val) as &Value)) },
             $next,
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = %$val:expr) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&$crate::field::display(&$val) as &$crate::field::Value)) },
+            @ { $($out),*, (&$next, Some(&display(&$val) as &Value)) },
             $next,
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = $val:expr) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&$val as &$crate::field::Value)) },
+            @ { $($out),*, (&$next, Some(&$val as &Value)) },
             $next,
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&$($k).+ as &$crate::field::Value)) },
+            @ { $($out),*, (&$next, Some(&$($k).+ as &Value)) },
             $next,
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, ?$($k:ident).+) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&$crate::field::debug(&$($k).+) as &$crate::field::Value)) },
+            @ { $($out),*, (&$next, Some(&debug(&$($k).+) as &Value)) },
             $next,
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, %$($k:ident).+) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&$crate::field::display(&$($k).+) as &$crate::field::Value)) },
+            @ { $($out),*, (&$next, Some(&display(&$($k).+) as &Value)) },
             $next,
         )
     };
     // Remainder is unparseable, but exists --- must be format args!
     (@ { $(,)* $($out:expr),* }, $next:expr, $($rest:tt)+) => {
-        $crate::valueset!(@ { (&$next, Some(&format_args!($($rest)+) as &$crate::field::Value)), $($out),* }, $next, )
+        $crate::valueset!(@ { (&$next, Some(&format_args!($($rest)+) as &Value)), $($out),* }, $next, )
     };
 
     // === entry ===
     ($fields:expr, $($kvs:tt)+) => {
         {
             #[allow(unused_imports)]
+            use $crate::field::{debug, display, Value};
             let mut iter = $fields.iter();
             $fields.value_set($crate::valueset!(
                 @ { },


### PR DESCRIPTION
This reverts commit e3b3a3acb14141c3f5b72dad6dc45080fdfa0d5d.

This change was accidentally semver-incompatible, as user code was able
to use the imported `debug` and `display` functions without adding an
import outside the macro. Although this was not documented, downstream
code relied on these names being available, so this resulted in a
breaking change in a point release.

Fixes #820