### PR TITLE
Backport #1012

### DIFF
--- a/tracing-subscriber/src/filter/env/directive.rs
+++ b/tracing-subscriber/src/filter/env/directive.rs
@@ -181,7 +181,7 @@ impl FromStr for Directive {
                 ^(?P<global_level>trace|TRACE|debug|DEBUG|info|INFO|warn|WARN|error|ERROR|off|OFF|[0-5])$ |
                 ^
                 (?: # target name or span name
-                    (?P<target>[\w:]+)|(?P<span>\[[^\]]*\])
+                    (?P<target>[\w:-]+)|(?P<span>\[[^\]]*\])
                 ){1,2}
                 (?: # level or nothing
                     =(?P<level>trace|TRACE|debug|DEBUG|info|INFO|warn|WARN|error|ERROR|off|OFF|[0-5])?
@@ -1018,5 +1018,14 @@ mod test {
         assert_eq!(dirs[2].target, Some("crate2".to_string()));
         assert_eq!(dirs[2].level, LevelFilter::DEBUG);
         assert_eq!(dirs[2].in_span, Some("baz".to_string()));
+    }
+
+    #[test]
+    fn parse_directives_with_dash_in_target_name() {
+        let dirs = parse_directives("target-name=info");
+        assert_eq!(dirs.len(), 1, "\nparsed: {:#?}", dirs);
+        assert_eq!(dirs[0].target, Some("target-name".to_string()));
+        assert_eq!(dirs[0].level, LevelFilter::INFO);
+        assert_eq!(dirs[0].in_span, None);
     }
 }

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -68,6 +68,11 @@ use tracing_core::{
 /// - If only a level is provided, it will set the maximum level for all `Span`s and `Event`s
 ///   that are not enabled by other filters.
 /// - A directive without a level will enable anything that it matches. This is equivalent to `=trace`.
+/// - When a crate has a dash in its name, the default target for events will be the
+///   crate's module path as it appears in Rust. This means every dash will be replaced
+///   with an underscore.
+/// - A dash in a target will only appear when being specified explicitly:
+///   `tracing::info!(target: "target-name", ...);`
 ///
 /// ## Examples
 ///


### PR DESCRIPTION
Backports: https://github.com/tokio-rs/tracing/pull/1012

@hawkw should I directly bump the crate version?