### PR TITLE
serde: prepare to release 0.1.2

### DIFF
--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-serde"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 edition = "2018"

--- a/tracing-serde/src/lib.rs
+++ b/tracing-serde/src/lib.rs
@@ -125,7 +125,7 @@
 //!
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [`serde`]: https://crates.io/crates/serde
-#![doc(html_root_url = "https://docs.rs/tracing-serde/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/tracing-serde/0.1.2")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
### Added

- `SerdeMapVisitor::finish` to complete serializing the visited objects
  (#892)
- `SerdeMapVisitor::take_serializer` to return the serializer wrapped by
  a `SerdeMapVisitor` (#892)

Thanks to @bryanburgers for contributing to this release!