### PR TITLE
Add tracing-unwrap to the Related Crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ are not maintained by the `tokio` project. These include:
   events and spans via browser `console.log` and [User Timing API (`window.performance`)].
 - [`test-env-log`] takes care of initializing `tracing` for tests, based on
   environment variables with an `env_logger` compatible syntax.
+- [`tracing-unwrap`] provides convenience methods to report failed unwraps on `Result` or `Option` types to a `Subscriber`.
 
 (if you're the maintainer of a `tracing` ecosystem crate not in this list,
 please let us know!)
@@ -417,6 +418,7 @@ please let us know!)
 [`tracing-wasm`]: https://docs.rs/tracing-wasm
 [`test-env-log`]: https://crates.io/crates/test-env-log
 [User Timing API (`window.performance`)]: https://developer.mozilla.org/en-US/docs/Web/API/User_Timing_API
+[`tracing-unwrap`]: https://docs.rs/tracing-unwrap
 
 **Note:** that some of the ecosystem crates are currently unreleased and
 undergoing active development. They may be less stable than `tracing` and

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -381,6 +381,7 @@ maintained by the `tokio` project. These include:
   (Linux-only).
 - [`test-env-log`] takes care of initializing `tracing` for tests, based on
   environment variables with an `env_logger` compatible syntax.
+- [`tracing-unwrap`] provides convenience methods to report failed unwraps on `Result` or `Option` types to a `Subscriber`.
 
 If you're the maintainer of a `tracing` ecosystem crate not listed above,
 please let us know! We'd love to add your project to the list!
@@ -396,6 +397,7 @@ please let us know! We'd love to add your project to the list!
 [`tracing-coz`]: https://crates.io/crates/tracing-coz
 [coz]: https://github.com/plasma-umass/coz
 [`test-env-log`]: https://crates.io/crates/test-env-log
+[`tracing-unwrap`]: https://docs.rs/tracing-unwrap
 
 **Note:** that some of the ecosystem crates are currently unreleased and
 undergoing active development. They may be less stable than `tracing` and

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -726,6 +726,8 @@
 //!  - [`tide-tracing`] provides a [tide] middleware to trace all incoming requests and responses.
 //!  - [`test-env-log`] takes care of initializing `tracing` for tests, based on
 //!    environment variables with an `env_logger` compatible syntax.
+//!  - [`tracing-unwrap`] provides convenience methods to report failed unwraps
+//!    on `Result` or `Option` types to a `Subscriber`.
 //!
 //! If you're the maintainer of a `tracing` ecosystem crate not listed above,
 //! please let us know! We'd love to add your project to the list!
@@ -746,6 +748,7 @@
 //! [`tide-tracing`]: https://crates.io/crates/tide-tracing
 //! [tide]: https://crates.io/crates/tide
 //! [`test-env-log`]: https://crates.io/crates/test-env-log
+//! [`tracing-unwrap`]: https://docs.rs/tracing-unwrap
 //!
 //! <div class="information">
 //!     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>


### PR DESCRIPTION
This PR adds [`tracing-unwrap`](https://docs.rs/tracing-unwrap) to the list of related crates in the readme.

`tracing-unwrap` provides convenience methods to unwrap `Result` and `Option` types and automatically report failures via `tracing` before panicking.

Feel free to edit the description I wrote as you see fit. Thanks!