### PR TITLE
Backport #990 (subscriber: warn if trying to enable a statically disabled level)

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -34,7 +34,7 @@ json = ["tracing-serde", "serde", "serde_json"]
 tracing-core = { path = "../tracing-core", version = "0.1.17" }
 
 # only required by the filter feature
-tracing = { optional = true, path = "../tracing", version = "0.2" }
+tracing = { optional = true, path = "../tracing", version = "0.1" }
 matchers = { optional = true, version = "0.0.1" }
 regex = { optional = true, version = "1", default-features = false, features = ["std"] }
 smallvec = { optional = true, version = "1" }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -24,7 +24,7 @@ keywords = ["logging", "tracing", "metrics", "subscriber"]
 [features]
 
 default = ["env-filter", "smallvec", "fmt", "ansi", "chrono", "tracing-log", "json"]
-env-filter = ["matchers", "regex", "lazy_static"]
+env-filter = ["matchers", "regex", "lazy_static", "tracing"]
 fmt = ["registry"]
 ansi = ["fmt", "ansi_term"]
 registry = ["sharded-slab", "thread_local"]
@@ -34,6 +34,7 @@ json = ["tracing-serde", "serde", "serde_json"]
 tracing-core = { path = "../tracing-core", version = "0.1.17" }
 
 # only required by the filter feature
+tracing = { optional = true, path = "../tracing", version = "0.2" }
 matchers = { optional = true, version = "0.0.1" }
 regex = { optional = true, version = "1", default-features = false, features = ["std"] }
 smallvec = { optional = true, version = "1" }

--- a/tracing-subscriber/src/filter/env/directive.rs
+++ b/tracing-subscriber/src/filter/env/directive.rs
@@ -9,10 +9,10 @@ use tracing_core::{span, Level, Metadata};
 // TODO(eliza): add a builder for programmatically constructing directives?
 #[derive(Debug, Eq, PartialEq)]
 pub struct Directive {
-    target: Option<String>,
     in_span: Option<String>,
     fields: FilterVec<field::Match>,
-    level: LevelFilter,
+    pub(crate) target: Option<String>,
+    pub(crate) level: LevelFilter,
 }
 
 /// A directive which will statically enable or disable a given callsite.


### PR DESCRIPTION
This backports #990 so it can be used in rustc without having to upgrade to a new breaking version.