### PR TITLE
chore: correct the MSRV check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,13 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, 1.39.0]
+        rust: [stable, 1.44.0]
     steps:
     - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
         profile: minimal
+        override: true
     - name: Check
       uses: actions-rs/cargo@v1
       with:
@@ -71,6 +72,7 @@ jobs:
       with:
         toolchain: stable
         profile: minimal
+        override: true
     - name: Fetch latest release version of cargo-hack
       run: |
         mkdir -p .github/caching
@@ -107,6 +109,7 @@ jobs:
       with:
         toolchain: stable
         profile: minimal
+        override: true
     - name: cargo check
       working-directory: tracing
       run: cargo check --no-default-features --features "${{ matrix.featureset }}"
@@ -131,6 +134,7 @@ jobs:
       with:
         toolchain: stable
         profile: minimal
+        override: true
     - name: cargo check
       working-directory: tracing-subscriber
       run: cargo check --no-default-features --features "${{ matrix.featureset }}"
@@ -141,13 +145,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta, nightly, 1.39.0]
+        rust: [stable, beta, nightly, 1.44.0]
     steps:
     - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
         profile: minimal
+        override: true
     - name: Run tests
       uses: actions-rs/cargo@v1
       with:
@@ -167,6 +172,7 @@ jobs:
       with:
         toolchain: stable
         profile: minimal
+        override: true
     - name: Run tests
       uses: actions-rs/cargo@v1
       with:
@@ -183,6 +189,7 @@ jobs:
       with:
         toolchain: stable
         profile: minimal
+        override: true
     - name: "Test log support"
       run: (cd tracing/test-log-support && cargo test)
     - name: "Test static max level"
@@ -202,6 +209,7 @@ jobs:
         toolchain: stable
         components: rustfmt
         profile: minimal
+        override: true
     - name: rustfmt
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         rust: [stable, 1.44.0]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
@@ -67,7 +67,7 @@ jobs:
         #- tracing
         #- tracing-subscriber
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -104,7 +104,7 @@ jobs:
         - std log-always
         - std
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -129,7 +129,7 @@ jobs:
         - registry
         - env-filter
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -147,7 +147,7 @@ jobs:
       matrix:
         rust: [stable, beta, nightly, 1.44.0]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
@@ -167,7 +167,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -184,7 +184,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -203,7 +203,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -220,7 +220,7 @@ jobs:
     # Check for any warnings. This is informational and thus is allowed to fail.
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -235,7 +235,7 @@ jobs:
   cargo-audit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - name: Fetch latest release version of cargo-audit
       run: |
         mkdir -p .github/caching

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, 1.44.0]
+        rust: [stable, 1.40.0]
     steps:
     - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta, nightly, 1.44.0]
+        rust: [stable, beta, nightly, 1.40.0]
     steps:
     - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
## Motivation

The current MSRV check is lazybones, it's meaningless unless we override toolchain. Actually, we cannot compile tracing crates with 1.39.0, it should work with 1.44.0 or later because of the `protobuf` crate and others.

## Solution

This enforces to override toolchain and updates MSRV to 1.44.0, this should compile all the crates fine.
And replaces `actions/checkout@master` with `main` as they've renamed the default branch name to `main`.
