### PR TITLE
tracing: prepare to release 0.1.21

### DIFF
--- a/tracing-subscriber/src/util.rs
+++ b/tracing-subscriber/src/util.rs
@@ -14,8 +14,8 @@ use tracing_core::dispatcher::{self, Dispatch};
 /// `Subscriber`, may implement `Into<Dispatch>`, and will also receive an
 /// implementation of this trait.
 ///
-/// [default subscriber]: https://docs.rs/tracing/0.1.20/tracing/dispatcher/index.html#setting-the-default-subscriber
-/// [trace dispatcher]: https://docs.rs/tracing/0.1.20/tracing/dispatcher/index.html
+/// [default subscriber]: https://docs.rs/tracing/0.1.21/tracing/dispatcher/index.html#setting-the-default-subscriber
+/// [trace dispatcher]: https://docs.rs/tracing/0.1.21/tracing/dispatcher/index.html
 pub trait SubscriberInitExt
 where
     Self: Into<Dispatch>,
@@ -27,7 +27,7 @@ where
     /// a [`log`] compatibility layer. This allows the subscriber to consume
     /// `log::Record`s as though they were `tracing` `Event`s.
     ///
-    /// [default subscriber]: https://docs.rs/tracing/0.1.20/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [default subscriber]: https://docs.rs/tracing/0.1.21/tracing/dispatcher/index.html#setting-the-default-subscriber
     /// [`log`]: https://crates.io/log
     fn set_default(self) -> dispatcher::DefaultGuard {
         #[cfg(feature = "tracing-log")]
@@ -47,7 +47,7 @@ where
     /// been set, or if a `log` logger has already been set (when the
     /// "tracing-log" feature is enabled).
     ///
-    /// [global default subscriber]: https://docs.rs/tracing/0.1.20/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [global default subscriber]: https://docs.rs/tracing/0.1.21/tracing/dispatcher/index.html#setting-the-default-subscriber
     /// [`log`]: https://crates.io/log
     fn try_init(self) -> Result<(), TryInitError> {
         #[cfg(feature = "tracing-log")]
@@ -69,7 +69,7 @@ where
     /// or if a `log` logger has already been set (when the "tracing-log"
     /// feature is enabled).
     ///
-    /// [global default subscriber]: https://docs.rs/tracing/0.1.20/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [global default subscriber]: https://docs.rs/tracing/0.1.21/tracing/dispatcher/index.html#setting-the-default-subscriber
     /// [`log`]: https://crates.io/log
     fn init(self) {
         self.try_init()

--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,35 @@
+# 0.1.21 (September 28, 2020)
+
+### Fixed
+
+- Incorrect inlining of `Span::new`, `Span::new_root`, and `Span::new_child_of`,
+  which could result in  `dispatcher::get_default` being inlined at the callsite
+  ([#994])
+- Regression where using a struct field as a span or event field when other
+  fields on that struct are borrowed mutably would fail to compile ([#987])
+
+### Changed
+
+- Updated `tracing-core` to 0.1.17 ([#992])
+
+### Added
+
+- `Instrument` trait and `Instrumented` type for attaching a `Span` to a
+  `Future` ([#808])
+- `Copy` implementations for `Level` and `LevelFilter` ([#992])
+- Multiple documentation fixes and improvements ([#964], [#980], [#981])
+
+Thanks to @nagisa, and new contributors @SecurityInsanity, @froydnj, @jyn514 and
+@TaKO8Ki for contributing to this release!
+
+[#994]: https://github.com/tokio-rs/tracing/pull/994
+[#992]: https://github.com/tokio-rs/tracing/pull/992
+[#987]: https://github.com/tokio-rs/tracing/pull/987 
+[#980]: https://github.com/tokio-rs/tracing/pull/980
+[#981]: https://github.com/tokio-rs/tracing/pull/981
+[#964]: https://github.com/tokio-rs/tracing/pull/964
+[#808]: https://github.com/tokio-rs/tracing/pull/808
+
 # 0.1.20 (August 24, 2020)
 
 ### Changed

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.20"
+version = "0.1.21"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -16,9 +16,9 @@ Application-level tracing for Rust.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.20
+[crates-url]: https://crates.io/crates/tracing/0.1.21
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.20
+[docs-url]: https://docs.rs/tracing/0.1.21
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -246,7 +246,7 @@ my_future
 is as long as the future's.
 
 The second, and preferred, option is through the
-[`#[instrument]`](https://docs.rs/tracing/0.1.20/tracing/attr.instrument.html)
+[`#[instrument]`](https://docs.rs/tracing/0.1.21/tracing/attr.instrument.html)
 attribute:
 
 ```rust
@@ -293,7 +293,7 @@ span.in_scope(|| {
 // Dropping the span will close it, indicating that it has ended.
 ```
 
-The [`#[instrument]`](https://docs.rs/tracing/0.1.20/tracing/attr.instrument.html) attribute macro
+The [`#[instrument]`](https://docs.rs/tracing/0.1.21/tracing/attr.instrument.html) attribute macro
 can reduce some of this boilerplate:
 
 ```rust

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -781,7 +781,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing = { version = "0.1.20", default-features = false }
+//!   tracing = { version = "0.1.21", default-features = false }
 //!   ```
 //!
 //! <div class="information">
@@ -837,7 +837,7 @@
 //! [flags]: #crate-feature-flags
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.20")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.21")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
### Fixed

- Incorrect inlining of `Span::new`, `Span::new_root`, and
  `Span::new_child_of`, which could result in `dispatcher::get_default`
  being  inlined at the callsite ([#994])
- Regression where using a struct field as a span or event field when
  other fields on that struct are borrowed mutably would fail to compile
  ([#987])

### Changed

- Updated `tracing-core` to 0.1.17 ([#992])

### Added

- `Instrument` trait and `Instrumented` type for attaching a `Span` to a
  `Future` ([#808])
- `Copy` implementations for `Level` and `LevelFilter` ([#992])
- Multiple documentation fixes and improvements ([#964], [#980], [#981])

Thanks to @nagisa, and new contributors @SecurityInsanity, @froydnj,
@jyn514 and @TaKO8Ki for contributing to this release!

[#994]: https://github.com/tokio-rs/tracing/pull/994
[#992]: https://github.com/tokio-rs/tracing/pull/992
[#987]: https://github.com/tokio-rs/tracing/pull/987
[#980]: https://github.com/tokio-rs/tracing/pull/980
[#981]: https://github.com/tokio-rs/tracing/pull/981
[#964]: https://github.com/tokio-rs/tracing/pull/964
[#808]: https://github.com/tokio-rs/tracing/pull/808

Signed-off-by: Eliza Weisman <eliza@buoyant.io>