### PR TITLE
macros: fix breakage in experimental `tracing-macros` crate

### DIFF
--- a/tracing-macros/Cargo.toml
+++ b/tracing-macros/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["logging", "tracing"]
 license = "MIT"
 
 [dependencies]
-tracing = "0.1"
+tracing = "0.1.18"
 
 [dev-dependencies]
 tracing-log = "0.1"

--- a/tracing-macros/src/lib.rs
+++ b/tracing-macros/src/lib.rs
@@ -37,7 +37,7 @@ macro_rules! dbg {
             fields: value,
         };
         let val = $ex;
-        if tracing::is_enabled!(callsite) {
+        if callsite.is_enabled() {
             let meta = callsite.metadata();
             let fields = meta.fields();
             let key = meta


### PR DESCRIPTION
The `tracing-macros` crate uses internal `tracing` APIs that are
unstable. These APIs changed in 0.1.18 (not a breaking change, since
they are explicitly not stable API). `tracing-macros` needed to be
updated to use the new versions of the internal APIs.

As a side note, I'm surprised this wasn't caught before merging the
branch, and only happened on `master`. Are we not checking all crates
for PR builds? If so, we should probably fix that.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
