### PR TITLE
subscriber: warn if trying to enable a statically disabled level

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -24,7 +24,7 @@ keywords = ["logging", "tracing", "metrics", "subscriber"]
 [features]
 
 default = ["env-filter", "smallvec", "fmt", "ansi", "chrono", "tracing-log", "json"]
-env-filter = ["matchers", "regex", "lazy_static"]
+env-filter = ["matchers", "regex", "lazy_static", "tracing"]
 fmt = ["registry"]
 ansi = ["fmt", "ansi_term"]
 registry = ["sharded-slab", "thread_local"]
@@ -32,9 +32,9 @@ json = ["tracing-serde", "serde", "serde_json"]
 
 [dependencies]
 tracing-core = { path = "../tracing-core", version = "0.2" }
-tracing = { path = "../tracing", version = "0.2" }
 
 # only required by the filter feature
+tracing = { optional = true, path = "../tracing", version = "0.2" }
 matchers = { optional = true, version = "0.0.1" }
 regex = { optional = true, version = "1", default-features = false, features = ["std"] }
 smallvec = { optional = true, version = "1" }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -24,7 +24,7 @@ keywords = ["logging", "tracing", "metrics", "subscriber"]
 [features]
 
 default = ["env-filter", "smallvec", "fmt", "ansi", "chrono", "tracing-log", "json"]
-env-filter = ["matchers", "regex", "lazy_static"]
+env-filter = ["matchers", "regex", "lazy_static", "tracing"]
 fmt = ["registry"]
 ansi = ["fmt", "ansi_term"]
 registry = ["sharded-slab", "thread_local"]
@@ -34,6 +34,7 @@ json = ["tracing-serde", "serde", "serde_json"]
 tracing-core = { path = "../tracing-core", version = "0.2" }
 
 # only required by the filter feature
+tracing = { optional = true, path = "../tracing", version = "0.1.16" }
 matchers = { optional = true, version = "0.0.1" }
 regex = { optional = true, version = "1", default-features = false, features = ["std"] }
 smallvec = { optional = true, version = "1" }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -24,7 +24,7 @@ keywords = ["logging", "tracing", "metrics", "subscriber"]
 [features]
 
 default = ["env-filter", "smallvec", "fmt", "ansi", "chrono", "tracing-log", "json"]
-env-filter = ["matchers", "regex", "lazy_static", "tracing"]
+env-filter = ["matchers", "regex", "lazy_static"]
 fmt = ["registry"]
 ansi = ["fmt", "ansi_term"]
 registry = ["sharded-slab", "thread_local"]
@@ -32,9 +32,9 @@ json = ["tracing-serde", "serde", "serde_json"]
 
 [dependencies]
 tracing-core = { path = "../tracing-core", version = "0.2" }
+tracing = { path = "../tracing", version = "0.2" }
 
 # only required by the filter feature
-tracing = { optional = true, path = "../tracing", version = "0.2" }
 matchers = { optional = true, version = "0.0.1" }
 regex = { optional = true, version = "1", default-features = false, features = ["std"] }
 smallvec = { optional = true, version = "1" }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -34,7 +34,7 @@ json = ["tracing-serde", "serde", "serde_json"]
 tracing-core = { path = "../tracing-core", version = "0.2" }
 
 # only required by the filter feature
-tracing = { optional = true, path = "../tracing", version = "0.1.16" }
+tracing = { optional = true, path = "../tracing", version = "0.2" }
 matchers = { optional = true, version = "0.0.1" }
 regex = { optional = true, version = "1", default-features = false, features = ["std"] }
 smallvec = { optional = true, version = "1" }

