### PR TITLE
subscriber: adds From<Level> for Directive

### DIFF
--- a/tracing-subscriber/src/filter/env/directive.rs
+++ b/tracing-subscriber/src/filter/env/directive.rs
@@ -3,7 +3,7 @@ use super::{field, FieldMap, FilterVec};
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::{cmp::Ordering, error::Error, fmt, iter::FromIterator, str::FromStr};
-use tracing_core::{span, Metadata};
+use tracing_core::{span, Level, Metadata};
 
 /// A single filtering directive.
 // TODO(eliza): add a builder for programmatically constructing directives?
@@ -374,6 +374,12 @@ impl From<LevelFilter> for Directive {
             level,
             ..Self::default()
         }
+    }
+}
+
+impl From<Level> for Directive {
+    fn from(level: Level) -> Self {
+        LevelFilter::from_level(level).into()
     }
 }
 

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -85,11 +85,11 @@ use tracing_core::{
 ///
 /// [`Layer`]: ../layer/trait.Layer.html
 /// [`env_logger`]: https://docs.rs/env_logger/0.7.1/env_logger/#enabling-logging
-/// [`Span`]: ../../tracing_core/span/index.html
-/// [fields]: ../../tracing_core/struct.Field.html
-/// [`Event`]: ../../tracing_core/struct.Event.html
-/// [`level`]: ../../tracing_core/struct.Level.html
-/// [`Metadata`]: ../../tracing_core/struct.Metadata.html
+/// [`Span`]: https://docs.rs/tracing-core/latest/tracing_core/span/index.html
+/// [fields]: https://docs.rs/tracing-core/latest/tracing_core/struct.Field.html
+/// [`Event`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Event.html
+/// [`level`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Level.html
+/// [`Metadata`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Metadata.html
 #[cfg(feature = "env-filter")]
 #[cfg_attr(docsrs, doc(cfg(feature = "env-filter")))]
 #[derive(Debug)]
@@ -189,7 +189,7 @@ impl EnvFilter {
     /// directives, either added using this method or provided when the filter
     /// is constructed.
     ///
-    /// Filters may be created from may be [`LevelFilter`]s, which will
+    /// Filters may be created from [`LevelFilter`] or [`Level`], which will
     /// enable all traces at or below a certain verbosity level, or
     /// parsed from a string specifying a directive.
     ///
@@ -197,14 +197,30 @@ impl EnvFilter {
     /// and events as a previous filter, but sets a different level for those
     /// spans and events, the previous directive is overwritten.
     ///
-    /// [`LevelFilter`]: struct.LevelFilter.html
+    /// [`LevelFilter`]: ../filter/struct.LevelFilter.html
+    /// [`Level`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Level.html
     ///
     /// # Examples
+    ///
+    /// From [`LevelFilter`]:
+    ////
     /// ```rust
     /// use tracing_subscriber::filter::{EnvFilter, LevelFilter};
     /// let mut filter = EnvFilter::from_default_env()
     ///     .add_directive(LevelFilter::INFO.into());
     /// ```
+    ///
+    /// Or from [`Level`]:
+    ///
+    /// ```rust
+    /// # use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+    /// # use tracing::Level;
+    /// let mut filter = EnvFilter::from_default_env()
+    ///     .add_directive(Level::INFO.into());
+    /// ```
+    ////
+    /// Parsed from a string:
+    ////
     /// ```rust
     /// use tracing_subscriber::filter::{EnvFilter, Directive};
     ///


### PR DESCRIPTION
## Motivation

If you have a `Level` and want to set a directive for `EnvFilter` you need to do the mechanical transformation of: `     .add_directive(LevelFilter::from_level(log_lvl).into())`. To me, it wasn't obvious initially that this was even possible, I had to look through the docs for two different tracing repos to find that the pathway would work. 

## Solution

If this implementation is added, the definition will be shown on the `Directive` docs page, and you can write `.add_directive(Level::INFO.into())` and skip the intermediate transformation

There was some discussion on discord about this, if it's not desirable because of other reasons feel free to close
