### PR TITLE
Bump to opentelemetry:0.8, opentelemetry-jaeger:0.7

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -52,5 +52,5 @@ inferno = "0.10.0"
 tempdir = "0.3.7"
 
 # opentelemetry example
-opentelemetry = "0.7"
-opentelemetry-jaeger = "0.6"
+opentelemetry = "0.8"
+opentelemetry-jaeger = "0.7"

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2018"
 default = ["tracing-log"]
 
 [dependencies]
-opentelemetry = { version = "0.7", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.8", default-features = false, features = ["trace"] }
 rand = "0.7"
 tracing = { path = "../tracing", version = "0.1" }
 tracing-core = { path = "../tracing-core", version = "0.1" }
@@ -30,4 +30,4 @@ tracing-subscriber = { path = "../tracing-subscriber", version = "0.2", default-
 tracing-log = { path = "../tracing-log", version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
-opentelemetry-jaeger = "0.6"
+opentelemetry-jaeger = "0.7"

--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -67,7 +67,11 @@ where
 //
 // See https://github.com/tokio-rs/tracing/blob/4dad420ee1d4607bad79270c1520673fa6266a3d/tracing-error/src/layer.rs
 pub(crate) struct WithContext(
-    fn(&tracing::Dispatch, &span::Id, f: &mut dyn FnMut(&mut api::SpanBuilder, &dyn sdk::ShouldSample)),
+    fn(
+        &tracing::Dispatch,
+        &span::Id,
+        f: &mut dyn FnMut(&mut api::SpanBuilder, &dyn sdk::ShouldSample),
+    ),
 );
 
 impl WithContext {


### PR DESCRIPTION
## Motivation

I'm running into version conflicts in a project of mine, and changes are minor. Some traits/enums were moved into the `sdk` module. See https://github.com/open-telemetry/opentelemetry-rust/blob/master/CHANGELOG.md#v080 for more info.

## Solution

Bump the versions and rename the traits/enums.