### PR TITLE
chore: fix MSRV breakage

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -52,5 +52,5 @@ inferno = "0.10.0"
 tempdir = "0.3.7"
 
 # opentelemetry example
-opentelemetry = "0.8"
+opentelemetry = { version = "0.8", default-features = false, features = ["trace"] }
 opentelemetry-jaeger = "0.7"

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -929,8 +929,11 @@ fn get_async_trait_info(block: &Block, block_is_async: bool) -> Option<AsyncTrai
 
             None
         })
-        .next()
-        .flatten();
+        .next();
+    let self_type = match self_type {
+        Some(x) => x,
+        None => None,
+    };
 
     Some(AsyncTraitInfo {
         name: fun.sig.ident.to_string(),


### PR DESCRIPTION
This branch contains two commits that fix MSRV issues.

* **attributes: remove use of non-MSRV-compliant `Option::flatten`**

  PR #875 added code to `tracing-attributes` that uses
  `Option::flatten`, which was only added to the standard library in
  Rust 1.40. This broke our MSRV, but we missed it because the MSRV CI
  checks weren't working correctly (fixed in #934).
  
  This commit removes the use of `Option::flatten`, and replaces it with
  a manual implementation. It's a little less pretty, but it builds on
  our MSRV (1.39.0).

  Once this merges, we'll publish a new `tracing-attributes` version,
  and yank 0.1.10.

* **examples: disable `opentelemetry`'s default features**

  The `opentelemetry` crate depends on `prometheus`, which depends on
  `protobuf`, a crate which doesn't compile on our MSRV (Rust 1.39).
  This was missed due to issues with the MSRV CI checks, which will be
  fixed fixed in #934. Therefore, once the MSRV checks work properly,
  the `protobuf` dependency will break our builds.
  
  We don't _need_ the `opentelemetry/metrics` feature, which is what
  enables the `prometheus` (and thus `protobuf`) dependency.
  `tracing-opentelemetry` already has a `default-features = false`
  dependency on `opentelemetry`, but the examples don't. Therefore, I've
  changed the examples crate to disable `opentelemetry`'s default
  features as well.