### PR TITLE
subscriber: prepare to release 0.2.12

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,7 @@ tracing-core = { path = "../tracing-core", version = "0.1"}
 tracing-error = { path = "../tracing-error" }
 tracing-flame = { path = "../tracing-flame" }
 tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.11", features = ["json", "chrono"] }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.12", features = ["json", "chrono"] }
 tracing-futures = { version = "0.2.1", path = "../tracing-futures", features = ["futures-01"] }
 tracing-attributes =  { path = "../tracing-attributes", version = "0.1.2"}
 tracing-log = { path = "../tracing-log", version = "0.1.1", features = ["env_logger"] }
@@ -27,7 +27,7 @@ tracing-journald = { path = "../tracing-journald" }
 serde_json = "1.0"
 
 futures = "0.3"
-tokio = { version = "0.2.11", features = ["full"] }
+tokio = { version = "0.2.12", features = ["full"] }
 
 # env-logger example
 env_logger = "0.7"

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,4 +1,39 @@
-# 0.2.11 (August 10, 2020)
+# 0.2.12 (September 8, 2020)
+
+### Fixed
+
+- **env-filter**: Fixed a regression where `Option<Level>` lost its
+  `Into<LevelFilter>` impl ([#966])
+- **env-filter**: Fixed `EnvFilter` enabling spans that should not be enabled
+  when multiple subscribers are in use ([#927])
+  
+### Changed
+
+- **json**: `format::Json` now outputs fields in a more readable order ([#892])
+- Updated `tracing-core` dependency to 0.1.16
+
+### Added
+
+- **fmt**: Add `BoxMakeWriter` for erasing the type of a `MakeWriter`
+  implementation ([#958])
+- **fmt**: Add `TestWriter` `MakeWriter` implementation to support libtest
+  output capturing ([#938])
+- **layer**: Add `Layer` impl for `Option<T> where T: Layer` ([#910])
+- **env-filter**: Add `From<Level>` impl for `Directive` ([#918])
+- Multiple documentation fixes and improvements
+
+Thanks to @Pothulapati, @samrg472, @bryanburgers, @keetonian, and @SriRamanujam
+for contributing to this release!
+
+[#927]: https://github.com/tokio-rs/tracing/pull/927
+[#966]: https://github.com/tokio-rs/tracing/pull/966
+[#958]: https://github.com/tokio-rs/tracing/pull/958
+[#892]: https://github.com/tokio-rs/tracing/pull/892
+[#938]: https://github.com/tokio-rs/tracing/pull/938
+[#910]: https://github.com/tokio-rs/tracing/pull/910
+[#918]: https://github.com/tokio-rs/tracing/pull/918
+
+# 0.2.12 (August 10, 2020)
 
 ### Fixed
 

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -31,7 +31,7 @@ registry = ["sharded-slab", "thread_local"]
 json = ["tracing-serde", "serde", "serde_json"]
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.12" }
+tracing-core = { path = "../tracing-core", version = "0.1.16" }
 
 # only required by the filter feature
 matchers = { optional = true, version = "0.0.1" }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.11"
+version = "0.2.12"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -21,7 +21,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.2.11
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.12
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -67,7 +67,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.11")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.12")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.2.12 (September 8, 2020)

### Fixed

- **env-filter**: Fixed a regression where `Option<Level>` lost its
  `Into<LevelFilter>` impl ([#966])
- **env-filter**: Fixed `EnvFilter` enabling spans that should not be enabled
  when multiple subscribers are in use ([#927])
  
### Changed

- **json**: `format::Json` now outputs fields in a more readable order ([#892])
- Updated `tracing-core` dependency to 0.1.16

### Added

- **fmt**: Add `BoxMakeWriter` for erasing the type of a `MakeWriter`
  implementation ([#958])
- **fmt**: Add `TestWriter` `MakeWriter` implementation to support libtest
  output capturing ([#938])
- **layer**: Add `Layer` impl for `Option<T> where T: Layer` ([#910])
- **env-filter**: Add `From<Level>` impl for `Directive` ([#918])
- Multiple documentation fixes and improvements

Thanks to @Pothulapati, @samrg472, @bryanburgers, @keetonian, 
and @SriRamanujam for contributing to this release!

[#927]: https://github.com/tokio-rs/tracing/pull/927
[#966]: https://github.com/tokio-rs/tracing/pull/966
[#958]: https://github.com/tokio-rs/tracing/pull/958
[#892]: https://github.com/tokio-rs/tracing/pull/892
[#938]: https://github.com/tokio-rs/tracing/pull/938
[#910]: https://github.com/tokio-rs/tracing/pull/910
[#918]: https://github.com/tokio-rs/tracing/pull/918