### PR TITLE
subscriber: prepare to release 0.2.9

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,7 @@ tracing-core = { path = "../tracing-core", version = "0.1"}
 tracing-error = { path = "../tracing-error" }
 tracing-flame = { path = "../tracing-flame" }
 tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.8", features = ["json", "chrono"] }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.9", features = ["json", "chrono"] }
 tracing-futures = { version = "0.2.1", path = "../tracing-futures", features = ["futures-01"] }
 tracing-attributes =  { path = "../tracing-attributes", version = "0.1.2"}
 tracing-log = { path = "../tracing-log", version = "0.1.1", features = ["env_logger"] }

--- a/tracing-error/src/layer.rs
+++ b/tracing-error/src/layer.rs
@@ -15,10 +15,10 @@ use tracing_subscriber::{
 /// when formatting the fields of each span in a trace. When no formatter is
 /// provided, the [default format] is used instead.
 ///
-/// [`Layer`]: https://docs.rs/tracing-subscriber/0.2.7/tracing_subscriber/layer/trait.Layer.html
+/// [`Layer`]: https://docs.rs/tracing-subscriber/0.2.9/tracing_subscriber/layer/trait.Layer.html
 /// [`SpanTrace`]: ../struct.SpanTrace.html
-/// [field formatter]: https://docs.rs/tracing-subscriber/0.2.7/tracing_subscriber/fmt/trait.FormatFields.html
-/// [default format]: https://docs.rs/tracing-subscriber/0.2.7/tracing_subscriber/fmt/format/struct.DefaultFields.html
+/// [field formatter]: https://docs.rs/tracing-subscriber/0.2.9/tracing_subscriber/fmt/trait.FormatFields.html
+/// [default format]: https://docs.rs/tracing-subscriber/0.2.9/tracing_subscriber/fmt/format/struct.DefaultFields.html
 pub struct ErrorLayer<S, F = DefaultFields> {
     format: F,
 
@@ -70,7 +70,7 @@ where
 {
     /// Returns a new `ErrorLayer` with the provided [field formatter].
     ///
-    /// [field formatter]: https://docs.rs/tracing-subscriber/0.2.7/tracing_subscriber/fmt/trait.FormatFields.html
+    /// [field formatter]: https://docs.rs/tracing-subscriber/0.2.9/tracing_subscriber/fmt/trait.FormatFields.html
     pub fn new(format: F) -> Self {
         Self {
             format,

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,4 +1,16 @@
-# 0.2.8 (July 17, 2020)
+# 0.2.9 (July 23, 2020)
+
+### Fixed
+
+- **fmt**: Fixed compilation failure on MSRV when the `chrono` feature is
+  disabled (#844)
+
+### Added
+
+- **fmt**: Span lookup methods defined by `layer::Context` are now also provided
+  by `FmtContext` (#834)
+
+# 0.2.9 (July 17, 2020)
 
 ### Changed
 

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.8"
+version = "0.2.9"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -17,7 +17,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.2.8
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.9
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -49,7 +49,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.8")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.9")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo.svg",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
### Fixed

- **fmt**: Fixed compilation failure on MSRV when the `chrono` feature
  is disabled (#844)

### Added

- **fmt**: Span lookup methods defined by `layer::Context` are now also
  provided by `FmtContext` (#834)

