### PR TITLE
tracing: make the "log" feature honor `log`'s max level

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -2361,7 +2361,7 @@ macro_rules! __tracing_log {
         $crate::if_log_enabled! {{
             use $crate::log;
             let level = $crate::level_to_log!(&$level);
-            if level <= log::STATIC_MAX_LEVEL {
+            if level <= log::STATIC_MAX_LEVEL && level <= log::max_level() {
                 let log_meta = log::Metadata::builder()
                     .level(level)
                     .target($target)

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -994,29 +994,31 @@ impl Span {
     #[inline]
     fn log(&self, target: &str, level: log::Level, message: fmt::Arguments<'_>) {
         if let Some(ref meta) = self.meta {
-            let logger = log::logger();
-            let log_meta = log::Metadata::builder().level(level).target(target).build();
-            if logger.enabled(&log_meta) {
-                if let Some(ref inner) = self.inner {
-                    logger.log(
-                        &log::Record::builder()
-                            .metadata(log_meta)
-                            .module_path(meta.module_path())
-                            .file(meta.file())
-                            .line(meta.line())
-                            .args(format_args!("{}; span={}", message, inner.id.into_u64()))
-                            .build(),
-                    );
-                } else {
-                    logger.log(
-                        &log::Record::builder()
-                            .metadata(log_meta)
-                            .module_path(meta.module_path())
-                            .file(meta.file())
-                            .line(meta.line())
-                            .args(message)
-                            .build(),
-                    );
+            if level_to_log!(meta.level()) <= log::max_level() {
+                let logger = log::logger();
+                let log_meta = log::Metadata::builder().level(level).target(target).build();
+                if logger.enabled(&log_meta) {
+                    if let Some(ref inner) = self.inner {
+                        logger.log(
+                            &log::Record::builder()
+                                .metadata(log_meta)
+                                .module_path(meta.module_path())
+                                .file(meta.file())
+                                .line(meta.line())
+                                .args(format_args!("{}; span={}", message, inner.id.into_u64()))
+                                .build(),
+                        );
+                    } else {
+                        logger.log(
+                            &log::Record::builder()
+                                .metadata(log_meta)
+                                .module_path(meta.module_path())
+                                .file(meta.file())
+                                .line(meta.line())
+                                .args(message)
+                                .build(),
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Motivation

In `tracing/macros.rs` `tracing_log!()` computes whether to log
differently from the log crate.

While the log crate checks for `lvl <= log::STATIC_MAX_LEVEL && lvl <=
log::max_level()`, tracing instead checks for `lvl <=
log::STATIC_MAX_LEVEL` and later the output of `logger.enabled()`. This
causes differences in what is being logged including unexpected log
output.

Since most of our testing has been with `env_logger`, we missed this
issue, since `env_logger` will also return `false` from its `enabled`
method for any records below the max level. However, other loggers may
not. Also, `enabled` is more expensive than checking the max level, so
this should result in better filtering performance for `log` records
emitted by tracing.

## Solution

This commit...fixes that.

Fixes #856

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
