### PR TITLE
Implementing first draft of an env builder api

### DIFF
--- a/tracing-subscriber/src/filter/env/builder.rs
+++ b/tracing-subscriber/src/filter/env/builder.rs
@@ -1,0 +1,76 @@
+//! A builder API for `env` Filters
+
+use super::EnvFilter;
+use std::collections::BTreeMap;
+use tracing_core::Level;
+
+/// A filter directive for the builder
+pub enum Filter {
+    /// Inherit the level from the parent
+    ///
+    /// This variant can't be used as the root filter level and will
+    /// cause the builder to panic.
+    Inherit,
+    /// Provide any valid tracing Level.
+    Level(Level),
+}
+
+impl From<Level> for Filter {
+    fn from(l: Level) -> Self {
+        Self::Level(l)
+    }
+}
+
+impl Default for Filter {
+    fn default() -> Self {
+        Self::Inherit
+    }
+}
+
+/// A builder API for [`EnvFilter`]
+///
+/// [`EnvFilter`]: ../struct.EnvFilter.html
+pub struct EnvBuilder {
+    filter: Filter,
+    children: BTreeMap<String, EnvBuilder>,
+}
+
+impl EnvBuilder {
+    /// Add a sub-module to the builder scope
+    pub fn child<S: Into<String>>(mut self, name: S, b: EnvBuilder) -> Self {
+        self.children.insert(name.into(), b);
+        self
+    }
+
+    /// Evaluate this builder tree to produce a valid [`EnvFilter`]
+    ///
+    /// This function may panic if the root filter directive has been
+    /// set to `Filter::Inherit`.
+    ///
+    /// [`EnvFilter`]: ../struct.EnvFilter.html
+    pub fn process(self) -> EnvFilter {
+        todo!()
+    }
+}
+
+/// Create an [`EnvBuilder`] with a default log level
+///
+/// [`EnvBuilder`]: ./struct.EnvBuilder.html
+pub fn level<F: Into<Filter>>(filter: F) -> EnvBuilder {
+    EnvBuilder {
+        filter: filter.into(),
+        children: Default::default(),
+    }
+}
+
+#[test]
+fn use_the_api() {
+    let _b = level(Level::TRACE).child(
+        "my_crate",
+        level(Filter::Inherit)
+            .child("foo", level(Level::WARN))
+            .child("bar", level(Level::ERROR)),
+    );
+
+    // Will produce: my_crate::foo=warn,my_crate::bar=error,trace
+}

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -8,6 +8,8 @@ pub use self::{
     directive::{Directive, ParseError},
     field::BadName as BadFieldName,
 };
+
+mod builder;
 mod directive;
 mod field;
 


### PR DESCRIPTION
## Motivation

This thread: https://twitter.com/spacekookie/status/1308797692752154630

I think the docs are a bit confusing on the matter of env-filters, especially because it's not compatible to `env_logger` (afaik?). Currently the API is very verbose and not straight forward to use. This PR adds a draft builder API to create env-filter trees for crates. 

The current draft focuses on brevity, but I'd be happy to be a bit more explicit if it means being able to support more options/use-cases.

## Solution

A short example for the current API: 

```rust
EnvFilter::try_from_env("MY_LOG")
        .unwrap_or_default()
        .add_directive(LevelFilter::TRACE.into())
        .add_directive("my_crate::foo=warn".parse().unwrap())
        .add_directive("my_crate::bar=error".parse().unwrap());
```

The draft API in this PR would mirror this as follows:

```rust
use tracing_subscriber::env::builder as b;

b::level(Level::TRACE).child(
        "my_crate",
        b::level(Filter::Inherit)
            .child("foo", b::level(Level::WARN))
            .child("bar", b::level(Level::ERROR)),
    );
```

The primary motivation for this change is to avoid having to parse strings and expressing the relationship between log levels in the Rust type system. I have two open questions though before I'd go and implement this.

1. Should this API be additive, or replace the current one? If it's an addition it wouldn't necessarily have to support all of the old features
2. That being said, probably being able to create a builder based on an env var is a good idea?

Anyway, let me know what you think. This PR is related to issue #404 

cc/ @hawkw 