### PR TITLE
attributes: prepare to release 0.1.10

### DIFF
--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.1.10 (August 10, 2020)
+
+### Added
+
+- Support for using `self` in field expressions when instrumenting `async-trait`
+  functions (#875)
+- Several documentation improvements (#832, #897, #911, #913)
+
+Thanks to @anton-dutov and @nightmared for contributing to this release!
+
 # 0.1.9 (July 8, 2020)
 
 ### Added

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-attributes"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.9"
+version = "0.1.10"
 authors = [
     "Tokio Contributors <team@tokio.rs>",
     "Eliza Weisman <eliza@buoyant.io>",

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -18,7 +18,7 @@ Macro attributes for application-level tracing.
 [crates-badge]: https://img.shields.io/crates/v/tracing-attributes.svg
 [crates-url]: https://crates.io/crates/tracing-attributes
 [docs-badge]: https://docs.rs/tracing-attributes/badge.svg
-[docs-url]: https://docs.rs/tracing-attributes/0.1.9
+[docs-url]: https://docs.rs/tracing-attributes/0.1.10
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_attributes
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -43,7 +43,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing-attributes = "0.1.9"
+tracing-attributes = "0.1.10"
 ```
 
 *Compiler support: requires rustc 1.39+*

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tracing-attributes = "0.1.9"
+//! tracing-attributes = "0.1.10"
 //! ```
 //!
 //! *Compiler support: requires rustc 1.39+*
@@ -35,7 +35,7 @@
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 //! [instrument]: attr.instrument.html
-#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.9")]
+#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.10")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo.svg",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -27,9 +27,9 @@ keywords = ["logging", "tracing", "metrics", "async"]
 edition = "2018"
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.12", default-features = false }
+tracing-core = { path = "../tracing-core", version = "0.1.14", default-features = false }
 log = { version = "0.4", optional = true }
-tracing-attributes = { path = "../tracing-attributes", version = "0.1.9", optional = true }
+tracing-attributes = { path = "../tracing-attributes", version = "0.1.10", optional = true }
 cfg-if = "0.1.10"
 
 [dev-dependencies]


### PR DESCRIPTION
Added

- Support for using `self` in field expressions when instrumenting
  `async-trait` functions (#875)
- Several documentation improvements (#832, #897, #911, #913)

Thanks to @anton-dutov and @nightmared for contributing to this release!