### PR TITLE
Use the thread_local crate allowing multiple registries

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -27,7 +27,7 @@ default = ["env-filter", "smallvec", "fmt", "ansi", "chrono", "tracing-log", "js
 env-filter = ["matchers", "regex", "lazy_static"]
 fmt = ["registry"]
 ansi = ["fmt", "ansi_term"]
-registry = ["sharded-slab"]
+registry = ["sharded-slab", "thread_local"]
 json = ["tracing-serde", "serde", "serde_json"]
 
 [dependencies]
@@ -54,7 +54,7 @@ parking_lot = { version = ">= 0.7, <= 0.11", optional = true }
 
 # registry
 sharded-slab = { version = "^0.0.9", optional = true }
-thread_local = "1.0.1"
+thread_local = { version = "1.0.1", optional = true }
 
 [dev-dependencies]
 tracing = { path = "../tracing", version = "0.1" }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.10"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",
-    "Tokio Contributors <team@tokio.rs>"
+    "Tokio Contributors <team@tokio.rs>",
 ]
 edition = "2018"
 license = "MIT"
@@ -57,11 +57,13 @@ sharded-slab = { version = "^0.0.9", optional = true }
 thread_local = "1.0.1"
 
 [dev-dependencies]
-tracing = { path = "../tracing", version = "0.1"}
+tracing = { path = "../tracing", version = "0.1" }
 log = "0.4"
 tracing-log = { path = "../tracing-log", version = "0.1" }
 criterion = { version = "0.3", default_features = false }
 regex = { version = "1", default-features = false, features = ["std"] }
+tracing-futures = { path = "../tracing-futures", version = "0.2", default-features = false, features = ["std-future", "std"] }
+tokio = { version = "0.2", features = ["rt-core", "macros"] }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -54,6 +54,7 @@ parking_lot = { version = ">= 0.7, <= 0.11", optional = true }
 
 # registry
 sharded-slab = { version = "^0.0.9", optional = true }
+thread_local = "1.0.1"
 
 [dev-dependencies]
 tracing = { path = "../tracing", version = "0.1"}

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -202,8 +202,10 @@ impl Subscriber for Registry {
     fn event(&self, _: &Event<'_>) {}
 
     fn enter(&self, id: &span::Id) {
-        let spans = self.current_spans.get_or_default();
-        spans.borrow_mut().push(self.clone_span(id));
+        self.current_spans
+            .get_or_default()
+            .borrow_mut()
+            .push(self.clone_span(id));
     }
 
     fn exit(&self, id: &span::Id) {

--- a/tracing-subscriber/src/registry/stack.rs
+++ b/tracing-subscriber/src/registry/stack.rs
@@ -1,8 +1,8 @@
-use std::cell::RefCell;
 use std::collections::HashSet;
 
 pub(crate) use tracing_core::span::Id;
 
+#[derive(Debug)]
 struct ContextId {
     id: Id,
     duplicate: bool,
@@ -12,19 +12,13 @@ struct ContextId {
 ///
 /// A "separate current span" for each thread is a semantic choice, as each span
 /// can be executing in a different thread.
+#[derive(Debug, Default)]
 pub(crate) struct SpanStack {
     stack: Vec<ContextId>,
     ids: HashSet<Id>,
 }
 
 impl SpanStack {
-    pub(crate) fn new() -> Self {
-        SpanStack {
-            stack: vec![],
-            ids: HashSet::new(),
-        }
-    }
-
     pub(crate) fn push(&mut self, id: Id) {
         let duplicate = self.ids.contains(&id);
         if !duplicate {
@@ -61,17 +55,13 @@ impl SpanStack {
     }
 }
 
-thread_local! {
-    static CONTEXT: RefCell<SpanStack> = RefCell::new(SpanStack::new());
-}
-
 #[cfg(test)]
 mod tests {
     use super::{Id, SpanStack};
 
     #[test]
     fn pop_last_span() {
-        let mut stack = SpanStack::new();
+        let mut stack = SpanStack::default();
         let id = Id::from_u64(1);
         stack.push(id.clone());
 
@@ -80,7 +70,7 @@ mod tests {
 
     #[test]
     fn pop_first_span() {
-        let mut stack = SpanStack::new();
+        let mut stack = SpanStack::default();
         stack.push(Id::from_u64(1));
         stack.push(Id::from_u64(2));
 

--- a/tracing-subscriber/tests/registry_with_subscriber.rs
+++ b/tracing-subscriber/tests/registry_with_subscriber.rs
@@ -1,0 +1,25 @@
+ 
+use tracing_futures::{Instrument, WithSubscriber};
+use tracing_subscriber::prelude::*;
+
+#[tokio::test]
+async fn future_with_subscriber() {
+    let _default = tracing_subscriber::registry().init();
+    let span = tracing::info_span!("foo");
+    let _e = span.enter();
+    let span = tracing::info_span!("bar");
+    let _e = span.enter();
+    tokio::spawn(
+        async {
+            async {
+                let span = tracing::Span::current();
+                println!("{:?}", span);
+            }
+            .instrument(tracing::info_span!("hi"))
+            .await
+        }
+        .with_subscriber(tracing_subscriber::registry()),
+    )
+    .await
+    .unwrap();
+}

--- a/tracing-subscriber/tests/registry_with_subscriber.rs
+++ b/tracing-subscriber/tests/registry_with_subscriber.rs
@@ -1,4 +1,3 @@
- 
 use tracing_futures::{Instrument, WithSubscriber};
 use tracing_subscriber::prelude::*;
 


### PR DESCRIPTION
## Motivation

Fixes part of #898 where creating multiple registries made them fight over the thread_local-stored span stacks.

## Solution

Use the `thread_local` crate which has a tighter scope.

I believe @hawkw has a test that fails without this PR.