### PR TITLE
subscriber: format chrono timestamps the same way as non-chrono

### DIFF
--- a/tracing-subscriber/src/fmt/time/mod.rs
+++ b/tracing-subscriber/src/fmt/time/mod.rs
@@ -114,7 +114,11 @@ impl From<Instant> for Uptime {
 #[cfg(feature = "chrono")]
 impl FormatTime for SystemTime {
     fn format_time(&self, w: &mut dyn fmt::Write) -> fmt::Result {
-        write!(w, "{}", chrono::Local::now().format("%b %d %H:%M:%S%.3f"))
+        write!(
+            w,
+            "{}",
+            chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, true)
+        )
     }
 }
 


### PR DESCRIPTION
## Motivation

We're parsing JSON-formatted logs produced by tracing-subscriber / tracing-log and we noticed the timestamps were a bit hard to parse (eg: `Sep 24 07:22:51.437`). After some research, I realised there had been a PR (#807) which showed the right format, but only when _not_ using the chrono feature (which is enabled by default).

I felt like it would be more consistent to use the same format when the feature is on and off. It didn't bother me when running our app locally, but when it came to our production environment where logs are parsed: they should be consistent and in a format more easily digestible by a machine.

## Solution

This changes the format produced when using the chrono feature to match when not using the chrono feature.

The new output uses chrono's `to_rfc3339_opts` with microseconds resolution and `Z` at the end. This produces a format like: `2020-09-24T11:37:54.472625Z`

## Future consideration

Perhaps we'd want to make that configurable? I do like "local" timestamps when working on our app in my development environment, but I want UTC and RFC-compliant timestamps in production.