### PR TITLE
opentelemetry: set span kind through otel.kind

### DIFF
--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -135,13 +135,18 @@ pub(crate) fn build_span_context(
 }
 
 fn str_to_span_kind(s: &str) -> Option<api::SpanKind> {
-    match s {
-        "SERVER" => Some(api::SpanKind::Server),
-        "CLIENT" => Some(api::SpanKind::Client),
-        "PRODUCER" => Some(api::SpanKind::Producer),
-        "CONSUMER" => Some(api::SpanKind::Consumer),
-        "INTERNAL" => Some(api::SpanKind::Internal),
-        _ => None,
+    if s.eq_ignore_ascii_case("SERVER") {
+        Some(api::SpanKind::Server)
+    } else if s.eq_ignore_ascii_case("CLIENT") {
+        Some(api::SpanKind::Client)
+    } else if s.eq_ignore_ascii_case("PRODUCER") {
+        Some(api::SpanKind::Producer)
+    } else if s.eq_ignore_ascii_case("CONSUMER") {
+        Some(api::SpanKind::Consumer)
+    } else if s.eq_ignore_ascii_case("INTERNAL") {
+        Some(api::SpanKind::Internal)
+    } else {
+        None
     }
 }
 
@@ -617,7 +622,7 @@ mod tests {
         let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
 
         tracing::subscriber::with_default(subscriber, || {
-            tracing::debug_span!("request", otel.kind = "SERVER");
+            tracing::debug_span!("request", otel.kind = "Server");
         });
 
         let recorded_kind = tracer.0.lock().unwrap().as_ref().unwrap().span_kind.clone();

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! OpenTelemetry defines conventional names for attributes of common
 //! operations. These names can be assigned directly as fields, e.g.
-//! `trace_span!("request", "otel.kind" = "CLIENT", "http.url" = ..)`, and they
+//! `trace_span!("request", "otel.kind" = "client", "http.url" = ..)`, and they
 //! will be passed through to your configured OpenTelemetry exporter. You can
 //! find the full list of the operations and their expected field names in the
 //! [semantic conventions] spec.

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! OpenTelemetry defines conventional names for attributes of common
 //! operations. These names can be assigned directly as fields, e.g.
-//! `trace_span!("request", "span.kind" = "client", "http.url" = ..)`, and they
+//! `trace_span!("request", "otel.kind" = "CLIENT", "http.url" = ..)`, and they
 //! will be passed through to your configured OpenTelemetry exporter. You can
 //! find the full list of the operations and their expected field names in the
 //! [semantic conventions] spec.

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -18,6 +18,12 @@
 //! * `otel.name`: Override the span name sent to OpenTelemetry exporters.
 //! Setting this field is useful if you want to display non-static information
 //! in your span name.
+//! * `otel.kind`: Set the span kind to one of the supported OpenTelemetry
+//! [span kinds]. The value should be a string of any of the supported values:
+//! `SERVER`, `CLIENT`, `PRODUCER`, `CONSUMER` or `INTERNAL`. Other values are
+//! silently ignored.
+//!
+//! [span kinds]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#spankind
 //!
 //! ### Semantic Conventions
 //!


### PR DESCRIPTION
## Motivation

Some distributed tracing providers use information such as the span kind to enrich their UIs. The issue https://github.com/frigus02/opentelemetry-application-insights/issues/5 shows an example with Azure Application Insights, which builds an application map based on client/server spans sent from multiple applications.

In order to make use of this with a combination of this `tracing` crate, together with OpenTelemetry exporters, we need a way of setting the span kind through the OpenTelemetry layer.

## Solution

This solves the issue by adding support for the special attribute `otel.kind` to the OpenTelemetry layer. If set to `SERVER`, `CLIENT`, `PRODUCER`, `CONSUMER` or `INTERNAL` it sets the span kind of the internal OpenTelemetry span.

This follows the convention introduced with the `otel.name` attribute, which sets the name of the internal OpenTelemetry span.