### PR TITLE
attributes: add visibility to async-trait output

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -285,11 +285,12 @@ pub fn instrument(
             }
         }
 
+        let vis = &input.vis;
         let sig = &input.sig;
         let attrs = &input.attrs;
         quote!(
             #(#attrs) *
-            #sig {
+            #vis #sig {
                 #(#stmts) *
             }
         )


### PR DESCRIPTION
## Motivation

`instrument` removes the visibility of function that looks like its from `async-trait` even if its not inside a trait `impl` block.

## Solution

Add back the function visibility (`input.vis`) for when its reconstructed in `quote`.

Fixes: #976
