### PR TITLE
tracing: remove `dispatcher::has_been_set` check in macros

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -1841,13 +1841,10 @@ macro_rules! callsite {
 
 #[macro_export]
 // TODO: determine if this ought to be public API?`
-// TODO(eliza): is the `has_been_set` check still necessary? the max
-// level check should be equivalent...
 #[doc(hidden)]
 macro_rules! level_enabled {
     ($lvl:expr) => {
-        $crate::dispatcher::has_been_set()
-            && $lvl <= $crate::level_filters::STATIC_MAX_LEVEL
+        $lvl <= $crate::level_filters::STATIC_MAX_LEVEL
             && $lvl <= $crate::level_filters::LevelFilter::current()
     };
 }


### PR DESCRIPTION
This PR removes the `dispatcher::has_been_set` check from the
`level_enabled!` macro. We now check the static max level prior to
checking anything else, which avoids any atomic loads for callsites
disabled by the static max level. Also, checking the value of
`LevelFilter::current` should now be essentially equivalent to the
`dispatcher::has_been_set` check, since the default global max
`LevelFilter` is `OFF` when no dispatcher has been set. This means that
rather than doing *two* memory accesses if a callsite is disabled by the
global max level (one for the dispatcher set flag, and one for the max
level), we only do one memory access.

The `has_been_set` flag is also consumed by the `log` integration, for
determining whether to emit `log` records if "log-always" is not
enabled. We *could* probably replace that with a check if
`LevelFilter::current()` is `OFF`, but I dunno if this is necessary just
to remove that function. Also, we can't remove it from `tracing-core`,
since we want `tracing-core` to be backwards-compatible with previous
versions of `tracing`.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>