### PR TITLE
subscriber: bump serde dep, update release date

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.2.12 (September 8, 2020)
+# 0.2.12 (September 11, 2020)
 
 ### Fixed
 

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -47,7 +47,7 @@ chrono = { version = "0.4", optional = true }
 # only required by the json feature
 serde_json = { version = "1.0", optional = true }
 serde = { version = "1.0", optional = true }
-tracing-serde = { path = "../tracing-serde", version = "0.1.1", optional = true }
+tracing-serde = { path = "../tracing-serde", version = "0.1.2", optional = true }
 
 # opt-in deps
 parking_lot = { version = ">= 0.7, <= 0.11", optional = true }


### PR DESCRIPTION
`tracing-subscriber` depended on unreleased `tracing-serde` APIs and
thus couldn't be released earlier (I forgot to publish the
`tracing-serde` changes).

Now that they're published, we can bump `tracing-subscriber`'s
dependency and _actually_ publish a new version.
