### PR TITLE
start building most subcrates in wasm on CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -159,6 +159,39 @@ jobs:
         command: test
         args: --all
 
+  test-build-wasm:
+    needs: check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # TODO(securityinsanity): slowly add wasm32 test runner to each crate, and move to seperate actions that run tests.
+        subcrate:
+        - tracing
+        - tracing-appender
+        - tracing-attributes
+        - tracing-core
+        - tracing-error
+        - tracing-flame
+        - tracing-journald
+        - tracing-log
+        - tracing-macros
+        - tracing-opentelemetry
+        - tracing-serde
+        - tracing-subscriber
+        - tracing-tower
+    steps:
+    - uses: actions/checkout@main
+    - uses: actions-rs/toolchain@v1
+      with:
+        target: wasm32-unknown-unknown
+        toolchain: stable
+        override: true
+    - name: build all tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --no-run -p ${{ matrix.subcrate }}
+
   test-os:
     # Test against stable Rust across macOS, Windows, and Linux.
     needs: check


### PR DESCRIPTION
refs #642

## Motivation

More, and more code is targeting wasm architectures. This is useful for not only browsers, but also useful for environments that want extensibility where the host environment is protected, but still allows extensibility in a variety of languages. Tracing can help these architectures just as it can any other architecture.

## Solution

start building all crates, except `tracing-futures` in wasm32-unknown-unknown architecture. this will validate going forward we don't break wasm32 build support.

in the future we can start running tests crate by crate, and actually run those tests. the reason we're doing this is every single test has to be marked with another special attribute, and add a dev-only dependency. we don't wanna create a huge pr that has to have conflicts fixed all the time. in the future we can also look at adding in support for tracing-futures.
