### PR TITLE
subscriber: prepare to release 0.2.13

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,14 +10,14 @@ default = []
 [dev-dependencies]
 
 # tracing crates
-tracing = { path = "../tracing", version = "0.1"}
-tracing-core = { path = "../tracing-core", version = "0.1"}
+tracing = { path = "../tracing", version = "0.1" }
+tracing-core = { path = "../tracing-core", version = "0.1" }
 tracing-error = { path = "../tracing-error" }
 tracing-flame = { path = "../tracing-flame" }
 tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.12", features = ["json", "chrono"] }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.13", features = ["json", "chrono"] }
 tracing-futures = { version = "0.2.1", path = "../tracing-futures", features = ["futures-01"] }
-tracing-attributes =  { path = "../tracing-attributes", version = "0.1.2"}
+tracing-attributes = { path = "../tracing-attributes", version = "0.1.2" }
 tracing-log = { path = "../tracing-log", version = "0.1.1", features = ["env_logger"] }
 tracing-serde = { path = "../tracing-serde" }
 tracing-opentelemetry = { path = "../tracing-opentelemetry" }
@@ -27,7 +27,7 @@ tracing-journald = { path = "../tracing-journald" }
 serde_json = "1.0"
 
 futures = "0.3"
-tokio = { version = "0.2.12", features = ["full"] }
+tokio = { version = "0.2.13", features = ["full"] }
 
 # env-logger example
 env_logger = "0.7"

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 0.2.13 (October 7, 2020)
+
+### Changed
+
+- Updated `tracing-core` to 0.1.17 ([#992])
+
+### Added
+
+- **env-filter**: Added support for filtering on targets which contain dashes
+  ([#1014])
+- **env-filter**: Added a warning when creating an `EnvFilter` that contains
+  directives that would enable a level disabled by the `tracing` crate's
+  `static_max_level` features ([#1021])
+
+Thanks to @jyn514 and @bkchr for contributing to this release!
+
+[#992]: https://github.com/tokio-rs/tracing/pull/992
+[#1014]: https://github.com/tokio-rs/tracing/pull/1014
+[#1021]: https://github.com/tokio-rs/tracing/pull/1021
+
 # 0.2.12 (September 11, 2020)
 
 ### Fixed
@@ -6,7 +26,7 @@
   `Into<LevelFilter>` impl ([#966])
 - **env-filter**: Fixed `EnvFilter` enabling spans that should not be enabled
   when multiple subscribers are in use ([#927])
-  
+
 ### Changed
 
 - **json**: `format::Json` now outputs fields in a more readable order ([#892])
@@ -33,7 +53,7 @@ for contributing to this release!
 [#910]: https://github.com/tokio-rs/tracing/pull/910
 [#918]: https://github.com/tokio-rs/tracing/pull/918
 
-# 0.2.12 (August 10, 2020)
+# 0.2.11 (August 10, 2020)
 
 ### Fixed
 

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.12"
+version = "0.2.13"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -21,7 +21,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.2.12
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.13
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -67,7 +67,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.12")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.13")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
### Changed

- Updated `tracing-core` to 0.1.17 ([#992])

### Added

- **env-filter**: Added support for filtering on targets which contain
  dashes ([#1014])
- **env-filter**: Added a warning when creating an `EnvFilter` that
  contains directives that would enable a level disabled by the
  `tracing` crate's `static_max_level` features ([#1021])

Thanks to @jyn514 and @bkchr for contributing to this release!

[#992]: https://github.com/tokio-rs/tracing/pull/992
[#1014]: https://github.com/tokio-rs/tracing/pull/1014
[#1021]: https://github.com/tokio-rs/tracing/pull/1021