### PR TITLE
Convert _all_ the intra-doc links

### DIFF
--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -21,9 +21,9 @@
 //! ```
 //!
 //! This crate can be used in a few ways to record spans/events:
-//!  - Using a [`RollingFileAppender`][rolling_struct] to perform writes to a log file. This will block on writes.
+//!  - Using a [`RollingFileAppender`] to perform writes to a log file. This will block on writes.
 //!  - Using *any* type implementing [`std::io::Write`][write] in a non-blocking fashion.
-//!  - Using a combination of [`NonBlocking`][non_blocking] and [`RollingFileAppender`][rolling_struct] to allow writes to a log file
+//!  - Using a combination of [`NonBlocking`] and [`RollingFileAppender`] to allow writes to a log file
 //! without blocking.
 //!
 //! ## Rolling File Appender
@@ -89,9 +89,10 @@
 //! The [`non_blocking` module][non_blocking]'s documentation provides more detail on how to use `non_blocking`.
 //!
 //! [write]: https://doc.rust-lang.org/std/io/trait.Write.html
+//! [non_blocking]: mod@non_blocking
 //! [guard]: non_blocking::WorkerGuard
 //! [make_writer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/trait.MakeWriter.html
-//! [rolling_struct]: rolling::RollingFileAppender
+//! [`RollingFileAppender`]: rolling::RollingFileAppender
 //! [fmt_subscriber]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Subscriber.html
 //!
 //! ## Non-Blocking Rolling File Appender
@@ -163,8 +164,7 @@ mod worker;
 
 /// Convenience function for creating a non-blocking, off-thread writer.
 ///
-/// See the [`non_blocking` module's docs][non_blocking]'s for more details.
-///
+/// See the [`non_blocking` module's docs][mod@non_blocking]'s for more details.
 ///
 /// # Examples
 ///

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -10,7 +10,7 @@
 //! *Compiler support: [requires `rustc` 1.42+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
-//! [file_appender]: ./rolling/struct.RollingFileAppender.html
+//! [file_appender]: rolling::RollingFileAppender
 //! [tracing]: https://docs.rs/tracing/
 //!
 //! # Usage
@@ -88,12 +88,10 @@
 //!
 //! The [`non_blocking` module][non_blocking]'s documentation provides more detail on how to use `non_blocking`.
 //!
-//! [non_blocking]: ./non_blocking/index.html
 //! [write]: https://doc.rust-lang.org/std/io/trait.Write.html
-//! [guard]: ./non_blocking/struct.WorkerGuard.html
-//! [rolling]: ./rolling/index.html
+//! [guard]: non_blocking::WorkerGuard
 //! [make_writer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/trait.MakeWriter.html
-//! [rolling_struct]: ./rolling/struct.RollingFileAppender.html
+//! [rolling_struct]: rolling::RollingFileAppender
 //! [fmt_subscriber]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Subscriber.html
 //!
 //! ## Non-Blocking Rolling File Appender
@@ -167,7 +165,6 @@ mod worker;
 ///
 /// See the [`non_blocking` module's docs][non_blocking]'s for more details.
 ///
-/// [non_blocking]: ./non_blocking/index.html
 ///
 /// # Examples
 ///

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -19,7 +19,7 @@
 //! tracing_appender::non_blocking(std::io::stdout())
 //! # }
 //! ```
-//! [builder]: ./struct.NonBlockingBuilder.html#method.default
+//! [builder]: NonBlockingBuilder::default()
 //!
 //! <br/> This function returns a tuple of `NonBlocking` and `WorkerGuard`.
 //! `NonBlocking` implements [`MakeWriter`] which integrates with `tracing_subscriber`.
@@ -33,7 +33,7 @@
 //!
 //! See [`WorkerGuard`][worker_guard] for examples of using the guard.
 //!
-//! [worker_guard]: ./struct.WorkerGuard.html
+//! [worker_guard]: WorkerGuard
 //!
 //! # Examples
 //!
@@ -65,7 +65,7 @@ use tracing_subscriber::fmt::MakeWriter;
 /// backpressure will be exerted on senders, causing them to block their
 /// respective threads until there is available capacity.
 ///
-/// [non-blocking]: ./struct.NonBlocking.html
+/// [non-blocking]: NonBlocking
 /// Recommended to be a power of 2.
 pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 
@@ -78,7 +78,6 @@ pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 /// terminates abruptly (such as through an uncaught `panic` or a `std::process::exit`), some spans
 /// or events may not be written.
 ///
-/// [`NonBlocking`]: ./struct.NonBlocking.html
 /// Since spans/events and events recorded near a crash are often necessary for diagnosing the failure,
 /// `WorkerGuard` provides a mechanism to ensure that _all_ buffered logs are flushed to their output.
 /// `WorkerGuard` should be assigned in the `main` function or whatever the entrypoint of the program is.
@@ -135,8 +134,8 @@ impl NonBlocking {
     /// The returned `NonBlocking` writer will have the [default configuration][default] values.
     /// Other configurations can be specified using the [builder] interface.
     ///
-    /// [default]: ./struct.NonBlockingBuilder.html#method.default
-    /// [builder]: ./struct.NonBlockingBuilder.html
+    /// [default]: NonBlockingBuilder::default()
+    /// [builder]: NonBlockingBuilder
     pub fn new<T: Write + Send + Sync + 'static>(writer: T) -> (NonBlocking, WorkerGuard) {
         NonBlockingBuilder::default().finish(writer)
     }
