### PR TITLE
core, tracing: don't inline dispatcher::get_default

### DIFF
--- a/tracing-core/src/event.rs
+++ b/tracing-core/src/event.rs
@@ -29,7 +29,6 @@ pub struct Event<'a> {
 impl<'a> Event<'a> {
     /// Constructs a new `Event` with the specified metadata and set of values,
     /// and observes it with the current subscriber.
-    #[inline]
     pub fn dispatch(metadata: &'static Metadata<'static>, fields: &'a field::ValueSet<'_>) {
         let event = Event::new(metadata, fields);
         crate::dispatcher::get_default(|current| {
@@ -69,7 +68,6 @@ impl<'a> Event<'a> {
 
     /// Constructs a new `Event` with the specified metadata and set of values,
     /// and observes it with the current subscriber and an explicit parent.
-    #[inline]
     pub fn child_of(
         parent: impl Into<Option<Id>>,
         metadata: &'static Metadata<'static>,

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -404,7 +404,6 @@ impl Span {
     /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
     /// [field values]: ../field/struct.ValueSet.html
     /// [`follows_from`]: ../struct.Span.html#method.follows_from
-    #[inline]
     pub fn new(meta: &'static Metadata<'static>, values: &field::ValueSet<'_>) -> Span {
         dispatcher::get_default(|dispatch| Self::new_with(meta, values, dispatch))
     }
@@ -429,7 +428,6 @@ impl Span {
     /// [metadata]: ../metadata
     /// [field values]: ../field/struct.ValueSet.html
     /// [`follows_from`]: ../struct.Span.html#method.follows_from
-    #[inline]
     pub fn new_root(meta: &'static Metadata<'static>, values: &field::ValueSet<'_>) -> Span {
         dispatcher::get_default(|dispatch| Self::new_root_with(meta, values, dispatch))
     }


### PR DESCRIPTION
## Motivation

Presently, functions for recording new spans and events that can get the
current dispatcher (`Event::dispatch`, `Event::child_of`, `Span::new`,
and `Span::new_root`) are marked as `#[inline]`. This results in these
methods getting inlined in most cases, and `dispatcher::get_default` is
sometimes inlined into *those* methods. This, then, inlines all of
`dispatcher::get_default` into the callsites of the `span!` and `event!`
macros, generating *way* too much code (including thread local accesses)
inline. Since there's an `expect` in `get_default`, this also means that 
unwinding code is inlined into functions that wouldn't otherwise panic,
which is also not great. Inlining too much code this results in code that
optimizes poorly in many cases.

## Solution

This PR removes `#[inline]` attributes from these functions, ensuring
that the TLS hits are always behind a function call.
