### PR TITLE
subscriber: prepare to release 0.2.11

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,7 @@ tracing-core = { path = "../tracing-core", version = "0.1"}
 tracing-error = { path = "../tracing-error" }
 tracing-flame = { path = "../tracing-flame" }
 tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.10", features = ["json", "chrono"] }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.11", features = ["json", "chrono"] }
 tracing-futures = { version = "0.2.1", path = "../tracing-futures", features = ["futures-01"] }
 tracing-attributes =  { path = "../tracing-attributes", version = "0.1.2"}
 tracing-log = { path = "../tracing-log", version = "0.1.1", features = ["env_logger"] }

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 0.2.11 (August 10, 2020)
+
+### Fixed
+
+- **env-filter**: Incorrect max level hint when filters involving span field
+  values are in use (#907)
+- **registry**: Fixed inconsistent span stacks when multiple registries are in
+  use on the same thread (#901)
+
+### Changed
+
+- **env-filter**: `regex` dependency enables fewer unused feature flags (#899)
+
+Thanks to @bdonlan and @jeromegn for contributing to this release!
+
 # 0.2.10 (July 31, 2020)
 
 ### Fixed

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.10"
+version = "0.2.11"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -21,7 +21,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.2.10
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.11
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -49,7 +49,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.10")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.11")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo.svg",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
### Fixed

- **env-filter**: Incorrect max level hint when filters involving span
  field values are in use (#907)
- **registry**: Fixed inconsistent span stacks when multiple registries
  are in use on the same thread (#901)

### Changed

- **env-filter**: `regex` dependency enables fewer unused feature flags
  (#899)

Thanks to @bdonlan and @jeromegn for contributing to this release!