@@ -170,7 +169,7 @@ impl NonBlocking {
 
 /// A builder for [`NonBlocking`][non-blocking].
 ///
-/// [non-blocking]: ./struct.NonBlocking.html
+/// [non-blocking]: NonBlocking
 #[derive(Debug)]
 pub struct NonBlockingBuilder {
     buffered_lines_limit: usize,

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -17,10 +17,6 @@
 //! will be created daily
 //! - [`Rotation::never()`][never]: This will result in log file located at `some_directory/log_file_name`
 //!
-//! [minutely]: fn.minutely.html
-//! [hourly]: fn.hourly.html
-//! [daily]: fn.daily.html
-//! [never]: fn.never.html
 //!
 //! # Examples
 //!
@@ -43,7 +39,7 @@ use std::path::Path;
 /// blocking the current thread.
 ///
 /// [write]: https://doc.rust-lang.org/nightly/std/io/trait.Write.html
-/// [non-blocking]: ../non_blocking/struct.NonBlocking.html
+/// [non-blocking]: super::non_blocking::NonBlocking
 ///
 /// # Examples
 ///
@@ -73,10 +69,6 @@ impl RollingFileAppender {
     /// - [`Rotation::daily()`][daily],
     /// - [`Rotation::never()`][never]
     ///
-    /// [minutely]: fn.minutely.html
-    /// [hourly]: fn.hourly.html
-    /// [daily]: fn.daily.html
-    /// [never]: fn.never.html
     ///
     /// # Examples
     /// ```rust

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -35,6 +35,7 @@
 //! ```
 //!
 //! [`tracing`]: https://crates.io/crates/tracing
+//! [instrument]: macro@instrument
 //! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 //!
 //! ## Supported Rust Versions

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -36,7 +36,6 @@
 //!
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
-//! [instrument]: attr.instrument.html
 //!
 //! ## Supported Rust Versions
 //!

--- a/tracing-core/src/collect.rs
+++ b/tracing-core/src/collect.rs
@@ -440,7 +440,7 @@ pub trait Collect: 'static {
     /// with the provided `TypeId`. Failure to ensure this will result in
     /// undefined behaviour, so implementing `downcast_raw` is unsafe.
     ///
-    /// [`downcast_ref`]: Collect::downcast_ref()
+    /// [`downcast_ref`]: #method.downcast_ref
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
         if id == TypeId::of::<Self>() {
             Some(self as *const Self as *const ())

--- a/tracing-core/src/collect.rs
+++ b/tracing-core/src/collect.rs
@@ -63,7 +63,6 @@ use core::any::{Any, TypeId};
 /// [ID]: super::span::Id
 /// [`new_span`]: Collect::new_span
 /// [`register_callsite`]: Collect::register_callsite
-/// [`Interest`]: Interest
 /// [`enabled`]: Collect::enabled
 /// [`clone_span`]: Collect::clone_span
 /// [`try_close`]: Collect::try_close
@@ -134,7 +133,6 @@ pub trait Collect: 'static {
     ///
     /// [filter]: Self::enabled
     /// [metadata]: super::metadata::Metadata
-    /// [`Interest`]: Interest
     /// [`enabled`]: Self::enabled
     /// [`rebuild_interest_cache`]: super::callsite::fn.rebuild_interest_cache.html
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
@@ -163,7 +161,6 @@ pub trait Collect: 'static {
     ///
     /// [metadata]: super::metadata::Metadata
     /// [interested]: Interest
-    /// [`Interest::sometimes`]: Interest::sometimes
     /// [`register_callsite`]: Self::register_callsite
     fn enabled(&self, metadata: &Metadata<'_>) -> bool;
 
@@ -188,7 +185,6 @@ pub trait Collect: 'static {
     /// level changes.
     ///
     /// [level]: super::Level
-    /// [`Interest`]: Interest
     /// [rebuild]: super::callsite::fn.rebuild_interest_cache.html
     fn max_level_hint(&self) -> Option<LevelFilter> {
         None
@@ -444,7 +440,7 @@ pub trait Collect: 'static {
     /// with the provided `TypeId`. Failure to ensure this will result in
     /// undefined behaviour, so implementing `downcast_raw` is unsafe.
     ///
-    /// [`downcast_ref`]: #method.downcast_ref
+    /// [`downcast_ref`]: Collect::downcast_ref()
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
         if id == TypeId::of::<Self>() {
             Some(self as *const Self as *const ())

--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -538,7 +538,6 @@ impl Dispatch {
     /// initialization of statics.
     ///
     /// [collector]: super::collect::Collect
-    /// [`Dispatch::new`]: Dispatch::new
     /// [`lazy_static`]: https://crates.io/crates/lazy_static
     pub fn from_static(collector: &'static (dyn Collect + Send + Sync)) -> Self {
         #[cfg(feature = "alloc")]

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -121,7 +121,6 @@
 //! long as doing so complies with this policy.
 //!
 //!
-//! [`span::Id`]: span::Id
 //! [`Event`]: event::Event
 //! [`Collect`]: collect::Collect
 //! [`Metadata`]: metadata::Metadata

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -409,7 +409,7 @@ impl LevelFilter {
     /// if it is [`OFF`].
     ///
     /// [`Level`]: super::Level
-    /// [`OFF`]: #associatedconstant.OFF
+    /// [`OFF`]: LevelFilter::OFF
     pub const fn into_level(self) -> Option<Level> {
         self.0
     }

--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -38,7 +38,6 @@ pub struct Record<'a> {
 /// - "some", with the current span's [`Id`] and [`Metadata`].
 ///
 /// [the `Collector` considers]: super::collect::Collect::current_span
-/// [`Id`]: Id
 /// [`Metadata`]: super::metadata::Metadata
 #[derive(Debug)]
 pub struct Current {

--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -60,7 +60,7 @@ use tracing::{Metadata, Span};
 /// [fields]: https://docs.rs/tracing/latest/tracing/field/index.html
 /// [futures]: https://doc.rust-lang.org/std/future/trait.Future.html
 /// [`tracing-futures`]: https://docs.rs/tracing-futures/
-/// [`with_spans`]: #method.with_spans
+/// [`with_spans`]: SpanTrace::with_spans()
 #[derive(Clone)]
 pub struct SpanTrace {
     span: Span,

--- a/tracing-error/src/layer.rs
+++ b/tracing-error/src/layer.rs
@@ -16,7 +16,7 @@ use tracing_subscriber::{
 /// provided, the [default format] is used instead.
 ///
 /// [subscriber]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/subscriber/trait.Subscribe.html
-/// [`SpanTrace`]: ../struct.SpanTrace.html
+/// [`SpanTrace`]: super::SpanTrace
 /// [field formatter]: https://docs.rs/tracing-subscriber/0.2.10/tracing_subscriber/fmt/trait.FormatFields.html
 /// [default format]: https://docs.rs/tracing-subscriber/0.2.10/tracing_subscriber/fmt/format/struct.DefaultFields.html
 pub struct ErrorSubscriber<S, F = DefaultFields> {

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -157,13 +157,7 @@
 //! }
 //! ```
 //!
-//! [`SpanTrace`]: struct.SpanTrace.html
-//! [`ErrorSubscriber`]: struct.ErrorSubscriber.html
-//! [`TracedError`]: struct.TracedError.html
-//! [`InstrumentResult`]: trait.InstrumentResult.html
-//! [`InstrumentError`]: trait.InstrumentError.html
-//! [`ExtractSpanTrace`]: trait.ExtractSpanTrace.html
-//! [`in_current_span()`]: trait.InstrumentResult.html#tymethod.in_current_span
+//! [`in_current_span()`]: InstrumentResult::in_current_span
 //! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 //! [events]: https://docs.rs/tracing/latest/tracing/struct.Event.html
 //! [collector]: https://docs.rs/tracing/latest/tracing/trait.Collect.html

--- a/tracing-flame/src/lib.rs
+++ b/tracing-flame/src/lib.rs
@@ -91,8 +91,6 @@
 //!
 //! [`tracing`]: https://docs.rs/tracing
 //! [`inferno`]: https://docs.rs/inferno
-//! [`FlameLayer`]: struct.FlameLayer.html
-//! [`FlushGuard`]: struct.FlushGuard.html
 //! [`inferno-flamegraph`]: https://docs.rs/inferno/0.9.5/inferno/index.html#producing-a-flame-graph
 //!
 //! ## Supported Rust Versions
@@ -212,8 +210,7 @@ thread_local! {
 /// will flush the writer when it is dropped. If necessary, it can also be used to manually
 /// flush the writer.
 ///
-/// [`flush_on_drop`]: struct.FlameSubscriber.html#method.flush_on_drop
-/// [`FlushGuard`]: struct.FlushGuard.html
+/// [`flush_on_drop`]: FlameSubscriber::flush_on_drop()
 #[derive(Debug)]
 pub struct FlameSubscriber<C, W> {
     out: Arc<Mutex<W>>,

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -55,8 +55,6 @@
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 //! [collector]: https://docs.rs/tracing/latest/tracing/collect/index.html
-//! [`Instrument`]: trait.Instrument.html
-//! [`WithCollector`]: trait.WithCollector.html
 //! [`futures`]: https://crates.io/crates/futures
 //!
 //! ## Supported Rust Versions

--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -10,7 +10,7 @@
 //! [`tracing-subscriber::Subscriber`][subscriber] implementation for logging `tracing` spans
 //! and events to [`systemd-journald`][journald], on Linux distributions that
 //! use `systemd`.
-//!  
+//!
 //! *Compiler support: [requires `rustc` 1.42+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -87,12 +87,8 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
-//! [`init`]: struct.LogTracer.html#method.init
-//! [`init_with_filter`]: struct.LogTracer.html#method.init_with_filter
-//! [`AsTrace`]: trait.AsTrace.html
-//! [`AsLog`]: trait.AsLog.html
-//! [`LogTracer`]: struct.LogTracer.html
-//! [`env_logger`]: env_logger/index.html
+//! [`init`]: LogTracer::init()
+//! [`init_with_filter`]: LogTracer::init_with_filter()
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [`log`]: https://crates.io/crates/log
 //! [`env_logger` crate]: https://crates.io/crates/env-logger
@@ -380,7 +376,6 @@ impl AsTrace for log::Level {
 /// regardless of the source of its source.
 ///
 /// [`normalized_metadata`]: trait.NormalizeEvent.html#normalized_metadata
-/// [`AsTrace`]: trait.AsTrace.html
 /// [`log::Record`]: https://docs.rs/log/0.4.7/log/struct.Record.html
 pub trait NormalizeEvent<'a>: crate::sealed::Sealed {
     /// If this `Event` comes from a `log`, this method provides a new

--- a/tracing-log/src/log_tracer.rs
+++ b/tracing-log/src/log_tracer.rs
@@ -19,13 +19,12 @@
 //! such as when a crate emits both `tracing` diagnostics _and_ log records by
 //! default.
 //!
-//! [`LogTracer`]: struct.LogTracer.html
 //! [`log`]: https://docs.rs/log/0.4.8/log/
 //! [logger interface]: https://docs.rs/log/0.4.8/log/trait.Log.html
-//! [`init`]: struct.LogTracer.html#method.init.html
-//! [`init_with_filter`]: struct.LogTracer.html#method.init_with_filter.html
-//! [builder]: struct.LogTracer.html#method.builder
-//! [ignore]: struct.Builder.html#method.ignore_crate
+//! [`init`]: LogTracer.html#method.init
+//! [`init_with_filter`]: LogTracer.html#method.init_with_filter
+//! [builder]: LogTracer::builder()
+//! [ignore]: Builder::ignore_crate()
 use crate::{format_trace, AsTrace};
 pub use log::SetLoggerError;
 use tracing_core::dispatch;
@@ -93,7 +92,7 @@ impl LogTracer {
     /// # }
     /// ```
     ///
-    /// [`init`]: #method.init
+    /// [`init`]: LogTracer::init()
     /// [`init_with_filter`]: .#method.init_with_filter
     pub fn new() -> Self {
         Self {
@@ -109,7 +108,7 @@ impl LogTracer {
     /// The [`builder`] function can be used to customize the `LogTracer` before
     /// initializing it.
     ///
-    /// [`builder`]: #method.builder
+    /// [`builder`]: LogTracer::builder()
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn init_with_filter(level: log::LevelFilter) -> Result<(), SetLoggerError> {
@@ -143,8 +142,8 @@ impl LogTracer {
     /// If you know in advance you want to filter some log levels,
     /// use [`builder`] or [`init_with_filter`] instead.
     ///
-    /// [`init_with_filter`]: #method.init_with_filter
-    /// [`builder`]: #method.builder
+    /// [`init_with_filter`]: LogTracer::init_with_filter()
+    /// [`builder`]: LogTracer::builder()
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn init() -> Result<(), SetLoggerError> {
@@ -197,7 +196,6 @@ impl log::Log for LogTracer {
 impl Builder {
     /// Returns a new `Builder` to construct a [`LogTracer`].
     ///
-    /// [`LogTracer`]: struct.LogTracer.html
     pub fn new() -> Self {
         Self::default()
     }

--- a/tracing-opentelemetry/src/tracer.rs
+++ b/tracing-opentelemetry/src/tracer.rs
@@ -23,9 +23,6 @@ use opentelemetry::{api, sdk};
 /// [`Tracer`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/tracer/trait.Tracer.html
 /// [`SpanBuilder`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/tracer/struct.SpanBuilder.html
 /// [`SpanContext`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span_context/struct.SpanContext.html
-/// [`PreSampledTracer::sampled_span_context`]: trait.PreSampledTracer.html#tymethod.sampled_span_context
-/// [`OpenTelemetrySpanExt::set_parent`]: trait.OpenTelemetrySpanExt.html#tymethod.set_parent
-/// [`OpenTelemetrySpanExt::context`]: trait.OpenTelemetrySpanExt.html#tymethod.context
 pub trait PreSampledTracer {
     /// Produce a pre-sampled span context for the given span builder.
     fn sampled_span_context(&self, builder: &mut api::SpanBuilder) -> api::SpanContext;

--- a/tracing-opentelemetry/src/tracer.rs
+++ b/tracing-opentelemetry/src/tracer.rs
@@ -20,6 +20,8 @@ use opentelemetry::{api, sdk};
 /// See the [`OpenTelemetrySpanExt::set_parent`] and
 /// [`OpenTelemetrySpanExt::context`] methods for example usage.
 ///
+/// [`OpenTelemetrySpanExt::set_parent`]: crate::OpenTelemetrySpanExt::set_parent
+/// [`OpenTelemetrySpanExt::context`]: crate::OpenTelemetrySpanExt::context
 /// [`Tracer`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/tracer/trait.Tracer.html
 /// [`SpanBuilder`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/tracer/struct.SpanBuilder.html
 /// [`SpanContext`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span_context/struct.SpanContext.html

--- a/tracing-subscriber/src/field/delimited.rs
+++ b/tracing-subscriber/src/field/delimited.rs
@@ -41,7 +41,7 @@ impl<D, V> Delimited<D, V> {
     /// Returns a new [`MakeVisitor`] implementation that wraps `inner` so that
     /// it will format each visited field separated by the provided `delimiter`.
     ///
-    /// [`MakeVisitor`]: ../trait.MakeVisitor.html
+    /// [`MakeVisitor`]: super::MakeVisitor
     pub fn new(delimiter: D, inner: V) -> Self {
         Self { delimiter, inner }
     }

--- a/tracing-subscriber/src/field/display.rs
+++ b/tracing-subscriber/src/field/display.rs
@@ -18,7 +18,7 @@ impl<V> Messages<V> {
     /// Returns a new [`MakeVisitor`] implementation that will wrap `inner` so
     /// that any strings named `message` are formatted using `fmt::Display`.
     ///
-    /// [`MakeVisitor`]: ../trait.MakeVisitor.html
+    /// [`MakeVisitor`]: super::MakeVisitor
     pub fn new(inner: V) -> Self {
         Messages(inner)
     }

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -87,7 +87,7 @@ use tracing_core::{
 ///    - which has a field named `name` with value `bob`,
 ///    - at _any_ level.
 ///
-/// [`Subscriber`]: super::layer::Subscriber
+/// [`Subscriber`]: Subscribe
 /// [`env_logger`]: https://docs.rs/env_logger/0.7.1/env_logger/#enabling-logging
 /// [`Span`]: https://docs.rs/tracing-core/latest/tracing_core/span/index.html
 /// [fields]: https://docs.rs/tracing-core/latest/tracing_core/struct.Field.html
@@ -199,7 +199,6 @@ impl EnvFilter {
     /// and events as a previous filter, but sets a different level for those
     /// spans and events, the previous directive is overwritten.
     ///
-    /// [`LevelFilter`]: super::filter::LevelFilter
     /// [`Level`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Level.html
     ///
     /// # Examples

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -87,7 +87,7 @@ use tracing_core::{
 ///    - which has a field named `name` with value `bob`,
 ///    - at _any_ level.
 ///
-/// [`Subscriber`]: ../layer/trait.Subscriber.html
+/// [`Subscriber`]: super::layer::Subscriber
 /// [`env_logger`]: https://docs.rs/env_logger/0.7.1/env_logger/#enabling-logging
 /// [`Span`]: https://docs.rs/tracing-core/latest/tracing_core/span/index.html
 /// [fields]: https://docs.rs/tracing-core/latest/tracing_core/struct.Field.html
@@ -133,8 +133,6 @@ impl EnvFilter {
     /// `RUST_LOG` is the default environment variable used by
     /// [`EnvFilter::from_default_env`] and [`EnvFilter::try_from_default_env`].
     ///
-    /// [`EnvFilter::from_default_env`]: #method.from_default_env
-    /// [`EnvFilter::try_from_default_env`]: #method.try_from_default_env
     pub const DEFAULT_ENV: &'static str = "RUST_LOG";
 
     /// Returns a new `EnvFilter` from the value of the `RUST_LOG` environment
@@ -201,7 +199,7 @@ impl EnvFilter {
     /// and events as a previous filter, but sets a different level for those
     /// spans and events, the previous directive is overwritten.
     ///
-    /// [`LevelFilter`]: ../filter/struct.LevelFilter.html
+    /// [`LevelFilter`]: super::filter::LevelFilter
     /// [`Level`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Level.html
     ///
     /// # Examples

--- a/tracing-subscriber/src/filter/mod.rs
+++ b/tracing-subscriber/src/filter/mod.rs
@@ -1,7 +1,7 @@
 //! [`Subscriber`]s that control which spans and events are enabled by the wrapped
 //! subscriber.
 //!
-//! [`Subscriber`]: ../layer/trait.Subscriber.html
+//! [`Subscriber`]: super::layer::Subscriber
 #[cfg(feature = "env-filter")]
 mod env;
 mod level;

--- a/tracing-subscriber/src/filter/mod.rs
+++ b/tracing-subscriber/src/filter/mod.rs
@@ -1,7 +1,7 @@
 //! [`Subscriber`]s that control which spans and events are enabled by the wrapped
 //! subscriber.
 //!
-//! [`Subscriber`]: super::layer::Subscriber
+//! [`Subscriber`]: crate::fmt::Subscriber
 #[cfg(feature = "env-filter")]
 mod env;
 mod level;

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -56,7 +56,7 @@ use tracing_core::{
 /// # tracing::collect::set_global_default(subscriber).unwrap();
 /// ```
 ///
-/// [`Subscriber`]: super::layer::Subscriber
+/// [`Subscriber`]: subscribe::Subscribe
 #[derive(Debug)]
 pub struct Subscriber<
     S,
@@ -139,8 +139,8 @@ impl<S, N, E, W> Subscriber<S, N, E, W> {
     /// # let _ = layer.with_collector(tracing_subscriber::registry::Registry::default());
     /// ```
     ///
-    /// [`MakeWriter`]: super::fmt::MakeWriter
-    /// [`Subscriber`]: super::layer::Subscriber
+    /// [`MakeWriter`]: super::writer::MakeWriter
+    /// [`Subscriber`]: super::Subscriber
     pub fn with_writer<W2>(self, make_writer: W2) -> Subscriber<S, N, E, W2>
     where
         W2: MakeWriter + 'static,
@@ -175,7 +175,7 @@ impl<S, N, E, W> Subscriber<S, N, E, W> {
     /// ```
     /// [capturing]:
     /// https://doc.rust-lang.org/book/ch11-02-running-tests.html#showing-function-output
-    /// [`TestWriter`]: writer::TestWriter
+    /// [`TestWriter`]: super::writer::TestWriter
     pub fn with_test_writer(self) -> Subscriber<S, N, E, TestWriter> {
         Subscriber {
             fmt_fields: self.fmt_fields,
@@ -198,9 +198,10 @@ where
     /// Note that using the `chrono` feature flag enables the
     /// additional time formatters [`ChronoUtc`] and [`ChronoLocal`].
     ///
-    /// [`timer`]: time::FormatTime
-    /// [`ChronoUtc`]: time::ChronoUtc
-    /// [`ChronoLocal`]: time::ChronoLocal
+    /// [`time`]: mod@super::time
+    /// [`timer`]: super::time::FormatTime
+    /// [`ChronoUtc`]: super::time::ChronoUtc
+    /// [`ChronoLocal`]: super::time::ChronoLocal
     pub fn with_timer<T2>(self, timer: T2) -> Subscriber<S, N, format::Format<L, T2>, W> {
         Subscriber {
             fmt_event: self.fmt_event.with_timer(timer),
@@ -489,7 +490,7 @@ where
 /// formatters are in use, each can store its own formatted representation
 /// without conflicting.
 ///
-/// [extensions]: super::registry::Extensions
+/// [extensions]: crate::registry::Extensions
 #[derive(Default)]
 pub struct FormattedFields<E> {
     _format_event: PhantomData<fn(E)>,
@@ -789,7 +790,7 @@ where
     /// If this returns `None`, then no span exists for that ID (either it has
     /// closed or the ID is invalid).
     ///
-    /// [stored data]: super::registry::SpanRef
+    /// [stored data]: SpanRef
     #[inline]
     pub fn span(&self, id: &Id) -> Option<SpanRef<'_, S>>
     where
@@ -812,7 +813,7 @@ where
     ///
     /// If this returns `None`, then we are not currently within a span.
     ///
-    /// [stored data]: super::registry::SpanRef
+    /// [stored data]: SpanRef
     #[inline]
     pub fn lookup_current(&self) -> Option<SpanRef<'_, S>>
     where
@@ -825,7 +826,7 @@ where
     /// current context, starting the root of the trace tree and ending with
     /// the current span.
     ///
-    /// [stored data]: super::registry::SpanRef
+    /// [stored data]: SpanRef
     pub fn scope(&self) -> Scope<'_, S>
     where
         S: for<'lookup> LookupSpan<'lookup>,

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -56,7 +56,7 @@ use tracing_core::{
 /// # tracing::collect::set_global_default(subscriber).unwrap();
 /// ```
 ///
-/// [`Subscriber`]: ../layer/trait.Subscriber.html
+/// [`Subscriber`]: super::layer::Subscriber
 #[derive(Debug)]
 pub struct Subscriber<
     S,
@@ -104,8 +104,7 @@ where
     /// # use tracing_subscriber::Subscribe as _;
     /// # let _ = layer.with_collector(tracing_subscriber::registry::Registry::default());
     /// ```
-    /// [`FormatEvent`]: ./format/trait.FormatEvent.html
-    /// [`FmtContext`]: ./struct.FmtContext.html
+    /// [`FormatEvent`]: format::FormatEvent
     /// [`Event`]: https://docs.rs/tracing/latest/tracing/struct.Event.html
     pub fn event_format<E2>(self, e: E2) -> Subscriber<S, N, E2, W>
     where
@@ -140,8 +139,8 @@ impl<S, N, E, W> Subscriber<S, N, E, W> {
     /// # let _ = layer.with_collector(tracing_subscriber::registry::Registry::default());
     /// ```
     ///
-    /// [`MakeWriter`]: ../fmt/trait.MakeWriter.html
-    /// [`Subscriber`]: ../layer/trait.Subscriber.html
+    /// [`MakeWriter`]: super::fmt::MakeWriter
+    /// [`Subscriber`]: super::layer::Subscriber
     pub fn with_writer<W2>(self, make_writer: W2) -> Subscriber<S, N, E, W2>
     where
         W2: MakeWriter + 'static,
@@ -176,7 +175,7 @@ impl<S, N, E, W> Subscriber<S, N, E, W> {
     /// ```
     /// [capturing]:
     /// https://doc.rust-lang.org/book/ch11-02-running-tests.html#showing-function-output
-    /// [`TestWriter`]: writer/struct.TestWriter.html
+    /// [`TestWriter`]: writer::TestWriter
     pub fn with_test_writer(self) -> Subscriber<S, N, E, TestWriter> {
         Subscriber {
             fmt_fields: self.fmt_fields,
@@ -199,10 +198,9 @@ where
     /// Note that using the `chrono` feature flag enables the
     /// additional time formatters [`ChronoUtc`] and [`ChronoLocal`].
     ///
-    /// [`time`]: ./time/index.html
-    /// [`timer`]: ./time/trait.FormatTime.html
-    /// [`ChronoUtc`]: ./time/struct.ChronoUtc.html
-    /// [`ChronoLocal`]: ./time/struct.ChronoLocal.html
+    /// [`timer`]: time::FormatTime
+    /// [`ChronoUtc`]: time::ChronoUtc
+    /// [`ChronoLocal`]: time::ChronoLocal
     pub fn with_timer<T2>(self, timer: T2) -> Subscriber<S, N, format::Format<L, T2>, W> {
         Subscriber {
             fmt_event: self.fmt_event.with_timer(timer),
@@ -249,7 +247,7 @@ where
     /// `Subscriber`s added to this subscriber.
     ///
     /// [lifecycle]: https://docs.rs/tracing/latest/tracing/span/index.html#the-span-lifecycle
-    /// [time]: #method.without_time
+    /// [time]: Subscriber::without_time()
     pub fn with_span_events(self, kind: FmtSpan) -> Self {
         Subscriber {
             fmt_event: self.fmt_event,
@@ -371,7 +369,6 @@ where
     /// - [`Subscriber::flatten_event`] can be used to enable flattening event fields into the root
     /// object.
     ///
-    /// [`Subscriber::flatten_event`]: #method.flatten_event
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub fn json(self) -> Subscriber<S, format::JsonFields, format::Format<format::Json, T>, W> {
@@ -492,7 +489,7 @@ where
 /// formatters are in use, each can store its own formatted representation
 /// without conflicting.
 ///
-/// [extensions]: ../registry/struct.Extensions.html
+/// [extensions]: super::registry::Extensions
 #[derive(Default)]
 pub struct FormattedFields<E> {
     _format_event: PhantomData<fn(E)>,
@@ -792,7 +789,7 @@ where
     /// If this returns `None`, then no span exists for that ID (either it has
     /// closed or the ID is invalid).
     ///
-    /// [stored data]: ../registry/struct.SpanRef.html
+    /// [stored data]: super::registry::SpanRef
     #[inline]
     pub fn span(&self, id: &Id) -> Option<SpanRef<'_, S>>
     where
@@ -815,7 +812,7 @@ where
     ///
     /// If this returns `None`, then we are not currently within a span.
     ///
-    /// [stored data]: ../registry/struct.SpanRef.html
+    /// [stored data]: super::registry::SpanRef
     #[inline]
     pub fn lookup_current(&self) -> Option<SpanRef<'_, S>>
     where
@@ -828,7 +825,7 @@ where
     /// current context, starting the root of the trace tree and ending with
     /// the current span.
     ///
-    /// [stored data]: ../registry/struct.SpanRef.html
+    /// [stored data]: super::registry::SpanRef
     pub fn scope(&self) -> Scope<'_, S>
     where
         S: for<'lookup> LookupSpan<'lookup>,

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -359,8 +359,8 @@ impl<'a> FormatFields<'a> for JsonFields {
 
 /// The [visitor] produced by [`JsonFields`]'s [`MakeVisitor`] implementation.
 ///
-/// [visitor]: super::super::field::Visit
-/// [`MakeVisitor`]: super::super::field::MakeVisitor
+/// [visitor]: crate::field::Visit
+/// [`MakeVisitor`]: crate::field::MakeVisitor
 pub struct JsonVisitor<'a> {
     values: BTreeMap<&'a str, serde_json::Value>,
     writer: &'a mut dyn Write,

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -50,9 +50,6 @@ use tracing_log::NormalizeEvent;
 /// By default, event fields are not flattened, and both current span and span
 /// list are logged.
 ///
-/// [`Json::flatten_event`]: #method.flatten_event
-/// [`Json::with_current_span`]: #method.with_current_span
-/// [`Json::with_span_list`]: #method.with_span_list
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Json {
     pub(crate) flatten_event: bool,
@@ -286,7 +283,6 @@ impl Default for Json {
 
 /// The JSON [`FormatFields`] implementation.
 ///
-/// [`FormatFields`]: trait.FormatFields.html
 #[derive(Debug)]
 pub struct JsonFields {
     // reserve the ability to add fields to this without causing a breaking
@@ -297,7 +293,6 @@ pub struct JsonFields {
 impl JsonFields {
     /// Returns a new JSON [`FormatFields`] implementation.
     ///
-    /// [`FormatFields`]: trait.FormatFields.html
     pub fn new() -> Self {
         Self { _private: () }
     }
@@ -364,9 +359,8 @@ impl<'a> FormatFields<'a> for JsonFields {
 
 /// The [visitor] produced by [`JsonFields`]'s [`MakeVisitor`] implementation.
 ///
-/// [visitor]: ../../field/trait.Visit.html
-/// [`JsonFields`]: struct.JsonFields.html
-/// [`MakeVisitor`]: ../../field/trait.MakeVisitor.html
+/// [visitor]: super::super::field::Visit
+/// [`MakeVisitor`]: super::super::field::MakeVisitor
 pub struct JsonVisitor<'a> {
     values: BTreeMap<&'a str, serde_json::Value>,
     writer: &'a mut dyn Write,

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -79,12 +79,12 @@ where
 }
 /// A type that can format a [set of fields] to a `fmt::Write`.
 ///
-/// `FormatFields` is primarily used in the context of [`FmtSubscriber`]. Each
+/// `FormatFields` is primarily used in the context of [`fmt::Subscriber`]. Each
 /// time a span or event with fields is recorded, the subscriber will format
 /// those fields with its associated `FormatFields` implementation.
 ///
-/// [set of fields]: super::field::RecordFields
-/// [`FmtSubscriber`]: super::fmt::Collector
+/// [set of fields]: RecordFields
+/// [`fmt::Subscriber`]: super::Subscriber
 pub trait FormatFields<'writer> {
     /// Format the provided `fields` to the provided `writer`, returning a result.
     fn format_fields<R: RecordFields>(

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -46,8 +46,8 @@ use fmt::{Debug, Display};
 /// This trait is already implemented for function pointers with the same
 /// signature as `format_event`.
 ///
-/// [`fmt::Collector`]: ../struct.Collector.html
-/// [`fmt::Subscriber`]: ../struct.Subscriber.html
+/// [`fmt::Collector`]: super::Collector
+/// [`fmt::Subscriber`]: super::Subscriber
 pub trait FormatEvent<S, N>
 where
     S: Collect + for<'a> LookupSpan<'a>,
@@ -83,8 +83,8 @@ where
 /// time a span or event with fields is recorded, the subscriber will format
 /// those fields with its associated `FormatFields` implementation.
 ///
-/// [set of fields]: ../field/trait.RecordFields.html
-/// [`FmtSubscriber`]: ../fmt/struct.Collector.html
+/// [set of fields]: super::field::RecordFields
+/// [`FmtSubscriber`]: super::fmt::Collector
 pub trait FormatFields<'writer> {
     /// Format the provided `fields` to the provided `writer`, returning a result.
     fn format_fields<R: RecordFields>(
@@ -137,7 +137,6 @@ pub fn json() -> Format<Json> {
 /// Returns a [`FormatFields`] implementation that formats fields using the
 /// provided function or closure.
 ///
-/// [`FormatFields`]: trait.FormatFields.html
 pub fn debug_fn<F>(f: F) -> FieldFn<F>
 where
     F: Fn(&mut dyn fmt::Write, &Field, &dyn fmt::Debug) -> fmt::Result + Clone,
@@ -148,14 +147,12 @@ where
 /// A [`FormatFields`] implementation that formats fields by calling a function
 /// or closure.
 ///
-/// [`FormatFields`]: trait.FormatFields.html
 #[derive(Debug, Clone)]
 pub struct FieldFn<F>(F);
 /// The [visitor] produced by [`FieldFn`]'s [`MakeVisitor`] implementation.
 ///
-/// [visitor]: ../../field/trait.Visit.html
-/// [`FieldFn`]: struct.FieldFn.html
-/// [`MakeVisitor`]: ../../field/trait.MakeVisitor.html
+/// [visitor]: super::super::field::Visit
+/// [`MakeVisitor`]: super::super::field::MakeVisitor
 pub struct FieldFnVisitor<'a, F> {
     f: F,
     writer: &'a mut dyn fmt::Write,
@@ -255,7 +252,6 @@ impl<F, T> Format<F, T> {
     /// - [`Format::flatten_event`] can be used to enable flattening event fields into the root
     /// object.
     ///
-    /// [`Format::flatten_event`]: #method.flatten_event
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub fn json(self) -> Format<Json, T> {
@@ -277,10 +273,9 @@ impl<F, T> Format<F, T> {
     /// Note that using the `chrono` feature flag enables the
     /// additional time formatters [`ChronoUtc`] and [`ChronoLocal`].
     ///
-    /// [`time`]: ./time/index.html
-    /// [`timer`]: ./time/trait.FormatTime.html
-    /// [`ChronoUtc`]: ./time/struct.ChronoUtc.html
-    /// [`ChronoLocal`]: ./time/struct.ChronoLocal.html
+    /// [`timer`]: time::FormatTime
+    /// [`ChronoUtc`]: time::ChronoUtc
+    /// [`ChronoLocal`]: time::ChronoLocal
     pub fn with_timer<T2>(self, timer: T2) -> Format<F, T2> {
         Format {
             format: self.format,
@@ -581,7 +576,6 @@ where
 }
 /// The default [`FormatFields`] implementation.
 ///
-/// [`FormatFields`]: trait.FormatFields.html
 #[derive(Debug)]
 pub struct DefaultFields {
     // reserve the ability to add fields to this without causing a breaking
@@ -591,9 +585,8 @@ pub struct DefaultFields {
 
 /// The [visitor] produced by [`DefaultFields`]'s [`MakeVisitor`] implementation.
 ///
-/// [visitor]: ../../field/trait.Visit.html
-/// [`DefaultFields`]: struct.DefaultFields.html
-/// [`MakeVisitor`]: ../../field/trait.MakeVisitor.html
+/// [visitor]: super::super::field::Visit
+/// [`MakeVisitor`]: super::super::field::MakeVisitor
 pub struct DefaultVisitor<'a> {
     writer: &'a mut dyn Write,
     is_empty: bool,
@@ -603,7 +596,6 @@ pub struct DefaultVisitor<'a> {
 impl DefaultFields {
     /// Returns a new default [`FormatFields`] implementation.
     ///
-    /// [`FormatFields`]: trait.FormatFields.html
     pub fn new() -> Self {
         Self { _private: () }
     }

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -412,7 +412,7 @@ pub fn fmt() -> CollectorBuilder {
 /// This is a shorthand for the equivalent [`Subscriber::default`] function.
 ///
 /// [formatting subscriber]: Subscriber
-/// [composed]: super::layer
+/// [composed]: super::subscribe
 pub fn subscriber<S>() -> Subscriber<S> {
     Subscriber::default()
 }
@@ -616,6 +616,7 @@ where
     /// Note that using the `chrono` feature flag enables the
     /// additional time formatters [`ChronoUtc`] and [`ChronoLocal`].
     ///
+    /// [`time`]: mod@time
     /// [`timer`]: time::FormatTime
     /// [`ChronoUtc`]: time::ChronoUtc
     /// [`ChronoLocal`]: time::ChronoLocal
@@ -922,9 +923,8 @@ impl<N, E, F, W> CollectorBuilder<N, E, F, W> {
     /// Sets the maximum [verbosity level] that will be enabled by the
     /// collector.
     ///
-    /// If the max level has already been set, or a [`EnvFilter`] was added by
-    /// [`with_filter`], this replaces that configuration with the new
-    /// maximum level.
+    /// If the max level has already been set, this replaces that configuration
+    /// with the new maximum level.
     ///
     /// # Examples
     ///
@@ -947,7 +947,6 @@ impl<N, E, F, W> CollectorBuilder<N, E, F, W> {
     /// ```
     /// [verbosity level]: https://docs.rs/tracing-core/0.1.5/tracing_core/struct.Level.html
     /// [`EnvFilter`]: super::filter::EnvFilter
-    /// [`with_filter`]: CollectorBuilder::with_filter()
     pub fn with_max_level(
         self,
         filter: impl Into<LevelFilter>,

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -275,11 +275,11 @@
 //!     .init();
 //! ```
 //!
-//! [`EnvFilter`]: ../filter/struct.EnvFilter.html
+//! [`EnvFilter`]: super::filter::EnvFilter
 //! [`env_logger`]: https://docs.rs/env_logger/
-//! [`filter`]: ../filter/index.html
-//! [`fmtBuilder`]: ./struct.CollectorBuilder.html
-//! [`FmtCollector`]: ./struct.Collector.html
+//! [`filter`]: super::filter
+//! [`fmtBuilder`]: CollectorBuilder
+//! [`FmtCollector`]: Collector
 //! [`Collect`]:
 //!     https://docs.rs/tracing/latest/tracing/trait.Collect.html
 //! [`tracing`]: https://crates.io/crates/tracing
@@ -397,12 +397,11 @@ pub struct CollectorBuilder<
 /// })
 /// ```
 ///
-/// [`CollectorBuilder`]: struct.CollectorBuilder.html
-/// [formatting collector]: struct.Collector.html
-/// [`CollectorBuilder::default()`]: struct.CollectorBuilder.html#method.default
-/// [`init`]: struct.CollectorBuilder.html#method.init
-/// [`try_init`]: struct.CollectorBuilder.html#method.try_init
-/// [`finish`]: struct.CollectorBuilder.html#method.finish
+/// [formatting collector]: Collector
+/// [`CollectorBuilder::default()`]: CollectorBuilder::default()
+/// [`init`]: CollectorBuilder::init()
+/// [`try_init`]: CollectorBuilder::try_init()
+/// [`finish`]: CollectorBuilder::finish()
 pub fn fmt() -> CollectorBuilder {
     CollectorBuilder::default()
 }
@@ -412,9 +411,8 @@ pub fn fmt() -> CollectorBuilder {
 ///
 /// This is a shorthand for the equivalent [`Subscriber::default`] function.
 ///
-/// [formatting subscriber]: struct.Subscriber.html
-/// [composed]: ../subscribe/index.html
-/// [`Subscriber::default`]: struct.Subscriber.html#method.default
+/// [formatting subscriber]: Subscriber
+/// [composed]: super::layer
 pub fn subscriber<S>() -> Subscriber<S> {
     Subscriber::default()
 }
@@ -426,7 +424,6 @@ impl Collector {
     /// This can be overridden with the [`CollectorBuilder::with_max_level`] method.
     ///
     /// [verbosity level]: https://docs.rs/tracing-core/0.1.5/tracing_core/struct.Level.html
-    /// [`CollectorBuilder::with_max_level`]: struct.CollectorBuilder.html#method.with_max_level
     pub const DEFAULT_MAX_LEVEL: LevelFilter = LevelFilter::INFO;
 
     /// Returns a new `CollectorBuilder` for configuring a format subscriber.
@@ -619,10 +616,9 @@ where
     /// Note that using the `chrono` feature flag enables the
     /// additional time formatters [`ChronoUtc`] and [`ChronoLocal`].
     ///
-    /// [`time`]: ./time/index.html
-    /// [`timer`]: ./time/trait.FormatTime.html
-    /// [`ChronoUtc`]: ./time/struct.ChronoUtc.html
-    /// [`ChronoLocal`]: ./time/struct.ChronoLocal.html
+    /// [`timer`]: time::FormatTime
+    /// [`ChronoUtc`]: time::ChronoUtc
+    /// [`ChronoLocal`]: time::ChronoLocal
     pub fn with_timer<T2>(self, timer: T2) -> CollectorBuilder<N, format::Format<L, T2>, F, W> {
         CollectorBuilder {
             filter: self.filter,
@@ -663,7 +659,7 @@ where
     /// `Subscriber`s added to this subscriber.
     ///
     /// [lifecycle]: https://docs.rs/tracing/latest/tracing/span/index.html#the-span-lifecycle
-    /// [time]: #method.without_time
+    /// [time]: CollectorBuilder::without_time()
     pub fn with_span_events(self, kind: format::FmtSpan) -> Self {
         CollectorBuilder {
             filter: self.filter,
@@ -905,8 +901,8 @@ impl<N, E, F, W> CollectorBuilder<N, E, F, W> {
     ///     .try_init()?;
     /// # Ok(())}
     /// ```
-    /// [`EnvFilter`]: ../filter/struct.EnvFilter.html
-    /// [`with_max_level`]: #method.with_max_level
+    /// [`EnvFilter`]: super::filter::EnvFilter
+    /// [`with_max_level`]: CollectorBuilder::with_max_level()
     #[cfg(feature = "env-filter")]
     #[cfg_attr(docsrs, doc(cfg(feature = "env-filter")))]
     pub fn with_env_filter(
@@ -950,8 +946,8 @@ impl<N, E, F, W> CollectorBuilder<N, E, F, W> {
     ///     .finish();
     /// ```
     /// [verbosity level]: https://docs.rs/tracing-core/0.1.5/tracing_core/struct.Level.html
-    /// [`EnvFilter`]: ../filter/struct.EnvFilter.html
-    /// [`with_filter`]: #method.with_filter
+    /// [`EnvFilter`]: super::filter::EnvFilter
+    /// [`with_filter`]: CollectorBuilder::with_filter()
     pub fn with_max_level(
         self,
         filter: impl Into<LevelFilter>,
@@ -1037,7 +1033,6 @@ impl<N, E, F, W> CollectorBuilder<N, E, F, W> {
     ///     .init();
     /// ```
     ///
-    /// [`MakeWriter`]: trait.MakeWriter.html
     pub fn with_writer<W2>(self, make_writer: W2) -> CollectorBuilder<N, E, F, W2>
     where
         W2: MakeWriter + 'static,
@@ -1071,7 +1066,7 @@ impl<N, E, F, W> CollectorBuilder<N, E, F, W> {
     ///
     /// [capturing]:
     /// https://doc.rust-lang.org/book/ch11-02-running-tests.html#showing-function-output
-    /// [`TestWriter`]: writer/struct.TestWriter.html
+    /// [`TestWriter`]: writer::TestWriter
     pub fn with_test_writer(self) -> CollectorBuilder<N, E, F, TestWriter> {
         CollectorBuilder {
             filter: self.filter,

--- a/tracing-subscriber/src/fmt/time/mod.rs
+++ b/tracing-subscriber/src/fmt/time/mod.rs
@@ -18,7 +18,7 @@ mod datetime;
 ///
 /// The full list of provided implementations can be found in [`time`].
 ///
-/// [`time`]: ./index.html
+/// [`time`]: self
 pub trait FormatTime {
     /// Measure and write out the current time.
     ///

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -103,7 +103,7 @@ impl MakeWriter for TestWriter {
     }
 }
 
-/// A writer that erases the specific [`io::Write`] and [`Makewriter`] types being used.
+/// A writer that erases the specific [`io::Write`] and [`MakeWriter`] types being used.
 ///
 /// This is useful in cases where the concrete type of the writer cannot be known
 /// until runtime.

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -14,8 +14,8 @@ use std::{fmt::Debug, io};
 /// return an instance of [`io::Write`], such as [`io::stdout`] and [`io::stderr`].
 ///
 /// [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
-/// [`fmt::Collector`]: ../../fmt/struct.Collector.html
-/// [`fmt::Subscriber`]: ../../fmt/struct.Subscriber.html
+/// [`fmt::Collector`]: super::super::fmt::Collector
+/// [`fmt::Subscriber`]: super::super::fmt::Subscriber
 /// [`Event`]: https://docs.rs/tracing-core/0.1.5/tracing_core/event/struct.Event.html
 /// [`io::stdout`]: https://doc.rust-lang.org/std/io/fn.stdout.html
 /// [`io::stderr`]: https://doc.rust-lang.org/std/io/fn.stderr.html
@@ -23,7 +23,7 @@ pub trait MakeWriter {
     /// The concrete [`io::Write`] implementation returned by [`make_writer`].
     ///
     /// [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
-    /// [`make_writer`]: #tymethod.make_writer
+    /// [`make_writer`]: MakeWriter::make_writer
     type Writer: io::Write;
 
     /// Returns an instance of [`Writer`].
@@ -35,11 +35,10 @@ pub trait MakeWriter {
     /// creating a [`io::Write`] instance is expensive, be sure to cache it when implementing
     /// [`MakeWriter`] to improve performance.
     ///
-    /// [`Writer`]: #associatedtype.Writer
-    /// [`fmt::Subscriber`]: ../../fmt/struct.Subscriber.html
-    /// [`fmt::Collector`]: ../../fmt/struct.Collector.html
+    /// [`Writer`]: MakeWriter::Writer
+    /// [`fmt::Subscriber`]: super::super::fmt::Subscriber
+    /// [`fmt::Collector`]: super::super::fmt::Collector
     /// [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
-    /// [`MakeWriter`]: trait.MakeWriter.html
     fn make_writer(&self) -> Self::Writer;
 }
 
@@ -65,8 +64,8 @@ where
 /// Writing to [`io::stdout`] and [`io::stderr`] produces the same results as using
 /// [`libtest`'s `--nocapture` option][nocapture] which may make the results look unreadable.
 ///
-/// [`fmt::Collector`]: ../struct.Collector.html
-/// [`fmt::Subscriber`]: ../struct.Subscriber.html
+/// [`fmt::Collector`]: super::Collector
+/// [`fmt::Subscriber`]: super::Subscriber
 /// [capturing]: https://doc.rust-lang.org/book/ch11-02-running-tests.html#showing-function-output
 /// [nocapture]: https://doc.rust-lang.org/cargo/commands/cargo-test.html
 /// [`io::stdout`]: https://doc.rust-lang.org/std/io/fn.stdout.html
@@ -128,7 +127,6 @@ impl MakeWriter for TestWriter {
 /// }
 /// ```
 ///
-/// [`MakeWriter`]: trait.MakeWriter.html
 /// [`Collect`]: https://docs.rs/tracing/latest/tracing/trait.Collect.html
 /// [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 pub struct BoxMakeWriter {
@@ -138,7 +136,6 @@ pub struct BoxMakeWriter {
 impl BoxMakeWriter {
     /// Constructs a `BoxMakeWriter` wrapping a type implementing [`MakeWriter`].
     ///
-    /// [`MakeWriter`]: trait.MakeWriter.html
     pub fn new<M>(make_writer: M) -> Self
     where
         M: MakeWriter + Send + Sync + 'static,

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -59,14 +59,12 @@
 //!
 //! [`tracing`]: https://docs.rs/tracing/latest/tracing/
 //! [`Collect`]: https://docs.rs/tracing-core/latest/tracing_core/collect/trait.Collect.html
-//! [`EnvFilter`]: filter/struct.EnvFilter.html
-//! [`fmt`]: fmt/index.html
+//! [`EnvFilter`]: filter::EnvFilter
 //! [`tracing-log`]: https://crates.io/crates/tracing-log
 //! [`smallvec`]: https://crates.io/crates/smallvec
 //! [`chrono`]: https://crates.io/crates/chrono
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
-//! [`registry`]: registry/index.html
 #![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.12")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -57,6 +57,8 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
+//! [`fmt`]: mod@fmt
+//! [`registry`]: mod@registry
 //! [`tracing`]: https://docs.rs/tracing/latest/tracing/
 //! [`Collect`]: https://docs.rs/tracing-core/latest/tracing_core/collect/trait.Collect.html
 //! [`EnvFilter`]: filter::EnvFilter

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -54,11 +54,10 @@
 //! access to the [`Context`][ctx] methods, such as [`Context::span`][lookup], that
 //! require the root collector to be a registry.
 //!
-//! [`Subscribe`]: super::layer::serSubscribe
-//! [`Collect`]:
-//!     https://docs.rs/tracing-core/latest/tracing_core/collect/trait.Collect.html
-//! [ctx]: super::layer::Context
-//! [lookup]: super::layer::Context::span()
+//! [`Subscribe`]: crate::subscribe::Subscribe
+//! [`Collect`]: tracing_core::collect::Collect
+//! [ctx]: crate::subscribe::Context
+//! [lookup]: crate::subscribe::Context::span()
 use tracing_core::{field::FieldSet, span::Id, Metadata};
 
 /// A module containing a type map of span extensions.
@@ -82,9 +81,9 @@ pub use sharded::Registry;
 /// implement this trait; if they do, any [`Subscriber`]s wrapping them can look up
 /// metadata via the [`Context`] type's [`span()`] method.
 ///
-/// [`Subscriber`]: super::layer::Subscriber
-/// [`Context`]: super::layer::Context
-/// [`span()`]: super::layer::Context::span()
+/// [`Subscriber`]: crate::Subscribe
+/// [`Context`]: crate::subscribe::Context
+/// [`span()`]: crate::subscribe::Context::span()
 pub trait LookupSpan<'a> {
     /// The type of span data stored in this registry.
     type Data: SpanData<'a>;

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -54,14 +54,11 @@
 //! access to the [`Context`][ctx] methods, such as [`Context::span`][lookup], that
 //! require the root collector to be a registry.
 //!
-//! [`Subscribe`]: ../layer/trait.serSubscribe.html
+//! [`Subscribe`]: super::layer::serSubscribe
 //! [`Collect`]:
 //!     https://docs.rs/tracing-core/latest/tracing_core/collect/trait.Collect.html
-//! [`Registry`]: struct.Registry.html
-//! [ctx]: ../layer/struct.Context.html
-//! [lookup]: ../layer/struct.Context.html#method.span
-//! [`LookupSpan`]: trait.LookupSpan.html
-//! [`SpanData`]: trait.SpanData.html
+//! [ctx]: super::layer::Context
+//! [lookup]: super::layer::Context::span()
 use tracing_core::{field::FieldSet, span::Id, Metadata};
 
 /// A module containing a type map of span extensions.
@@ -85,9 +82,9 @@ pub use sharded::Registry;
 /// implement this trait; if they do, any [`Subscriber`]s wrapping them can look up
 /// metadata via the [`Context`] type's [`span()`] method.
 ///
-/// [`Subscriber`]: ../layer/trait.Subscriber.html
-/// [`Context`]: ../layer/struct.Context.html
-/// [`span()`]: ../layer/struct.Context.html#method.span
+/// [`Subscriber`]: super::layer::Subscriber
+/// [`Context`]: super::layer::Context
+/// [`span()`]: super::layer::Context::span()
 pub trait LookupSpan<'a> {
     /// The type of span data stored in this registry.
     type Data: SpanData<'a>;
@@ -106,7 +103,6 @@ pub trait LookupSpan<'a> {
     /// capable of performing more sophisiticated queries.
     /// </pre></div>
     ///
-    /// [`SpanData`]: trait.SpanData.html
     fn span_data(&'a self, id: &Id) -> Option<Self::Data>;
 
     /// Returns a [`SpanRef`] for the span with the given `Id`, if it exists.
@@ -118,9 +114,7 @@ pub trait LookupSpan<'a> {
     /// rather than the [`span_data`] method; while _implementors_ of this trait
     /// should only implement `span_data`.
     ///
-    /// [`SpanRef`]: struct.SpanRef.html
-    /// [`SpanData`]: trait.SpanData.html
-    /// [`span_data`]: #method.span_data
+    /// [`span_data`]: LookupSpan::span_data()
     fn span(&'a self, id: &Id) -> Option<SpanRef<'_, Self>>
     where
         Self: Sized,
@@ -163,8 +157,8 @@ pub trait SpanData<'a> {
 /// provides additional methods for querying the registry based on values from
 /// the span.
 ///
-/// [span data]: trait.SpanData.html
-/// [registry]: trait.LookupSpan.html
+/// [span data]: SpanData
+/// [registry]: LookupSpan
 #[derive(Debug)]
 pub struct SpanRef<'a, R: LookupSpan<'a>> {
     registry: &'a R,
@@ -175,7 +169,6 @@ pub struct SpanRef<'a, R: LookupSpan<'a>> {
 ///
 /// This is returned by the [`SpanRef::parents`] method.
 ///
-/// [`SpanRef::parents`]: struct.SpanRef.html#method.parents
 #[derive(Debug)]
 pub struct Parents<'a, R> {
     registry: &'a R,
@@ -187,7 +180,7 @@ pub struct Parents<'a, R> {
 ///
 /// For additonal details, see [`SpanRef::from_root`].
 ///
-/// [`Span::from_root`]: struct.SpanRef.html#method.from_root
+/// [`Span::from_root`]: SpanRef::from_root()
 pub struct FromRoot<'a, R: LookupSpan<'a>> {
     #[cfg(feature = "smallvec")]
     inner: std::iter::Rev<smallvec::IntoIter<SpanRefVecArray<'a, R>>>,

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -37,10 +37,9 @@ use tracing_core::{
 /// highly optimized for concurrent access.
 ///
 /// [slab]: https://docs.rs/crate/sharded-slab/
-/// [`Collect`]:
-///     https://docs.rs/crate/tracing-core/latest/tracing_core/collect/trait.Collect.html
-/// [`Subscriber`]: super::Subscriber
-/// [added]: super::Subscriber::with_subscriber()
+/// [`Subscriber`]: crate::Subscribe
+/// [added]: crate::FmtSubscriber::with_collector()
+/// [extensions]: super::Extensions
 #[cfg(feature = "registry")]
 #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
 #[derive(Debug)]
@@ -56,7 +55,7 @@ pub struct Registry {
 /// [`Subscriber`s], such as formatted fields, metrics, or distributed traces should
 /// be stored in the [extensions] typemap.
 ///
-/// [`Subscriber`s]: super::layer::Subscriber
+/// [`Subscriber`s]: crate::Subscribe
 /// [extensions]: Extensions
 #[cfg(feature = "registry")]
 #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -39,10 +39,8 @@ use tracing_core::{
 /// [slab]: https://docs.rs/crate/sharded-slab/
 /// [`Collect`]:
 ///     https://docs.rs/crate/tracing-core/latest/tracing_core/collect/trait.Collect.html
-/// [`Subscriber`]: ../trait.Subscriber.html
-/// [added]: ../trait.Subscriber.html#method.with_subscriber
-/// [`LookupSpan`]: trait.LookupSpan.html
-/// [extensions]: extensions/index.html
+/// [`Subscriber`]: super::Subscriber
+/// [added]: super::Subscriber::with_subscriber()
 #[cfg(feature = "registry")]
 #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
 #[derive(Debug)]
@@ -58,9 +56,8 @@ pub struct Registry {
 /// [`Subscriber`s], such as formatted fields, metrics, or distributed traces should
 /// be stored in the [extensions] typemap.
 ///
-/// [`Registry`]: struct.Registry.html
-/// [`Subscriber`s]: ../layer/trait.Subscriber.html
-/// [extensions]: struct.Extensions.html
+/// [`Subscriber`s]: super::layer::Subscriber
+/// [extensions]: Extensions
 #[cfg(feature = "registry")]
 #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
 #[derive(Debug)]
@@ -127,7 +124,6 @@ fn id_to_idx(id: &Id) -> usize {
 ///    greater than 0, `CloseGuard` decrements the counter by one and
 ///    _does not_ remove the span from the [`Registry`].
 ///
-/// [`Registry`]: ./struct.Registry.html
 pub(crate) struct CloseGuard<'a> {
     id: Id,
     registry: &'a Registry,
@@ -143,7 +139,6 @@ impl Registry {
     /// processed an `on_close` notification via the `CLOSE_COUNT` thread-local.
     /// For additional details, see [`CloseGuard`].
     ///
-    /// [`CloseGuard`]: ./struct.CloseGuard.html
     pub(crate) fn start_close(&self, id: Id) -> CloseGuard<'_> {
         CLOSE_COUNT.with(|count| {
             let c = count.get();
@@ -162,7 +157,6 @@ thread_local! {
     /// track how many layers have processed the close.
     /// For additional details, see [`CloseGuard`].
     ///
-    /// [`CloseGuard`]: ./struct.CloseGuard.html
     static CLOSE_COUNT: Cell<usize> = Cell::new(0);
 }
 

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -9,7 +9,7 @@
 //! change at runtime. Note that this subscriber introduces a (relatively small)
 //! amount of overhead, and should thus only be used as needed.
 //!
-//! [`Subscribe`]: ../subscriber/trait.Subscribe.html
+//! [`Subscribe`]: super::subscriber::Subscribe
 use crate::subscribe;
 use crate::sync::RwLock;
 

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -9,7 +9,7 @@
 //! change at runtime. Note that this subscriber introduces a (relatively small)
 //! amount of overhead, and should thus only be used as needed.
 //!
-//! [`Subscribe`]: super::subscriber::Subscribe
+//! [`Subscribe`]: crate::Subscribe
 use crate::subscribe;
 use crate::sync::RwLock;
 

--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -150,10 +150,8 @@ use std::{any::TypeId, marker::PhantomData};
 /// additional behavior when composed with a subscriber may provide their own
 /// implementations of `SubscriberExt::with`.
 ///
-/// [`SubscriberExt::with`]: trait.SubscriberExt.html#method.with
-/// [`Layered`]: struct.Layered.html
-/// [prelude]: ../prelude/index.html
-/// [with-col]: #method.with_collector
+/// [prelude]: super::prelude
+/// [with-col]: Subscribe::with_collector()
 ///
 /// ## Recording Traces
 ///
@@ -191,13 +189,10 @@ use std::{any::TypeId, marker::PhantomData};
 ///
 /// [`Collect`]: https://docs.rs/tracing-core/latest/tracing_core/collect/trait.Collect.html
 /// [span IDs]: https://docs.rs/tracing-core/latest/tracing_core/span/struct.Id.html
-/// [`Context`]: struct.Context.html
-/// [the current span]: struct.Context.html#method.current_span
-/// [`register_callsite`]: #method.register_callsite
-/// [`enabled`]: #method.enabled
-/// [`on_enter`]: #method.on_enter
-/// [`Subscribe::register_callsite`]: #method.register_callsite
-/// [`Subscribe::enabled`]: #method.enabled
+/// [the current span]: Context::current_span()
+/// [`register_callsite`]: Subscribe::register_callsite()
+/// [`enabled`]: Subscribe::enabled()
+/// [`on_enter`]: Subscribe::on_enter()
 /// [`Interest::never()`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/struct.Interest.html#method.never
 pub trait Subscribe<C>
 where
@@ -242,11 +237,11 @@ where
     /// [`Collector::register_callsite`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html#method.register_callsite
     /// [`Interest::never()`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/struct.Interest.html#method.never
     /// [`Interest::always()`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/struct.Interest.html#method.always
-    /// [`self.enabled`]: #method.enabled
-    /// [`Subscriber::enabled`]: #method.enabled
-    /// [`on_event`]: #method.on_event
-    /// [`on_enter`]: #method.on_enter
-    /// [`on_exit`]: #method.on_exit
+    /// [`self.enabled`]: Subscribe::enabled()
+    /// [`Subscriber::enabled`]: Subscribe::enabled()
+    /// [`on_event`]: Subscribe::on_event()
+    /// [`on_enter`]: Subscribe::on_enter()
+    /// [`on_exit`]: Subscribe::on_exit()
     /// [the trait-level documentation]: #filtering-with-layers
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         if self.enabled(metadata, Context::none()) {
@@ -286,12 +281,12 @@ where
     /// with `Subscriber`s.
     ///
     /// [`Interest`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Interest.html
-    /// [`Context`]: ../struct.Context.html
+    /// [`Context`]: super::Context
     /// [`Collector::enabled`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html#method.enabled
-    /// [`Subscriber::register_callsite`]: #method.register_callsite
-    /// [`on_event`]: #method.on_event
-    /// [`on_enter`]: #method.on_enter
-    /// [`on_exit`]: #method.on_exit
+    /// [`Subscriber::register_callsite`]: Subscribe::register_callsite()
+    /// [`on_event`]: Subscribe::on_event()
+    /// [`on_enter`]: Subscribe::on_enter()
+    /// [`on_exit`]: Subscribe::on_exit()
     /// [the trait-level documentation]: #filtering-with-layers
     fn enabled(&self, metadata: &Metadata<'_>, ctx: Context<'_, C>) -> bool {
         let _ = (metadata, ctx);
@@ -548,9 +543,9 @@ pub trait CollectorExt: Collect + crate::sealed::Sealed {
 /// }
 /// ```
 ///
-/// [subscriber]: ../subscriber/trait.Subscribe.html
+/// [subscriber]: super::subscriber::Subscribe
 /// [collector]: https://docs.rs/tracing-core/latest/tracing_core/trait.Collect.html
-/// [stored data]: ../registry/struct.SpanRef.html
+/// [stored data]: super::registry::SpanRef
 /// [`LookupSpan`]: "../registry/trait.LookupSpan.html
 #[derive(Debug)]
 pub struct Context<'a, S> {
@@ -560,7 +555,7 @@ pub struct Context<'a, S> {
 /// A [collector] composed of a collector wrapped by one or more
 /// [subscriber]s.
 ///
-/// [subscriber]: ../subscribe/trait.Subscribe.html
+/// [subscriber]: super::subscribe::Subscribe
 /// [collector]: https://docs.rs/tracing-core/latest/tracing_core/trait.Collect.html
 #[derive(Clone, Debug)]
 pub struct Layered<S, I, C = I> {
@@ -581,8 +576,7 @@ pub struct Identity {
 ///
 /// This is returned by [`Context::scope`].
 ///
-/// [stored data]: ../registry/struct.SpanRef.html
-/// [`Context::scope`]: struct.Context.html#method.scope
+/// [stored data]: super::registry::SpanRef
 #[cfg(feature = "registry")]
 #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
 pub struct Scope<'a, L: LookupSpan<'a>>(
@@ -988,7 +982,7 @@ where
     ///
     /// [register]: https://docs.rs/tracing-core/latest/tracing_core/collect/trait.Collect.html#method.register_callsite
     /// [`enabled`]: https://docs.rs/tracing-core/latest/tracing_core/collect/trait.Collect.html#method.enabled
-    /// [`Context::enabled`]: #method.enabled
+    /// [`Context::enabled`]: Layered::enabled()
     #[inline]
     pub fn event(&self, event: &Event<'_>) {
         if let Some(ref subscriber) = self.subscriber {
@@ -1027,7 +1021,7 @@ where
     /// declaration</a> for details.
     /// </pre></div>
     ///
-    /// [stored data]: ../registry/struct.SpanRef.html
+    /// [stored data]: super::registry::SpanRef
     #[inline]
     #[cfg(feature = "registry")]
     #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
@@ -1076,7 +1070,7 @@ where
     /// declaration</a> for details.
     /// </pre></div>
     ///
-    /// [stored data]: ../registry/struct.SpanRef.html
+    /// [stored data]: super::registry::SpanRef
     #[inline]
     #[cfg(feature = "registry")]
     #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
@@ -1113,7 +1107,7 @@ where
     /// declaration</a> for details.
     /// </pre></div>
     ///
-    /// [stored data]: ../registry/struct.SpanRef.html
+    /// [stored data]: super::registry::SpanRef
     #[cfg(feature = "registry")]
     #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
     pub fn scope(&self) -> Scope<'_, C>

--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -40,7 +40,7 @@ use std::{any::TypeId, marker::PhantomData};
 /// particular `Collect` implementation, or additional trait bounds may be
 /// added to constrain what types implementing `Collect` a subscriber can wrap.
 ///
-/// Subscribers may be added to a `Collect` by using the [`SubscriberExt::with`]
+/// Subscribers may be added to a `Collect` by using the [`CollectorExt::with`]
 /// method, which is provided by `tracing-subscriber`'s [prelude]. This method
 /// returns a [`Layered`] struct that implements `Collect` by composing the
 /// subscriber with the collector.
@@ -143,8 +143,8 @@ use std::{any::TypeId, marker::PhantomData};
 ///
 /// The [`Subscribe::with_collector` method][with-col] constructs the `Layered`
 /// type from a `Subscribe` and `Collect`, and is called by
-/// [`SubscriberExt::with`]. In general, it is more idiomatic to use
-/// `SubscriberExt::with`, and treat `Subscribe::with_collector` as an
+/// [`CollectorExt::with`]. In general, it is more idiomatic to use
+/// `CollectorExt::with`, and treat `Subscribe::with_collector` as an
 /// implementation detail, as `with_collector` calls must be nested, leading to
 /// less clear code for the reader. However, subscribers which wish to perform
 /// additional behavior when composed with a subscriber may provide their own
@@ -253,7 +253,7 @@ where
 
     /// Returns `true` if this subscriber is interested in a span or event with the
     /// given `metadata` in the current [`Context`], similarly to
-    /// [`Collector::enabled`].
+    /// [`Collect::enabled`].
     ///
     /// By default, this always returns `true`, allowing the wrapped collector
     /// to choose to disable the span.
@@ -281,12 +281,9 @@ where
     /// with `Subscriber`s.
     ///
     /// [`Interest`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Interest.html
-    /// [`Context`]: super::Context
-    /// [`Collector::enabled`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html#method.enabled
-    /// [`Subscriber::register_callsite`]: Subscribe::register_callsite()
-    /// [`on_event`]: Subscribe::on_event()
-    /// [`on_enter`]: Subscribe::on_enter()
-    /// [`on_exit`]: Subscribe::on_exit()
+    /// [`on_event`]: Layer::on_event()
+    /// [`on_enter`]: Layer::on_enter()
+    /// [`on_exit`]: Layer::on_exit()
     /// [the trait-level documentation]: #filtering-with-layers
     fn enabled(&self, metadata: &Metadata<'_>, ctx: Context<'_, C>) -> bool {
         let _ = (metadata, ctx);
@@ -543,10 +540,9 @@ pub trait CollectorExt: Collect + crate::sealed::Sealed {
 /// }
 /// ```
 ///
-/// [subscriber]: super::subscriber::Subscribe
-/// [collector]: https://docs.rs/tracing-core/latest/tracing_core/trait.Collect.html
+/// [subscriber]: Subscribe
+/// [collector]: tracing_core::Collect
 /// [stored data]: super::registry::SpanRef
-/// [`LookupSpan`]: "../registry/trait.LookupSpan.html
 #[derive(Debug)]
 pub struct Context<'a, S> {
     subscriber: Option<&'a S>,


### PR DESCRIPTION
## Motivation

Closes https://github.com/tokio-rs/tracing/issues/940.

## Solution

Uses ~~a heavily patched version~~ the latest master version of https://github.com/poliorcetics/cargo-intraconv/ to automatically convert the links. Fixes remaining issues by hand.