### PR TITLE
subscriber: Fix Incorrectly Rendered Documenation and Broken Links

### DIFF
--- a/tracing-subscriber/src/filter/mod.rs
+++ b/tracing-subscriber/src/filter/mod.rs
@@ -1,7 +1,7 @@
 //! [`Layer`]s that control which spans and events are enabled by the wrapped
 //! subscriber.
 //!
-//! [`Layer`]: ../trait.Layer.html
+//! [`Layer`]: ../layer/trait.Layer.html
 #[cfg(feature = "env-filter")]
 mod env;
 mod level;

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -131,8 +131,8 @@ where
     /// # use tracing_subscriber::Layer as _;
     /// # let _ = layer.with_subscriber(tracing_subscriber::registry::Registry::default());
     /// ```
-    /// [event formatter]: ../format/trait.FormatEvent.html
-    /// [`FmtContext`]: ../struct.FmtContext.html
+    /// [`FormatEvent`]: ./format/trait.FormatEvent.html
+    /// [`FmtContext`]: ./struct.FmtContext.html
     /// [`Event`]: https://docs.rs/tracing/latest/tracing/struct.Event.html
     pub fn event_format<E2>(self, e: E2) -> Layer<S, N, E2, W>
     where
@@ -491,7 +491,7 @@ where
 /// formatters are in use, each can store its own formatted representation
 /// without conflicting.
 ///
