### PR TITLE
subscriber: disable regex dependency default features

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -35,7 +35,7 @@ tracing-core = { path = "../tracing-core", version = "0.1.12" }
 
 # only required by the filter feature
 matchers = { optional = true, version = "0.0.1" }
-regex = { optional = true, version = "1" }
+regex = { optional = true, version = "1", default-features = false, features = ["std"] }
 smallvec = { optional = true, version = "1" }
 lazy_static = { optional = true, version = "1" }
 
@@ -60,7 +60,7 @@ tracing = { path = "../tracing", version = "0.1"}
 log = "0.4"
 tracing-log = { path = "../tracing-log", version = "0.1" }
 criterion = { version = "0.3", default_features = false }
-regex = "1"
+regex = { version = "1", default-features = false, features = ["std"] }
 
 [badges]
 maintenance = { status = "experimental" }


### PR DESCRIPTION
The regex dependency is used only to parse configuration directives, and
therefore is not performance critical.  This change turns off all default
features (except 'std') from regex in order to optimize for compile times for
this non-performance-critical code.

Note that due to the presence of the 'criterion' dependency (which has its own
default-features dependency on regex), the tests do not normally run with only
the minimal set of regex features. I did remove the criterion dependency to
verify that tests build, but I'm not sure how to test that we're not using
disabled regex features on an ongoing basis.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
