### PR TITLE
docs: put splash graphic in all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![Tracing — Structured, application-level diagnostics](assets/splash.svg)
+![Tracing — Structured, application-level diagnostics][splash]
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]

--- a/tracing-appender/README.md
+++ b/tracing-appender/README.md
@@ -1,3 +1,6 @@
+![Tracing — Structured, application-level diagnostics][splash]
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+
 # tracing-appender
 
 Writers for logging events and spans

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -1,3 +1,6 @@
+![Tracing — Structured, application-level diagnostics][splash]
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+
 # tracing-attributes
 
 Macro attributes for application-level tracing.

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -1,3 +1,6 @@
+![Tracing — Structured, application-level diagnostics][splash]
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+
 # tracing-core
 
 Core primitives for application-level tracing.

--- a/tracing-error/README.md
+++ b/tracing-error/README.md
@@ -1,3 +1,6 @@
+![Tracing — Structured, application-level diagnostics][splash]
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+
 # tracing-error
 
 Utilities for enriching error handling with [`tracing`] diagnostic

--- a/tracing-flame/README.md
+++ b/tracing-flame/README.md
@@ -1,3 +1,6 @@
+![Tracing — Structured, application-level diagnostics][splash]
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+
 # tracing-flame
 
 A [tracing] [`Layer`][`FlameLayer`] for generating a folded stack trace for generating flamegraphs

--- a/tracing-futures/README.md
+++ b/tracing-futures/README.md
@@ -1,3 +1,6 @@
+![Tracing — Structured, application-level diagnostics][splash]
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+
 # tracing-futures
 
 Utilities for instrumenting futures-based code with [`tracing`].

--- a/tracing-journald/README.md
+++ b/tracing-journald/README.md
@@ -1,3 +1,6 @@
+![Tracing — Structured, application-level diagnostics][splash]
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+
 # tracing-journald
 
 Support for logging [`tracing`][tracing] events natively to journald, preserving structured information.

--- a/tracing-log/README.md
+++ b/tracing-log/README.md
@@ -1,3 +1,6 @@
+![Tracing — Structured, application-level diagnostics][splash]
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+
 # tracing-log
 
 [`log`] compatibility for [`tracing`].

--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -1,3 +1,6 @@
+![Tracing — Structured, application-level diagnostics][splash]
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+
 # Tracing OpenTelemetry
 
 Utilities for adding [OpenTelemetry] interoperability to [`tracing`].

--- a/tracing-serde/README.md
+++ b/tracing-serde/README.md
@@ -1,3 +1,6 @@
+![Tracing — Structured, application-level diagnostics][splash]
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+
 # tracing-serde
 
 An adapter for serializing `tracing` types using `serde`.

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -1,3 +1,6 @@
+![Tracing — Structured, application-level diagnostics][splash]
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+
 # tracing
 
 Application-level tracing for Rust.


### PR DESCRIPTION
This puts the splash SVG in every crate's README, so
that it will be rendered on crates.io.

I also changed the link to an absolute URL, to ensure that
it works even outside of the repo.
