### PR TITLE
rebuild_interest_cache on Dispatch's inner Subscriber Drop

### DIFF
--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -218,6 +218,11 @@ where
     }
 
     #[inline]
+    fn drop_span(&self, id: span::Id) {
+        self.0.drop_span(id)
+    }
+
+    #[inline]
     fn try_close(&self, id: span::Id) -> bool {
         self.0.try_close(id)
     }
@@ -473,7 +478,7 @@ impl Dispatch {
     #[inline]
     pub fn none() -> Self {
         Dispatch {
-            subscriber: Arc::new(Inner(NoSubscriber)),
+            subscriber: Arc::new(NoSubscriber),
         }
     }
 


### PR DESCRIPTION
## Motivation

Filters can leak (#902) when switching subscriber using `WithSubscriber`.

## Solution

Rebuild the `Interest` cache when dropping the last Subscriber Arc clone from the Dispatcher by wrapping it in a inner struct.