### PR TITLE
subscriber: Impl TestWriter for correct capturing of logs by cargo test

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -209,7 +209,7 @@ impl<S, N, E, W> Layer<S, N, E, W> {
             fmt_fields: self.fmt_fields,
             fmt_event: self.fmt_event,
             fmt_span: self.fmt_span,
-            make_writer: TestWriter,
+            make_writer: TestWriter::default(),
             _inner: self._inner,
         }
     }

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -1,6 +1,6 @@
 use crate::{
     field::RecordFields,
-    fmt::{format, FormatEvent, FormatFields, MakeWriter},
+    fmt::{format, FormatEvent, FormatFields, MakeWriter, TestWriter},
     layer::{self, Context, Scope},
     registry::{LookupSpan, SpanRef},
 };
@@ -178,6 +178,38 @@ impl<S, N, E, W> Layer<S, N, E, W> {
             fmt_event: self.fmt_event,
             fmt_span: self.fmt_span,
             make_writer,
+            _inner: self._inner,
+        }
+    }
+
+    /// Configures the subscriber to support [`libtest`'s output capturing][capturing] when used in
+    /// unit tests.
+    ///
+    /// See [`TestWriter`] for additional details.
+    ///
+    /// # Examples
+    ///
+    /// Using [`TestWriter`] to let `cargo test` capture test output:
+    ///
+    /// ```rust
+    /// use std::io;
+    /// use tracing_subscriber::fmt;
+    ///
+    /// let layer = fmt::layer()
+    ///     .with_test_writer();
+    /// # // this is necessary for type inference.
+    /// # use tracing_subscriber::Layer as _;
+    /// # let _ = layer.with_subscriber(tracing_subscriber::registry::Registry::default());
+    /// ```
+    /// [capturing]:
+    /// https://doc.rust-lang.org/book/ch11-02-running-tests.html#showing-function-output
+    /// [`TestWriter`]: writer/struct.TestWriter.html
+    pub fn with_test_writer(self) -> Layer<S, N, E, TestWriter> {
+        Layer {
+            fmt_fields: self.fmt_fields,
+            fmt_event: self.fmt_event,
+            fmt_span: self.fmt_span,
+            make_writer: TestWriter,
             _inner: self._inner,
         }
     }

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -874,8 +874,30 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
         }
     }
 
-    /// Prints text using the standard library's macro `print!`. This writer allows stdout logs to
-    /// be correctly captured by commands such as `cargo test`.
+    /// Configures the subscriber to support [`libtest`'s output capturing][capturing] when used in
+    /// unit tests.
+    ///
+    /// See [`TestWriter`] for additional details.
+    ///
+    /// # Examples
+    ///
+    /// Using [`TestWriter`] to let `cargo test` capture test output. Note that we do not install it
+    /// globally as it may cause conflicts.
+    ///
+    /// ```rust
+    /// use tracing_subscriber::fmt;
+    /// use tracing::subscriber;
+    ///
+    /// subscriber::set_default(
+    ///     fmt()
+    ///         .with_test_writer()
+    ///         .finish()
+    /// );
+    /// ```
+    ///
+    /// [capturing]:
+    /// https://doc.rust-lang.org/book/ch11-02-running-tests.html#showing-function-output
+    /// [`TestWriter`]: writer/struct.TestWriter.html
     pub fn with_test_writer(self) -> SubscriberBuilder<N, E, F, TestWriter> {
         SubscriberBuilder {
             filter: self.filter,

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -901,7 +901,7 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
     pub fn with_test_writer(self) -> SubscriberBuilder<N, E, F, TestWriter> {
         SubscriberBuilder {
             filter: self.filter,
-            inner: self.inner.with_writer(TestWriter),
+            inner: self.inner.with_writer(TestWriter::default()),
         }
     }
 }

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -143,7 +143,7 @@ use crate::{
 pub use self::{
     format::{format, FormatEvent, FormatFields},
     time::time,
-    writer::MakeWriter,
+    writer::{MakeWriter, TestWriter},
 };
 
 /// A `Subscriber` that logs formatted representations of `tracing` events.
@@ -871,6 +871,15 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
         SubscriberBuilder {
             filter: self.filter,
             inner: self.inner.with_writer(make_writer),
+        }
+    }
+
+    /// Prints text using the standard library's macro `print!`. This writer allows stdout logs to
+    /// be correctly captured by commands such as `cargo test`.
+    pub fn with_test_writer(self) -> SubscriberBuilder<N, E, F, TestWriter> {
+        SubscriberBuilder {
+            filter: self.filter,
+            inner: self.inner.with_writer(TestWriter),
         }
     }
 }

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -76,6 +76,13 @@ pub struct TestWriter {
     _p: (),
 }
 
