### PR TITLE
tracing: move `ValueSet` construction out of closures

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1005,14 +1005,6 @@ pub mod __macro_support {
                 || crate::dispatcher::get_default(|default| default.enabled(self.meta))
         }
 
-        pub fn dispatch_event(&'static self, interest: Interest, f: impl FnOnce(&crate::Dispatch)) {
-            tracing_core::dispatcher::get_current(|current| {
-                if interest.is_always() || current.enabled(self.meta) {
-                    f(current)
-                }
-            });
-        }
-
         #[inline]
         #[cfg(feature = "log")]
         pub fn disabled_span(&self) -> crate::Span {
@@ -1023,24 +1015,6 @@ pub mod __macro_support {
         #[cfg(not(feature = "log"))]
         pub fn disabled_span(&self) -> crate::Span {
             crate::Span::none()
-        }
-
-        pub fn dispatch_span(
-            &'static self,
-            interest: Interest,
-            f: impl FnOnce(&crate::Dispatch) -> crate::Span,
-        ) -> crate::Span {
-            if interest.is_never() {
-                return self.disabled_span();
-            }
-
-            tracing_core::dispatcher::get_current(|current| {
-                if interest.is_always() || current.enabled(self.meta) {
-                    return f(current);
-                }
-                self.disabled_span()
-            })
-            .unwrap_or_else(|| self.disabled_span())
         }
     }
 

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1000,6 +1000,11 @@ pub mod __macro_support {
             }
         }
 
+        pub fn is_enabled(&self, interest: Interest) -> bool {
+            interest.is_always()
+                || crate::dispatcher::get_default(|default| default.enabled(self.meta))
+        }
+
         pub fn dispatch_event(&'static self, interest: Interest, f: impl FnOnce(&crate::Dispatch)) {
             tracing_core::dispatcher::get_current(|current| {
                 if interest.is_always() || current.enabled(self.meta) {

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -606,9 +606,10 @@ macro_rules! event {
             };
             let interest = CALLSITE.interest();
             if !interest.is_never() {
-                CALLSITE.dispatch_event(interest, |current| {
-                    let meta = CALLSITE.metadata();
-                    current.event(&$crate::Event::new_child_of($parent, meta, &$crate::valueset!(meta.fields(), $($fields)*)))
+                let meta = CALLSITE.metadata();
+                let values = &$crate::valueset!(meta.fields(), $($fields)*);
+                CALLSITE.dispatch_event(interest, move |current| {
+                    current.event(&$crate::Event::new_child_of($parent, meta, values))
                 });
             }
         }
@@ -650,9 +651,10 @@ macro_rules! event {
             };
             let interest = CALLSITE.interest();
             if !interest.is_never() {
-                CALLSITE.dispatch_event(interest, |current| {
-                    let meta = CALLSITE.metadata();
-                    current.event(&$crate::Event::new(meta, &$crate::valueset!(meta.fields(), $($fields)*)));
+                let meta = CALLSITE.metadata();
+                let values = &$crate::valueset!(meta.fields(), $($fields)*);
+                CALLSITE.dispatch_event(interest, move |current| {
+                    current.event(&$crate::Event::new(meta, values));
                 });
             }
         }

--- a/tracing/tests/macros.rs
+++ b/tracing/tests/macros.rs
@@ -838,6 +838,18 @@ fn field_shorthand_only() {
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
+fn borrow_val() {
+    let mut foo = (String::new(), String::new());
+    let zero = &mut foo.0;
+    trace!(one = ?foo.1);
+    debug!(one = ?foo.1);
+    info!(one = ?foo.1);
+    warn!(one = ?foo.1);
+    error!(one = ?foo.1);
+    zero.push_str("hello world");
+}
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
 fn callsite_macro_api() {
     // This test should catch any inadvertent breaking changes
     // caused by changes to the macro.

--- a/tracing/tests/macros.rs
+++ b/tracing/tests/macros.rs
@@ -838,7 +838,8 @@ fn field_shorthand_only() {
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
-fn borrow_val() {
+fn borrow_val_events() {
+    // Reproduces https://github.com/tokio-rs/tracing/issues/954
     let mut foo = (String::new(), String::new());
     let zero = &mut foo.0;
     trace!(one = ?foo.1);
@@ -848,6 +849,21 @@ fn borrow_val() {
     error!(one = ?foo.1);
     zero.push_str("hello world");
 }
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn borrow_val_spans() {
+    // Reproduces https://github.com/tokio-rs/tracing/issues/954
+    let mut foo = (String::new(), String::new());
+    let zero = &mut foo.0;
+    let _span = trace_span!("span", one = ?foo.1);
+    let _span = debug_span!("span", one = ?foo.1);
+    let _span = info_span!("span", one = ?foo.1);
+    let _span = warn_span!("span", one = ?foo.1);
+    let _span = error_span!("span", one = ?foo.1);
+    zero.push_str("hello world");
+}
+
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn callsite_macro_api() {


### PR DESCRIPTION
## Motivation

In PR #943, the construction of `ValueSet`s for events and spans was
moved out of the code expanded at the callsite and into a closure, in
order to reduce the amount of assembly generated in functions containing
tracing macros. However, this introduced an accidental breaking change
for some dependent crates. Borrowing values inside a closure meant that
when a field of a struct, array, or tuple was used as a field value, the
closure must borrow the _entire_ struct, array, or tuple, rather than
the individual field. This broke code where another unrelated field of
that struct, array, or tuple would then be mutably borrowed or moved
elsewhere. 

## Solution

This branch fixes the breaking change by moving `ValueSet` construction
back out of a closure and into the code expanded at the callsite. This
_does_ regress the amount of assembly generated a bit: a function
containing a single `event!` macro generates 32 instructions in release
mode on master, and after this change, it generates 83 instructions.
However, this is better than reverting PR #943 entirely, which generates
103 instructions for the same function. This change allows us to
continue to benefit from *some* of the changes made in #943, although we
no longer can benefit from the most significant one.

Rather than trying to further optimize the macro expanded code now, I
think we should wait for the `ValueSet` rework that will land in
`tracing` 0.2, where we could potentially generate significantly less
code by virtue of constructing a `ValueSet` with a much simpler array
literal (no `FieldSet` iteration required).

Fixes #954 
Closes #986
