### PR TITLE
core: add conversion from `Option<Level>` to `LevelFilter`

### DIFF
--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -368,10 +368,14 @@ impl From<Level> for LevelFilter {
 impl From<Option<Level>> for LevelFilter {
     #[inline]
     fn from(level: Option<Level>) -> Self {
-        match level {
-            Some(level) => LevelFilter::from_level(level),
-            None => LevelFilter::OFF,
-        }
+        Self(level)
+    }
+}
+
+impl Into<Option<Level>> for LevelFilter {
+    #[inline]
+    fn into(self) -> Option<Level> {
+        self.into_level()
     }
 }
 

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -365,10 +365,13 @@ impl From<Level> for LevelFilter {
     }
 }
 
-impl Into<Option<Level>> for LevelFilter {
+impl From<Option<Level>> for LevelFilter {
     #[inline]
-    fn into(self) -> Option<Level> {
-        self.into_level()
+    fn from(level: Option<Level>) -> Self {
+        match level {
+            Some(level) => LevelFilter::from_level(level),
+            None => LevelFilter::OFF,
+        }
     }
 }
 
@@ -819,8 +822,15 @@ mod tests {
         ];
         for (filter, level) in mapping.iter() {
             assert_eq!(filter.clone().into_level(), *level);
-            if let Some(level) = level {
-                assert_eq!(LevelFilter::from_level(level.clone()), *filter);
+            match level {
+                Some(level) => {
+                    let actual: LevelFilter = level.clone().into();
+                    assert_eq!(actual, *filter);
+                }
+                None => {
+                    let actual: LevelFilter = None.into();
+                    assert_eq!(actual, *filter);
+                }
             }
         }
     }


### PR DESCRIPTION
This PR resolves a previously unreported regression where `Option<Level>`  was no longer a valid `LevelFilter`. Below is a minimal reproduction of the issue:

```rust
tracing_subscriber::fmt().with_max_level(Some(tracing::Level::WARN)).init();
```

I've added an `From<Option<Level>> for LevelFilter` implementation which _might_ require an MSRV version bump to 1.41 to support the [rebalanced coherence changes](https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html).