### PR TITLE
core: add faster fast path for level filtering

### DIFF
--- a/tracing-core/CHANGELOG.md
+++ b/tracing-core/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## Added
 
-- `LevelFilter` type and `LevelFilter::max()` for returning the highest level
+- `LevelFilter` type and `LevelFilter::current()` for returning the highest level
   that any subscriber will enable (#853)
 - `Subscriber::max_level_hint` optional trait method, for setting the value
-  returned by `LevelFilter::max()` (#853)
+  returned by `LevelFilter::current()` (#853)
 
 # 0.1.11 (June 8, 2020)
 

--- a/tracing-core/CHANGELOG.md
+++ b/tracing-core/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Added
 
-- `LevelFilter` type and `LevelFilter::max()`
-- `Subscriber::max_level_hint` for setting the value returned by `LevelFilter::max()`
+- `LevelFilter` type and `LevelFilter::max()` for returning the highest level
+  that any subscriber will enable (#853)
+- `Subscriber::max_level_hint` optional trait method, for setting the value
+  returned by `LevelFilter::max()` (#853)
 
 # 0.1.11 (June 8, 2020)
 

--- a/tracing-core/CHANGELOG.md
+++ b/tracing-core/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.12 (UNRELEASED)
+
+## Added
+
+- `LevelFilter` type and `LevelFilter::max()`
+- `Subscriber::max_level_hint` for setting the value returned by `LevelFilter::max()`
+
 # 0.1.11 (June 8, 2020)
 
 ## Changed

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-core"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.11"
+version = "0.1.12"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -8,7 +8,7 @@ use crate::stdlib::{
 };
 use crate::{
     dispatcher::{self, Dispatch},
-    metadata::{Level, LevelFilter, Metadata},
+    metadata::{LevelFilter, Metadata},
     subscriber::Interest,
 };
 
@@ -40,7 +40,7 @@ impl Registry {
     }
 
     fn rebuild_interest(&mut self) {
-        let mut max_level = Level::TRACE;
+        let mut max_level = LevelFilter::TRACE;
         self.dispatchers.retain(|registrar| {
             if let Some(dispatch) = registrar.upgrade() {
                 if let Some(level) = dispatch.max_level_hint() {
@@ -57,7 +57,7 @@ impl Registry {
         self.callsites.iter().for_each(|&callsite| {
             self.rebuild_callsite_interest(callsite);
         });
-        LevelFilter::set_max(LevelFilter::from_level(max_level));
+        LevelFilter::set_max(max_level);
     }
 }
 

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -135,7 +135,7 @@
 use crate::{
     callsite, span,
     subscriber::{self, Subscriber},
-    Event, Level, Metadata,
+    Event, LevelFilter, Metadata,
 };
 
 use crate::stdlib::{
@@ -440,7 +440,7 @@ impl Dispatch {
     /// [`register_callsite`]: ../subscriber/trait.Subscriber.html#method.max_level_hint
     // TODO(eliza): consider making this a public API?
     #[inline]
-    pub(crate) fn max_level_hint(&self) -> Option<Level> {
+    pub(crate) fn max_level_hint(&self) -> Option<LevelFilter> {
         self.subscriber.max_level_hint()
     }
 

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -434,7 +434,6 @@ impl Dispatch {
     /// This calls the [`max_level_hint`] function on the [`Subscriber`]
     /// that this `Dispatch` forwards to.
     ///
-    ///
     /// [level]: ../struct.Level.html
     /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
     /// [`register_callsite`]: ../subscriber/trait.Subscriber.html#method.max_level_hint

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -135,7 +135,7 @@
 use crate::{
     callsite, span,
     subscriber::{self, Subscriber},
-    Event, Metadata,
+    Event, Level, Metadata,
 };
 
 use crate::stdlib::{
@@ -427,6 +427,23 @@ impl Dispatch {
         self.subscriber.register_callsite(metadata)
     }
 
+    /// Returns the highest [verbosity level][level] that this [`Subscriber`] will
+    /// enable, or `None`, if the subscriber does not implement level-based
+    /// filtering or chooses not to implement this method.
+    ///
+    /// This calls the [`max_level_hint`] function on the [`Subscriber`]
+    /// that this `Dispatch` forwards to.
+    ///
+    ///
+    /// [level]: ../struct.Level.html
+    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
+    /// [`register_callsite`]: ../subscriber/trait.Subscriber.html#method.max_level_hint
+    // TODO(eliza): consider making this a public API?
+    #[inline]
+    pub(crate) fn max_level_hint(&self) -> Option<Level> {
+        self.subscriber.max_level_hint()
+    }
+
     /// Record the construction of a new span, returning a new [ID] for the
     /// span being constructed.
     ///
@@ -670,8 +687,8 @@ impl Registrar {
         self.0.upgrade().map(|s| s.register_callsite(metadata))
     }
 
-    pub(crate) fn is_alive(&self) -> bool {
-        self.0.upgrade().is_some()
+    pub(crate) fn upgrade(&self) -> Option<Dispatch> {
+        self.0.upgrade().map(|subscriber| Dispatch { subscriber })
     }
 }
 

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -251,7 +251,7 @@ pub use self::{
     dispatcher::Dispatch,
     event::Event,
     field::Field,
-    metadata::{Level, Metadata},
+    metadata::{Level, LevelFilter, Metadata},
     subscriber::Subscriber,
 };
 

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -486,7 +486,7 @@ impl PartialEq<LevelFilter> for Level {
 impl PartialOrd<LevelFilter> for Level {
     fn partial_cmp(&self, other: &LevelFilter) -> Option<cmp::Ordering> {
         match other.0 {
-            None => Some(cmp::Ordering::Less),
+            None => Some(cmp::Ordering::Greater),
             Some(ref level) => self.partial_cmp(level),
         }
     }
@@ -495,7 +495,7 @@ impl PartialOrd<LevelFilter> for Level {
 impl PartialOrd<Level> for LevelFilter {
     fn partial_cmp(&self, other: &Level) -> Option<cmp::Ordering> {
         match self.0 {
-            None => Some(cmp::Ordering::Greater),
+            None => Some(cmp::Ordering::Less),
             Some(ref level) => level.partial_cmp(other),
         }
     }

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -112,7 +112,7 @@ pub struct LevelFilter(Option<Level>);
 
 /// Indicates that a string could not be parsed to a valid level.
 #[derive(Clone, Debug)]
-pub struct ParseError(());
+pub struct ParseLevelFilterError(());
 
 static MAX_LEVEL: AtomicUsize = AtomicUsize::new(LevelFilter::OFF_USIZE);
 
@@ -365,6 +365,13 @@ impl From<Level> for LevelFilter {
     }
 }
 
+impl Into<Option<Level>> for LevelFilter {
+    #[inline]
+    fn into(self) -> Option<Level> {
+        self.into_level()
+    }
+}
+
 impl LevelFilter {
     /// The "off" level.
     ///
@@ -530,7 +537,7 @@ impl fmt::Debug for LevelFilter {
 }
 
 impl FromStr for LevelFilter {
-    type Err = ParseError;
+    type Err = ParseLevelFilterError;
     fn from_str(from: &str) -> Result<Self, Self::Err> {
         from.parse::<usize>()
             .ok()
@@ -553,7 +560,7 @@ impl FromStr for LevelFilter {
                 s if s.eq_ignore_ascii_case("off") => Some(LevelFilter::OFF),
                 _ => None,
             })
-            .ok_or_else(|| ParseError(()))
+            .ok_or_else(|| ParseLevelFilterError(()))
     }
 }
 
@@ -571,6 +578,18 @@ impl fmt::Display for ParseLevelError {
         )
     }
 }
+
+impl fmt::Display for ParseLevelFilterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad(
+            "error parsing level filter: expected one of \"off\", \"error\", \
+            \"warn\", \"info\", \"debug\", \"trace\", or a number 0-5",
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParseLevelFilterError {}
 
 #[cfg(test)]
 mod tests {

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -423,7 +423,7 @@ impl LevelFilter {
     // Using the value of the last variant + 1 ensures that we match the value
     // for `Option::None` as selected by the niche optimization for
     // `LevelFilter`. If this is the case, converting a `usize` value into a
-    // `LevelFilter` (in `LevelFilter::max`) will be an identity conversion,
+    // `LevelFilter` (in `LevelFilter::current`) will be an identity conversion,
     // rather than generating a lookup table.
     const OFF_USIZE: usize = LevelInner::Error as usize + 1;
 
@@ -444,7 +444,7 @@ impl LevelFilter {
     /// [`Level`]: ../struct.Level.html
     /// [`Subscriber`]: ../../trait.Subscriber.html
     #[inline(always)]
-    pub fn max() -> Self {
+    pub fn current() -> Self {
         match MAX_LEVEL.load(Ordering::Relaxed) {
             Self::ERROR_USIZE => Self::ERROR,
             Self::WARN_USIZE => Self::WARN,

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -606,7 +606,7 @@ impl std::error::Error for ParseLevelFilterError {}
 //    `Option<Level>`) compiles down to a single integer value. This is
 //    necessary for storing the global max in an `AtomicUsize`, and for ensuring
 //    that we use fast integer-integer comparisons, as mentioned previously. In
-//    order to ensure this, we exploint the niche optimization. The niche
+//    order to ensure this, we exploit the niche optimization. The niche
 //    optimization for `Option<{enum with a numeric repr}>` will choose
 //    `(HIGHEST_DISCRIMINANT_VALUE + 1)` as the representation for `None`.
 //    Therefore, the integer representation of `LevelFilter::OFF` (which is

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -466,7 +466,7 @@ impl LevelFilter {
                 // the inputs to `set_max` to the set of valid discriminants.
                 // Therefore, **as long as `MAX_VALUE` is only ever set by
                 // `set_max`**, this is safe.
-                core::hint::unreachable_unchecked()
+                crate::stdlib::hint::unreachable_unchecked()
             },
         }
     }
@@ -784,7 +784,7 @@ impl PartialOrd<Level> for LevelFilter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::mem;
+    use crate::stdlib::mem;
 
     #[test]
     fn level_from_str() {

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -429,6 +429,20 @@ impl LevelFilter {
 
     /// Returns a `LevelFilter` that matches the most verbose [`Level`] that any
     /// currently active [`Subscriber`] will enable.
+    ///
+    /// User code should treat this as a *hint*. If a given span or event has a
+    /// level *higher* than the returned `LevelFilter`, it will not be enabled.
+    /// However, if the level is less than or equal to this value, the span or
+    /// event is *not* guaranteed to be enabled; the subscriber will still
+    /// filter each callsite individually.
+    ///
+    /// Therefore, comparing a given span or event's level to the returned
+    /// `LevelFilter` **can** be used for determining if something is
+    /// *disabled*, but **should not** be used for determining if something is
+    /// *enabled*.`
+    ///
+    /// [`Level`]: ../struct.Level.html
+    /// [`Subscriber`]: ../../trait.Subscriber.html
     #[inline(always)]
     pub fn max() -> Self {
         match MAX_LEVEL.load(Ordering::Relaxed) {

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -768,7 +768,7 @@ impl PartialOrd<Level> for LevelFilter {
 
     #[inline(always)]
     fn ge(&self, other: &Level) -> bool {
-        (other.0 as usize) > filter_as_usize(&self.0)
+        (other.0 as usize) >= filter_as_usize(&self.0)
     }
 }
 

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -438,6 +438,15 @@ impl LevelFilter {
             Self::DEBUG_USIZE => Self::DEBUG,
             Self::TRACE_USIZE => Self::TRACE,
             Self::OFF_USIZE => Self::OFF,
+            #[cfg(debug_assertions)]
+            unknown => unreachable!(
+                "/!\\ `LevelFilter` representation seems to have changed! /!\\ \n\
+                This is a bug (and it's pretty bad). Please contact the `tracing` \
+                maintainers. Thank you and I'm sorry.\n \
+                The offending repr was: {:?}",
+                unknown,
+            ),
+            #[cfg(not(debug_assertions))]
             _ => unsafe {
                 // Using `unreachable_unchecked` here (rather than
                 // `unreachable!()`) is necessary to ensure that rustc generates

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -1,5 +1,5 @@
 //! Subscribers collect and record trace data.
-use crate::{span, Event, Metadata, Level};
+use crate::{span, Event, LevelFilter, Metadata};
 
 use crate::stdlib::any::{Any, TypeId};
 
@@ -190,7 +190,7 @@ pub trait Subscriber: 'static {
     /// [level]: ../struct.Level.html
     /// [`Interest`]: struct.Interest.html
     /// [rebuild]: ../callsite/fn.rebuild_interest_cache.html
-    fn max_level_hint(&self) -> Option<Level> {
+    fn max_level_hint(&self) -> Option<LevelFilter> {
         None
     }
 

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -1,5 +1,5 @@
 //! Subscribers collect and record trace data.
-use crate::{span, Event, Metadata};
+use crate::{span, Event, Metadata, Level};
 
 use crate::stdlib::any::{Any, TypeId};
 
@@ -166,6 +166,33 @@ pub trait Subscriber: 'static {
     /// [`Interest::sometimes`]: struct.Interest.html#method.sometimes
     /// [`register_callsite`]: #method.register_callsite
     fn enabled(&self, metadata: &Metadata<'_>) -> bool;
+
+    /// Returns the highest [verbosity level][level] that this `Subscriber` will
+    /// enable, or `None`, if the subscriber does not implement level-based
+    /// filtering or chooses not to implement this method.
+    ///
+    /// If this method returns a [`Level`][level], it will be used as a hint to
+    /// determine the most verbose level that will be enabled. This will allow
+    /// spans and events which are more verbose than that level to be skipped
+    /// more efficiently. Subscribers which perform filtering are strongly
+    /// encouraged to provide an implementation of this method.
+    ///
+    /// If the maximum level the subscriber will enable can change over the
+    /// course of its lifetime, it is free to return a different value from
+    /// multiple invocations of this method. However, note that changes in the
+    /// maximum level will **only** be reflected after the callsite [`Interest`]
+    /// cache is rebuilt, by calling the [`callsite::rebuild_interest_cache`][rebuild]
+    /// function. Therefore, if the subscriber will change the value returned by
+    /// this method, it is responsible for ensuring that
+    /// [`rebuild_interest_cache`][rebuild] is called after the value of the max
+    /// level changes.
+    ///
+    /// [level]: ../struct.Level.html
+    /// [`Interest`]: struct.Interest.html
+    /// [rebuild]: ../callsite/fn.rebuild_interest_cache.html
+    fn max_level_hint(&self) -> Option<Level> {
+        None
+    }
 
     /// Visit the construction of a new span, returning a new [span ID] for the
     /// span being constructed.

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -31,7 +31,7 @@ registry = ["sharded-slab"]
 json = ["tracing-serde", "serde", "serde_json"]
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.2" }
+tracing-core = { path = "../tracing-core", version = "0.1.12" }
 
 # only required by the filter feature
 matchers = { optional = true, version = "0.0.1" }

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -22,7 +22,7 @@ use tracing_core::{
     field::Field,
     span,
     subscriber::{Interest, Subscriber},
-    Metadata,
+    Level, Metadata,
 };
 
 /// A [`Layer`] which filters spans and events based on a set of filter
@@ -275,6 +275,13 @@ impl<S: Subscriber> Layer<S> for EnvFilter {
         } else {
             self.base_interest()
         }
+    }
+
+    fn max_level_hint(&self) -> Option<Level> {
+        std::cmp::max(
+            self.statics.max_level.clone().into(),
+            self.dynamics.max_level.clone().into(),
+        )
     }
 
     fn enabled(&self, metadata: &Metadata<'_>, _: Context<'_, S>) -> bool {

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -22,7 +22,7 @@ use tracing_core::{
     field::Field,
     span,
     subscriber::{Interest, Subscriber},
-    Level, Metadata,
+    Metadata,
 };
 
 /// A [`Layer`] which filters spans and events based on a set of filter
@@ -277,7 +277,7 @@ impl<S: Subscriber> Layer<S> for EnvFilter {
         }
     }
 
-    fn max_level_hint(&self) -> Option<Level> {
+    fn max_level_hint(&self) -> Option<LevelFilter> {
         std::cmp::max(
             self.statics.max_level.clone().into(),
             self.dynamics.max_level.clone().into(),

--- a/tracing-subscriber/src/filter/level.rs
+++ b/tracing-subscriber/src/filter/level.rs
@@ -1,51 +1,12 @@
-use std::{cmp::Ordering, fmt, str::FromStr};
 use tracing_core::{
     subscriber::{Interest, Subscriber},
     Level, Metadata,
 };
 
-/// A filter which is enabled for a given verbosity level and below.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
-pub struct LevelFilter(Inner);
-
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
-enum Inner {
-    Off,
-    Level(Level),
-}
-
-/// Indicates that a string could not be parsed to a valid level.
-#[derive(Clone, Debug)]
-pub struct ParseError(());
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
+pub use tracing_core::metadata::{LevelFilter, ParseLevelFilterError as ParseError};
 
 // === impl LevelFilter ===
-
-impl LevelFilter {
-    /// The "off" level.
-    ///
-    /// Designates that trace instrumentation should be completely disabled.
-    pub const OFF: LevelFilter = LevelFilter(Inner::Off);
-    /// The "error" level.
-    ///
-    /// Designates very serious errors.
-    pub const ERROR: LevelFilter = LevelFilter(Inner::Level(Level::ERROR));
-    /// The "warn" level.
-    ///
-    /// Designates hazardous situations.
-    pub const WARN: LevelFilter = LevelFilter(Inner::Level(Level::WARN));
-    /// The "info" level.
-    ///
-    /// Designates useful information.
-    pub const INFO: LevelFilter = LevelFilter(Inner::Level(Level::INFO));
-    /// The "debug" level.
-    ///
-    /// Designates lower priority information.
-    pub const DEBUG: LevelFilter = LevelFilter(Inner::Level(Level::DEBUG));
-    /// The "trace" level.
-    ///
-    /// Designates very low priority, often extremely verbose, information.
-    pub const TRACE: LevelFilter = LevelFilter(Inner::Level(Level::TRACE));
-}
 
 impl<S: Subscriber> crate::Layer<S> for LevelFilter {
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
@@ -59,110 +20,8 @@ impl<S: Subscriber> crate::Layer<S> for LevelFilter {
     fn enabled(&self, metadata: &Metadata<'_>, _: crate::layer::Context<'_, S>) -> bool {
         self >= metadata.level()
     }
-}
 
-impl PartialEq<Level> for LevelFilter {
-    fn eq(&self, other: &Level) -> bool {
-        match self.0 {
-            Inner::Off => false,
-            Inner::Level(ref level) => level == other,
-        }
+    fn max_level_hint(&self) -> Option<Level> {
+        self.clone().into()
     }
 }
-
-impl PartialOrd<Level> for LevelFilter {
-    fn partial_cmp(&self, other: &Level) -> Option<Ordering> {
-        match self.0 {
-            Inner::Off => Some(Ordering::Less),
-            Inner::Level(ref level) => level.partial_cmp(other),
-        }
-    }
-}
-
-impl fmt::Display for LevelFilter {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.0 {
-            Inner::Off => f.pad("off"),
-            Inner::Level(Level::ERROR) => f.pad("error"),
-            Inner::Level(Level::WARN) => f.pad("warn"),
-            Inner::Level(Level::INFO) => f.pad("info"),
-            Inner::Level(Level::DEBUG) => f.pad("debug"),
-            Inner::Level(Level::TRACE) => f.pad("trace"),
-        }
-    }
-}
-
-impl fmt::Debug for LevelFilter {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.0 {
-            Inner::Off => f.pad("LevelFilter::OFF"),
-            Inner::Level(Level::ERROR) => f.pad("LevelFilter::ERROR"),
-            Inner::Level(Level::WARN) => f.pad("LevelFilter::WARN"),
-            Inner::Level(Level::INFO) => f.pad("LevelFilter::INFO"),
-            Inner::Level(Level::DEBUG) => f.pad("LevelFilter::DEBUG"),
-            Inner::Level(Level::TRACE) => f.pad("LevelFilter::TRACE"),
-        }
-    }
-}
-
-impl FromStr for LevelFilter {
-    type Err = ParseError;
-    fn from_str(from: &str) -> Result<Self, Self::Err> {
-        from.parse::<usize>()
-            .ok()
-            .and_then(|num| match num {
-                0 => Some(LevelFilter::OFF),
-                1 => Some(LevelFilter::ERROR),
-                2 => Some(LevelFilter::WARN),
-                3 => Some(LevelFilter::INFO),
-                4 => Some(LevelFilter::DEBUG),
-                5 => Some(LevelFilter::TRACE),
-                _ => None,
-            })
-            .or_else(|| match from {
-                "" => Some(LevelFilter::ERROR),
-                s if s.eq_ignore_ascii_case("error") => Some(LevelFilter::ERROR),
-                s if s.eq_ignore_ascii_case("warn") => Some(LevelFilter::WARN),
-                s if s.eq_ignore_ascii_case("info") => Some(LevelFilter::INFO),
-                s if s.eq_ignore_ascii_case("debug") => Some(LevelFilter::DEBUG),
-                s if s.eq_ignore_ascii_case("trace") => Some(LevelFilter::TRACE),
-                s if s.eq_ignore_ascii_case("off") => Some(LevelFilter::OFF),
-                _ => None,
-            })
-            .ok_or_else(|| ParseError(()))
-    }
-}
-
-impl Into<Option<Level>> for LevelFilter {
-    fn into(self) -> Option<Level> {
-        match self.0 {
-            Inner::Off => None,
-            Inner::Level(l) => Some(l),
-        }
-    }
-}
-
-impl From<Option<Level>> for LevelFilter {
-    fn from(level: Option<Level>) -> Self {
-        match level {
-            Some(level) => LevelFilter(Inner::Level(level)),
-            None => LevelFilter(Inner::Off),
-        }
-    }
-}
-
-impl From<Level> for LevelFilter {
-    fn from(level: Level) -> Self {
-        LevelFilter(Inner::Level(level))
-    }
-}
-
-// === impl ParseError ===
-
-impl fmt::Display for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "invalid level`")
-    }
-}
-
-impl std::error::Error for ParseError {}

--- a/tracing-subscriber/src/filter/level.rs
+++ b/tracing-subscriber/src/filter/level.rs
@@ -1,6 +1,6 @@
 use tracing_core::{
     subscriber::{Interest, Subscriber},
-    Level, Metadata,
+    Metadata,
 };
 
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
@@ -21,7 +21,7 @@ impl<S: Subscriber> crate::Layer<S> for LevelFilter {
         self >= metadata.level()
     }
 
-    fn max_level_hint(&self) -> Option<Level> {
+    fn max_level_hint(&self) -> Option<LevelFilter> {
         self.clone().into()
     }
 }

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -627,12 +627,7 @@ where
     }
 
     fn max_level_hint(&self) -> Option<Level> {
-        match (self.layer.max_level_hint(), self.inner.max_level_hint()) {
-            (Some(this), Some(that)) => Some(std::cmp::max(this, that)),
-            (Some(this), None) => Some(this),
-            (None, Some(that)) => Some(that),
-            (None, None) => None,
-        }
+        std::cmp::max(self.layer.max_level_hint(), self.inner.max_level_hint())
     }
 
     fn new_span(&self, span: &span::Attributes<'_>) -> span::Id {

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -3,7 +3,7 @@ use tracing_core::{
     metadata::Metadata,
     span,
     subscriber::{Interest, Subscriber},
-    Event, Level,
+    Event, LevelFilter,
 };
 
 #[cfg(feature = "registry")]
@@ -309,7 +309,7 @@ where
     // filtering layers to a separate trait, we may no longer want `Layer`s to
     // be able to participate in max level hinting...
     #[doc(hidden)]
-    fn max_level_hint(&self) -> Option<Level> {
+    fn max_level_hint(&self) -> Option<LevelFilter> {
         None
     }
 
@@ -626,7 +626,7 @@ where
         }
     }
 
-    fn max_level_hint(&self) -> Option<Level> {
+    fn max_level_hint(&self) -> Option<LevelFilter> {
         std::cmp::max(self.layer.max_level_hint(), self.inner.max_level_hint())
     }
 

--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.18 (UNRELEASED)
+
+### Fixed
+
+- Fixed a bug where `LevelFilter::OFF` (and thus also the `static_max_level_off`
+  feature flag) would enable *all* traces, rather than *none* (#853)
+
 # 0.1.17 (July 22, 2020)
 
 ### Changed

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -27,7 +27,7 @@ keywords = ["logging", "tracing", "metrics", "async"]
 edition = "2018"
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.11", default-features = false }
+tracing-core = { path = "../tracing-core", version = "0.1.12", default-features = false }
 log = { version = "0.4", optional = true }
 tracing-attributes = { path = "../tracing-attributes", version = "0.1.9", optional = true }
 cfg-if = "0.1.10"

--- a/tracing/src/level_filters.rs
+++ b/tracing/src/level_filters.rs
@@ -53,7 +53,10 @@ pub use tracing_core::{metadata::ParseLevelFilterError, LevelFilter};
 pub const STATIC_MAX_LEVEL: LevelFilter = MAX_LEVEL;
 
 cfg_if! {
-    if #[cfg(all(not(debug_assertions), feature = "release_max_level_off"))] {
+    if #[cfg(test)] {
+        // Don't break the tests when testing with `--all-features`.
+        const MAX_LEVEL: LevelFilter = LevelFilter::TRACE;
+    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_off"))] {
         const MAX_LEVEL: LevelFilter = LevelFilter::OFF;
     } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_error"))] {
         const MAX_LEVEL: LevelFilter = LevelFilter::ERROR;

--- a/tracing/src/level_filters.rs
+++ b/tracing/src/level_filters.rs
@@ -79,27 +79,3 @@ cfg_if! {
         const MAX_LEVEL: LevelFilter = LevelFilter::TRACE;
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::Level;
-
-    #[test]
-    fn filter_level_conversion() {
-        let mapping = [
-            (LevelFilter::OFF, None),
-            (LevelFilter::ERROR, Some(Level::ERROR)),
-            (LevelFilter::WARN, Some(Level::WARN)),
-            (LevelFilter::INFO, Some(Level::INFO)),
-            (LevelFilter::DEBUG, Some(Level::DEBUG)),
-            (LevelFilter::TRACE, Some(Level::TRACE)),
-        ];
-        for (filter, level) in mapping.iter() {
-            assert_eq!(filter.clone().into_level(), *level);
-            if let Some(level) = level {
-                assert_eq!(LevelFilter::from_level(level.clone()), *filter);
-            }
-        }
-    }
-}

--- a/tracing/src/level_filters.rs
+++ b/tracing/src/level_filters.rs
@@ -53,10 +53,7 @@ pub use tracing_core::{metadata::ParseLevelFilterError, LevelFilter};
 pub const STATIC_MAX_LEVEL: LevelFilter = MAX_LEVEL;
 
 cfg_if! {
-    if #[cfg(test)] {
-        // Don't break the tests when testing with `--all-features`.
-        const MAX_LEVEL: LevelFilter = LevelFilter::TRACE;
-    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_off"))] {
+    if #[cfg(all(not(debug_assertions), feature = "release_max_level_off"))] {
         const MAX_LEVEL: LevelFilter = LevelFilter::OFF;
     } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_error"))] {
         const MAX_LEVEL: LevelFilter = LevelFilter::ERROR;

--- a/tracing/src/level_filters.rs
+++ b/tracing/src/level_filters.rs
@@ -37,87 +37,7 @@
 //! *Compiler support: requires rustc 1.39+*
 //!
 //! [`log` crate]: https://docs.rs/log/0.4.6/log/#compile-time-filters
-use crate::stdlib::cmp::Ordering;
-use tracing_core::Level;
-
-/// A filter comparable to trace verbosity `Level`.
-///
-/// If a `Level` is considered less than a `LevelFilter`, it should be
-/// considered disabled; if greater than or equal to the `LevelFilter`, that
-/// level is enabled.
-///
-/// Note that this is essentially identical to the `Level` type, but with the
-/// addition of an `OFF` level that completely disables all trace
-/// instrumentation.
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct LevelFilter(Option<Level>);
-
-impl From<Level> for LevelFilter {
-    #[inline]
-    fn from(level: Level) -> Self {
-        Self::from_level(level)
-    }
-}
-
-impl LevelFilter {
-    /// The "off" level.
-    ///
-    /// Designates that trace instrumentation should be completely disabled.
-    pub const OFF: LevelFilter = LevelFilter(None);
-    /// The "error" level.
-    ///
-    /// Designates very serious errors.
-    pub const ERROR: LevelFilter = LevelFilter::from_level(Level::ERROR);
-    /// The "warn" level.
-    ///
-    /// Designates hazardous situations.
-    pub const WARN: LevelFilter = LevelFilter::from_level(Level::WARN);
-    /// The "info" level.
-    ///
-    /// Designates useful information.
-    pub const INFO: LevelFilter = LevelFilter::from_level(Level::INFO);
-    /// The "debug" level.
-    ///
-    /// Designates lower priority information.
-    pub const DEBUG: LevelFilter = LevelFilter::from_level(Level::DEBUG);
-    /// The "trace" level.
-    ///
-    /// Designates very low priority, often extremely verbose, information.
-    pub const TRACE: LevelFilter = LevelFilter(Some(Level::TRACE));
-
-    /// Returns a `LevelFilter` that enables spans and events with verbosity up
-    /// to and including `level`.
-    pub const fn from_level(level: Level) -> Self {
-        Self(Some(level))
-    }
-
-    /// Returns the most verbose [`Level`] that this filter accepts, or `None`
-    /// if it is [`OFF`].
-    ///
-    /// [`Level`]: ../struct.Level.html
-    /// [`OFF`]: #associatedconstant.OFF
-    pub const fn into_level(self) -> Option<Level> {
-        self.0
-    }
-}
-
-impl PartialEq<LevelFilter> for Level {
-    fn eq(&self, other: &LevelFilter) -> bool {
-        match other.0 {
-            None => false,
-            Some(ref level) => self.eq(level),
-        }
-    }
-}
-
-impl PartialOrd<LevelFilter> for Level {
-    fn partial_cmp(&self, other: &LevelFilter) -> Option<Ordering> {
-        match other.0 {
-            None => Some(Ordering::Less),
-            Some(ref level) => self.partial_cmp(level),
-        }
-    }
-}
+pub use tracing_core::{metadata::ParseLevelFilterError, LevelFilter};
 
 /// The statically configured maximum trace level.
 ///
@@ -163,6 +83,7 @@ cfg_if! {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Level;
 
     #[test]
     fn filter_level_conversion() {

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -1848,7 +1848,7 @@ macro_rules! level_enabled {
     ($lvl:expr) => {
         $crate::dispatcher::has_been_set()
             && $lvl <= $crate::level_filters::STATIC_MAX_LEVEL
-            && $lvl <= $crate::level_filters::LevelFilter::max()
+            && $lvl <= $crate::level_filters::LevelFilter::current()
     };
 }
 

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -1840,11 +1840,15 @@ macro_rules! callsite {
 }
 
 #[macro_export]
-// TODO: determine if this ought to be public API?
+// TODO: determine if this ought to be public API?`
+// TODO(eliza): is the `has_been_set` check still necessary? the max
+// level check should be equivalent...
 #[doc(hidden)]
 macro_rules! level_enabled {
     ($lvl:expr) => {
-        $crate::dispatcher::has_been_set() && $lvl <= $crate::level_filters::STATIC_MAX_LEVEL
+        $crate::dispatcher::has_been_set()
+            && $lvl <= $crate::level_filters::STATIC_MAX_LEVEL
+            && $lvl <= $crate::level_filters::LevelFilter::max()
     };
 }
 

--- a/tracing/test_static_max_level_features/tests/test.rs
+++ b/tracing/test_static_max_level_features/tests/test.rs
@@ -33,7 +33,7 @@ impl Subscriber for TestSubscriber {
     fn exit(&self, _span: &Id) {}
 }
 
-#[cfg(test)]
+#[test]
 fn test_static_max_level_features() {
     let me = Arc::new(State {
         last_level: Mutex::new(None),


### PR DESCRIPTION
## Motivation

Tracing currently stores cached filter evaluations in a per-callsite
cache. Once filters have been evaluated, this allows us to skip disabled
callsites with a single load and compare, which is a nice fast path for
skipping. However, determining the value to store in the callsite cache
is expensive: it requires acquiring a lock to register the callsite, and
asking the subscriber for an `Interest` value to cache.

In long-running applications, such as servers, daemons, and interactive
applications that are used for a long period of time, this cost is not
very visible; it's amortized over the rest of the application's
lifetime. However, in batch-oriented programs and CLI tools that run to
completion, the cost of building the initial cached value has a much
bigger impact. If a given callsite is hit twice over the thirty seconds
that a CLI tool runs for (for example), the cost of the initial
evaluation is _much_ more meaningful than if the same callsite is hit
hundreds of thousands of times by a server that runs for several weeks
before its restarted. Even in a long running application, though, it
could lead to a surprising latency hit if a given callsite is only hit
after a long period of operation.

Per-callsite caching allows high performance for more granular filters,
since it tracks the state of _every_ callsite; we still get a fast path
for skipping a `trace` event in the `foo::bar` module if the `trace`
level is only enabled for the `baz` module. Because of this, we didn't
initially believe that a global maximum level fast path was necessary.
However, in `rustc`, it turns out that the cost of just building the
callsite cache for the first time has a noticeable impact on
performance. See here for details:
https://github.com/rust-lang/rust/pull/74726#issuecomment-664181180

## Solution

This branch adds a faster fast path for skipping callsites whose level
is higher than the highest level enabled for _any_ target/metadata
combination, similar to the `log` crate's `max_level`.

Unlike the `log` crate, which only ever has a single global logger,
`tracing` allows multiple `Subscriber`s to coexist in the same process.
Therefore, our implementation is somewhat different than `log`'s. We
can't simply provide a `set_max_level` function call, because _another_
subscriber may have already set a lower max level, and just overwriting
the max level with ours may result in diagnostics being skipped that
another subscriber wants to collect.

Instead, we've added a `max_level_hint` method to the `Subscriber`
trait, returning an `Option<LevelFilter>`. By default, this returns
`None`, for backwards compatibility. However, if it returns `Some`, the
resulting `LevelFilter` is stored in a global `MAX_LEVEL` atomic. This
method is called by the `register_dispatch` function, which handles the
creation of a new `Dispatch`. This allows us to compare the max level
from a new subscriber with those of all other currently active
subscribers. Similarly, when cached interests are invalidated (such as
by changing a filter, or when a `Subscriber` is dropped), we can
reevaluate the max level.

The path for _checking_ the max level (e.g. in the macros) should be
very efficient. We load the atomic, convert the `usize` value into a
`LevelFilter`, and compare it to the callsite's level. With help from
@eddyb, I was able to implement the conversion such that it should
hopefully be an identity conversion in release mode, rather than
requiring rustc to generate a LUT. The macros have been updated to check
the max level before anything requiring hitting the callsite cache _or_
the subscriber TLS var.

Also, I've updated `tracing` and `tracing-subscriber` to reexport the
`LevelFilter` type from `tracing-core` rather than defining their own.
The API should be a superset of those crates' versions.

Thanks to @oli-obk for uncovering this issue when adding `tracing` to
`rustc`, and for doing a lot of the preliminary analysis of the cause!

So far, there doesn't appear to be a significant change in any of `tracing`'s
internal benchmarks on this branch. However, my guess is that this is
because of `criterion`'s outlier elimination: since the cache is constructed
only on the first iteration, it's pretty likely that `criterion` considers this an
outlier and throws it out entirely, so the benchmark results on master don't
include the cost of evaluating the filter for the initial time.

Incidentally, this PR also fixes a bug in the `tracing` crate's version
of `LevelFilter`, where the `OFF` level actually enabled *everything*,
rather than *nothing*. Oopsie!