### PR TITLE
tracing: remove `Into<Option<Id>>` impl for `Span`

### DIFF
--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -993,22 +993,14 @@ impl Span {
     /// # use tracing::{span, Id, Level, Span};
     /// let span1 = span!(Level::INFO, "span_1");
     /// let span2 = span!(Level::DEBUG, "span_2");
-    /// span2.follows_from(span1);
+    /// span2.follows_from(&span1);
     /// ```
     ///
     /// Setting a `follows_from` relationship with the current span:
     /// ```
     /// # use tracing::{span, Id, Level, Span};
     /// let span = span!(Level::INFO, "hello!");
-    /// span.follows_from(Span::current());
-    /// ```
-    ///
-    /// Setting a `follows_from` relationship with a `Span` reference:
-    /// ```
-    /// # use tracing::{span, Id, Level, Span};
-    /// let span = span!(Level::INFO, "hello!");
-    /// let curr = Span::current();
-    /// span.follows_from(&curr);
+    /// span.follows_from(&Span::current());
     /// ```
     ///
     /// Setting a `follows_from` relationship with an `Id`:

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -1145,12 +1145,6 @@ impl<'a> Into<Option<Id>> for &'a Span {
     }
 }
 
-impl Into<Option<Id>> for Span {
-    fn into(self) -> Option<Id> {
-        self.inner.as_ref().map(Inner::id)
-    }
-}
-
 impl Drop for Span {
     fn drop(&mut self) {
         if let Some(Inner {


### PR DESCRIPTION
This doesn't work correctly, since the span is dropped when the function
returns, calling `try_close` on that span. We could remove the inner
value in this case, but then `try_close` will _never_ be called on that
ID, leaking the parent. If the span is dropped *after* the new span is
created, instead, everything will work correctly, because the subscriber
will have already increased its reference count (as it now has a
child). Thus, only `&Span` is valid here.

Fixes #688

Signed-off-by: Eliza Weisman <eliza@buoyant.io>