### PR TITLE
Fix broken tracing documentation formatting

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -786,7 +786,6 @@
 //! <pre class="ignore" style="white-space:normal;font:inherit;">
 //! <strong>Note</strong>: <code>tracing</code>'s <code>no_std</code> support
 //! requires <code>liballoc</code>.
-//! </div>
 //! </pre></div>
 //!
 //! [`log`]: https://docs.rs/log/0.4.6/log/


### PR DESCRIPTION
I wasn't able to reproduce the exact formatting issues seen on docs.rs locally, though from some source inspection, this extra `</div>` appears to be the culprit.

(hopefully) fixes #880
