### PR TITLE
update all crate versions for v0.2.x

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,26 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "cargo",
+			"command": "build",
+			"problemMatcher": [
+				"$rustc"
+			],
+			"group": "build",
+			"label": "rust: cargo build"
+		},
+		{
+			"type": "cargo",
+			"command": "clippy",
+			"args": [
+				"--all"
+			],
+			"problemMatcher": [
+				"$rustc"
+			],
+			"group": "build",
+			"label": "rust: cargo clippy"
+		}
+	]
+}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,15 +10,15 @@ default = []
 [dev-dependencies]
 
 # tracing crates
-tracing = { path = "../tracing", version = "0.1"}
-tracing-core = { path = "../tracing-core", version = "0.1"}
+tracing = { path = "../tracing", version = "0.2"}
+tracing-core = { path = "../tracing-core", version = "0.2"}
 tracing-error = { path = "../tracing-error" }
 tracing-flame = { path = "../tracing-flame" }
 tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.12", features = ["json", "chrono"] }
-tracing-futures = { version = "0.2.1", path = "../tracing-futures", features = ["futures-01"] }
-tracing-attributes =  { path = "../tracing-attributes", version = "0.1.2"}
-tracing-log = { path = "../tracing-log", version = "0.1.1", features = ["env_logger"] }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", features = ["json", "chrono"] }
+tracing-futures = { version = "0.3", path = "../tracing-futures", features = ["futures-01"] }
+tracing-attributes =  { path = "../tracing-attributes", version = "0.2"}
+tracing-log = { path = "../tracing-log", version = "0.2", features = ["env_logger"] }
 tracing-serde = { path = "../tracing-serde" }
 tracing-opentelemetry = { path = "../tracing-opentelemetry" }
 tracing-journald = { path = "../tracing-journald" }

--- a/examples/examples/all-levels.rs
+++ b/examples/examples/all-levels.rs
@@ -1,5 +1,11 @@
 use tracing::Level;
 
