### PR TITLE
tracing-opentelemetry: implement additional record types (bool, i64, u64)

### DIFF
--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -103,6 +103,51 @@ fn str_to_span_kind(s: &str) -> Option<api::SpanKind> {
 struct SpanEventVisitor<'a>(&'a mut api::Event);
 
 impl<'a> field::Visit for SpanEventVisitor<'a> {
+    /// Record events on the underlying OpenTelemetry [`Span`] from `bool` values.
+    ///
+    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    fn record_bool(&mut self, field: &field::Field, value: bool) {
+        match field.name() {
+            "message" => self.0.name = value.to_string(),
+            // Skip fields that are actually log metadata that have already been handled
+            #[cfg(feature = "tracing-log")]
+            name if name.starts_with("log.") => (),
+            name => {
+                self.0.attributes.push(api::KeyValue::new(name, value));
+            }
+        }
+    }
+
+    /// Record events on the underlying OpenTelemetry [`Span`] from `i64` values.
+    ///
+    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    fn record_i64(&mut self, field: &field::Field, value: i64) {
+        match field.name() {
+            "message" => self.0.name = value.to_string(),
+            // Skip fields that are actually log metadata that have already been handled
+            #[cfg(feature = "tracing-log")]
+            name if name.starts_with("log.") => (),
+            name => {
+                self.0.attributes.push(api::KeyValue::new(name, value));
+            }
+        }
+    }
+
+    /// Record events on the underlying OpenTelemetry [`Span`] from `u64` values.
+    ///
+    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    fn record_u64(&mut self, field: &field::Field, value: u64) {
+        match field.name() {
+            "message" => self.0.name = value.to_string(),
+            // Skip fields that are actually log metadata that have already been handled
+            #[cfg(feature = "tracing-log")]
+            name if name.starts_with("log.") => (),
+            name => {
+                self.0.attributes.push(api::KeyValue::new(name, value));
+            }
+        }
+    }
+
     /// Record events on the underlying OpenTelemetry [`Span`] from `&str` values.
     ///
     /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
@@ -140,6 +185,42 @@ impl<'a> field::Visit for SpanEventVisitor<'a> {
 struct SpanAttributeVisitor<'a>(&'a mut api::SpanBuilder);
 
 impl<'a> field::Visit for SpanAttributeVisitor<'a> {
+    /// Set attributes on the underlying OpenTelemetry [`Span`] from `bool` values.
+    ///
+    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    fn record_bool(&mut self, field: &field::Field, value: bool) {
+        let attribute = api::KeyValue::new(field.name(), value);
+        if let Some(attributes) = &mut self.0.attributes {
+            attributes.push(attribute);
+        } else {
+            self.0.attributes = Some(vec![attribute]);
+        }
+    }
+
+    /// Set attributes on the underlying OpenTelemetry [`Span`] from `i64` values.
+    ///
+    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    fn record_i64(&mut self, field: &field::Field, value: i64) {
+        let attribute = api::KeyValue::new(field.name(), value);
+        if let Some(attributes) = &mut self.0.attributes {
+            attributes.push(attribute);
+        } else {
+            self.0.attributes = Some(vec![attribute]);
+        }
+    }
+
+    /// Set attributes on the underlying OpenTelemetry [`Span`] from `u64` values.
+    ///
+    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    fn record_u64(&mut self, field: &field::Field, value: u64) {
+        let attribute = api::KeyValue::new(field.name(), value);
+        if let Some(attributes) = &mut self.0.attributes {
+            attributes.push(attribute);
+        } else {
+            self.0.attributes = Some(vec![attribute]);
+        }
+    }
+
     /// Set attributes on the underlying OpenTelemetry [`Span`] from `&str` values.
     ///
     /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

While using `tracing-opentelemetry` I noticed all the data gets sent to the collector as a string. This implements the additional data types and (possibly) saves bandwidth.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I just implemented additional `fn record_$type(...)` methods of the `field::Visit` trait to `SpanEventVisitor` and `SpanAttributeVisitor`.

PSA: I don't really know what I'm doing :) 
