### PR TITLE
docs: Mention test-env-log as "related crate"

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,8 @@ are not maintained by the `tokio` project. These include:
   _inside_ of functions.
 - [`tracing-wasm`] provides a `Subscriber`/`Layer` implementation that reports
   events and spans via browser `console.log` and [User Timing API (`window.performance`)].
+- [`test-env-log`] takes care of initializing `tracing` for tests, based on
+  environment variables with an `env_logger` compatible syntax.
 
 (if you're the maintainer of a `tracing` ecosystem crate not in this list,
 please let us know!)
@@ -400,6 +402,7 @@ please let us know!)
 [`color-eyre`]: https://docs.rs/color-eyre
 [`spandoc`]: https://docs.rs/spandoc
 [`tracing-wasm`]: https://docs.rs/tracing-wasm
+[`test-env-log`]: https://crates.io/crates/test-env-log
 [User Timing API (`window.performance`)]: https://developer.mozilla.org/en-US/docs/Web/API/User_Timing_API
 
 **Note:** that some of the ecosystem crates are currently unreleased and

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -364,6 +364,8 @@ maintained by the `tokio` project. These include:
   GELF format.
 - [`tracing-coz`] provides integration with the [coz] causal profiler
   (Linux-only).
+- [`test-env-log`] takes care of initializing `tracing` for tests, based on
+  environment variables with an `env_logger` compatible syntax.
 
 If you're the maintainer of a `tracing` ecosystem crate not listed above,
 please let us know! We'd love to add your project to the list!
@@ -378,6 +380,7 @@ please let us know! We'd love to add your project to the list!
 [`tracing-gelf`]: https://crates.io/crates/tracing-gelf
 [`tracing-coz`]: https://crates.io/crates/tracing-coz
 [coz]: https://github.com/plasma-umass/coz
+[`test-env-log`]: https://crates.io/crates/test-env-log
 
 **Note:** that some of the ecosystem crates are currently unreleased and
 undergoing active development. They may be less stable than `tracing` and

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -721,6 +721,8 @@
 //!  - [`tracing-wasm`] provides a `Subscriber`/`Layer` implementation that reports
 //!    events and spans via browser `console.log` and [User Timing API (`window.performance`)].
 //!  - [`tide-tracing`] provides a [tide] middleware to trace all incoming requests and responses.
+//!  - [`test-env-log`] takes care of initializing `tracing` for tests, based on
+//!    environment variables with an `env_logger` compatible syntax.
 //!
 //! If you're the maintainer of a `tracing` ecosystem crate not listed above,
 //! please let us know! We'd love to add your project to the list!
@@ -740,6 +742,7 @@
 //! [User Timing API (`window.performance`)]: https://developer.mozilla.org/en-US/docs/Web/API/User_Timing_API
 //! [`tide-tracing`]: https://crates.io/crates/tide-tracing
 //! [tide]: https://crates.io/crates/tide
+//! [`test-env-log`]: https://crates.io/crates/test-env-log
 //!
 //! <div class="information">
 //!     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>


### PR DESCRIPTION
The test-env-log crate comes in useful when testing tracing based
applications/libraries. With this change we mention it in the Related
Crates section of the README.
