### PR TITLE
opentelemetry: Upgrade to opentelemetry v0.7.0

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -52,5 +52,5 @@ inferno = "0.10.0"
 tempdir = "0.3.7"
 
 # opentelemetry example
-opentelemetry = "0.6"
-opentelemetry-jaeger = "0.5"
+opentelemetry = "0.7"
+opentelemetry-jaeger = "0.6"

--- a/examples/examples/opentelemetry-remote-context.rs
+++ b/examples/examples/opentelemetry-remote-context.rs
@@ -25,7 +25,7 @@ fn main() {
     let subscriber = Registry::default().with(tracing_opentelemetry::layer());
 
     // Propagator can be swapped with trace context propagator binary propagator, etc.
-    let propagator = api::B3Propagator::new(true);
+    let propagator = api::B3Propagator::new();
 
     tracing::subscriber::with_default(subscriber, || {
         // Extract from request headers, or any type that impls `opentelemetry::api::Carrier`

--- a/examples/examples/opentelemetry.rs
+++ b/examples/examples/opentelemetry.rs
@@ -27,7 +27,7 @@ fn init_tracer() -> Result<(), Box<dyn std::error::Error>> {
     let provider = sdk::Provider::builder()
         .with_simple_exporter(exporter)
         .with_config(sdk::Config {
-            default_sampler: Box::new(sdk::Sampler::Always),
+            default_sampler: Box::new(sdk::Sampler::AlwaysOn),
             ..Default::default()
         })
         .build();

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2018"
 default = ["tracing-log"]
 
 [dependencies]
-opentelemetry = { version = "0.6", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.7", default-features = false, features = ["trace"] }
 rand = "0.7"
 tracing = { path = "../tracing", version = "0.1" }
 tracing-core = { path = "../tracing-core", version = "0.1" }
@@ -30,4 +30,4 @@ tracing-subscriber = { path = "../tracing-subscriber", version = "0.2", default-
 tracing-log = { path = "../tracing-log", version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
-opentelemetry-jaeger = "0.5"
+opentelemetry-jaeger = "0.6"

--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -33,7 +33,7 @@ where
     S: Subscriber + for<'span> LookupSpan<'span>,
 {
     fn default() -> Self {
-        OpenTelemetryLayer::new(api::NoopTracer {}, sdk::Sampler::Always)
+        OpenTelemetryLayer::new(api::NoopTracer {}, sdk::Sampler::AlwaysOn)
     }
 }
 
@@ -240,7 +240,7 @@ where
     /// let provider = sdk::Provider::builder()
     ///     .with_simple_exporter(exporter)
     ///     .with_config(sdk::Config {
-    ///         default_sampler: Box::new(sdk::Sampler::Always),
+    ///         default_sampler: Box::new(sdk::Sampler::AlwaysOn),
     ///         ..Default::default()
     ///     })
     ///     .build();
@@ -299,7 +299,7 @@ where
     /// let provider = sdk::Provider::builder()
     ///     .with_simple_exporter(exporter)
     ///     .with_config(sdk::Config {
-    ///         default_sampler: Box::new(sdk::Sampler::Always),
+    ///         default_sampler: Box::new(sdk::Sampler::AlwaysOn),
     ///         ..Default::default()
     ///     })
     ///     .build();

--- a/tracing-opentelemetry/src/span_ext.rs
+++ b/tracing-opentelemetry/src/span_ext.rs
@@ -26,7 +26,7 @@ pub trait OpenTelemetrySpanExt {
     /// let mut carrier = HashMap::new();
     ///
     /// // Propagator can be swapped with trace context propagator binary propagator, etc.
-    /// let propagator = api::B3Propagator::new(true);
+    /// let propagator = api::B3Propagator::new();
     ///
     /// // Extract otel parent context via the chosen propagator
     /// let parent_context = propagator.extract(&carrier);


### PR DESCRIPTION
Upgrade `opentelemetry` to latest release version, updating some names in accordance with spec changes.

Resolves #797