-/// [extensions]: ../registry/extensions/index.html
+/// [extensions]: ../registry/struct.Extensions.html
 #[derive(Default)]
 pub struct FormattedFields<E> {
     _format_event: PhantomData<fn(E)>,

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -32,14 +32,15 @@ pub use json::*;
 
 /// A type that can format a tracing `Event` for a `fmt::Write`.
 ///
-/// `FormatEvent` is primarily used in the context of [`FmtSubscriber`]. Each time an event is
-/// dispatched to [`FmtSubscriber`], the subscriber forwards it to its associated `FormatEvent` to
-/// emit a log message.
+/// `FormatEvent` is primarily used in the context of [`fmt::Subscriber`] or [`fmt::Layer`]. Each time an event is
+/// dispatched to [`fmt::Subscriber`] or [`fmt::Layer`], the subscriber or layer forwards it to
+/// its associated `FormatEvent` to emit a log message.
 ///
 /// This trait is already implemented for function pointers with the same
 /// signature as `format_event`.
 ///
-/// [`FmtSubscriber`]: ../fmt/struct.Subscriber.html
+/// [`fmt::Subscriber`]: ../struct.Subscriber.html
+/// [`fmt::Layer`]: ../struct.Layer.html
 pub trait FormatEvent<S, N>
 where
     S: Subscriber + for<'a> LookupSpan<'a>,

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -6,14 +6,15 @@ use std::io;
 
 /// A type that can create [`io::Write`] instances.
 ///
-/// `MakeWriter` is used by [`FmtSubscriber`] to print formatted text representations of
+/// `MakeWriter` is used by [`fmt::Subscriber`] or [`fmt::Layer`] to print formatted text representations of
 /// [`Event`]s.
 ///
 /// This trait is already implemented for function pointers and immutably-borrowing closures that
 /// return an instance of [`io::Write`], such as [`io::stdout`] and [`io::stderr`].
 ///
 /// [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
-/// [`FmtSubscriber`]: ../struct.Subscriber.html
+/// [`fmt::Subscriber`]: ../../fmt/struct.Subscriber.html
+/// [`fmt::Layer`]: ../../fmt/struct.Layer.html
 /// [`Event`]: https://docs.rs/tracing-core/0.1.5/tracing_core/event/struct.Event.html
 /// [`io::stdout`]: https://doc.rust-lang.org/std/io/fn.stdout.html
 /// [`io::stderr`]: https://doc.rust-lang.org/std/io/fn.stderr.html
@@ -28,13 +29,14 @@ pub trait MakeWriter {
     ///
     /// # Implementer notes
     ///
-    /// [`FmtSubscriber`] will call this method each time an event is recorded. Ensure any state
+    /// [`fmt::Layer`] or [`fmt::Subscriber`] will call this method each time an event is recorded. Ensure any state
     /// that must be saved across writes is not lost when the [`Writer`] instance is dropped. If
     /// creating a [`io::Write`] instance is expensive, be sure to cache it when implementing
     /// [`MakeWriter`] to improve performance.
     ///
     /// [`Writer`]: #associatedtype.Writer
-    /// [`FmtSubscriber`]: ../struct.Subscriber.html
+    /// [`fmt::Layer`]: ../../fmt/struct.Layer.html
+    /// [`fmt::Subscriber`]: ../../fmt/struct.Subscriber.html
     /// [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
     /// [`MakeWriter`]: trait.MakeWriter.html
     fn make_writer(&self) -> Self::Writer;

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -226,7 +226,7 @@ where
     /// globally disable them should ignore those spans or events in their
     /// <a href="#method.on_event"><code>on_event</code></a>,
     /// <a href="#method.on_enter"><code>on_enter</code></a>,
-    /// <a href="#method.on_exit"><code>on_exit<code></a>, and other notification
+    /// <a href="#method.on_exit"><code>on_exit</code></a>, and other notification
     /// methods.
     /// </pre></div>
     ///
@@ -278,7 +278,7 @@ where
     /// globally disable them should ignore those spans or events in their
     /// <a href="#method.on_event"><code>on_event</code></a>,
     /// <a href="#method.on_enter"><code>on_enter</code></a>,
-    /// <a href="#method.on_exit"><code>on_exit<code></a>, and other notification
+    /// <a href="#method.on_exit"><code>on_exit</code></a>, and other notification
     /// methods.
     /// </pre></div>
     ///
@@ -523,8 +523,28 @@ pub trait SubscriberExt: Subscriber + crate::sealed::Sealed {
 /// Represents information about the current context provided to [`Layer`]s by the
 /// wrapped [`Subscriber`].
 ///
+/// To access [stored data] keyed by a span ID, implementors of the `Layer`
+/// trait should ensure that the `Subscriber` type parameter is *also* bound by the
+/// [`LookupSpan`]:
+///
+/// ```rust
+/// use tracing::Subscriber;
+/// use tracing_subscriber::{Layer, registry::LookupSpan};
+///
+/// pub struct MyLayer;
+///
+/// impl<S> Layer<S> for MyLayer
+/// where
+///     S: Subscriber + for<'a> LookupSpan<'a>,
+/// {
+///     // ...
+/// }
+/// ```
+///
 /// [`Layer`]: ../layer/trait.Layer.html
 /// [`Subscriber`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html
+/// [stored data]: ../registry/struct.SpanRef.html
+/// [`LookupSpan`]: "../registry/trait.LookupSpan.html
 #[derive(Debug)]
 pub struct Context<'a, S> {
     subscriber: Option<&'a S>,
@@ -814,7 +834,10 @@ impl<S: Subscriber> SubscriberExt for S {}
 
 // === impl Context ===
 
-impl<'a, S: Subscriber> Context<'a, S> {
+impl<'a, S> Context<'a, S>
+where
+    S: Subscriber,
+{
     /// Returns the wrapped subscriber's view of the current span.
     #[inline]
     pub fn current_span(&self) -> span::Current {
@@ -867,20 +890,6 @@ impl<'a, S: Subscriber> Context<'a, S> {
     ///
     /// If this returns `None`, then no span exists for that ID (either it has
     /// closed or the ID is invalid).
-    ///
-    /// <div class="information">
-    ///     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>
-    /// </div>
-    /// <div class="example-wrap" style="display:inline-block">
-    /// <pre class="ignore" style="white-space:normal;font:inherit;">
-    /// <strong>Note</strong>: This requires the wrapped subscriber to implement the
-    /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
-    /// <code>Layer</code> implementations that wish to use this
-    /// function can bound their <code>Subscriber</code> type parameter with:
-    /// </pre></div>
-    /// ```rust,ignore
-    /// where S: Subscriber + for<'a> LookupSpan<'a>,`
-    /// ```
     #[inline]
     #[cfg(feature = "registry")]
     #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
@@ -904,15 +913,11 @@ impl<'a, S: Subscriber> Context<'a, S> {
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: This requires the wrapped subscriber to implement the
     /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
-    /// <code>Layer</code> implementations that wish to use this
-    /// function can bound their <code>Subscriber</code> type parameter with:
+    /// See the documentation on <a href="./struct.Context.html"><code>Context</code>'s
+    /// declaration</a> for details.
     /// </pre></div>
-    /// ```rust,ignore
-    /// where S: Subscriber + for<'a> LookupSpan<'a>,`
-    /// ```
     ///
     /// [stored data]: ../registry/struct.SpanRef.html
-    /// [`LookupSpan`]: ../registry/trait.LookupSpan.html
     #[inline]
     #[cfg(feature = "registry")]
     #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
@@ -932,14 +937,9 @@ impl<'a, S: Subscriber> Context<'a, S> {
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: This requires the wrapped subscriber to implement the
     /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
-    /// <code>Layer</code> implementations that wish to use this
-    /// function can bound their <code>Subscriber</code> type parameter with:
+    /// See the documentation on <a href="./struct.Context.html"><code>Context</code>'s
+    /// declaration</a> for details.
     /// </pre></div>
-    /// ```rust,ignore
-    /// where S: Subscriber + for<'a> LookupSpan<'a>,`
-    /// ```
-    ///
-    /// [`LookupSpan`]: ../registry/trait.LookupSpan.html
     #[inline]
     #[cfg(feature = "registry")]
     #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
@@ -962,15 +962,11 @@ impl<'a, S: Subscriber> Context<'a, S> {
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: This requires the wrapped subscriber to implement the
     /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
-    /// <code>Layer</code> implementations that wish to use this
-    /// function can bound their <code>Subscriber</code> type parameter with:
+    /// See the documentation on <a href="./struct.Context.html"><code>Context</code>'s
+    /// declaration</a> for details.
     /// </pre></div>
-    /// ```rust,ignore
-    /// where S: Subscriber + for<'a> LookupSpan<'a>,`
-    /// ```
     ///
     /// [stored data]: ../registry/struct.SpanRef.html
-    /// [`LookupSpan`]: ../registry/trait.LookupSpan.html
     #[inline]
     #[cfg(feature = "registry")]
     #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
@@ -994,7 +990,7 @@ impl<'a, S: Subscriber> Context<'a, S> {
     /// current context, starting the root of the trace tree and ending with
     /// the current span.
     ///
-    /// If this iterator is empty, then there are no spans in the current context
+    /// If this iterator is empty, then there are no spans in the current context.
     ///
     /// <div class="information">
     ///     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>
@@ -1003,15 +999,11 @@ impl<'a, S: Subscriber> Context<'a, S> {
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: This requires the wrapped subscriber to implement the
     /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
-    /// <code>Layer</code> implementations that wish to use this
-    /// function can bound their <code>Subscriber</code> type parameter with:
+    /// See the documentation on <a href="./struct.Context.html"><code>Context</code>'s
+    /// declaration</a> for details.
     /// </pre></div>
-    /// ```rust,ignore
-    /// where S: Subscriber + for<'a> LookupSpan<'a>,`
-    /// ```
     ///
     /// [stored data]: ../registry/struct.SpanRef.html
-    /// [`LookupSpan`]: ../registry/trait.LookupSpan.html
     #[cfg(feature = "registry")]
     #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
     pub fn scope(&self) -> Scope<'_, S>

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -87,7 +87,7 @@ pub use sharded::Registry;
 ///
 /// [`Layer`]: ../layer/trait.Layer.html
 /// [`Context`]: ../layer/struct.Context.html
-/// [`span()`]: ../layer/struct.Context.html#method.metadata
+/// [`span()`]: ../layer/struct.Context.html#method.span
 pub trait LookupSpan<'a> {
     /// The type of span data stored in this registry.
     type Data: SpanData<'a>;
@@ -99,8 +99,8 @@ pub trait LookupSpan<'a> {
     /// </div>
     /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
-    /// <strong>Note</strong>: users of the <code>LookupSpan<code> trait should
-    /// typically call the <a href="#method.span"><code>span</code> method rather
+    /// <strong>Note</strong>: users of the <code>LookupSpan</code> trait should
+    /// typically call the <a href="#method.span"><code>span</code></a> method rather
     /// than this method. The <code>span</code> method is implemented by
     /// <em>calling</em> <code>span_data</code>, but returns a reference which is
     /// capable of performing more sophisiticated queries.

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -57,8 +57,8 @@ pub struct Registry {
 /// be stored in the [extensions] typemap.
 ///
 /// [`Registry`]: struct.Registry.html
-/// [`Layer`s]: ../trait.Layer.html
-/// [extensions]: extensions/index.html
+/// [`Layer`s]: ../layer/trait.Layer.html
+/// [extensions]: struct.Extensions.html
 #[cfg(feature = "registry")]
 #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
 #[derive(Debug)]


### PR DESCRIPTION
This PR resolves two issues.

## Incorrectly Rendered Documentation
Here are a few examples:
- https://docs.rs/tracing-subscriber/0.2.9/tracing_subscriber/layer/trait.Layer.html
- https://docs.rs/tracing-subscriber/0.2.9/tracing_subscriber/layer/struct.Context.html#method.scope
- https://docs.rs/tracing-subscriber/0.2.9/tracing_subscriber/registry/trait.LookupSpan.html

Most of the incorrectly rendered document occurred due to a missing closing tag.

## Broken Links

I think I've gotten _most_ of them, but I'm not entirely sure. This is due to two reasons:
- `cargo-deadlinks` returns false positives.
- `MakeWriter` [appears twice](https://docs.rs/tracing-subscriber/0.2.9/tracing_subscriber/?search=MakeWriter) due to  `#[doc(inline)]` in [`tracing_subscriber/fmt/mod.rs`](https://github.com/tokio-rs/tracing/blob/master/tracing-subscriber/src/fmt/mod.rs#L142). This means that I'm able to fix these links in only _one_ location, not both, at least until [intra-doc links](https://github.com/rust-lang/rust/pull/74430) are stabilized.