### PR TITLE
core: prepare to release 0.1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ attachment that `Future::instrument` does.
 [tracing-futures-docs]: https://docs.rs/tracing-futures
 [closing]: https://docs.rs/tracing/latest/tracing/span/index.html#closing-spans
 [`Future::instrument`]: https://docs.rs/tracing-futures/latest/tracing_futures/trait.Instrument.html#method.instrument
-[instrument]: https://docs.rs/tracing/0.1.11/tracing/attr.instrument.html
+[instrument]: https://docs.rs/tracing/0.1.12/tracing/attr.instrument.html
 
 
 ## Getting Help

--- a/tracing-core/CHANGELOG.md
+++ b/tracing-core/CHANGELOG.md
@@ -1,26 +1,33 @@
-# 0.1.12 (UNRELEASED)
+# 0.1.12 (July 31, 2020)
 
-## Added
+### Added
 
 - `LevelFilter` type and `LevelFilter::current()` for returning the highest level
   that any subscriber will enable (#853)
 - `Subscriber::max_level_hint` optional trait method, for setting the value
   returned by `LevelFilter::current()` (#853)
+  
+### Fixed
+
+- **docs**: Removed outdated reference to a Tokio API that no longer exists
+  (#857)
+
+Thanks to new contributor @dignati for contributing to this release!
 
 # 0.1.11 (June 8, 2020)
 
-## Changed
+### Changed
 
 - Replaced use of `inner_local_macros` with `$crate::` (#729)
 
-## Added
+### Added
 
 - `must_use` warning to guards returned by `dispatcher::set_default` (#686)
 - `fmt::Debug` impl to `dyn Value`s (#696) 
 - Functions to convert between `span::Id` and `NonZeroU64` (#770)
 - More obvious warnings in documentation (#769)
 
-## Fixed
+### Fixed
 
 - Compiler error when `tracing-core/std` feature is enabled but `tracing/std` is
   not (#760)

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -12,9 +12,9 @@ Core primitives for application-level tracing.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-core.svg
-[crates-url]: https://crates.io/crates/tracing-core/0.1.11
+[crates-url]: https://crates.io/crates/tracing-core/0.1.12
 [docs-badge]: https://docs.rs/tracing-core/badge.svg
-[docs-url]: https://docs.rs/tracing-core/0.1.11
+[docs-url]: https://docs.rs/tracing-core/0.1.12
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_core
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -71,7 +71,7 @@ The following crate feature flags are available:
 
   ```toml
   [dependencies]
-  tracing-core = { version = "0.1.11", default-features = false }
+  tracing-core = { version = "0.1.12", default-features = false }
   ```
 
   *Compiler support: requires rustc 1.39+*
@@ -79,16 +79,16 @@ The following crate feature flags are available:
   **Note**:`tracing-core`'s `no_std` support requires `liballoc`.
 
 [`tracing`]: ../tracing
-[`span::Id`]: https://docs.rs/tracing-core/0.1.11/tracing_core/span/struct.Id.html
-[`Event`]: https://docs.rs/tracing-core/0.1.11/tracing_core/event/struct.Event.html
-[`Subscriber`]: https://docs.rs/tracing-core/0.1.11/tracing_core/subscriber/trait.Subscriber.html
-[`Metadata`]: https://docs.rs/tracing-core/0.1.11/tracing_core/metadata/struct.Metadata.html
-[`Callsite`]: https://docs.rs/tracing-core/0.1.11/tracing_core/callsite/trait.Callsite.html
-[`Field`]: https://docs.rs/tracing-core/0.1.11/tracing_core/field/struct.Field.html
-[`FieldSet`]: https://docs.rs/tracing-core/0.1.11/tracing_core/field/struct.FieldSet.html
-[`Value`]: https://docs.rs/tracing-core/0.1.11/tracing_core/field/trait.Value.html
-[`ValueSet`]: https://docs.rs/tracing-core/0.1.11/tracing_core/field/struct.ValueSet.html
-[`Dispatch`]: https://docs.rs/tracing-core/0.1.11/tracing_core/dispatcher/struct.Dispatch.html
+[`span::Id`]: https://docs.rs/tracing-core/0.1.12/tracing_core/span/struct.Id.html
+[`Event`]: https://docs.rs/tracing-core/0.1.12/tracing_core/event/struct.Event.html
+[`Subscriber`]: https://docs.rs/tracing-core/0.1.12/tracing_core/subscriber/trait.Subscriber.html
+[`Metadata`]: https://docs.rs/tracing-core/0.1.12/tracing_core/metadata/struct.Metadata.html
+[`Callsite`]: https://docs.rs/tracing-core/0.1.12/tracing_core/callsite/trait.Callsite.html
+[`Field`]: https://docs.rs/tracing-core/0.1.12/tracing_core/field/struct.Field.html
+[`FieldSet`]: https://docs.rs/tracing-core/0.1.12/tracing_core/field/struct.FieldSet.html
+[`Value`]: https://docs.rs/tracing-core/0.1.12/tracing_core/field/trait.Value.html
+[`ValueSet`]: https://docs.rs/tracing-core/0.1.12/tracing_core/field/struct.ValueSet.html
+[`Dispatch`]: https://docs.rs/tracing-core/0.1.12/tracing_core/dispatcher/struct.Dispatch.html
 
 ## License
 

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -49,7 +49,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing-core = { version = "0.1.11", default-features = false }
+//!   tracing-core = { version = "0.1.12", default-features = false }
 //!   ```
 //!
 //!   *Compiler support: requires rustc 1.39+*
@@ -68,7 +68,7 @@
 //! [`Dispatch`]: dispatcher/struct.Dispatch.html
 //! [`tokio-rs/tracing`]: https://github.com/tokio-rs/tracing
 //! [`tracing`]: https://crates.io/crates/tracing
-#![doc(html_root_url = "https://docs.rs/tracing-core/0.1.11")]
+#![doc(html_root_url = "https://docs.rs/tracing-core/0.1.12")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo.svg",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
### Added

- `LevelFilter` type and `LevelFilter::current()` for returning the
  highest level that any subscriber will enable (#853)
- `Subscriber::max_level_hint` optional trait method, for setting the
  value returned by `LevelFilter::current()` (#853)

### Fixed

- **docs**: Removed outdated reference to a Tokio API that no longer exists
  (#857)

Thanks to new contributor @dignati for contributing to this release!

Signed-off-by: Eliza Weisman <eliza@buoyant.io>