### PR TITLE
attributes:  fix `#[instrument(err)]` in case of early returns

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -467,7 +467,7 @@ fn gen_body(
         quote_spanned!(block.span()=>
             let __tracing_attr_span = #span;
             let __tracing_attr_guard = __tracing_attr_span.enter();
-            match { #block } {
+            match (move || { #block })() {
                 Ok(x) => Ok(x),
                 Err(e) => {
                     tracing::error!(error = %e);

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -467,7 +467,7 @@ fn gen_body(
         quote_spanned!(block.span()=>
             let __tracing_attr_span = #span;
             let __tracing_attr_guard = __tracing_attr_span.enter();
-            let f = move || { #block };
+            let f = move || #return_type { #block };
             match f() {
                 Ok(x) => Ok(x),
                 Err(e) => {

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -467,7 +467,8 @@ fn gen_body(
         quote_spanned!(block.span()=>
             let __tracing_attr_span = #span;
             let __tracing_attr_guard = __tracing_attr_span.enter();
-            match (move || { #block })() {
+            let f = move || { #block };
+            match f() {
                 Ok(x) => Ok(x),
                 Err(e) => {
                     tracing::error!(error = %e);

--- a/tracing-attributes/tests/err.rs
+++ b/tracing-attributes/tests/err.rs
@@ -32,6 +32,27 @@ fn test() {
 }
 
 #[instrument(err)]
+fn err_early_return() -> Result<u8, TryFromIntError> {
+    u8::try_from(1234)?;
+    Ok(5)
+}
+
+#[test]
+fn test_early_return() {
+    let span = span::mock().named("err_early_return");
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(span.clone())
+        .enter(span.clone())
+        .event(event::mock().at_level(Level::ERROR))
+        .exit(span.clone())
+        .drop_span(span)
+        .done()
+        .run_with_handle();
+    with_default(subscriber, || err_early_return().ok());
+    handle.assert_finished();
+}
+
+#[instrument(err)]
 async fn err_async(polls: usize) -> Result<u8, TryFromIntError> {
     let future = PollN::new_ok(polls);
     tracing::trace!(awaiting = true);


### PR DESCRIPTION
## Motivation

For the non-async case, early returns could escape the block so that the
error handling was skipped.

I was wondering for quite some time now what was going on here 😆 

## Solution

Just put the block into the all-mighty "try-catch-closure" construct.  I'm unsure whether this will negatively impact the quality of error messages in case of type checking issues.  Maybe, we should add some type annotations to the closure?
