### PR TITLE
chore: remove all-features tests that can't actually pass

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -191,12 +191,6 @@ jobs:
       run: (cd tracing-core && cargo test --no-default-features)
     - name: "Test tracing no-std support"
       run: (cd tracing && cargo test --no-default-features)
-    - name: "Test tracing all features"
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: -p tracing --all-features
-
   style:
     # Check style.
     needs: check


### PR DESCRIPTION
It turns out that the test run with `--all-features` should never be
able to pass, due to the `static_max_level` features. Setting
`--all-features` will enable `static_max_level_off`, which disables all
tracing. Therefore, all the integration tests will fail.

However, due to a bug in `tracing`'s `LevelFilter::OFF` implementation,
`static_max_level_off` actually _enables_ everything. This makes the
tests pass accidentally. If we fix this bug, though, everything will be
disabled, as it should be, causing the tests to fail. Therefore, we
can't merge a PR that fixes this, like #853, without first resolving the
issues with the tests.

Unfortunately, these are integration tests, so we cannot just put 
```rust
#[cfg(not(any(feature = "static_max_level_off", feature = ...))]
```
on the tests to skip them when the feature is set --- features set on
the _crate_ being tested are not visible to integration tests.
Similarly, we cannot use 
```rust
#[cfg(test)]
```
to not set the max level when running the tests, because the test cfg is
not set for the crate when running integration tests, only unit tests.

We could change all these tests to be integration tests, I suppose.
However, we are already running a `cargo hack` job that tests every
feature combination for `tracing` _except_ for the `static_max_level`
ones, so I think it's fine to just remove this.