### PR TITLE
subscriber: fix level hint not considering value filters

### DIFF
--- a/tracing-subscriber/src/filter/env/directive.rs
+++ b/tracing-subscriber/src/filter/env/directive.rs
@@ -476,6 +476,12 @@ impl Dynamics {
             None
         }
     }
+
+    pub(crate) fn has_value_filters(&self) -> bool {
+        self.directives
+            .iter()
+            .any(|d| d.fields.iter().any(|f| f.value.is_some()))
+    }
 }
 
 // === impl Statics ===

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -278,6 +278,12 @@ impl<S: Subscriber> Layer<S> for EnvFilter {
     }
 
     fn max_level_hint(&self) -> Option<LevelFilter> {
+        if self.dynamics.has_value_filters() {
+            // If we perform any filtering on span field *values*, we will
+            // enable *all* spans, because their field values are not known
+            // until recording.
+            return Some(LevelFilter::TRACE);
+        }
         std::cmp::max(
             self.statics.max_level.clone().into(),
             self.dynamics.max_level.clone().into(),


### PR DESCRIPTION
This fixes an issue with `EnvFilter`'s `max_level_hint` not considering
that span field value filters may enable *any* span, regardless of the
level enabled inside that span. This is because the field value must be
recorded to be known.

We may wish to change this behavior to only check spans up to the
selected level, but this isn't what it does currently. This branch fixes
the wrong max level hint.

This bug was not caught due to an issue where hinting was too permissive
(#906), but fixing that bug uncovers this issue. A subsequent PR fixing
hint calculation introduces new test failures without this change.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