--- a/tracing-subscriber/src/filter/env/directive.rs
+++ b/tracing-subscriber/src/filter/env/directive.rs
@@ -9,10 +9,10 @@ use tracing_core::{span, Level, Metadata};
 // TODO(eliza): add a builder for programmatically constructing directives?
 #[derive(Debug, Eq, PartialEq)]
 pub struct Directive {
-    target: Option<String>,
+    pub(crate) target: Option<String>,
     in_span: Option<String>,
     fields: FilterVec<field::Match>,
-    level: LevelFilter,
+    pub(crate) level: LevelFilter,
 }
 
 /// A directive which will statically enable or disable a given callsite.

--- a/tracing-subscriber/src/filter/env/directive.rs
+++ b/tracing-subscriber/src/filter/env/directive.rs
@@ -9,9 +9,9 @@ use tracing_core::{span, Level, Metadata};
 // TODO(eliza): add a builder for programmatically constructing directives?
 #[derive(Debug, Eq, PartialEq)]
 pub struct Directive {
-    pub(crate) target: Option<String>,
     in_span: Option<String>,
     fields: FilterVec<field::Match>,
+    pub(crate) target: Option<String>,
     pub(crate) level: LevelFilter,
 }
 

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -258,6 +258,8 @@ impl EnvFilter {
             .collect();
 
         if !disabled.is_empty() {
+            // NOTE: this can't use `MakeWriter` because it's not yet available;
+            // there is not yet a subscriber.
             eprintln!("warning: some trace filter directives would enable traces that are disabled statically");
             for directive in disabled {
                 let target = if let Some(target) = &directive.target {

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -259,7 +259,7 @@ impl EnvFilter {
 
         if !disabled.is_empty() {
             // NOTE: We can't use a configured `MakeWriter` because the EnvFilter
-            // has no knowledge of any underlying subscriber or collector, which 
+            // has no knowledge of any underlying subscriber or collector, which
             // may or may not use a `MakeWriter`.
             eprintln!("warning: some trace filter directives would enable traces that are disabled statically");
             for directive in disabled {

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -275,17 +275,19 @@ impl EnvFilter {
                 };
                 eprintln!("{}", msg);
             };
-            let ctx_help = |msg: &str| {
+            let ctx_prefixed = |prefix: &str, msg: &str| {
                 #[cfg(not(feature = "ansi_term"))]
                 let msg = format!("note: {}", msg);
                 #[cfg(feature = "ansi_term")]
                 let msg = {
                     let mut equal = Color::Fixed(21).paint("="); // dark blue
                     equal.style_ref_mut().is_bold = true;
-                    format!(" {} {} {}", equal, Style::new().bold().paint("help:"), msg)
+                    format!(" {} {} {}", equal, Style::new().bold().paint(prefix), msg)
                 };
                 eprintln!("{}", msg);
             };
+            let ctx_help = |msg| ctx_prefixed("help:", msg);
+            let ctx_note = |msg| ctx_prefixed("note:", msg);
             let ctx = |msg: &str| {
                 #[cfg(not(feature = "ansi_term"))]
                 let msg = format!("note: {}", msg);
@@ -314,7 +316,7 @@ impl EnvFilter {
                     directive, level, target
                 ));
             }
-            ctx(&format!("the static max level is {}", STATIC_MAX_LEVEL));
+            ctx_note(&format!("the static max level is `{}`", STATIC_MAX_LEVEL));
             let help_msg = || {
                 let (feature, filter) = match STATIC_MAX_LEVEL.into_level() {
                     Some(Level::TRACE) => unreachable!(

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -258,8 +258,9 @@ impl EnvFilter {
             .collect();
 
         if !disabled.is_empty() {
-            // NOTE: this can't use `MakeWriter` because it's not yet available;
-            // there is not yet a subscriber.
+            // NOTE: We can't use a configured `MakeWriter` because the EnvFilter
+            // has no knowledge of any underlying subscriber or collector, which 
+            // may or may not use a `MakeWriter`.
             eprintln!("warning: some trace filter directives would enable traces that are disabled statically");
             for directive in disabled {
                 let target = if let Some(target) = &directive.target {

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -247,6 +247,55 @@ impl EnvFilter {
     }
 
     fn from_directives(directives: impl IntoIterator<Item = Directive>) -> Self {
+        use tracing::level_filters::STATIC_MAX_LEVEL;
+        use tracing::Level;
+
+        let directives: Vec<_> = directives.into_iter().collect();
+
+        let disabled: Vec<_> = directives
+            .iter()
+            .filter(|directive| directive.level > STATIC_MAX_LEVEL)
+            .collect();
+
+        if !disabled.is_empty() {
+            eprintln!("warning: some trace filter directives would enable traces that are disabled statically");
+            for directive in disabled {
+                let target = if let Some(target) = &directive.target {
+                    format!("the `{}` target", target)
+                } else {
+                    "all targets".into()
+                };
+                let level = directive
+                    .level
+                    .clone()
+                    .into_level()
+                    .expect("=off would not have enabled any filters");
+                eprintln!(
+                    " | `{}` would enable the {} level for {}",
+                    directive, level, target
+                );
+            }
+            eprintln!(" | the static max level is {}", STATIC_MAX_LEVEL);
+            let help_msg = || {
+                let (feature, filter) = match STATIC_MAX_LEVEL.into_level() {
+                    Some(Level::TRACE) => unreachable!(
+                        "if the max level is trace, no static filtering features are enabled"
+                    ),
+                    Some(Level::DEBUG) => ("max_level_debug", Level::TRACE),
+                    Some(Level::INFO) => ("max_level_info", Level::DEBUG),
+                    Some(Level::WARN) => ("max_level_warn", Level::INFO),
+                    Some(Level::ERROR) => ("max_level_error", Level::WARN),
+                    None => return ("max_level_off", String::new()),
+                };
+                (feature, format!("{} ", filter))
+            };
+            let (feature, earlier_level) = help_msg();
+            eprintln!(
+                "note: to enable {}logging, remove the `{}` feature",
+                earlier_level, feature
+            );
+        }
+
         let (dynamics, mut statics) = Directive::make_tables(directives);
         let has_dynamics = !dynamics.is_empty();
 

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -309,7 +309,10 @@ impl EnvFilter {
                     .clone()
                     .into_level()
                     .expect("=off would not have enabled any filters");
-                ctx(&format!("`{}` would enable the {} level for {}", directive, level, target));
+                ctx(&format!(
+                    "`{}` would enable the {} level for {}",
+                    directive, level, target
+                ));
             }
             ctx(&format!("the static max level is {}", STATIC_MAX_LEVEL));
             let help_msg = || {
@@ -326,7 +329,10 @@ impl EnvFilter {
                 (feature, format!("{} ", filter))
             };
             let (feature, earlier_level) = help_msg();
-            ctx_help(&format!("to enable {}logging, remove the `{}` feature", earlier_level, feature));
+            ctx_help(&format!(
+                "to enable {}logging, remove the `{}` feature",
+                earlier_level, feature
+            ));
         }
 
         let (dynamics, mut statics) = Directive::make_tables(directives);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Fixes https://github.com/tokio-rs/tracing/issues/975.

## Solution

This implements the warning in `tracing-subscriber` only, as mentioned in https://github.com/tokio-rs/tracing/issues/975#issuecomment-692903469. It warns whenever directives are parsed, including programmatically and through environment variables. It does not include the suggested new API which returns the filters that wouldn't be parsed.

- List filters that would be ignored
- Mention 'static max level'
- Describe how to enable the logging

Example output:

```
$ RUST_LOG=off,debug,silenced[x]=trace cargo run -q
warning: some trace filter directives would enable traces that are disabled statically
 | `debug` would enable the DEBUG level for all targets
 | `silenced[x]=trace` would enable the TRACE level for the `silenced` target
 = note: the static max level is info
 = note: to enable DEBUG logging, remove the `max_level_info` feature
```
![image](https://user-images.githubusercontent.com/23638587/95243324-77dc6a00-07de-11eb-8ed3-6ee2109940d4.png)