### PR TITLE
attributes: remove unnecessary syn features

### DIFF
--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -39,7 +39,7 @@ async-await = []
 
 [dependencies]
 proc-macro2 = "1"
-syn = { version = "1", features = ["full", "extra-traits", "visit-mut"] }
+syn = { version = "1", default-features = false, features = ["full", "parsing", "printing", "visit-mut", "clone-impls", "extra-traits", "proc-macro"] }
 quote = "1"
 
 


### PR DESCRIPTION
This PR removes the "derive" feature, which is not used.

The "extra-traits" flag could be eliminated, but at the cost of removing `Debug` implementations for a few structs.