### PR TITLE
opentelemetry: prepare for v0.6.0 release

### DIFF
--- a/tracing-opentelemetry/CHANGELOG.md
+++ b/tracing-opentelemetry/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Breaking Changes
 
 - Upgrade to `v0.7.0` of `opentelemetry` (#867)
+  For list of breaking changes in OpenTelemetry, see the
+  [v0.7.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/master/CHANGELOG.md#v070).
 
 # 0.5.0 (June 2, 2020)
 

--- a/tracing-opentelemetry/CHANGELOG.md
+++ b/tracing-opentelemetry/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.6.0 (August 4, 2020)
+
+### Breaking Changes
+
+- Upgrade to `v0.7.0` of `opentelemetry` (#867)
+
 # 0.5.0 (June 2, 2020)
 
 ### Added

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-opentelemetry"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Julian Tescher <julian@tescher.me>",
     "Tokio Contributors <team@tokio.rs>"

--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -13,9 +13,9 @@ Utilities for adding [OpenTelemetry] interoperability to [`tracing`].
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-opentelemetry.svg
-[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.3.1
+[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.6.0
 [docs-badge]: https://docs.rs/tracing-opentelemetry/badge.svg
-[docs-url]: https://docs.rs/tracing-opentelemetry/0.3.1/tracing_opentelemetry
+[docs-url]: https://docs.rs/tracing-opentelemetry/0.6.0/tracing_opentelemetry
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_opentelemetry
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -65,7 +65,7 @@
 //! ```
 #![deny(unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.5.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.6.0")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo.svg",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
Changelog: 

### Breaking Changes

- Upgrade to `v0.7.0` of `opentelemetry` (#867) 
   For list of breaking changes in OpenTelemetry, see the [v0.7.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/master/CHANGELOG.md#v070).