### PR TITLE
test: add nicer debug output to mock subscribers

### DIFF
--- a/tracing/tests/multiple_max_level_hints.rs
+++ b/tracing/tests/multiple_max_level_hints.rs
@@ -25,6 +25,7 @@ fn multiple_max_level_hints() {
     }
 
     let (subscriber1, handle1) = subscriber::mock()
+        .named("subscriber1")
         .with_max_level_hint(Level::INFO)
         .with_filter(|meta| {
             let level = dbg!(meta.level());
@@ -40,6 +41,7 @@ fn multiple_max_level_hints() {
         .done()
         .run_with_handle();
     let (subscriber2, handle2) = subscriber::mock()
+        .named("subscriber2")
         .with_max_level_hint(Level::DEBUG)
         .with_filter(|meta| {
             let level = dbg!(meta.level());


### PR DESCRIPTION
## Motivation

The test-support mock subscribers currently `println!` a bunch of
debugging output. The debugging output is displayed if the test panics,
or if the test is run with `--nocapture`. This can be useful for
figuring out what went wrong if a test fails.

In some cases, tests involve multiple subscribers, to test behavior that
results from interactions between subscribers. In this case, there's no
way to tell which subscriber in the test the debug output came from.
Similarly, if a bunch of tests are run at the same time with
`--nocapture`, output from different test threads are interleaved,
making it impossible to interpret.

## Solution

This branch adds names to the mock subscribers, which are prepended to
their debugging output.

By default, the mock subscriber's name is the  name of the test
(*technically*, the name of the thread where it was created, which is
the name of the test unless tests are run with `--test-threads=1`).

When a test has only one mock subscriber, this is sufficient. However,
some tests may include multiple subscribers, in order to test
interactions between multiple subscribers. In that case, it can be
helpful to give each subscriber a separate name to distinguish where the
debugging output comes from. Therefore, this branch also adds a `.named`
method to the mock subscriber builder, allowing them to be given custom
names in tests with more than one subscriber.