### PR TITLE
tracing: prepare to release 0.1.19

### DIFF
--- a/tracing-macros/Cargo.toml
+++ b/tracing-macros/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["logging", "tracing"]
 license = "MIT"
 
 [dependencies]
-tracing = "0.1.18"
+tracing = "0.1.19"
 
 [dev-dependencies]
 tracing-log = "0.1"

--- a/tracing-macros/Cargo.toml
+++ b/tracing-macros/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["logging", "tracing"]
 license = "MIT"
 
 [dependencies]
-tracing = "0.1.19"
+tracing = "0.1.18"
 
 [dev-dependencies]
 tracing-log = "0.1"

--- a/tracing-subscriber/src/util.rs
+++ b/tracing-subscriber/src/util.rs
@@ -14,8 +14,8 @@ use tracing_core::dispatcher::{self, Dispatch};
 /// `Subscriber`, may implement `Into<Dispatch>`, and will also receive an
 /// implementation of this trait.
 ///
-/// [default subscriber]: https://docs.rs/tracing/0.1.18/tracing/dispatcher/index.html#setting-the-default-subscriber
-/// [trace dispatcher]: https://docs.rs/tracing/0.1.18/tracing/dispatcher/index.html
+/// [default subscriber]: https://docs.rs/tracing/0.1.19/tracing/dispatcher/index.html#setting-the-default-subscriber
+/// [trace dispatcher]: https://docs.rs/tracing/0.1.19/tracing/dispatcher/index.html
 pub trait SubscriberInitExt
 where
     Self: Into<Dispatch>,
@@ -27,7 +27,7 @@ where
     /// a [`log`] compatibility layer. This allows the subscriber to consume
     /// `log::Record`s as though they were `tracing` `Event`s.
     ///
-    /// [default subscriber]: https://docs.rs/tracing/0.1.18/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [default subscriber]: https://docs.rs/tracing/0.1.19/tracing/dispatcher/index.html#setting-the-default-subscriber
     /// [`log`]: https://crates.io/log
     fn set_default(self) -> dispatcher::DefaultGuard {
         #[cfg(feature = "tracing-log")]
@@ -47,7 +47,7 @@ where
     /// been set, or if a `log` logger has already been set (when the
     /// "tracing-log" feature is enabled).
     ///
-    /// [global default subscriber]: https://docs.rs/tracing/0.1.18/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [global default subscriber]: https://docs.rs/tracing/0.1.19/tracing/dispatcher/index.html#setting-the-default-subscriber
     /// [`log`]: https://crates.io/log
     fn try_init(self) -> Result<(), TryInitError> {
         #[cfg(feature = "tracing-log")]
@@ -69,7 +69,7 @@ where
     /// or if a `log` logger has already been set (when the "tracing-log"
     /// feature is enabled).
     ///
-    /// [global default subscriber]: https://docs.rs/tracing/0.1.18/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [global default subscriber]: https://docs.rs/tracing/0.1.19/tracing/dispatcher/index.html#setting-the-default-subscriber
     /// [`log`]: https://crates.io/log
     fn init(self) {
         self.try_init()

--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,4 +1,20 @@
-# 0.1.18 (July 31, 2020)
+# 0.1.19 (August 10, 2020)
+
+### Fixed
+
+- Updated `tracing-core` to fix incorrect calculation of the global max level
+  filter (#908)
+
+### Added
+
+- **attributes**: Support for using `self` in field expressions when
+  instrumenting `async-trait` functions (#875)
+- Several documentation improvements (#832, #881, #896, #897, #911, #913)
+
+Thanks to @anton-dutov, @nightmared, @mystor, and @toshokan for contributing to
+this release!
+  
+# 0.1.19 (July 31, 2020)
 
 ### Fixed
 

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.18"
+version = "0.1.19"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -16,9 +16,9 @@ Application-level tracing for Rust.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.18
+[crates-url]: https://crates.io/crates/tracing/0.1.19
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.18
+[docs-url]: https://docs.rs/tracing/0.1.19
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -245,7 +245,7 @@ my_future
 is as long as the future's.
 
 The second, and preferred, option is through the
-[`#[instrument]`](https://docs.rs/tracing/0.1.18/tracing/attr.instrument.html)
+[`#[instrument]`](https://docs.rs/tracing/0.1.19/tracing/attr.instrument.html)
 attribute:
 
 ```rust
@@ -292,7 +292,7 @@ span.in_scope(|| {
 // Dropping the span will close it, indicating that it has ended.
 ```
 
-The [`#[instrument]`](https://docs.rs/tracing/0.1.18/tracing/attr.instrument.html) attribute macro
+The [`#[instrument]`](https://docs.rs/tracing/0.1.19/tracing/attr.instrument.html) attribute macro
 can reduce some of this boilerplate:
 
 ```rust

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -774,7 +774,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing = { version = "0.1.18", default-features = false }
+//!   tracing = { version = "0.1.19", default-features = false }
 //!   ```
 //!
 //!   *Compiler support: requires rustc 1.39+*
@@ -817,7 +817,7 @@
 //! [flags]: #crate-feature-flags
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.18")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.19")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo.svg",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
### Fixed

- Updated `tracing-core` to fix incorrect calculation of the global max
  level filter (#908)

### Added

- **attributes**: Support for using `self` in field expressions when
  instrumenting `async-trait` functions (#875)
- Several documentation improvements (#832, #881, #896, #897, #911,
  #913)

Thanks to @anton-dutov, @nightmared, @mystor, and @toshokan for
contributing to  this release!