### PR TITLE
Switch to intra-doc links in tracing-core

### DIFF
--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -77,12 +77,12 @@ impl Registry {
 pub trait Callsite: Sync {
     /// Sets the [`Interest`] for this callsite.
     ///
-    /// [`Interest`]: ../subscriber/struct.Interest.html
+    /// [`Interest`]: super::subscriber::Interest
     fn set_interest(&self, interest: Interest);
 
     /// Returns the [metadata] associated with the callsite.
     ///
-    /// [metadata]: ../metadata/struct.Metadata.html
+    /// [metadata]: super::metadata::Metadata
     fn metadata(&self) -> &Metadata<'_>;
 }
 
@@ -90,7 +90,7 @@ pub trait Callsite: Sync {
 ///
 /// Two `Identifier`s are equal if they both refer to the same callsite.
 ///
-/// [`Callsite`]: ../callsite/trait.Callsite.html
+/// [`Callsite`]: super::callsite::Callsite
 #[derive(Clone)]
 pub struct Identifier(
     /// **Warning**: The fields on this type are currently `pub` because it must
@@ -119,11 +119,11 @@ pub struct Identifier(
 /// implementation at runtime, then it **must** call this function after that
 /// value changes, in order for the change to be reflected.
 ///
-/// [`max_level_hint`]: ../subscriber/trait.Subscriber.html#method.max_level_hint
-/// [`Callsite`]: ../callsite/trait.Callsite.html
-/// [`enabled`]: ../subscriber/trait.Subscriber.html#tymethod.enabled
-/// [`Interest::sometimes()`]: ../subscriber/struct.Interest.html#method.sometimes
-/// [`Subscriber`]: ../subscriber/trait.Subscriber.html
+/// [`max_level_hint`]: super::subscriber::Subscriber::max_level_hint
+/// [`Callsite`]: super::callsite::Callsite
+/// [`enabled`]: super::subscriber::Subscriber::enabled
+/// [`Interest::sometimes()`]: super::subscriber::Interest::sometimes
+/// [`Subscriber`]: super::subscriber::Subscriber
 pub fn rebuild_interest_cache() {
     let mut registry = REGISTRY.lock().unwrap();
     registry.rebuild_interest();

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -127,11 +127,11 @@
 //! currently default `Dispatch`. This is used primarily by `tracing`
 //! instrumentation.
 //!
-//! [`Subscriber`]: struct.Subscriber.html
+//! [`Subscriber`]: Subscriber
 //! [`with_default`]: fn.with_default.html
 //! [`set_global_default`]: fn.set_global_default.html
 //! [`get_default`]: fn.get_default.html
-//! [`Dispatch`]: struct.Dispatch.html
+//! [`Dispatch`]: Dispatch
 use crate::{
     callsite, span,
     subscriber::{self, Subscriber},
@@ -155,7 +155,7 @@ use crate::stdlib::{
 
 /// `Dispatch` trace data to a [`Subscriber`].
 ///
-/// [`Subscriber`]: trait.Subscriber.html
+/// [`Subscriber`]: Subscriber
 #[derive(Clone)]
 pub struct Dispatch {
     subscriber: Arc<dyn Subscriber + Send + Sync>,
@@ -217,14 +217,14 @@ pub struct DefaultGuard(Option<Dispatch>);
 /// <div class="example-wrap" style="display:inline-block">
 /// <pre class="ignore" style="white-space:normal;font:inherit;">
 /// <strong>Note</strong>: This function required the Rust standard library.
-/// <code>no_std</code> users should use <a href="../fn.set_global_default.html">
+/// <code>no_std</code> users should use <a href="super::fn.set_global_default.html">
 /// <code>set_global_default</code></a> instead.
 /// </pre></div>
 ///
-/// [span]: ../span/index.html
-/// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-/// [`Event`]: ../event/struct.Event.html
-/// [`set_global_default`]: ../fn.set_global_default.html
+/// [span]: super::span::index.html
+/// [`Subscriber`]: super::subscriber::Subscriber
+/// [`Event`]: super::event::Event
+/// [`set_global_default`]: super::fn.set_global_default.html
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn with_default<T>(dispatcher: &Dispatch, f: impl FnOnce() -> T) -> T {
@@ -245,11 +245,11 @@ pub fn with_default<T>(dispatcher: &Dispatch, f: impl FnOnce() -> T) -> T {
 /// <div class="example-wrap" style="display:inline-block">
 /// <pre class="ignore" style="white-space:normal;font:inherit;">
 /// <strong>Note</strong>: This function required the Rust standard library.
-/// <code>no_std</code> users should use <a href="../fn.set_global_default.html">
+/// <code>no_std</code> users should use <a href="super::fn.set_global_default.html">
 /// <code>set_global_default</code></a> instead.
 /// </pre></div>
 ///
-/// [`set_global_default`]: ../fn.set_global_default.html
+/// [`set_global_default`]: super::fn.set_global_default.html
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[must_use = "Dropping the guard unregisters the dispatcher."]
@@ -276,9 +276,9 @@ pub fn set_default(dispatcher: &Dispatch) -> DefaultGuard {
 /// executables that depend on the library try to set the default later.
 /// </pre></div>
 ///
-/// [span]: ../span/index.html
-/// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-/// [`Event`]: ../event/struct.Event.html
+/// [span]: super::span::index.html
+/// [`Subscriber`]: super::subscriber::Subscriber
+/// [`Event`]: super::event::Event
 pub fn set_global_default(dispatcher: Dispatch) -> Result<(), SetGlobalDefaultError> {
     if GLOBAL_INIT.compare_and_swap(UNINITIALIZED, INITIALIZING, Ordering::SeqCst) == UNINITIALIZED
     {
@@ -325,7 +325,7 @@ impl error::Error for SetGlobalDefaultError {}
 /// called while inside of another `get_default`, that closure will be provided
 /// with `Dispatch::none` rather than the previously set dispatcher.
 ///
-/// [dispatcher]: ../dispatcher/struct.Dispatch.html
+/// [dispatcher]: super::dispatcher::Dispatch
 #[cfg(feature = "std")]
 pub fn get_default<T, F>(mut f: F) -> T
 where
@@ -348,7 +348,7 @@ where
 /// called while inside of another `get_default`, that closure will be provided
 /// with `Dispatch::none` rather than the previously set dispatcher.
 ///
-/// [dispatcher]: ../dispatcher/struct.Dispatch.html
+/// [dispatcher]: super::dispatcher::Dispatch
 #[cfg(feature = "std")]
 #[doc(hidden)]
 #[inline(never)]
@@ -363,7 +363,7 @@ pub fn get_current<T>(f: impl FnOnce(&Dispatch) -> T) -> Option<T> {
 
 /// Executes a closure with a reference to the current [dispatcher].
 ///
-/// [dispatcher]: ../dispatcher/struct.Dispatch.html
+/// [dispatcher]: super::dispatcher::Dispatch
 #[cfg(not(feature = "std"))]
 #[doc(hidden)]
 pub fn get_current<T>(f: impl FnOnce(&Dispatch) -> T) -> Option<T> {
@@ -373,7 +373,7 @@ pub fn get_current<T>(f: impl FnOnce(&Dispatch) -> T) -> Option<T> {
 
 /// Executes a closure with a reference to the current [dispatcher].
 ///
-/// [dispatcher]: ../dispatcher/struct.Dispatch.html
+/// [dispatcher]: super::dispatcher::Dispatch
 #[cfg(not(feature = "std"))]
 pub fn get_default<T, F>(mut f: F) -> T
 where
@@ -412,7 +412,7 @@ impl Dispatch {
 
     /// Returns a `Dispatch` that forwards to the given [`Subscriber`].
     ///
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
+    /// [`Subscriber`]: super::subscriber::Subscriber
     pub fn new<S>(subscriber: S) -> Self
     where
         S: Subscriber + Send + Sync + 'static,
@@ -434,8 +434,8 @@ impl Dispatch {
     /// This calls the [`register_callsite`] function on the [`Subscriber`]
     /// that this `Dispatch` forwards to.
     ///
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`register_callsite`]: ../subscriber/trait.Subscriber.html#method.register_callsite
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`register_callsite`]: super::subscriber::Subscriber::register_callsite
     #[inline]
     pub fn register_callsite(&self, metadata: &'static Metadata<'static>) -> subscriber::Interest {
         self.subscriber.register_callsite(metadata)
@@ -448,9 +448,9 @@ impl Dispatch {
     /// This calls the [`max_level_hint`] function on the [`Subscriber`]
     /// that this `Dispatch` forwards to.
     ///
-    /// [level]: ../struct.Level.html
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`register_callsite`]: ../subscriber/trait.Subscriber.html#method.max_level_hint
+    /// [level]: super::Level
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`register_callsite`]: super::subscriber::Subscriber::max_level_hint
     // TODO(eliza): consider making this a public API?
     #[inline]
     pub(crate) fn max_level_hint(&self) -> Option<LevelFilter> {
@@ -463,9 +463,9 @@ impl Dispatch {
     /// This calls the [`new_span`] function on the [`Subscriber`] that this
     /// `Dispatch` forwards to.
     ///
-    /// [ID]: ../span/struct.Id.html
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
+    /// [ID]: super::span::Id
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`new_span`]: super::subscriber::Subscriber::new_span
     #[inline]
     pub fn new_span(&self, span: &span::Attributes<'_>) -> span::Id {
         self.subscriber.new_span(span)
@@ -476,8 +476,8 @@ impl Dispatch {
     /// This calls the [`record`] function on the [`Subscriber`] that this
     /// `Dispatch` forwards to.
     ///
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`record`]: ../subscriber/trait.Subscriber.html#method.record
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`record`]: super::subscriber::Subscriber::record
     #[inline]
     pub fn record(&self, span: &span::Id, values: &span::Record<'_>) {
         self.subscriber.record(span, values)
@@ -489,8 +489,8 @@ impl Dispatch {
     /// This calls the [`record_follows_from`] function on the [`Subscriber`]
     /// that this `Dispatch` forwards to.
     ///
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`record_follows_from`]: ../subscriber/trait.Subscriber.html#method.record_follows_from
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`record_follows_from`]: super::subscriber::Subscriber::record_follows_from
     #[inline]
     pub fn record_follows_from(&self, span: &span::Id, follows: &span::Id) {
         self.subscriber.record_follows_from(span, follows)
@@ -502,9 +502,9 @@ impl Dispatch {
     /// This calls the [`enabled`] function on the [`Subscriber`] that this
     /// `Dispatch` forwards to.
     ///
-    /// [metadata]: ../metadata/struct.Metadata.html
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`enabled`]: ../subscriber/trait.Subscriber.html#method.enabled
+    /// [metadata]: super::metadata::Metadata
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`enabled`]: super::subscriber::Subscriber::enabled
     #[inline]
     pub fn enabled(&self, metadata: &Metadata<'_>) -> bool {
         self.subscriber.enabled(metadata)
@@ -515,9 +515,9 @@ impl Dispatch {
     /// This calls the [`event`] function on the [`Subscriber`] that this
     /// `Dispatch` forwards to.
     ///
-    /// [`Event`]: ../event/struct.Event.html
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`event`]: ../subscriber/trait.Subscriber.html#method.event
+    /// [`Event`]: super::event::Event
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`event`]: super::subscriber::Subscriber::event
     #[inline]
     pub fn event(&self, event: &Event<'_>) {
         self.subscriber.event(event)
@@ -528,8 +528,8 @@ impl Dispatch {
     /// This calls the [`enter`] function on the [`Subscriber`] that this
     /// `Dispatch` forwards to.
     ///
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`enter`]: ../subscriber/trait.Subscriber.html#method.enter
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`enter`]: super::subscriber::Subscriber::enter
     #[inline]
     pub fn enter(&self, span: &span::Id) {
         self.subscriber.enter(span);
@@ -540,8 +540,8 @@ impl Dispatch {
     /// This calls the [`exit`] function on the [`Subscriber`] that this
     /// `Dispatch` forwards to.
     ///
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`exit`]: ../subscriber/trait.Subscriber.html#method.exit
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`exit`]: super::subscriber::Subscriber::exit
     #[inline]
     pub fn exit(&self, span: &span::Id) {
         self.subscriber.exit(span);
@@ -557,10 +557,10 @@ impl Dispatch {
     /// This calls the [`clone_span`] function on the `Subscriber` that this
     /// `Dispatch` forwards to.
     ///
-    /// [span ID]: ../span/struct.Id.html
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`clone_span`]: ../subscriber/trait.Subscriber.html#method.clone_span
-    /// [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
+    /// [span ID]: super::span::Id
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`clone_span`]: super::subscriber::Subscriber::clone_span
+    /// [`new_span`]: super::subscriber::Subscriber::new_span
     #[inline]
     pub fn clone_span(&self, id: &span::Id) -> span::Id {
         self.subscriber.clone_span(&id)
@@ -580,16 +580,16 @@ impl Dispatch {
     ///     <div class="tooltip compile_fail" style="">&#x26a0; &#xfe0f;<span class="tooltiptext">Warning</span></div>
     /// </div>
     /// <div class="example-wrap" style="display:inline-block"><pre class="compile_fail" style="white-space:normal;font:inherit;">
-    /// <strong>Deprecated</strong>: The <a href="#method.try_close"><code>try_close</code></a>
+    /// <strong>Deprecated</strong>: The <a href="Self::try_close"><code>try_close</code></a>
     /// method is functionally identical, but returns <code>true</code> if the span is now closed.
     /// It should be used instead of this method.
     /// </pre></div>
     ///
-    /// [span ID]: ../span/struct.Id.html
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`drop_span`]: ../subscriber/trait.Subscriber.html#method.drop_span
-    /// [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
-    /// [`try_close`]: #method.try_close
+    /// [span ID]: super::span::Id
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`drop_span`]: super::subscriber::Subscriber::drop_span
+    /// [`new_span`]: super::subscriber::Subscriber::new_span
+    /// [`try_close`]: Self::try_close
     #[inline]
     #[deprecated(since = "0.1.2", note = "use `Dispatch::try_close` instead")]
     pub fn drop_span(&self, id: span::Id) {
@@ -608,10 +608,10 @@ impl Dispatch {
     /// This calls the [`try_close`] function on the [`Subscriber`] that this
     ///  `Dispatch` forwards to.
     ///
-    /// [span ID]: ../span/struct.Id.html
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`try_close`]: ../subscriber/trait.Subscriber.html#method.try_close
-    /// [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
+    /// [span ID]: super::span::Id
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`try_close`]: super::subscriber::Subscriber::try_close
+    /// [`new_span`]: super::subscriber::Subscriber::new_span
     #[inline]
     pub fn try_close(&self, id: span::Id) -> bool {
         self.subscriber.try_close(id)
@@ -622,7 +622,7 @@ impl Dispatch {
     /// This calls the [`current`] function on the `Subscriber` that this
     /// `Dispatch` forwards to.
     ///
-    /// [`current`]: ../subscriber/trait.Subscriber.html#method.current
+    /// [`current`]: super::subscriber::Subscriber::current_span
     #[inline]
     pub fn current_span(&self) -> span::Current {
         self.subscriber.current_span()

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -125,9 +125,6 @@
 //! [`get_default`] function, which executes a closure with a reference to the
 //! currently default `Dispatch`. This is used primarily by `tracing`
 //! instrumentation.
-//!
-//! [`Subscriber`]: Subscriber
-//! [`Dispatch`]: Dispatch
 use crate::{
     callsite, span,
     subscriber::{self, Subscriber},
@@ -150,8 +147,6 @@ use crate::stdlib::{
 };
 
 /// `Dispatch` trace data to a [`Subscriber`].
-///
-/// [`Subscriber`]: Subscriber
 #[derive(Clone)]
 pub struct Dispatch {
     subscriber: Arc<dyn Subscriber + Send + Sync>,
@@ -219,10 +214,9 @@ pub struct DefaultGuard(Option<Dispatch>);
 ///
 /// </pre></div>
 ///
-/// [span]: super::span::index.html
+/// [span]: super::span
 /// [`Subscriber`]: super::subscriber::Subscriber
 /// [`Event`]: super::event::Event
-/// [`set_global_default`]: set_global_default
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn with_default<T>(dispatcher: &Dispatch, f: impl FnOnce() -> T) -> T {
@@ -273,7 +267,7 @@ pub fn set_default(dispatcher: &Dispatch) -> DefaultGuard {
 /// executables that depend on the library try to set the default later.
 /// </pre></div>
 ///
-/// [span]: super::span::index.html
+/// [span]: super::span
 /// [`Subscriber`]: super::subscriber::Subscriber
 /// [`Event`]: super::event::Event
 pub fn set_global_default(dispatcher: Dispatch) -> Result<(), SetGlobalDefaultError> {

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -113,11 +113,10 @@
 //! </div>
 //! <div class="example-wrap" style="display:inline-block">
 //! <pre class="ignore" style="white-space:normal;font:inherit;">
-//! <strong>Note</strong>:the thread-local scoped dispatcher
-//! (<a href="#fn.with_default"><code>with_default</code></a>) requires the
-//! Rust standard library. <code>no_std</code> users should use
-//! <a href="#fn.set_global_default"><code>set_global_default</code></a>
-//! instead.
+//!
+//! **Note**: the thread-local scoped dispatcher ([`with_default`]) requires the
+//! Rust standard library. `no_std` users should use [`set_global_default`] instead.
+//!
 //! </pre></div>
 //!
 //! ## Accessing the Default Subscriber
@@ -128,9 +127,6 @@
 //! instrumentation.
 //!
 //! [`Subscriber`]: Subscriber
-//! [`with_default`]: fn.with_default.html
-//! [`set_global_default`]: fn.set_global_default.html
-//! [`get_default`]: fn.get_default.html
 //! [`Dispatch`]: Dispatch
 use crate::{
     callsite, span,
@@ -217,14 +213,16 @@ pub struct DefaultGuard(Option<Dispatch>);
 /// <div class="example-wrap" style="display:inline-block">
 /// <pre class="ignore" style="white-space:normal;font:inherit;">
 /// <strong>Note</strong>: This function required the Rust standard library.
-/// <code>no_std</code> users should use <a href="super::fn.set_global_default.html">
-/// <code>set_global_default</code></a> instead.
+/// <!-- hack: this whitespace makes rustdoc interpret the next line as markdown again -->
+///
+/// `no_std` users should use [`set_global_default`] instead.
+///
 /// </pre></div>
 ///
 /// [span]: super::span::index.html
 /// [`Subscriber`]: super::subscriber::Subscriber
 /// [`Event`]: super::event::Event
-/// [`set_global_default`]: super::fn.set_global_default.html
+/// [`set_global_default`]: set_global_default
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn with_default<T>(dispatcher: &Dispatch, f: impl FnOnce() -> T) -> T {
@@ -244,12 +242,11 @@ pub fn with_default<T>(dispatcher: &Dispatch, f: impl FnOnce() -> T) -> T {
 /// </div>
 /// <div class="example-wrap" style="display:inline-block">
 /// <pre class="ignore" style="white-space:normal;font:inherit;">
-/// <strong>Note</strong>: This function required the Rust standard library.
-/// <code>no_std</code> users should use <a href="super::fn.set_global_default.html">
-/// <code>set_global_default</code></a> instead.
-/// </pre></div>
 ///
-/// [`set_global_default`]: super::fn.set_global_default.html
+/// **Note**: This function required the Rust standard library.
+/// `no_std` users should use [`set_global_default`] instead.
+///
+/// </pre></div>
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[must_use = "Dropping the guard unregisters the dispatcher."]
@@ -580,9 +577,10 @@ impl Dispatch {
     ///     <div class="tooltip compile_fail" style="">&#x26a0; &#xfe0f;<span class="tooltiptext">Warning</span></div>
     /// </div>
     /// <div class="example-wrap" style="display:inline-block"><pre class="compile_fail" style="white-space:normal;font:inherit;">
-    /// <strong>Deprecated</strong>: The <a href="Self::try_close"><code>try_close</code></a>
-    /// method is functionally identical, but returns <code>true</code> if the span is now closed.
+    ///
+    /// **Deprecated**: The [`try_close`] method is functionally identical, but returns `true` if the span is now closed.
     /// It should be used instead of this method.
+    ///
     /// </pre></div>
     ///
     /// [span ID]: super::span::Id

--- a/tracing-core/src/event.rs
+++ b/tracing-core/src/event.rs
@@ -81,7 +81,7 @@ impl<'a> Event<'a> {
 
     /// Visits all the fields on this `Event` with the specified [visitor].
     ///
-    /// [visitor]: ../field/trait.Visit.html
+    /// [visitor]: super::field::Visit
     #[inline]
     pub fn record(&self, visitor: &mut dyn field::Visit) {
         self.fields.record(visitor);
@@ -94,7 +94,7 @@ impl<'a> Event<'a> {
 
     /// Returns [metadata] describing this `Event`.
     ///
-    /// [metadata]: ../struct.Metadata.html
+    /// [metadata]: super::Metadata
     pub fn metadata(&self) -> &'static Metadata<'static> {
         self.metadata
     }

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -27,8 +27,7 @@
 //! we might record integers by incrementing counters for their field names,
 //! rather than printing them.
 //!
-//! [`Value`]: Value
-//! [span]: ../span/
+//! [span]: super::span
 //! [`Event`]: super::event::Event
 //! [`Metadata`]: super::metadata::Metadata
 //! [`Attributes`]:  super::span::Attributes
@@ -36,8 +35,6 @@
 //! [`new_span`]: super::subscriber::Subscriber::new_span
 //! [`record`]: super::subscriber::Subscriber::record
 //! [`event`]:  super::subscriber::Subscriber::event
-//! [`Value::record`]: Value::record
-//! [`Visit`]: Visit
 use crate::callsite;
 use crate::stdlib::{
     borrow::Borrow,
@@ -166,7 +163,7 @@ pub struct Iter {
 /// This visitor (which is probably not particularly useful) keeps a running
 /// sum of all the numeric values it records, and ignores all other values. A
 /// more practical example of recording typed values is presented in
-/// `examples::counters.rs`, which demonstrates a very simple metrics system
+/// `examples/counters.rs`, which demonstrates a very simple metrics system
 /// implemented using `tracing`.
 ///
 /// <div class="information">
@@ -179,13 +176,11 @@ pub struct Iter {
 /// <code>std::error::Error</code> trait.
 /// </pre></div>
 ///
-/// [`Value`]: Value
 /// [recorded]: Value::record
 /// [`Subscriber`]: super::subscriber::Subscriber
 /// [records an `Event`]: super::subscriber::Subscriber::event
 /// [set of `Value`s added to a `Span`]: super::subscriber::Subscriber::record
 /// [`Event`]: super::event::Event
-/// [`ValueSet`]: ValueSet
 pub trait Visit {
     /// Visit a signed 64-bit integer value.
     fn record_i64(&mut self, field: &Field, value: i64) {

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -27,17 +27,17 @@
 //! we might record integers by incrementing counters for their field names,
 //! rather than printing them.
 //!
-//! [`Value`]: trait.Value.html
+//! [`Value`]: Value
 //! [span]: ../span/
-//! [`Event`]: ../event/struct.Event.html
-//! [`Metadata`]: ../metadata/struct.Metadata.html
-//! [`Attributes`]:  ../span/struct.Attributes.html
-//! [`Record`]: ../span/struct.Record.html
-//! [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
-//! [`record`]: ../subscriber/trait.Subscriber.html#method.record
-//! [`event`]:  ../subscriber/trait.Subscriber.html#method.event
-//! [`Value::record`]: trait.Value.html#method.record
-//! [`Visit`]: trait.Visit.html
+//! [`Event`]: super::event::Event
+//! [`Metadata`]: super::metadata::Metadata
+//! [`Attributes`]:  super::span::Attributes
+//! [`Record`]: super::span::Record
+//! [`new_span`]: super::subscriber::Subscriber::new_span
+//! [`record`]: super::subscriber::Subscriber::record
+//! [`event`]:  super::subscriber::Subscriber::event
+//! [`Value::record`]: Value::record
+//! [`Visit`]: Visit
 use crate::callsite;
 use crate::stdlib::{
     borrow::Borrow,
@@ -166,7 +166,7 @@ pub struct Iter {
 /// This visitor (which is probably not particularly useful) keeps a running
 /// sum of all the numeric values it records, and ignores all other values. A
 /// more practical example of recording typed values is presented in
-/// `examples/counters.rs`, which demonstrates a very simple metrics system
+/// `examples::counters.rs`, which demonstrates a very simple metrics system
 /// implemented using `tracing`.
 ///
 /// <div class="information">
@@ -179,13 +179,13 @@ pub struct Iter {
 /// <code>std::error::Error</code> trait.
 /// </pre></div>
 ///
-/// [`Value`]: trait.Value.html
-/// [recorded]: trait.Value.html#method.record
-/// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-/// [records an `Event`]: ../subscriber/trait.Subscriber.html#method.event
-/// [set of `Value`s added to a `Span`]: ../subscriber/trait.Subscriber.html#method.record
-/// [`Event`]: ../event/struct.Event.html
-/// [`ValueSet`]: struct.ValueSet.html
+/// [`Value`]: Value
+/// [recorded]: Value::record
+/// [`Subscriber`]: super::subscriber::Subscriber
+/// [records an `Event`]: super::subscriber::Subscriber::event
+/// [set of `Value`s added to a `Span`]: super::subscriber::Subscriber::record
+/// [`Event`]: super::event::Event
+/// [`ValueSet`]: ValueSet
 pub trait Visit {
     /// Visit a signed 64-bit integer value.
     fn record_i64(&mut self, field: &Field, value: i64) {
@@ -233,7 +233,7 @@ pub trait Visit {
 /// the [visitor] passed to their `record` method in order to indicate how
 /// their data should be recorded.
 ///
-/// [visitor]: trait.Visit.html
+/// [visitor]: Visit
 pub trait Value: crate::sealed::Sealed {
     /// Visits this value with the given `Visitor`.
     fn record(&self, key: &Field, visitor: &mut dyn Visit);
@@ -532,8 +532,8 @@ impl Field {
     /// Returns an [`Identifier`] that uniquely identifies the [`Callsite`]
     /// which defines this field.
     ///
-    /// [`Identifier`]: ../callsite/struct.Identifier.html
-    /// [`Callsite`]: ../callsite/trait.Callsite.html
+    /// [`Identifier`]: super::callsite::Identifier
+    /// [`Callsite`]: super::callsite::Callsite
     #[inline]
     pub fn callsite(&self) -> callsite::Identifier {
         self.fields.callsite()
@@ -598,15 +598,15 @@ impl FieldSet {
     /// Returns an [`Identifier`] that uniquely identifies the [`Callsite`]
     /// which defines this set of fields..
     ///
-    /// [`Identifier`]: ../callsite/struct.Identifier.html
-    /// [`Callsite`]: ../callsite/trait.Callsite.html
+    /// [`Identifier`]: super::callsite::Identifier
+    /// [`Callsite`]: super::callsite::Callsite
     pub(crate) fn callsite(&self) -> callsite::Identifier {
         callsite::Identifier(self.callsite.0)
     }
 
     /// Returns the [`Field`] named `name`, or `None` if no such field exists.
     ///
-    /// [`Field`]: ../struct.Field.html
+    /// [`Field`]: super::Field
     pub fn field<Q: ?Sized>(&self, name: &Q) -> Option<Field>
     where
         Q: Borrow<str>,
@@ -727,8 +727,8 @@ impl<'a> ValueSet<'a> {
     /// Returns an [`Identifier`] that uniquely identifies the [`Callsite`]
     /// defining the fields this `ValueSet` refers to.
     ///
-    /// [`Identifier`]: ../callsite/struct.Identifier.html
-    /// [`Callsite`]: ../callsite/trait.Callsite.html
+    /// [`Identifier`]: super::callsite::Identifier
+    /// [`Callsite`]: super::callsite::Callsite
     #[inline]
     pub fn callsite(&self) -> callsite::Identifier {
         self.fields.callsite()
@@ -736,7 +736,7 @@ impl<'a> ValueSet<'a> {
 
     /// Visits all the fields in this `ValueSet` with the provided [visitor].
     ///
-    /// [visitor]: ../trait.Visit.html
+    /// [visitor]: super::Visit
     pub(crate) fn record(&self, visitor: &mut dyn Visit) {
         let my_callsite = self.callsite();
         for (field, value) in self.values {

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -39,7 +39,7 @@
 //! for instrumenting libraries and applications, and are generally not
 //! necessary for `Subscriber` implementations.
 //!
-//! The [`tokio-rs::tracing`] repository contains less stable crates designed to
+//! The [`tokio-rs/tracing`] repository contains less stable crates designed to
 //! be used with the `tracing` ecosystem. It includes a collection of
 //! `Subscriber` implementations, as well as utility and adapter crates.
 //!
@@ -83,12 +83,12 @@
 //! [`Value`]: field::Value
 //! [`ValueSet`]: field::ValueSet
 //! [`Dispatch`]: dispatcher::Dispatch
-//! [`tokio-rs::tracing`]: https://github.com::tokio-rs::tracing
-//! [`tracing`]: https://crates.io::crates::tracing
-#![doc(html_root_url = "https://docs.rs::tracing-core/0.1.17")]
+//! [`tokio-rs/tracing`]: https://github.com/tokio-rs/tracing
+//! [`tracing`]: https://crates.io/crates/tracing
+#![doc(html_root_url = "https://docs.rs/tracing-core/0.1.17")]
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com::tokio-rs::tracing::master::assets::logo-type.png",
-    issue_tracker_base_url = "https://github.com::tokio-rs::tracing::issues/"
+    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
+    issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -39,7 +39,7 @@
 //! for instrumenting libraries and applications, and are generally not
 //! necessary for `Subscriber` implementations.
 //!
-//! The [`tokio-rs/tracing`] repository contains less stable crates designed to
+//! The [`tokio-rs::tracing`] repository contains less stable crates designed to
 //! be used with the `tracing` ecosystem. It includes a collection of
 //! `Subscriber` implementations, as well as utility and adapter crates.
 //!
@@ -73,22 +73,22 @@
 //! long as doing so complies with this policy.
 //!
 //!
-//! [`span::Id`]: span/struct.Id.html
-//! [`Event`]: event/struct.Event.html
-//! [`Subscriber`]: subscriber/trait.Subscriber.html
-//! [`Metadata`]: metadata/struct.Metadata.html
-//! [`Callsite`]: callsite/trait.Callsite.html
-//! [`Field`]: field/struct.Field.html
-//! [`FieldSet`]: field/struct.FieldSet.html
-//! [`Value`]: field/trait.Value.html
-//! [`ValueSet`]: field/struct.ValueSet.html
-//! [`Dispatch`]: dispatcher/struct.Dispatch.html
-//! [`tokio-rs/tracing`]: https://github.com/tokio-rs/tracing
-//! [`tracing`]: https://crates.io/crates/tracing
-#![doc(html_root_url = "https://docs.rs/tracing-core/0.1.17")]
+//! [`span::Id`]: span::Id
+//! [`Event`]: event::Event
+//! [`Subscriber`]: subscriber::Subscriber
+//! [`Metadata`]: metadata::Metadata
+//! [`Callsite`]: callsite::Callsite
+//! [`Field`]: field::Field
+//! [`FieldSet`]: field::FieldSet
+//! [`Value`]: field::Value
+//! [`ValueSet`]: field::ValueSet
+//! [`Dispatch`]: dispatcher::Dispatch
+//! [`tokio-rs::tracing`]: https://github.com::tokio-rs::tracing
+//! [`tracing`]: https://crates.io::crates::tracing
+#![doc(html_root_url = "https://docs.rs::tracing-core/0.1.17")]
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
-    issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
+    html_logo_url = "https://raw.githubusercontent.com::tokio-rs::tracing::master::assets::logo-type.png",
+    issue_tracker_base_url = "https://github.com::tokio-rs::tracing::issues/"
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]
@@ -120,7 +120,7 @@ extern crate alloc;
 /// Statically constructs an [`Identifier`] for the provided [`Callsite`].
 ///
 /// This may be used in contexts, such as static initializers, where the
-/// [`Callsite::id`] function is not currently usable.
+/// [`Metadata::callsite`] function is not currently usable.
 ///
 /// For example:
 /// ```rust
@@ -146,9 +146,9 @@ extern crate alloc;
 /// # }
 /// ```
 ///
-/// [`Identifier`]: callsite/struct.Identifier.html
-/// [`Callsite`]: callsite/trait.Callsite.html
-/// [`Callsite::id`]: callsite/trait.Callsite.html#method.id
+/// [`Identifier`]: callsite::Identifier
+/// [`Callsite`]: callsite::Callsite
+/// [`Metadata::callsite`]: metadata::Metadata::callsite
 #[macro_export]
 macro_rules! identify_callsite {
     ($callsite:expr) => {
@@ -186,8 +186,8 @@ macro_rules! identify_callsite {
 /// # }
 /// ```
 ///
-/// [metadata]: metadata/struct.Metadata.html
-/// [`Metadata::new`]: metadata/struct.Metadata.html#method.new
+/// [metadata]: metadata::Metadata
+/// [`Metadata::new`]: metadata::Metadata::new
 #[macro_export]
 macro_rules! metadata {
     (

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -39,25 +39,25 @@ use crate::stdlib::{
 /// <div class="example-wrap" style="display:inline-block">
 /// <pre class="ignore" style="white-space:normal;font:inherit;">
 /// <strong>Note</strong>: Although instances of <code>Metadata</code> cannot
-/// be compared directly, they provide a method <a href="struct.Metadata.html#method.id">
-/// <code>id</code></a>, returning an opaque <a href="../callsite/struct.Identifier.html">
+/// be compared directly, they provide a method <a href="Metadata::id">
+/// <code>id</code></a>, returning an opaque <a href="super::callsite::Identifier">
 /// callsite identifier</a>  which uniquely identifies the callsite where the metadata
 /// originated. This can be used to determine if two <code>Metadata</code> correspond to
 /// the same callsite.
 /// </pre></div>
 ///
-/// [span]: ../span/index.html
-/// [event]: ../event/index.html
-/// [name]: #method.name
-/// [target]: #method.target
-/// [fields]: #method.fields
-/// [verbosity level]: #method.level
-/// [file name]: #method.file
-/// [line number]: #method.line
-/// [module path]: #method.module
-/// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-/// [`id`]: struct.Metadata.html#method.id
-/// [callsite identifier]: ../callsite/struct.Identifier.html
+/// [span]: super::span
+/// [event]: super::event
+/// [name]: Self::name
+/// [target]: Self::target
+/// [fields]: Self::fields
+/// [verbosity level]: Self::level
+/// [file name]: Self::file
+/// [line number]: Self::line
+/// [module path]: Self::module_path
+/// [`Subscriber`]: super::subscriber::Subscriber
+/// [`id`]: Metadata::id
+/// [callsite identifier]: super::callsite::Identifier
 pub struct Metadata<'a> {
     /// The name of the span described by this metadata.
     name: &'static str,
@@ -408,7 +408,7 @@ impl LevelFilter {
     /// Returns the most verbose [`Level`] that this filter accepts, or `None`
     /// if it is [`OFF`].
     ///
-    /// [`Level`]: ../struct.Level.html
+    /// [`Level`]: super::Level
     /// [`OFF`]: #associatedconstant.OFF
     pub const fn into_level(self) -> Option<Level> {
         self.0
@@ -442,8 +442,8 @@ impl LevelFilter {
     /// *disabled*, but **should not** be used for determining if something is
     /// *enabled*.`
     ///
-    /// [`Level`]: ../struct.Level.html
-    /// [`Subscriber`]: ../../trait.Subscriber.html
+    /// [`Level`]: super::Level
+    /// [`Subscriber`]: super::../Subscriber
     #[inline(always)]
     pub fn current() -> Self {
         match MAX_LEVEL.load(Ordering::Relaxed) {
@@ -468,7 +468,7 @@ impl LevelFilter {
                 // an identity conversion from integer -> discriminant, rather
                 // than generating a lookup table. We want to ensure this
                 // function is a single `mov` instruction (on x86) if at all
-                // possible, because it is called *every* time a span/event
+                // possible, because it is called *every* time a span::event
                 // callsite is hit; and it is (potentially) the only code in the
                 // hottest path for skipping a majority of callsites when level
                 // filtering is in use.

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -443,7 +443,7 @@ impl LevelFilter {
     /// *enabled*.`
     ///
     /// [`Level`]: super::Level
-    /// [`Subscriber`]: super::../Subscriber
+    /// [`Subscriber`]: super::Subscriber
     #[inline(always)]
     pub fn current() -> Self {
         match MAX_LEVEL.load(Ordering::Relaxed) {
@@ -468,7 +468,7 @@ impl LevelFilter {
                 // an identity conversion from integer -> discriminant, rather
                 // than generating a lookup table. We want to ensure this
                 // function is a single `mov` instruction (on x86) if at all
-                // possible, because it is called *every* time a span::event
+                // possible, because it is called *every* time a span/event
                 // callsite is hit; and it is (potentially) the only code in the
                 // hottest path for skipping a majority of callsites when level
                 // filtering is in use.

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -38,12 +38,13 @@ use crate::stdlib::{
 /// </div>
 /// <div class="example-wrap" style="display:inline-block">
 /// <pre class="ignore" style="white-space:normal;font:inherit;">
-/// <strong>Note</strong>: Although instances of <code>Metadata</code> cannot
-/// be compared directly, they provide a method <a href="Metadata::id">
-/// <code>id</code></a>, returning an opaque <a href="super::callsite::Identifier">
-/// callsite identifier</a>  which uniquely identifies the callsite where the metadata
-/// originated. This can be used to determine if two <code>Metadata</code> correspond to
-/// the same callsite.
+///
+/// **Note**: Although instances of `Metadata` cannot
+/// be compared directly, they provide a method [`callsite`][Metadata::callsite],
+/// returning an opaque [callsite identifier] which uniquely identifies the
+/// callsite where the metadata originated. This can be used to determine if two
+/// `Metadata` correspond to the same callsite.
+///
 /// </pre></div>
 ///
 /// [span]: super::span
@@ -56,7 +57,6 @@ use crate::stdlib::{
 /// [line number]: Self::line
 /// [module path]: Self::module_path
 /// [`Subscriber`]: super::subscriber::Subscriber
-/// [`id`]: Metadata::id
 /// [callsite identifier]: super::callsite::Identifier
 pub struct Metadata<'a> {
     /// The name of the span described by this metadata.

--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -9,8 +9,8 @@ use crate::{field, Metadata};
 /// the [`new_span`] trait method. See the documentation for that method for
 /// more information on span ID generation.
 ///
-/// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-/// [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
+/// [`Subscriber`]: super::subscriber::Subscriber
+/// [`new_span`]: super::subscriber::Subscriber::new_span
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Id(NonZeroU64);
 
@@ -37,9 +37,9 @@ pub struct Record<'a> {
 /// - "none", indicating that the current context is known to not be in a span,
 /// - "some", with the current span's [`Id`] and [`Metadata`].
 ///
-/// [the `Subscriber` considers]: ../subscriber/trait.Subscriber.html#method.current_span
-/// [`Id`]: struct.Id.html
-/// [`Metadata`]: ../metadata/struct.Metadata.html
+/// [the `Subscriber` considers]: super::subscriber::Subscriber::current_span
+/// [`Id`]: Id
+/// [`Metadata`]: super::metadata::Metadata
 #[derive(Debug)]
 pub struct Current {
     inner: CurrentInner,
@@ -75,7 +75,7 @@ impl Id {
 
     /// Constructs a new span ID from the given `NonZeroU64`.
     ///
-    /// Unlike [`Id::from_u64`](#method.from_u64), this will never panic.
+    /// Unlike [`Id::from_u64`](Self::from_u64), this will never panic.
     #[inline]
     pub const fn from_non_zero_u64(id: NonZeroU64) -> Self {
         Id(id)
@@ -181,7 +181,7 @@ impl<'a> Attributes<'a> {
     /// Records all the fields in this set of `Attributes` with the provided
     /// [Visitor].
     ///
-    /// [visitor]: ../field/trait.Visit.html
+    /// [visitor]: super::field::Visit
     pub fn record(&self, visitor: &mut dyn field::Visit) {
         self.values.record(visitor)
     }
@@ -208,7 +208,7 @@ impl<'a> Record<'a> {
 
     /// Records all the fields in this `Record` with the provided [Visitor].
     ///
-    /// [visitor]: ../field/trait.Visit.html
+    /// [visitor]: super::field::Visit
     pub fn record(&self, visitor: &mut dyn field::Visit) {
         self.values.record(visitor)
     }
@@ -260,9 +260,9 @@ impl Current {
     /// `None`, but in this case, that is because the subscriber does not keep
     /// track of the currently-entered span.
     ///
-    /// [`id`]: #method.id
-    /// [`metadata`]: #method.metadata
-    /// [`into_inner`]: #method.into_inner
+    /// [`id`]: Self::id
+    /// [`metadata`]: Self::metadata
+    /// [`into_inner`]: Self::into_inner
     pub fn is_known(&self) -> bool {
         !matches!(self.inner, CurrentInner::Unknown)
     }

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -60,13 +60,13 @@ use crate::stdlib::any::{Any, TypeId};
 ///   Subscribers which store per-span data or which need to track span closures
 ///   should override these functions together.
 ///
-/// [ID]: ../span/struct.Id.html
-/// [`new_span`]: trait.Subscriber.html#method.new_span
-/// [`register_callsite`]: trait.Subscriber.html#method.register_callsite
-/// [`Interest`]: struct.Interest.html
-/// [`enabled`]: trait.Subscriber.html#method.enabled
-/// [`clone_span`]: trait.Subscriber.html#method.clone_span
-/// [`try_close`]: trait.Subscriber.html#method.try_close
+/// [ID]: super::span::Id
+/// [`new_span`]: Subscriber::new_span
+/// [`register_callsite`]: Subscriber::register_callsite
+/// [`Interest`]: Interest
+/// [`enabled`]: Subscriber::enabled
+/// [`clone_span`]: Subscriber::clone_span
+/// [`try_close`]: Subscriber::try_close
 pub trait Subscriber: 'static {
     // === Span registry methods ==============================================
 
@@ -96,7 +96,7 @@ pub trait Subscriber: 'static {
     /// never be enabled unless a new subscriber expresses interest in it.
     ///
     /// `Subscriber`s which require their filters to be run every time an event
-    /// occurs or a span is entered/exited should return `Interest::sometimes`.
+    /// occurs or a span is entered::exited should return `Interest::sometimes`.
     /// If a subscriber returns `Interest::sometimes`, then its' [`enabled`] method
     /// will be called every time an event or span is created from that callsite.
     ///
@@ -132,11 +132,11 @@ pub trait Subscriber: 'static {
     /// _may_ still see spans and events originating from that callsite, if
     /// another subscriber expressed interest in it.
     ///
-    /// [filter]: #method.enabled
-    /// [metadata]: ../metadata/struct.Metadata.html
-    /// [`Interest`]: struct.Interest.html
-    /// [`enabled`]: #method.enabled
-    /// [`rebuild_interest_cache`]: ../callsite/fn.rebuild_interest_cache.html
+    /// [filter]: Self::enabled
+    /// [metadata]: super::metadata::Metadata
+    /// [`Interest`]: Interest
+    /// [`enabled`]: Self::enabled
+    /// [`rebuild_interest_cache`]: super::callsite::fn.rebuild_interest_cache.html
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         if self.enabled(metadata) {
             Interest::always()
@@ -161,10 +161,10 @@ pub trait Subscriber: 'static {
     /// [`Interest::sometimes`]. In that case, this function will be called every
     /// time that span or event occurs.
     ///
-    /// [metadata]: ../metadata/struct.Metadata.html
-    /// [interested]: struct.Interest.html
-    /// [`Interest::sometimes`]: struct.Interest.html#method.sometimes
-    /// [`register_callsite`]: #method.register_callsite
+    /// [metadata]: super::metadata::Metadata
+    /// [interested]: Interest
+    /// [`Interest::sometimes`]: Interest::sometimes
+    /// [`register_callsite`]: Self::register_callsite
     fn enabled(&self, metadata: &Metadata<'_>) -> bool;
 
     /// Returns the highest [verbosity level][level] that this `Subscriber` will
@@ -187,9 +187,9 @@ pub trait Subscriber: 'static {
     /// [`rebuild_interest_cache`][rebuild] is called after the value of the max
     /// level changes.
     ///
-    /// [level]: ../struct.Level.html
-    /// [`Interest`]: struct.Interest.html
-    /// [rebuild]: ../callsite/fn.rebuild_interest_cache.html
+    /// [level]: super::Level
+    /// [`Interest`]: Interest
+    /// [rebuild]: super::callsite::fn.rebuild_interest_cache.html
     fn max_level_hint(&self) -> Option<LevelFilter> {
         None
     }
@@ -214,10 +214,10 @@ pub trait Subscriber: 'static {
     /// scheme it sees fit. Any guarantees about uniqueness, ordering, or ID
     /// reuse are left up to the subscriber implementation to determine.
     ///
-    /// [span ID]: ../span/struct.Id.html
-    /// [`Attributes`]: ../span/struct.Attributes.html
-    /// [visitor]: ../field/trait.Visit.html
-    /// [`record` method]: ../span/struct.Attributes.html#method.record
+    /// [span ID]: super::span::Id
+    /// [`Attributes`]: super::span::Attributes
+    /// [visitor]: super::field::Visit
+    /// [`record` method]: super::span::Attributes::record
     fn new_span(&self, span: &span::Attributes<'_>) -> span::Id;
 
     // === Notification methods ===============================================
@@ -256,9 +256,9 @@ pub trait Subscriber: 'static {
     /// span.record("baz", &"a string");
     /// ```
     ///
-    /// [visitor]: ../field/trait.Visit.html
-    /// [`record`]: ../span/struct.Attributes.html#method.record
-    /// [`record` method]: ../span/struct.Record.html#method.record
+    /// [visitor]: super::field::Visit
+    /// [`record`]: super::span::Attributes::record
+    /// [`record` method]: super::span::Record::record
     fn record(&self, span: &span::Id, values: &span::Record<'_>);
 
     /// Adds an indication that `span` follows from the span with the id
@@ -295,10 +295,10 @@ pub trait Subscriber: 'static {
     /// event. The subscriber may pass a [visitor] to the `Event`'s
     /// [`record` method] to record these values.
     ///
-    /// [`Event`]: ../event/struct.Event.html
-    /// [visitor]: ../field/trait.Visit.html
-    /// [`record` method]: ../event/struct.Event.html#method.record
-    /// [`dispatch` method]: ../event/struct.Event.html#method.dispatch
+    /// [`Event`]: super::event::Event
+    /// [visitor]: super::field::Visit
+    /// [`record` method]: super::event::Event::record
+    /// [`dispatch` method]: super::event::Event::dispatch
     fn event(&self, event: &Event<'_>);
 
     /// Records that a span has been entered.
@@ -308,7 +308,7 @@ pub trait Subscriber: 'static {
     /// [span ID] of the entered span, and should update any internal state
     /// tracking the current span accordingly.
     ///
-    /// [span ID]: ../span/struct.Id.html
+    /// [span ID]: super::span::Id
     fn enter(&self, span: &span::Id);
 
     /// Records that a span has been exited.
@@ -320,7 +320,7 @@ pub trait Subscriber: 'static {
     ///
     /// Exiting a span does not imply that the span will not be re-entered.
     ///
-    /// [span ID]: ../span/struct.Id.html
+    /// [span ID]: super::span::Id
     fn exit(&self, span: &span::Id);
 
     /// Notifies the subscriber that a [span ID] has been cloned.
@@ -341,8 +341,8 @@ pub trait Subscriber: 'static {
     /// kind this can be used as a hook to "clone" the pointer, depending on
     /// what that means for the specified pointer.
     ///
-    /// [span ID]: ../span/struct.Id.html
-    /// [`try_close`]: trait.Subscriber.html#method.try_close
+    /// [span ID]: super::span::Id
+    /// [`try_close`]: Subscriber::try_close
     fn clone_span(&self, id: &span::Id) -> span::Id {
         id.clone()
     }
@@ -355,7 +355,7 @@ pub trait Subscriber: 'static {
     ///
     /// The default implementation of this function does nothing.
     ///
-    /// [`try_close`]: trait.Subscriber.html#method.try_close
+    /// [`try_close`]: Subscriber::try_close
     #[deprecated(since = "0.1.2", note = "use `Subscriber::try_close` instead")]
     fn drop_span(&self, _id: span::Id) {}
 
@@ -392,9 +392,9 @@ pub trait Subscriber: 'static {
     /// inside of a `try_close` function may cause a double panic, if the span
     /// was dropped due to a thread unwinding.
     ///
-    /// [span ID]: ../span/struct.Id.html
-    /// [`clone_span`]: trait.Subscriber.html#method.clone_span
-    /// [`drop_span`]: trait.Subscriber.html#method.drop_span
+    /// [span ID]: super::span::Id
+    /// [`clone_span`]: Subscriber::clone_span
+    /// [`drop_span`]: Subscriber::drop_span
     fn try_close(&self, id: span::Id) -> bool {
         #[allow(deprecated)]
         self.drop_span(id);
@@ -412,8 +412,8 @@ pub trait Subscriber: 'static {
     /// does **not** track what span is current. If the subscriber does not
     /// implement a current span, it should not override this method.
     ///
-    /// [`Current::new`]: ../span/struct.Current.html#tymethod.new
-    /// [`Current::none`]: ../span/struct.Current.html#tymethod.none
+    /// [`Current::new`]: super::span::Current::new
+    /// [`Current::none`]: super::span::Current::none
     fn current_span(&self) -> span::Current {
         span::Current::unknown()
     }
@@ -479,8 +479,8 @@ impl dyn Subscriber {
 /// `Subscriber`s return an `Interest` from their [`register_callsite`] methods
 /// in order to determine whether that span should be enabled or disabled.
 ///
-/// [`Subscriber`]: ../trait.Subscriber.html
-/// [`register_callsite`]: ../trait.Subscriber.html#method.register_callsite
+/// [`Subscriber`]: super::Subscriber
+/// [`register_callsite`]: super::Subscriber::register_callsite
 #[derive(Clone, Debug)]
 pub struct Interest(InterestKind);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

This caught multiple broken links in the documentation. Partially addresses https://github.com/tokio-rs/tracing/issues/940.

## Solution

Use intra-doc links so rustdoc will give a loud warning if the documentation has errors.