### PR TITLE
log: make span enter/exit targets always TRACE

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -644,8 +644,12 @@
 //! populated. Additionally, `log` records are also generated when spans are
 //! entered, exited, and closed. Since these additional span lifecycle logs have
 //! the potential to be very verbose, and don't include additional fields, they
-//! are categorized under a separate `log` target, "tracing::span", which may be
-//! enabled or disabled separately from other `log` records emitted by `tracing`.
+//! will always be emitted at the `Trace` level, rather than inheriting the
+//! level of the span that generated them. Furthermore, they are are categorized
+//! under a separate `log` target, "tracing::span" (and its sub-target,
+//! "tracing::span::active", for the logs on entering and exiting a span), which
+//! may be enabled or disabled separately from other `log` records emitted by
+//! `tracing`.
 //!
 //! ### Consuming `log` Records
 //!

--- a/tracing/test-log-support/tests/span_lifecycle_can_be_enabled.rs
+++ b/tracing/test-log-support/tests/span_lifecycle_can_be_enabled.rs
@@ -1,0 +1,77 @@
+#[macro_use]
+extern crate tracing;
+extern crate test_log_support;
+
+use test_log_support::Test;
+use tracing::Level;
+
+#[test]
+fn span_lifecycle_can_be_enabled() {
+    let test = Test::with_filters(&[
+        (module_path!(), log::LevelFilter::Trace),
+        ("tracing::span", log::LevelFilter::Trace),
+    ]);
+
+    error!(foo = 5);
+    test.assert_logged("foo=5");
+
+    warn!("hello {};", "world");
+    test.assert_logged("hello world;");
+
+    info!(message = "hello world;", thingy = 42, other_thingy = 666);
+    test.assert_logged("hello world; thingy=42 other_thingy=666");
+
+    let foo = span!(Level::TRACE, "foo");
+    test.assert_logged("foo");
+
+    foo.in_scope(|| {
+        // enter should be logged
+        test.assert_logged("-> foo");
+
+        trace!({foo = 3, bar = 4}, "hello {};", "san francisco");
+        test.assert_logged("hello san francisco; foo=3 bar=4");
+    });
+    // exit should be logged
+    test.assert_logged("<- foo");
+
+    drop(foo);
+    // drop should be logged
+    test.assert_logged("-- foo");
+
+    trace!(foo = 1, bar = 2, "hello world");
+    test.assert_logged("hello world foo=1 bar=2");
+
+    let foo = span!(Level::TRACE, "foo", bar = 3, baz = false);
+    // creating a span with fields _should_ be logged.
+    test.assert_logged("foo; bar=3 baz=false");
+
+    foo.in_scope(|| {
+        // entering the span should be logged
+        test.assert_logged("-> foo");
+    });
+    // exiting the span should be logged
+    test.assert_logged("<- foo");
+
+    foo.record("baz", &true);
+    // recording a field should be logged
+    test.assert_logged("foo; baz=true");
+
+    let bar = span!(Level::INFO, "bar");
+    // lifecycles for INFO spans should be logged
+    test.assert_logged("bar");
+
+    bar.in_scope(|| {
+        // entering the INFO span should be logged
+        test.assert_logged("-> bar");
+    });
+    // exiting the INFO span should be logged
+    test.assert_logged("<- bar");
+
+    drop(foo);
+    // drop should be logged.
+    test.assert_logged("-- foo");
+
+    drop(bar);
+    // dropping the INFO should be logged.
+    test.assert_logged("-- bar");
+}

--- a/tracing/test-log-support/tests/span_lifecycle_is_trace.rs
+++ b/tracing/test-log-support/tests/span_lifecycle_is_trace.rs
@@ -6,8 +6,11 @@ use test_log_support::Test;
 use tracing::Level;
 
 #[test]
-fn span_lifecycle_defaults_off() {
-    let test = Test::with_filters(&[(module_path!(), log::LevelFilter::Trace)]);
+fn span_lifecycle_is_trace() {
+    let test = Test::with_filters(&[
+        (module_path!(), log::LevelFilter::Trace),
+        ("", log::LevelFilter::Info),
+    ]);
 
     error!(foo = 5);
     test.assert_logged("foo=5");
@@ -19,6 +22,7 @@ fn span_lifecycle_defaults_off() {
     test.assert_logged("hello world; thingy=42 other_thingy=666");
 
     let foo = span!(Level::TRACE, "foo");
+    // A span without fields should not be logged
     test.assert_not_logged();
 
     foo.in_scope(|| {


### PR DESCRIPTION
## Motivation
 
Currently, `tracing`'s `log` feature emits log records for creating,
entering, exiting, and dropping a `Span` at the `log` equivalent of that
span's `tracing` level. If the span has any fields, the span creation
logs are sent to the same target that the span would have, since the
fields provide high-value information that users enabling that target
will probably want to see. However, the other events for entering,
exiting, and dropping a span do not include fields, and are much more
verbose, so they are sent to a special `tracing::span` target. This
allows them to be filtered independently, and only enabled when needed.

However, some `log` users have noted that when using _blanket_ `log`
filters, like setting the level to `info` globally, the more verbose
activity logs will still be enabled for spans whose level matches. This
can be annoying.

## Solution

Therefore, this branch changes the span activity and lifecycle logs to
_always_ have the `Trace` `log` level, even when the span that generated
them has a less-verbose level. When fields are recorded, the emitted log
records are sent to the span's target instead, since users probably want
this information if they have enabled the span's level for its target.

Additionally, I've added a sub-target of `tracing::span` for the
enter/exit logs in particular (`tracing::span::active`). This allows
them to be filtered independently of the less frequent creation/drop
logs.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>