### PR TITLE
opentelemetry: Add semantic convention docs

### DIFF
--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -19,6 +19,25 @@
 //! Setting this field is useful if you want to display non-static information
 //! in your span name.
 //!
+//! ### Semantic Conventions
+//!
+//! OpenTelemetry defines conventional names for attributes of common
+//! operations. These names can be assigned directly as fields, e.g.
+//! `trace_span!("request", "span.kind" = "client", "http.url" = ..)`, and they
+//! will be passed through to your configured OpenTelemetry exporter. You can
+//! find the full list of the operations and their expected field names in the
+//! [semantic conventions] spec.
+//!
+//! [semantic conventions]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/trace/semantic_conventions
+//!
+//! ### Stability Status
+//!
+//! The OpenTelemetry specification is currently in beta so some breaking
+//! may still occur on the path to 1.0. You can follow the changes via the
+//! [spec repository] to track progress toward stabilization.
+//!
+//! [spec repository]: (https://github.com/open-telemetry/opentelemetry-specification)
+//!
 //! ## Examples
 //!
 //! ```


### PR DESCRIPTION
This branch adds crate-level docs for the otel trace semantic conventions and their usage as well as notes on stability status.

Resolves #747