### PR TITLE
Docs: Fix newline in dispatcher note

### DIFF
--- a/tracing/src/dispatcher.rs
+++ b/tracing/src/dispatcher.rs
@@ -112,8 +112,8 @@
 //! </div>
 //! <div class="example-wrap" style="display:inline-block">
 //! <pre class="ignore" style="white-space:normal;font:inherit;">
-//! <strong>Note</strong>: The thread-local scoped dispatcher (<code>with_default
-//! </code>) requires the Rust standard library. <code>no_std</code> users should
+//! <strong>Note</strong>: The thread-local scoped dispatcher (<code>with_default</code>)
+//! requires the Rust standard library. <code>no_std</code> users should
 //! use <a href="fn.set_global_default.html"><code>set_global_default</code></a>
 //! instead.
 //! </pre></div>


### PR DESCRIPTION
Newlines in `<code>` blocks are displayed, resulting in a newline before the closing parentheses.

![2020-08-12-113114_976x87_scrot](https://user-images.githubusercontent.com/105168/89999672-64ee6300-dc8f-11ea-9cae-baf47305155d.png)
