### PR TITLE
Implement Value for Send + Sync variants of dyn Error

### DIFF
--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -422,6 +422,39 @@ impl Value for dyn std::error::Error + 'static {
     }
 }
 
+#[cfg(feature = "std")]
+impl crate::sealed::Sealed for dyn std::error::Error + Send + 'static {}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl Value for dyn std::error::Error + Send + 'static {
+    fn record(&self, key: &Field, visitor: &mut dyn Visit) {
+        visitor.record_error(key, self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl crate::sealed::Sealed for dyn std::error::Error + Sync + 'static {}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl Value for dyn std::error::Error + Sync + 'static {
+    fn record(&self, key: &Field, visitor: &mut dyn Visit) {
+        visitor.record_error(key, self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl crate::sealed::Sealed for dyn std::error::Error + Send + Sync + 'static {}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl Value for dyn std::error::Error + Send + Sync + 'static {
+    fn record(&self, key: &Field, visitor: &mut dyn Visit) {
+        visitor.record_error(key, self)
+    }
+}
+
 impl<'a, T: ?Sized> crate::sealed::Sealed for &'a T where T: Value + crate::sealed::Sealed + 'a {}
 
 impl<'a, T: ?Sized> Value for &'a T


### PR DESCRIPTION
## Motivation

I am trying to log an `anyhow::Error`. While this type doesn't implement `std::error::Error` directly, it does `Deref` to `dyn (Error + Send + Sync + 'static)`. The `Value` trait is only implemented for `dyn Error + 'static`, so alongside the `&*` needed to trigger deref coercion I need to write an explicit cast.

Adding these impls means I can make my logging code a bit cleaner:

```diff
   let error = anyhow::Error::msg("Oops...");
   tracing::error!(
-     error = &*error as &dyn std::error::Error,
+     error = &*error,
      "Something bad happened",
  );
```

## Solution

This adds `tracing_core::field::Value` impls for 

- `dyn Error + Send + 'static`
- `dyn Error + Sync + 'static`
- `dyn Error + Send + Sync + 'static`