+impl TestWriter {
+    /// Returns a new `TestWriter` with the default configuration.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
 impl io::Write for TestWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let out_str = String::from_utf8_lossy(buf);

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -71,8 +71,10 @@ where
 /// [`io::stdout`]: https://doc.rust-lang.org/std/io/fn.stdout.html
 /// [`io::stderr`]: https://doc.rust-lang.org/std/io/fn.stderr.html
 /// [`print!`]: https://doc.rust-lang.org/std/macro.print.html
-#[derive(Debug)]
-pub struct TestWriter;
+#[derive(Default, Debug)]
+pub struct TestWriter {
+    _p: (),
+}
 
 impl io::Write for TestWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
@@ -90,7 +92,7 @@ impl MakeWriter for TestWriter {
     type Writer = Self;
 
     fn make_writer(&self) -> Self::Writer {
-        Self
+        Self::default()
     }
 }
 

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -54,6 +54,31 @@ where
     }
 }
 
+/// Prints text using the standard library's macro `print!`. This writer allows stdout logs to be
+/// correctly captured by commands such as `cargo test`.
+#[derive(Debug)]
+pub struct TestWriter;
+
+impl io::Write for TestWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let out_str = String::from_utf8_lossy(buf);
+        print!("{}", out_str);
+        Ok(out_str.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl MakeWriter for TestWriter {
+    type Writer = Self;
+
+    fn make_writer(&self) -> Self::Writer {
+        Self
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::MakeWriter;

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -78,7 +78,7 @@ impl io::Write for TestWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let out_str = String::from_utf8_lossy(buf);
         print!("{}", out_str);
-        Ok(out_str.len())
+        Ok(buf.len())
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -54,8 +54,23 @@ where
     }
 }
 
-/// Prints text using the standard library's macro `print!`. This writer allows stdout logs to be
-/// correctly captured by commands such as `cargo test`.
+/// A writer intended to support [`libtest`'s output capturing][capturing] for use in unit tests.
+///
+/// `TestWriter` is used by [`fmt::Subscriber`] or [`fmt::Layer`] to enable capturing support.
+///
+/// `cargo test` can only capture output from the standard library's [`print!`] macro. See
+/// [`libtest`'s output capturing][capturing] for more details about output capturing.
+///
+/// Writing to [`io::stdout`] and [`io::stderr`] produces the same results as using
+/// [`libtest`'s `--nocapture` option][nocapture] which may make the results look unreadable.
+///
+/// [`fmt::Subscriber`]: ../struct.Subscriber.html
+/// [`fmt::Layer`]: ../struct.Layer.html
+/// [capturing]: https://doc.rust-lang.org/book/ch11-02-running-tests.html#showing-function-output
+/// [nocapture]: https://doc.rust-lang.org/cargo/commands/cargo-test.html
+/// [`io::stdout`]: https://doc.rust-lang.org/std/io/fn.stdout.html
+/// [`io::stderr`]: https://doc.rust-lang.org/std/io/fn.stderr.html
+/// [`print!`]: https://doc.rust-lang.org/std/macro.print.html
 #[derive(Debug)]
 pub struct TestWriter;
 


### PR DESCRIPTION
## Motivation

Using `cargo test` doesn't correctly capture stdout. This is due to the difference between the `print!` macros and writing directly to the output stream. The result is messy output during testing.

## Solution

A `TestWriter` was created that implements the `MakeWriter` and `std::io::Write` traits to wrap around the `print!` macro.

Closes #638