+#[no_mangle]
+#[inline(never)]
+pub fn event() {
+    tracing::info!("general informational messages relevant to users");
+}
+
 fn main() {
     tracing_subscriber::fmt()
         // all spans/events with a level higher than TRACE (e.g, info, warn, etc.)
@@ -7,6 +13,7 @@ fn main() {
         .with_max_level(Level::TRACE)
         // sets this to be the default, global subscriber for this application.
         .init();
+    event();
 
     tracing::error!("SOMETHING IS SERIOUSLY WRONG!!!");
     tracing::warn!("important informational messages; might indicate an error");

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-appender"
-version = "0.1.1"
+version = "0.2.0"
 authors = [
     "Zeki Sherif <zekshi@amazon.com>",
     "Tokio Contributors <team@tokio.rs>"
@@ -25,10 +25,10 @@ chrono = "0.4.11"
 
 [dependencies.tracing-subscriber]
 path = "../tracing-subscriber"
-version = "0.2.7"
+version = "0.3"
 default-features = false
 features = ["fmt"]
 
 [dev-dependencies]
-tracing = { path = "../tracing", version = "0.1" }
+tracing = { path = "../tracing", version = "0.2" }
 tempdir = "0.3"

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -7,8 +7,8 @@ name = "tracing-attributes"
 #   - Cargo.toml
 #   - README.md
 # - Update CHANGELOG.md.
-# - Create "v0.1.x" git tag.
-version = "0.1.11"
+# - Create "v0.2.x" git tag.
+version = "0.2.0"
 authors = [
     "Tokio Contributors <team@tokio.rs>",
     "Eliza Weisman <eliza@buoyant.io>",
@@ -32,11 +32,6 @@ edition = "2018"
 [lib]
 proc-macro = true
 
-[features]
-
-# This feature flag is no longer necessary.
-async-await = []
-
 [dependencies]
 proc-macro2 = "1"
 syn = { version = "1", default-features = false, features = ["full", "parsing", "printing", "visit-mut", "clone-impls", "extra-traits", "proc-macro"] }
@@ -44,9 +39,9 @@ quote = "1"
 
 
 [dev-dependencies]
-tracing = { path = "../tracing", version = "0.1" }
+tracing = { path = "../tracing", version = "0.2" }
 tokio-test = { version = "0.2.0" }
-tracing-core = { path = "../tracing-core", version = "0.1"}
+tracing-core = { path = "../tracing-core", version = "0.2"}
 async-trait = "0.1"
 
 [badges]

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -7,8 +7,8 @@ name = "tracing-core"
 #   - Cargo.toml
 #   - README.md
 # - Update CHANGELOG.md.
-# - Create "v0.1.x" git tag.
-version = "0.1.17"
+# - Create "v0.2.x" git tag.
+version = "0.2.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -7,8 +7,8 @@ name = "tracing-error"
 #   - Cargo.toml
 #   - README.md
 # - Update CHANGELOG.md.
-# - Create "v0.1.x" git tag
-version = "0.1.2"
+# - Create "v0.2.x" git tag
+version = "0.2.0"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "Jane Lusby <jlusby@yaah.dev>",
@@ -38,8 +38,8 @@ default = ["traced-error"]
 traced-error = []
 
 [dependencies]
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.7", default-features = false, features = ["registry", "fmt"] }
-tracing = { path = "../tracing", version = "0.1.12"}
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry", "fmt"] }
+tracing = { path = "../tracing", version = "0.2"}
 
 [badges]
 maintenance = { status = "experimental" }

--- a/tracing-flame/Cargo.toml
+++ b/tracing-flame/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-flame"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "Jane Lusby <jlusby@yaah.dev>",
     "Tokio Contributors <team@tokio.rs>"
@@ -25,8 +25,8 @@ default = ["smallvec"]
 smallvec = ["tracing-subscriber/smallvec"]
 
 [dependencies]
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.3", default-features = false, features = ["registry", "fmt"] }
-tracing = { path = "../tracing", version = "0.1.12"}
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry", "fmt"] }
+tracing = { path = "../tracing", version = "0.2"}
 lazy_static = "1.3.0"
 
 [dev-dependencies]

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-futures"
-version = "0.2.6"
+version = "0.3.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"
@@ -29,14 +29,14 @@ futures_01 = { package = "futures", version = "0.1", optional = true }
 futures = { version = "0.3.0", optional = true }
 futures-task = { version = "0.3", optional = true }
 pin-project = { version = "0.4", optional = true }
-tracing = { path = "../tracing", version = "0.1", default-features = false }
+tracing = { path = "../tracing", version = "0.2", default-features = false }
 tokio-executor = { version = "0.1", optional = true }
 tokio = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tokio = "0.1.22"
 tokio-test = "0.2"
-tracing-core = { path = "../tracing-core", version = "0.1.2" }
+tracing-core = { path = "../tracing-core", version = "0.2" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/tracing-journald/Cargo.toml
+++ b/tracing-journald/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-journald"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -15,5 +15,5 @@ categories = [
 keywords = ["tracing", "journald"]
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.10" }
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.5" }
+tracing-core = { path = "../tracing-core", version = "0.2" }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.3" }

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-log"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"
@@ -23,13 +23,13 @@ log-tracer = []
 trace-logger = []
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.17"}
+tracing-core = { path = "../tracing-core", version = "0.2"}
 log = { version = "0.4" }
 lazy_static = "1.3.0"
 env_logger = { version = "0.7", optional = true }
 
 [dev-dependencies]
-tracing = { path = "../tracing", version = "0.1"}
+tracing = { path = "../tracing", version = "0.2"}
 
 [badges]
 maintenance = { status = "actively-maintained" }

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-opentelemetry"
-version = "0.7.0"
+version = "0.8.0"
 authors = [
     "Julian Tescher <julian@tescher.me>",
     "Tokio Contributors <team@tokio.rs>"
@@ -24,10 +24,10 @@ default = ["tracing-log"]
 [dependencies]
 opentelemetry = { version = "0.8", default-features = false, features = ["trace"] }
 rand = "0.7"
-tracing = { path = "../tracing", version = "0.1" }
-tracing-core = { path = "../tracing-core", version = "0.1" }
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.2", default-features = false, features = ["registry"] }
-tracing-log = { path = "../tracing-log", version = "0.1", default-features = false, optional = true }
+tracing = { path = "../tracing", version = "0.2" }
+tracing-core = { path = "../tracing-core", version = "0.2" }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry"] }
+tracing-log = { path = "../tracing-log", version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
 opentelemetry-jaeger = "0.7"

--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-serde"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 edition = "2018"
@@ -19,7 +19,7 @@ keywords = ["logging", "tracing", "serialization"]
 
 [dependencies]
 serde = "1"
-tracing-core = { path = "../tracing-core", version = "0.1.2"}
+tracing-core = { path = "../tracing-core", version = "0.2"}
 
 [dev-dependencies]
 serde_json = "1"

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.12"
+version = "0.3.0"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",
@@ -31,7 +31,7 @@ registry = ["sharded-slab", "thread_local"]
 json = ["tracing-serde", "serde", "serde_json"]
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.17" }
+tracing-core = { path = "../tracing-core", version = "0.2" }
 
 # only required by the filter feature
 matchers = { optional = true, version = "0.0.1" }
@@ -40,14 +40,14 @@ smallvec = { optional = true, version = "1" }
 lazy_static = { optional = true, version = "1" }
 
 # fmt
-tracing-log = { path = "../tracing-log", version = "0.1", optional = true, default-features = false, features = ["log-tracer", "std"] }
+tracing-log = { path = "../tracing-log", version = "0.2", optional = true, default-features = false, features = ["log-tracer", "std"] }
 ansi_term = { version = "0.12", optional = true }
 chrono = { version = "0.4", optional = true }
 
 # only required by the json feature
 serde_json = { version = "1.0", optional = true }
 serde = { version = "1.0", optional = true }
-tracing-serde = { path = "../tracing-serde", version = "0.1.2", optional = true }
+tracing-serde = { path = "../tracing-serde", version = "0.2", optional = true }
 
 # opt-in deps
 parking_lot = { version = ">= 0.7, <= 0.11", optional = true }
@@ -57,12 +57,12 @@ sharded-slab = { version = "^0.0.9", optional = true }
 thread_local = { version = "1.0.1", optional = true }
 
 [dev-dependencies]
-tracing = { path = "../tracing", version = "0.1" }
+tracing = { path = "../tracing", version = "0.2" }
 log = "0.4"
-tracing-log = { path = "../tracing-log", version = "0.1" }
+tracing-log = { path = "../tracing-log", version = "0.2" }
 criterion = { version = "0.3", default_features = false }
 regex = { version = "1", default-features = false, features = ["std"] }
-tracing-futures = { path = "../tracing-futures", version = "0.2", default-features = false, features = ["std-future", "std"] }
+tracing-futures = { path = "../tracing-futures", version = "0.3", default-features = false, features = ["std-future", "std"] }
 tokio = { version = "0.2", features = ["rt-core", "macros"] }
 
 [badges]

--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -24,8 +24,8 @@ tower-make = [
 ]
 
 [dependencies]
-tracing = { path = "../tracing", version = "0.1"}
-tracing-futures = { version = "0.2.1", path = "../tracing-futures", features = ["std-future"] }
+tracing = { path = "../tracing", version = "0.2"}
+tracing-futures = { version = "0.3", path = "../tracing-futures", features = ["std-future"] }
 futures = "0.3"
 tower-service = "0.3"
 tower-layer = { version = "0.3", optional = true }

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -7,8 +7,8 @@ name = "tracing"
 #   - Cargo.toml
 #   - README.md
 # - Update CHANGELOG.md.
-# - Create "v0.1.x" git tag
-version = "0.1.21"
+# - Create "v0.2.x" git tag
+version = "0.2.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
@@ -27,9 +27,9 @@ keywords = ["logging", "tracing", "metrics", "async"]
 edition = "2018"
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.17", default-features = false }
+tracing-core = { path = "../tracing-core", version = "0.2", default-features = false }
 log = { version = "0.4", optional = true }
-tracing-attributes = { path = "../tracing-attributes", version = "0.1.10", optional = true }
+tracing-attributes = { path = "../tracing-attributes", version = "0.2", optional = true }
 cfg-if = "0.1.10"
 pin-project-lite = "0.1"
 


### PR DESCRIPTION
This branch updates all crate versions to 0.2.x. After this PR merges,
we can now develop `tracing`/`tracing-core` v0.2.x on `master`. 

There is now a separate, protected `v0.1.x` branch. Changes backported
to 0.1 versions of `tracing` crates can be merged to that branch. 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>