### PR TITLE
tracing: wasm test running

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -166,7 +166,6 @@ jobs:
       matrix:
         # TODO(securityinsanity): slowly add wasm32 test runner to each crate, and move to seperate actions that run tests.
         subcrate:
-        - tracing
         - tracing-appender
         - tracing-attributes
         - tracing-core
@@ -191,6 +190,25 @@ jobs:
       with:
         command: test
         args: --no-run -p ${{ matrix.subcrate }}
+
+  test-wasm:
+    needs: check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        subcrate:
+        - tracing
+    steps:
+    - uses: actions/checkout@main
+    - uses: actions-rs/toolchain@v1
+      with:
+        target: wasm32-unknown-unknown
+        toolchain: stable
+        override: true
+    - name: install test runner for wasm
+      run:  curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+    - name: run wasm tests
+      run: cd ${{ matrix.subcrate }} && wasm-pack test --node
 
   test-os:
     # Test against stable Rust across macOS, Windows, and Linux.

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -37,6 +37,9 @@ futures = "0.1"
 criterion = { version = "0.3", default_features = false }
 log = "0.4"
 
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "^0.3"
+
 [features]
 default = ["std", "attributes"]
 

--- a/tracing/test-log-support/tests/log_no_trace.rs
+++ b/tracing/test-log-support/tests/log_no_trace.rs
@@ -5,6 +5,7 @@ extern crate test_log_support;
 use test_log_support::Test;
 use tracing::Level;
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn test_always_log() {
     let test = Test::start();

--- a/tracing/test-log-support/tests/log_with_trace.rs
+++ b/tracing/test-log-support/tests/log_with_trace.rs
@@ -26,6 +26,7 @@ impl tracing::Subscriber for NopSubscriber {
     }
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn log_with_trace() {
     tracing::subscriber::set_global_default(NopSubscriber).expect("set global should succeed");

--- a/tracing/test-log-support/tests/span_activity_filtered_separately.rs
+++ b/tracing/test-log-support/tests/span_activity_filtered_separately.rs
@@ -5,6 +5,7 @@ extern crate test_log_support;
 use test_log_support::Test;
 use tracing::Level;
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn span_activity_filtered_separately() {
     let test = Test::with_filters(&[

--- a/tracing/test-log-support/tests/span_lifecycle_can_be_enabled.rs
+++ b/tracing/test-log-support/tests/span_lifecycle_can_be_enabled.rs
@@ -5,6 +5,7 @@ extern crate test_log_support;
 use test_log_support::Test;
 use tracing::Level;
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn span_lifecycle_can_be_enabled() {
     let test = Test::with_filters(&[

--- a/tracing/test-log-support/tests/span_lifecycle_defaults_off.rs
+++ b/tracing/test-log-support/tests/span_lifecycle_defaults_off.rs
@@ -5,6 +5,7 @@ extern crate test_log_support;
 use test_log_support::Test;
 use tracing::Level;
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn span_lifecycle_defaults_off() {
     let test = Test::with_filters(&[(module_path!(), log::LevelFilter::Trace)]);

--- a/tracing/test-log-support/tests/span_lifecycle_is_trace.rs
+++ b/tracing/test-log-support/tests/span_lifecycle_is_trace.rs
@@ -5,6 +5,7 @@ extern crate test_log_support;
 use test_log_support::Test;
 use tracing::Level;
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn span_lifecycle_is_trace() {
     let test = Test::with_filters(&[

--- a/tracing/test_static_max_level_features/tests/test.rs
+++ b/tracing/test_static_max_level_features/tests/test.rs
@@ -33,6 +33,7 @@ impl Subscriber for TestSubscriber {
     fn exit(&self, _span: &Id) {}
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn test_static_max_level_features() {
     let me = Arc::new(State {

--- a/tracing/tests/event.rs
+++ b/tracing/tests/event.rs
@@ -20,6 +20,7 @@ use tracing::{
 
 macro_rules! event_without_message {
     ($name:ident: $e:expr) => {
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
         #[test]
         fn $name() {
             let (subscriber, handle) = subscriber::mock()
@@ -55,6 +56,7 @@ event_without_message! {nonzeroi32_event_without_message: std::num::NonZeroI32::
 // needs API breakage
 //event_without_message!{nonzerou128_event_without_message: std::num::NonZeroU128::new(42).unwrap()}
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn event_with_message() {
     let (subscriber, handle) = subscriber::mock()
@@ -71,6 +73,7 @@ fn event_with_message() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn message_without_delims() {
     let (subscriber, handle) = subscriber::mock()
@@ -99,6 +102,7 @@ fn message_without_delims() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn string_message_without_delims() {
     let (subscriber, handle) = subscriber::mock()
@@ -126,6 +130,7 @@ fn string_message_without_delims() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn one_with_everything() {
     let (subscriber, handle) = subscriber::mock()
@@ -160,6 +165,7 @@ fn one_with_everything() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn moved_field() {
     let (subscriber, handle) = subscriber::mock()
@@ -180,6 +186,7 @@ fn moved_field() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn dotted_field_name() {
     let (subscriber, handle) = subscriber::mock()
@@ -200,6 +207,7 @@ fn dotted_field_name() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn borrowed_field() {
     let (subscriber, handle) = subscriber::mock()
@@ -222,6 +230,7 @@ fn borrowed_field() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 // If emitting log instrumentation, this gets moved anyway, breaking the test.
 #[cfg(not(feature = "log"))]
@@ -262,6 +271,7 @@ fn move_field_out_of_struct() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn display_shorthand() {
     let (subscriber, handle) = subscriber::mock()
@@ -281,6 +291,7 @@ fn display_shorthand() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn debug_shorthand() {
     let (subscriber, handle) = subscriber::mock()
@@ -300,6 +311,7 @@ fn debug_shorthand() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn both_shorthands() {
     let (subscriber, handle) = subscriber::mock()
@@ -320,6 +332,7 @@ fn both_shorthands() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn explicit_child() {
     let (subscriber, handle) = subscriber::mock()
@@ -336,6 +349,7 @@ fn explicit_child() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn explicit_child_at_levels() {
     let (subscriber, handle) = subscriber::mock()

--- a/tracing/tests/filter_caching_is_lexically_scoped.rs
+++ b/tracing/tests/filter_caching_is_lexically_scoped.rs
@@ -19,6 +19,7 @@ use std::sync::{
     Arc,
 };
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn filter_caching_is_lexically_scoped() {
     pub fn my_great_function() -> bool {

--- a/tracing/tests/filters_are_not_reevaluated_for_the_same_span.rs
+++ b/tracing/tests/filters_are_not_reevaluated_for_the_same_span.rs
@@ -18,6 +18,7 @@ use std::sync::{
     Arc,
 };
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn filters_are_not_reevaluated_for_the_same_span() {
     // Asserts that the `span!` macro caches the result of calling

--- a/tracing/tests/filters_are_reevaluated_for_different_call_sites.rs
+++ b/tracing/tests/filters_are_reevaluated_for_different_call_sites.rs
@@ -18,6 +18,7 @@ use std::sync::{
     Arc,
 };
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn filters_are_reevaluated_for_different_call_sites() {
     // Asserts that the `span!` macro caches the result of calling

--- a/tracing/tests/filters_dont_leak.rs
+++ b/tracing/tests/filters_dont_leak.rs
@@ -3,6 +3,7 @@
 mod support;
 use self::support::*;
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn spans_dont_leak() {
     fn do_span() {
@@ -43,6 +44,7 @@ fn spans_dont_leak() {
     handle2.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn events_dont_leak() {
     fn do_event() {

--- a/tracing/tests/macro_imports.rs
+++ b/tracing/tests/macro_imports.rs
@@ -1,5 +1,6 @@
 use tracing::Level;
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn prefixed_span_macros() {
     tracing::span!(Level::DEBUG, "foo");
@@ -10,6 +11,7 @@ fn prefixed_span_macros() {
     tracing::error_span!("foo");
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn prefixed_event_macros() {
     tracing::event!(Level::DEBUG, "foo");

--- a/tracing/tests/macros.rs
+++ b/tracing/tests/macros.rs
@@ -9,6 +9,7 @@ extern crate tracing;
 // they're compile-time tests, so I want to get line numbers etc out of
 // failures, and producing them with a macro would muddy the waters a bit.
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn span() {
     span!(target: "foo_events", Level::DEBUG, "foo", bar.baz = ?2, quux = %3, quuux = 4);
@@ -26,6 +27,7 @@ fn span() {
     span!(Level::DEBUG, "bar",);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn trace_span() {
     trace_span!(target: "foo_events", "foo", bar.baz = ?2, quux = %3, quuux = 4);
@@ -41,6 +43,7 @@ fn trace_span() {
     trace_span!("bar",);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn debug_span() {
     debug_span!(target: "foo_events", "foo", bar.baz = ?2, quux = %3, quuux = 4);
@@ -56,6 +59,7 @@ fn debug_span() {
     debug_span!("bar",);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn info_span() {
     info_span!(target: "foo_events", "foo", bar.baz = ?2, quux = %3, quuux = 4);
@@ -71,6 +75,7 @@ fn info_span() {
     info_span!("bar",);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn warn_span() {
     warn_span!(target: "foo_events", "foo", bar.baz = ?2, quux = %3, quuux = 4);
@@ -86,6 +91,7 @@ fn warn_span() {
     warn_span!("bar",);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn error_span() {
     error_span!(target: "foo_events", "foo", bar.baz = ?2, quux = %3, quuux = 4);
@@ -101,6 +107,7 @@ fn error_span() {
     error_span!("bar",);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn span_root() {
     span!(target: "foo_events", parent: None, Level::TRACE, "foo", bar.baz = 2, quux = 3);
@@ -114,6 +121,7 @@ fn span_root() {
     span!(parent: None, Level::DEBUG, "bar",);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn trace_span_root() {
     trace_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 3);
@@ -126,6 +134,7 @@ fn trace_span_root() {
     trace_span!(parent: None, "bar",);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn debug_span_root() {
     debug_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 3);
@@ -138,6 +147,7 @@ fn debug_span_root() {
     debug_span!(parent: None, "bar",);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn info_span_root() {
     info_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 3);
@@ -150,6 +160,7 @@ fn info_span_root() {
     info_span!(parent: None, "bar",);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn warn_span_root() {
     warn_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 3);
@@ -162,6 +173,7 @@ fn warn_span_root() {
     warn_span!(parent: None, "bar",);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn error_span_root() {
     error_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 3);
@@ -174,6 +186,7 @@ fn error_span_root() {
     error_span!(parent: None, "bar",);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn span_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
@@ -187,6 +200,7 @@ fn span_with_parent() {
     span!(parent: &p, Level::DEBUG, "bar",);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn trace_span_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
@@ -202,6 +216,7 @@ fn trace_span_with_parent() {
     trace_span!(parent: &p, "bar",);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn debug_span_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
@@ -217,6 +232,7 @@ fn debug_span_with_parent() {
     debug_span!(parent: &p, "bar",);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn info_span_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
@@ -232,6 +248,7 @@ fn info_span_with_parent() {
     info_span!(parent: &p, "bar",);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn warn_span_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
@@ -247,6 +264,7 @@ fn warn_span_with_parent() {
     warn_span!(parent: &p, "bar",);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn error_span_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
@@ -262,6 +280,7 @@ fn error_span_with_parent() {
     error_span!(parent: &p, "bar",);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn span_with_non_rust_symbol() {
     span!(Level::TRACE, "non-rust", "guid:x-request-id" = ?"abcdef", "more {}", 42);
@@ -278,6 +297,7 @@ fn span_with_non_rust_symbol() {
     span!(Level::TRACE, "non-rust", "guid:x-request-id" = "abcdef");
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn event() {
     event!(Level::DEBUG, foo = ?3, bar.baz = %2, quux = false);
@@ -313,6 +333,7 @@ fn event() {
     event!(Level::DEBUG, foo);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn locals_with_message() {
     let data = (42, "forty-two");
@@ -329,6 +350,7 @@ fn locals_with_message() {
     );
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn locals_no_message() {
     let data = (42, "forty-two");
@@ -357,6 +379,7 @@ fn locals_no_message() {
     event!(Level::WARN, private_data, ?data, error,);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn trace() {
     trace!(foo = ?3, bar.baz = %2, quux = false);
@@ -386,6 +409,7 @@ fn trace() {
     trace!(foo);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn debug() {
     debug!(foo = ?3, bar.baz = %2, quux = false);
@@ -415,6 +439,7 @@ fn debug() {
     debug!(foo);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn info() {
     info!(foo = ?3, bar.baz = %2, quux = false);
@@ -444,6 +469,7 @@ fn info() {
     info!(foo);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn warn() {
     warn!(foo = ?3, bar.baz = %2, quux = false);
@@ -473,6 +499,7 @@ fn warn() {
     warn!(foo);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn error() {
     error!(foo = ?3, bar.baz = %2, quux = false);
@@ -502,6 +529,7 @@ fn error() {
     error!(foo);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn event_root() {
     event!(parent: None, Level::DEBUG, foo = ?3, bar.baz = %2, quux = false);
@@ -529,6 +557,7 @@ fn event_root() {
     event!(target: "foo_events", parent: None, Level::DEBUG, { foo = 2, bar.baz = 78, }, "quux");
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn trace_root() {
     trace!(parent: None, foo = ?3, bar.baz = %2, quux = false);
@@ -551,6 +580,7 @@ fn trace_root() {
     trace!(target: "foo_events", parent: None, { foo = 2, bar.baz = 78, }, "quux");
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn debug_root() {
     debug!(parent: None, foo = ?3, bar.baz = %2, quux = false);
@@ -573,6 +603,7 @@ fn debug_root() {
     debug!(target: "foo_events", parent: None, { foo = 2, bar.baz = 78, }, "quux");
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn info_root() {
     info!(parent: None, foo = ?3, bar.baz = %2, quux = false);
@@ -595,6 +626,7 @@ fn info_root() {
     info!(target: "foo_events", parent: None, { foo = 2, bar.baz = 78, }, "quux");
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn warn_root() {
     warn!(parent: None, foo = ?3, bar.baz = %2, quux = false);
@@ -617,6 +649,7 @@ fn warn_root() {
     warn!(target: "foo_events", parent: None, { foo = 2, bar.baz = 78, }, "quux");
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn error_root() {
     error!(parent: None, foo = ?3, bar.baz = %2, quux = false);
@@ -639,6 +672,7 @@ fn error_root() {
     error!(target: "foo_events", parent: None, { foo = 2, bar.baz = 78, }, "quux");
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn event_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
@@ -661,6 +695,7 @@ fn event_with_parent() {
     event!(target: "foo_events", parent: &p, Level::DEBUG, { foo = 2, bar.baz = 78, }, "quux");
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn trace_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
@@ -684,6 +719,7 @@ fn trace_with_parent() {
     trace!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 78, }, "quux");
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn debug_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
@@ -707,6 +743,7 @@ fn debug_with_parent() {
     debug!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 78, }, "quux");
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn info_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
@@ -730,6 +767,7 @@ fn info_with_parent() {
     info!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 78, }, "quux");
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn warn_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
@@ -753,6 +791,7 @@ fn warn_with_parent() {
     warn!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 78, }, "quux");
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn error_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
@@ -776,6 +815,7 @@ fn error_with_parent() {
     error!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 78, }, "quux");
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn field_shorthand_only() {
     #[derive(Debug)]
@@ -796,6 +836,7 @@ fn field_shorthand_only() {
     event!(Level::TRACE, ?pos.x, ?pos.y);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn callsite_macro_api() {
     // This test should catch any inadvertent breaking changes

--- a/tracing/tests/max_level_hint.rs
+++ b/tracing/tests/max_level_hint.rs
@@ -3,6 +3,7 @@ mod support;
 use self::support::*;
 use tracing::Level;
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn max_level_hints() {
     // This test asserts that when a subscriber provides us with the global

--- a/tracing/tests/multiple_max_level_hints.rs
+++ b/tracing/tests/multiple_max_level_hints.rs
@@ -4,6 +4,7 @@ mod support;
 use self::support::*;
 use tracing::Level;
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn multiple_max_level_hints() {
     // This test ensures that when multiple subscribers are active, their max

--- a/tracing/tests/span.rs
+++ b/tracing/tests/span.rs
@@ -84,6 +84,11 @@ fn spans_always_go_to_the_subscriber_that_tagged_them() {
     with_default(subscriber2, move || foo.in_scope(|| {}));
 }
 
+// This gets exempt from testing in wasm because of: `thread::spawn` which is
+// not yet possible to do in WASM. There is work going on see:
+// <https://rustwasm.github.io/2018/10/24/multithreading-rust-and-wasm.html>
+//
+// But for now since it's not possible we don't need to test for it :)
 #[test]
 fn spans_always_go_to_the_subscriber_that_tagged_them_even_across_threads() {
     let subscriber1 = subscriber::mock()

--- a/tracing/tests/span.rs
+++ b/tracing/tests/span.rs
@@ -15,6 +15,7 @@ use tracing::{
     Level, Span,
 };
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn handles_to_the_same_span_are_equal() {
     // Create a mock subscriber that will return `true` on calls to
@@ -29,6 +30,7 @@ fn handles_to_the_same_span_are_equal() {
     });
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn handles_to_different_spans_are_not_equal() {
     with_default(subscriber::mock().run(), || {
@@ -41,6 +43,7 @@ fn handles_to_different_spans_are_not_equal() {
     });
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn handles_to_different_spans_with_the_same_metadata_are_not_equal() {
     // Every time time this function is called, it will return a _new
@@ -58,6 +61,7 @@ fn handles_to_different_spans_with_the_same_metadata_are_not_equal() {
     });
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn spans_always_go_to_the_subscriber_that_tagged_them() {
     let subscriber1 = subscriber::mock()
@@ -107,6 +111,7 @@ fn spans_always_go_to_the_subscriber_that_tagged_them_even_across_threads() {
     .unwrap();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn dropping_a_span_calls_drop_span() {
     let (subscriber, handle) = subscriber::mock()
@@ -124,6 +129,7 @@ fn dropping_a_span_calls_drop_span() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn span_closes_after_event() {
     let (subscriber, handle) = subscriber::mock()
@@ -142,6 +148,7 @@ fn span_closes_after_event() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn new_span_after_event() {
     let (subscriber, handle) = subscriber::mock()
@@ -164,6 +171,7 @@ fn new_span_after_event() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn event_outside_of_span() {
     let (subscriber, handle) = subscriber::mock()
@@ -181,6 +189,7 @@ fn event_outside_of_span() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn cloning_a_span_calls_clone_span() {
     let (subscriber, handle) = subscriber::mock()
@@ -196,6 +205,7 @@ fn cloning_a_span_calls_clone_span() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn drop_span_when_exiting_dispatchers_context() {
     let (subscriber, handle) = subscriber::mock()
@@ -212,6 +222,7 @@ fn drop_span_when_exiting_dispatchers_context() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn clone_and_drop_span_always_go_to_the_subscriber_that_tagged_the_span() {
     let (subscriber1, handle1) = subscriber::mock()
@@ -242,6 +253,7 @@ fn clone_and_drop_span_always_go_to_the_subscriber_that_tagged_the_span() {
     handle1.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn span_closes_when_exited() {
     let (subscriber, handle) = subscriber::mock()
@@ -261,6 +273,7 @@ fn span_closes_when_exited() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn enter() {
     let (subscriber, handle) = subscriber::mock()
@@ -279,6 +292,7 @@ fn enter() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn moved_field() {
     let (subscriber, handle) = subscriber::mock()
@@ -307,6 +321,7 @@ fn moved_field() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn dotted_field_name() {
     let (subscriber, handle) = subscriber::mock()
@@ -324,6 +339,7 @@ fn dotted_field_name() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn borrowed_field() {
     let (subscriber, handle) = subscriber::mock()
@@ -352,6 +368,7 @@ fn borrowed_field() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 // If emitting log instrumentation, this gets moved anyway, breaking the test.
 #[cfg(not(feature = "log"))]
@@ -401,6 +418,7 @@ fn move_field_out_of_struct() {
 // TODO(#1138): determine a new syntax for uninitialized span fields, and
 // re-enable these.
 /*
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn add_field_after_new_span() {
     let (subscriber, handle) = subscriber::mock()
@@ -429,6 +447,7 @@ fn add_field_after_new_span() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn add_fields_only_after_new_span() {
     let (subscriber, handle) = subscriber::mock()
@@ -458,6 +477,7 @@ fn add_fields_only_after_new_span() {
 }
 */
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn record_new_value_for_field() {
     let (subscriber, handle) = subscriber::mock()
@@ -488,6 +508,7 @@ fn record_new_value_for_field() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn record_new_values_for_fields() {
     let (subscriber, handle) = subscriber::mock()
@@ -523,6 +544,7 @@ fn record_new_values_for_fields() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn new_span_with_target_and_log_level() {
     let (subscriber, handle) = subscriber::mock()
@@ -542,6 +564,7 @@ fn new_span_with_target_and_log_level() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn explicit_root_span_is_root() {
     let (subscriber, handle) = subscriber::mock()
@@ -556,6 +579,7 @@ fn explicit_root_span_is_root() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn explicit_root_span_is_root_regardless_of_ctx() {
     let (subscriber, handle) = subscriber::mock()
@@ -575,6 +599,7 @@ fn explicit_root_span_is_root_regardless_of_ctx() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn explicit_child() {
     let (subscriber, handle) = subscriber::mock()
@@ -591,6 +616,7 @@ fn explicit_child() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn explicit_child_at_levels() {
     let (subscriber, handle) = subscriber::mock()
@@ -615,6 +641,7 @@ fn explicit_child_at_levels() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn explicit_child_regardless_of_ctx() {
     let (subscriber, handle) = subscriber::mock()
@@ -634,6 +661,7 @@ fn explicit_child_regardless_of_ctx() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn contextual_root() {
     let (subscriber, handle) = subscriber::mock()
@@ -648,6 +676,7 @@ fn contextual_root() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn contextual_child() {
     let (subscriber, handle) = subscriber::mock()
@@ -671,6 +700,7 @@ fn contextual_child() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn display_shorthand() {
     let (subscriber, handle) = subscriber::mock()
@@ -690,6 +720,7 @@ fn display_shorthand() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn debug_shorthand() {
     let (subscriber, handle) = subscriber::mock()
@@ -709,6 +740,7 @@ fn debug_shorthand() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn both_shorthands() {
     let (subscriber, handle) = subscriber::mock()

--- a/tracing/tests/subscriber.rs
+++ b/tracing/tests/subscriber.rs
@@ -14,6 +14,7 @@ use tracing::{
     Event, Level, Metadata,
 };
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn event_macros_dont_infinite_loop() {
     // This test ensures that an event macro within a subscriber


### PR DESCRIPTION
## Motivation

refs #642 

Start Testing the core crate in a wasm environment. This requires a special runner, and an extra dev-dependency.

All tests have been ported over except for `span::spans_always_go_to_the_subscriber_that_tagged_them_even_across_threads` because that spins up a thread, and wasm has no concept of threads being spun up.

## Solution

Add a wasm-pack tester, and properly tag all tests.
