### PR TITLE
tracing: fix missing `debug`/`display` with `log`

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -2288,6 +2288,8 @@ macro_rules! __mk_format_args {
     // === entry ===
     ($($kv:tt)*) => {
         {
+            #[allow(unused_imports)]
+            use $crate::field::{debug, display};
             // use $crate::__mk_format_string;
             $crate::__mk_format_args!(@ { }, $crate::__mk_format_string!($($kv)*), fields: $($kv)*)
         }

--- a/tracing/test-log-support/tests/log_no_trace.rs
+++ b/tracing/test-log-support/tests/log_no_trace.rs
@@ -15,7 +15,11 @@ fn test_always_log() {
     warn!("hello {};", "world");
     test.assert_logged("hello world;");
 
-    info!(message = "hello world;", thingy = 42, other_thingy = 666);
+    info!(
+        message = "hello world;",
+        thingy = display(42),
+        other_thingy = debug(666)
+    );
     test.assert_logged("hello world; thingy=42 other_thingy=666");
 
     let foo = span!(Level::TRACE, "foo");


### PR DESCRIPTION
## Motivation

When the `log` feature is enabled, the expressions provided for field
values are passed into two separate macros: one which prepares the
`tracing` structured value set that is used to construct the `tracing`
event, and another which formats a textual message to send to `log`, if
emitting a `log` record for the event is enabled. The issue is that the
macro that generates the `tracing` value set generates a block
containing an import for `tracing::field::debug` and
`tracing::field::display`, while the block generated by the `log`
message formatting macro does not import those functions. Therefore, the
block where the `log` message is formatted fails to compile, since the
functions are not present in the scope it expands to.

It turns out this is not, in fact, an accidental breaking change in
0.1.16 as was suspected, but a long-standing bug that has existed since
commit 76b5e80405cc1f2e0c8ad85d1201f7369de83fd5, which predates
`tracing` 0.1.0. This issue existed as far back as when the library was
still called `tokio-trace`!

However, the issue only exists when the `log` feature flag is enabled
--- and it's disabled by default. The bug hadn't caused any issues in
the past, since use of the `log` feature flag was not widespread enough
to be coincident with an instance of someone relying on the
implicitly-imported function names. The breakage happened specifically
because `hyper` 0.13.7 enables `tracing`'s `log` feature by default, so
_everyone_ depending on `hyper` suddenly had that feature enabled ---
now, the set of people enabling the `log` feature is suddenly _much_
larger!

## Solution

This branch adds the missing imports in the `__tracing_mk_format_args!`
helper macro, which generates the `log` format args.

I've also added uses of `debug` and `display` without imports to the
tests for the `log` feature flag, which don't compile prior to the fix.

Fixes #820 (for real, this time!)