### PR TITLE
tracing: move macro callsite impls out of macro expansion

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -898,6 +898,14 @@ pub mod __macro_support {
     use crate::{subscriber::Interest, Callsite, Metadata};
     use tracing_core::Once;
 
+    /// Callsite implementation used by macro-generated code.
+    ///
+    /// /!\ WARNING: This is *not* a stable API! /!\
+    /// This type, and all code contained in the `__macro_support` module, is
+    /// a *private* API of `tracing`. It is exposed publicly because it is used
+    /// by the `tracing` macros, but it is not part of the stable versioned API.
+    /// Breaking changes to this module may occur in small-numbered versions
+    /// warnings.
     #[derive(Debug)]
     pub struct MacroCallsite {
         interest: AtomicUsize,
@@ -906,6 +914,14 @@ pub mod __macro_support {
     }
 
     impl MacroCallsite {
+        /// Returns a new `MacroCallsite` with the specified `Metadata`.
+        ///
+        /// /!\ WARNING: This is *not* a stable API! /!\
+        /// This method, and all code contained in the `__macro_support` module, is
+        /// a *private* API of `tracing`. It is exposed publicly because it is used
+        /// by the `tracing` macros, but it is not part of the stable versioned API.
+        /// Breaking changes to this module may occur in small-numbered versions
+        /// warnings.
         pub const fn new(meta: &'static Metadata<'static>) -> Self {
             Self {
                 interest: AtomicUsize::new(0),
@@ -914,15 +930,16 @@ pub mod __macro_support {
             }
         }
 
-        #[inline(always)]
-        fn interest(&self) -> Interest {
-            match self.interest.load(Ordering::Relaxed) {
-                0 => Interest::never(),
-                2 => Interest::always(),
-                _ => Interest::sometimes(),
-            }
-        }
-
+        /// Returns `true` if the callsite is enabled by a cached interest, or
+        /// by the current `Dispatch`'s `enabled` method if the cached
+        /// `Interest` is `sometimes`.
+        ///
+        /// /!\ WARNING: This is *not* a stable API! /!\
+        /// This method, and all code contained in the `__macro_support` module, is
+        /// a *private* API of `tracing`. It is exposed publicly because it is used
+        /// by the `tracing` macros, but it is not part of the stable versioned API.
+        /// Breaking changes to this module may occur in small-numbered versions
+        /// warnings.
         #[inline(always)]
         pub fn is_enabled(&self) -> bool {
             let interest = self.interest();
@@ -936,10 +953,29 @@ pub mod __macro_support {
             crate::dispatcher::get_default(|current| current.enabled(self.meta))
         }
 
+        /// Registers this callsite with the global callsite registry.
+        ///
+        /// If the callsite is already registered, this does nothing.
+        ///
+        /// /!\ WARNING: This is *not* a stable API! /!\
+        /// This method, and all code contained in the `__macro_support` module, is
+        /// a *private* API of `tracing`. It is exposed publicly because it is used
+        /// by the `tracing` macros, but it is not part of the stable versioned API.
+        /// Breaking changes to this module may occur in small-numbered versions
+        /// warnings.
         #[inline(always)]
         pub fn register(&'static self) {
             self.registration
                 .call_once(|| crate::callsite::register(self))
+        }
+
+        #[inline(always)]
+        fn interest(&self) -> Interest {
+            match self.interest.load(Ordering::Relaxed) {
+                0 => Interest::never(),
+                2 => Interest::always(),
+                _ => Interest::sometimes(),
+            }
         }
     }
 

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -914,7 +914,7 @@ pub mod __macro_support {
             }
         }
 
-        #[inline]
+        #[inline(always)]
         fn interest(&self) -> Interest {
             match self.interest.load(Ordering::Relaxed) {
                 0 => Interest::never(),
@@ -923,7 +923,7 @@ pub mod __macro_support {
             }
         }
 
-        #[inline]
+        #[inline(always)]
         pub fn is_enabled(&self) -> bool {
             let interest = self.interest();
             if interest.is_always() {
@@ -953,7 +953,7 @@ pub mod __macro_support {
             self.interest.store(interest, Ordering::SeqCst);
         }
 
-        #[inline]
+        #[inline(always)]
         fn metadata(&self) -> &Metadata<'static> {
             &self.meta
         }

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -893,7 +893,8 @@ pub mod subscriber;
 
 #[doc(hidden)]
 pub mod __macro_support {
-    pub use crate::stdlib::sync::atomic::{AtomicUsize, Ordering};
+    pub use crate::callsite::Callsite as _;
+    use crate::stdlib::sync::atomic::{AtomicUsize, Ordering};
     use crate::{subscriber::Interest, Callsite, Metadata};
     use tracing_core::Once;
 

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -958,17 +958,6 @@ pub mod __macro_support {
             &self.meta
         }
     }
-
-    #[inline]
-    pub fn dispatch_if_enabled(meta: &Metadata<'_>, f: impl Fn()) {
-        // resolves https://github.com/tokio-rs/tracing/issues/783 by forcing a monomorphization
-        // in tracing, not downstream crates.
-        crate::dispatcher::get_default(|current| {
-            if current.enabled(meta) {
-                f()
-            }
-        })
-    }
 }
 
 mod sealed {

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -897,7 +897,7 @@ pub mod __macro_support {
     use crate::{subscriber::Interest, Callsite, Metadata};
     use tracing_core::Once;
 
-    #[derive()]
+    #[derive(Debug)]
     pub struct MacroCallsite {
         interest: AtomicUsize,
         meta: &'static Metadata<'static>,

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -905,7 +905,7 @@ pub mod __macro_support {
     /// a *private* API of `tracing`. It is exposed publicly because it is used
     /// by the `tracing` macros, but it is not part of the stable versioned API.
     /// Breaking changes to this module may occur in small-numbered versions
-    /// warnings.
+    /// without warning.
     #[derive(Debug)]
     pub struct MacroCallsite {
         interest: AtomicUsize,
@@ -921,7 +921,7 @@ pub mod __macro_support {
         /// a *private* API of `tracing`. It is exposed publicly because it is used
         /// by the `tracing` macros, but it is not part of the stable versioned API.
         /// Breaking changes to this module may occur in small-numbered versions
-        /// warnings.
+        /// without warning.
         pub const fn new(meta: &'static Metadata<'static>) -> Self {
             Self {
                 interest: AtomicUsize::new(0),
@@ -939,7 +939,7 @@ pub mod __macro_support {
         /// a *private* API of `tracing`. It is exposed publicly because it is used
         /// by the `tracing` macros, but it is not part of the stable versioned API.
         /// Breaking changes to this module may occur in small-numbered versions
-        /// warnings.
+        /// without warning.
         #[inline(always)]
         pub fn is_enabled(&self) -> bool {
             let interest = self.interest();
@@ -962,7 +962,7 @@ pub mod __macro_support {
         /// a *private* API of `tracing`. It is exposed publicly because it is used
         /// by the `tracing` macros, but it is not part of the stable versioned API.
         /// Breaking changes to this module may occur in small-numbered versions
-        /// warnings.
+        /// without warning.
         #[inline(always)]
         pub fn register(&'static self) {
             self.registration

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -966,7 +966,7 @@ pub mod __macro_support {
         #[inline(always)]
         pub fn register(&'static self) {
             self.registration
-                .call_once(|| crate::callsite::register(self))
+                .call_once(|| crate::callsite::register(self));
         }
 
         #[inline(always)]


### PR DESCRIPTION
## Motivation

Currently, every `tracing` macro generates a _new implementation_ of the
`Callsite` trait for a zero-sized struct created for that particular
callsite. This callsite accesses several statics defined in the macro
expansion.

This means that each tracing macro expands to a _lot_ of code — check
out the `cargo expand` output:

```
eliza on butterfly in tracing/examples on  master [$?] is v0.0.0 via ⚙️ v1.44.0
:; cargo expand --example all-levels | wc -l
    Checking tracing-examples v0.0.0 (/home/eliza/code/tracing/examples)
    Finished check [unoptimized + debuginfo] target(s) in 0.20s

463
```

More code in the macro expansion means more code in the function
*invoking* the macro, which may make that function harder for `rustc` to
optimize. This effects the performance of *other* code in the function,
not the `tracing` code, so this isn't necessarily visible in `tracing`'s
microbenchmarks, which only contain `tracing` code. 

In `rustc` itself, there is a small but noticeable performance impact
from switching from `log` to `tracing` even after making changes that
should make the filtering overhead equivalent:
https://github.com/rust-lang/rust/pull/74726#issuecomment-665247203.
This appears to be due to more complex generated code impacting
optimizer behavior.

## Solution

This branch moves the callsite generated by each macro out of the macro
expansion and into a single `MacroCallsite` private API type in the
`__macro_support` module. Instead of creating a zero-sized `Callsite`
static and multiple statics for the `Metadata`, the `Once` cell for
registration, and the `Interest` atomic, these are all now fields on the
`Callsite` struct. This shouldn't result in any real change, but makes
the implementation simpler. All the hot filtering functions on
`MacroCallsite` are `#[inline(always)]`, so we shouldn't be adding stack
frames to code that was previously generated in the macro expansion.

After making this change, the expanded output is about half as long 
as it was before:

```
eliza on butterfly in tracing/examples on  eliza/smaller-macros [$?] is v0.0.0 via ⚙️ v1.44.0 
:; cargo expand --example all-levels | wc -l
    Checking tracing-examples v0.0.0 (/home/eliza/code/tracing/examples)
    Finished check [unoptimized + debuginfo] target(s) in 0.75s

233
```

This change appears to fix most of the remaining `rustc` performance
regressions:
https://github.com/rust-lang/rust/pull/74726#issuecomment-666865545

Additionally, it has some other side benefits. I imagine it probably
improves compile times a bit for crates using `tracing` (although I
haven't tested this), since the compiler is generating fewer callsite
implementations. Reducing the number of branches in the macro expansion
probably helps make the pesky `cognitive_complexity` Clippy lint show up
less often, and improves maintainability for the macros as well.
