### PR TITLE
appender: Added BoxMakeWriter.

### DIFF
--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -151,7 +151,7 @@
 )]
 use crate::non_blocking::{NonBlocking, WorkerGuard};
 
-use std::{fmt::Debug, io::Write};
+use std::io::Write;
 
 mod inner;
 

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -151,7 +151,7 @@
 )]
 use crate::non_blocking::{NonBlocking, WorkerGuard};
 
-use std::io::Write;
+use std::{fmt::Debug, io::Write};
 
 mod inner;
 

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -116,7 +116,7 @@ pub struct BoxMakeWriter {
 }
 
 impl BoxMakeWriter {
-    /// Accepts an instance of [`MakeWriter`] and returns a BoxMakeWriter that wraps it.
+    /// Constructs a `BoxMakeWriter` wrapping a type implementing [`MakeWriter`].
     ///
     /// [`MakeWriter`]: trait.MakeWriter.html
     pub fn new<M>(make_writer: M) -> Self
@@ -132,7 +132,7 @@ impl BoxMakeWriter {
 
 impl Debug for BoxMakeWriter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "BoxMakeWriter")
+        f.pad("BoxMakeWriter { ... }")
     }
 }
 

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -109,7 +109,27 @@ impl MakeWriter for TestWriter {
 /// This is useful in cases where the concrete type of the writer cannot be known
 /// until runtime.
 ///
+/// # Examples
+///
+/// A function that returns a [`Subscriber`] that will write to either stdout or stderr:
+///
+/// ```rust
+/// # use tracing::Subscriber;
+/// # use tracing_subscriber::fmt::writer::BoxMakeWriter;
+///
+/// fn dynamic_writer(use_stderr: bool) -> impl Subscriber {
+///     let writer = if use_stderr {
+///         BoxMakeWriter::new(std::io::stderr)
+///     } else {
+///         BoxMakeWriter::new(std::io::stdout)
+///     };
+///
+///     tracing_subscriber::fmt().with_writer(writer).finish()
+/// }
+/// ```
+///
 /// [`MakeWriter`]: trait.MakeWriter.html
+/// [`Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
 /// [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 pub struct BoxMakeWriter {
     inner: Box<dyn MakeWriter<Writer = Box<dyn Write>> + Send + Sync>,


### PR DESCRIPTION
Add an new implementation of `MakeWriter` called `BoxMakeWriter` that wraps another instance of
`MakeWriter` and erases its concrete type, as well as the concrete type of its `io::Write`.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

See context from https://github.com/tokio-rs/tracing/pull/776#discussion_r468056925. This should unblock the effort to land an appender that can write the same log line to multiple writers.

## Solution

Implement `BoxMakeWriter` as suggested by @hawkw in the above thread. 
