### PR TITLE
docs: fix broken splash graphic link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![Tracing — Structured, application-level diagnostics][splash]
+
 [splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
 
 [![Crates.io][crates-badge]][crates-url]

--- a/tracing-appender/README.md
+++ b/tracing-appender/README.md
@@ -1,4 +1,5 @@
 ![Tracing — Structured, application-level diagnostics][splash]
+
 [splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
 
 # tracing-appender

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -1,4 +1,5 @@
 ![Tracing — Structured, application-level diagnostics][splash]
+
 [splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
 
 # tracing-attributes

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -1,4 +1,5 @@
 ![Tracing — Structured, application-level diagnostics][splash]
+
 [splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
 
 # tracing-core

--- a/tracing-error/README.md
+++ b/tracing-error/README.md
@@ -1,4 +1,5 @@
 ![Tracing — Structured, application-level diagnostics][splash]
+
 [splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
 
 # tracing-error

--- a/tracing-flame/README.md
+++ b/tracing-flame/README.md
@@ -1,4 +1,5 @@
 ![Tracing — Structured, application-level diagnostics][splash]
+
 [splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
 
 # tracing-flame

--- a/tracing-futures/README.md
+++ b/tracing-futures/README.md
@@ -1,4 +1,5 @@
 ![Tracing — Structured, application-level diagnostics][splash]
+
 [splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
 
 # tracing-futures

--- a/tracing-journald/README.md
+++ b/tracing-journald/README.md
@@ -1,4 +1,5 @@
 ![Tracing — Structured, application-level diagnostics][splash]
+
 [splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
 
 # tracing-journald

--- a/tracing-log/README.md
+++ b/tracing-log/README.md
@@ -1,4 +1,5 @@
 ![Tracing — Structured, application-level diagnostics][splash]
+
 [splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
 
 # tracing-log

--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -1,4 +1,5 @@
 ![Tracing — Structured, application-level diagnostics][splash]
+
 [splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
 
 # Tracing OpenTelemetry

--- a/tracing-serde/README.md
+++ b/tracing-serde/README.md
@@ -1,4 +1,5 @@
 ![Tracing — Structured, application-level diagnostics][splash]
+
 [splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
 
 # tracing-serde

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -1,3 +1,7 @@
+![Tracing — Structured, application-level diagnostics][splash]
+
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+
 # tracing-subscriber
 
 Utilities for implementing and composing [`tracing`][tracing] subscribers.

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -1,4 +1,5 @@
 ![Tracing — Structured, application-level diagnostics][splash]
+
 [splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
 
 # tracing


### PR DESCRIPTION
Somehow a single line of whitespace is load-bearing I guess? MARKDOWN!

Signed-off-by: Eliza Weisman <eliza@buoyant.io>