### PR TITLE
chore: fix nightly clippy warnings (#991)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, 1.40.0]
+        rust: [stable, 1.42.0]
     steps:
     - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta, nightly, 1.40.0]
+        rust: [stable, beta, nightly, 1.42.0]
     steps:
     - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ attachment that `Future::instrument` does.
 ## Supported Rust Versions
 
 Tracing is built against the latest stable release. The minimum supported
-version is 1.40. The current Tracing version is not guaranteed to build on Rust
+version is 1.42. The current Tracing version is not guaranteed to build on Rust
 versions earlier than the minimum supported version.
 
 Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-appender/README.md
+++ b/tracing-appender/README.md
@@ -36,7 +36,7 @@ allows events and spans to be recorded in a non-blocking manner through a
 dedicated logging thread. It also provides a [`RollingFileAppender`][file_appender] 
 that can be used with _or_ without the non-blocking writer.
 
-*Compiler support: [requires `rustc` 1.40+][msrv]*
+*Compiler support: [requires `rustc` 1.42+][msrv]*
 
 [msrv]: #supported-rust-versions
 
@@ -146,7 +146,7 @@ fn main() {
 ## Supported Rust Versions
 
 Tracing is built against the latest stable release. The minimum supported
-version is 1.40. The current Tracing version is not guaranteed to build on Rust
+version is 1.42. The current Tracing version is not guaranteed to build on Rust
 versions earlier than the minimum supported version.
 
 Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -7,7 +7,7 @@
 //! a dedicated logging thread. It also provides a [`RollingFileAppender`][file_appender] that can
 //! be used with _or_ without the non-blocking writer.
 //!
-//! *Compiler support: [requires `rustc` 1.40+][msrv]*
+//! *Compiler support: [requires `rustc` 1.42+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
 //! [file_appender]: ./rolling/struct.RollingFileAppender.html
@@ -111,7 +111,7 @@
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported
-//! version is 1.40. The current Tracing version is not guaranteed to build on
+//! version is 1.42. The current Tracing version is not guaranteed to build on
 //! Rust versions earlier than the minimum supported version.
 //!
 //! Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -37,7 +37,7 @@ structured, event-based diagnostic information. This crate provides the
 
 Note that this macro is also re-exported by the main `tracing` crate.
 
-*Compiler support: [requires `rustc` 1.40+][msrv]*
+*Compiler support: [requires `rustc` 1.42+][msrv]*
 
 [msrv]: #supported-rust-versions
 
@@ -69,7 +69,7 @@ pub fn my_function(my_arg: usize) {
 ## Supported Rust Versions
 
 Tracing is built against the latest stable release. The minimum supported
-version is 1.40. The current Tracing version is not guaranteed to build on Rust
+version is 1.42. The current Tracing version is not guaranteed to build on Rust
 versions earlier than the minimum supported version.
 
 Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! Note that this macro is also re-exported by the main `tracing` crate.
 //!
-//! *Compiler support: [requires `rustc` 1.40+][msrv]*
+//! *Compiler support: [requires `rustc` 1.42+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
 //!
@@ -41,7 +41,7 @@
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported
-//! version is 1.40. The current Tracing version is not guaranteed to build on
+//! version is 1.42. The current Tracing version is not guaranteed to build on
 //! Rust versions earlier than the minimum supported version.
 //!
 //! Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-attributes/tests/async_fn.rs
+++ b/tracing-attributes/tests/async_fn.rs
@@ -223,7 +223,7 @@ fn async_fn_with_async_trait_and_fields_expressions_with_generic_parameter() {
         async fn call_with_self(&self) {}
 
         #[instrument(fields(Self=std::any::type_name::<Self>()))]
-        async fn call_with_mut_self(self: &mut Self) {}
+        async fn call_with_mut_self(&mut self) {}
     }
 
     //let span = span::mock().named("call");

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -53,7 +53,7 @@ The crate provides:
 In addition, it defines the global callsite registry and per-thread current
 dispatcher which other components of the tracing system rely on.
 
-*Compiler support: [requires `rustc` 1.40+][msrv]*
+*Compiler support: [requires `rustc` 1.42+][msrv]*
 
 [msrv]: #supported-rust-versions
 
@@ -99,7 +99,7 @@ The following crate feature flags are available:
 ## Supported Rust Versions
 
 Tracing is built against the latest stable release. The minimum supported
-version is 1.40. The current Tracing version is not guaranteed to build on Rust
+version is 1.42. The current Tracing version is not guaranteed to build on Rust
 versions earlier than the minimum supported version.
 
 Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-core/src/event.rs
+++ b/tracing-core/src/event.rs
@@ -101,10 +101,7 @@ impl<'a> Event<'a> {
 
     /// Returns true if the new event should be a root.
     pub fn is_root(&self) -> bool {
-        match self.parent {
-            Parent::Root => true,
-            _ => false,
-        }
+        matches!(self.parent, Parent::Root)
     }
 
     /// Returns true if the new event's parent should be determined based on the
@@ -115,10 +112,7 @@ impl<'a> Event<'a> {
     /// thread is _not_ inside a span, then the new event will be the root of its
     /// own trace tree.
     pub fn is_contextual(&self) -> bool {
-        match self.parent {
-            Parent::Current => true,
-            _ => false,
-        }
+        matches!(self.parent, Parent::Current)
     }
 
     /// Returns the new event's explicitly-specified parent, if there is one.

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -23,7 +23,7 @@
 //! In addition, it defines the global callsite registry and per-thread current
 //! dispatcher which other components of the tracing system rely on.
 //!
-//! *Compiler support: [requires `rustc` 1.40+][msrv]*
+//! *Compiler support: [requires `rustc` 1.42+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
 //!
@@ -61,7 +61,7 @@
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported
-//! version is 1.40. The current Tracing version is not guaranteed to build on
+//! version is 1.42. The current Tracing version is not guaranteed to build on
 //! Rust versions earlier than the minimum supported version.
 //!
 //! Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -251,18 +251,12 @@ impl Kind {
 
     /// Return true if the callsite kind is `Span`
     pub fn is_span(&self) -> bool {
-        match self {
-            Kind(KindInner::Span) => true,
-            _ => false,
-        }
+        matches!(self, Kind(KindInner::Span))
     }
 
     /// Return true if the callsite kind is `Event`
     pub fn is_event(&self) -> bool {
-        match self {
-            Kind(KindInner::Event) => true,
-            _ => false,
-        }
+        matches!(self, Kind(KindInner::Event))
     }
 }
 
@@ -554,7 +548,7 @@ impl FromStr for LevelFilter {
                 s if s.eq_ignore_ascii_case("off") => Some(LevelFilter::OFF),
                 _ => None,
             })
-            .ok_or_else(|| ParseLevelFilterError(()))
+            .ok_or(ParseLevelFilterError(()))
     }
 }
 

--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -153,10 +153,7 @@ impl<'a> Attributes<'a> {
 
     /// Returns true if the new span should be a root.
     pub fn is_root(&self) -> bool {
-        match self.parent {
-            Parent::Root => true,
-            _ => false,
-        }
+        matches!(self.parent, Parent::Root)
     }
 
     /// Returns true if the new span's parent should be determined based on the
@@ -167,10 +164,7 @@ impl<'a> Attributes<'a> {
     /// thread is _not_ inside a span, then the new span will be the root of its
     /// own trace tree.
     pub fn is_contextual(&self) -> bool {
-        match self.parent {
-            Parent::Current => true,
-            _ => false,
-        }
+        matches!(self.parent, Parent::Current)
     }
 
     /// Returns the new span's explicitly-specified parent, if there is one.
@@ -270,10 +264,7 @@ impl Current {
     /// [`metadata`]: #method.metadata
     /// [`into_inner`]: #method.into_inner
     pub fn is_known(&self) -> bool {
-        match self.inner {
-            CurrentInner::Unknown => false,
-            _ => true,
-        }
+        !matches!(self.inner, CurrentInner::Unknown)
     }
 
     /// Consumes `self` and returns the span `Id` and `Metadata` of the current

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -528,30 +528,21 @@ impl Interest {
     /// about this callsite.
     #[inline]
     pub fn is_never(&self) -> bool {
-        match self.0 {
-            InterestKind::Never => true,
-            _ => false,
-        }
+        matches!(self.0, InterestKind::Never)
     }
 
     /// Returns `true` if the subscriber is sometimes interested in being notified
     /// about this callsite.
     #[inline]
     pub fn is_sometimes(&self) -> bool {
-        match self.0 {
-            InterestKind::Sometimes => true,
-            _ => false,
-        }
+        matches!(self.0, InterestKind::Sometimes)
     }
 
     /// Returns `true` if the subscriber is always interested in being notified
     /// about this callsite.
     #[inline]
     pub fn is_always(&self) -> bool {
-        match self.0 {
-            InterestKind::Always => true,
-            _ => false,
-        }
+        matches!(self.0, InterestKind::Always)
     }
 
     /// Returns the common interest between these two Interests.

--- a/tracing-error/README.md
+++ b/tracing-error/README.md
@@ -48,7 +48,7 @@ The crate provides the following:
 
 **Note**: This crate is currently experimental.
 
-*Compiler support: [requires `rustc` 1.40+][msrv]*
+*Compiler support: [requires `rustc` 1.42+][msrv]*
 
 [msrv]: #supported-rust-versions
 
@@ -186,7 +186,7 @@ fn main() {
 ## Supported Rust Versions
 
 Tracing is built against the latest stable release. The minimum supported
-version is 1.40. The current Tracing version is not guaranteed to build on Rust
+version is 1.42. The current Tracing version is not guaranteed to build on Rust
 versions earlier than the minimum supported version.
 
 Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! **Note**: This crate is currently experimental.
 //!
-//! *Compiler support: [requires `rustc` 1.40+][msrv]*
+//! *Compiler support: [requires `rustc` 1.42+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
 //!
@@ -174,7 +174,7 @@
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported
-//! version is 1.40. The current Tracing version is not guaranteed to build on
+//! version is 1.42. The current Tracing version is not guaranteed to build on
 //! Rust versions earlier than the minimum supported version.
 //!
 //! Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-flame/README.md
+++ b/tracing-flame/README.md
@@ -26,7 +26,7 @@ flamegraph/flamechart. Flamegraphs/flamecharts are useful for identifying perfor
 bottlenecks in an application. For more details, see Brendan Gregg's [post]
 on flamegraphs.
 
-*Compiler support: [requires `rustc` 1.40+][msrv]*
+*Compiler support: [requires `rustc` 1.42+][msrv]*
 
 [msrv]: #supported-rust-versions
 [post]: http://www.brendangregg.com/flamegraphs.html
@@ -107,7 +107,7 @@ _flamechart_, which _does not_ sort or collapse identical stack frames.
 ## Supported Rust Versions
 
 Tracing is built against the latest stable release. The minimum supported
-version is 1.40. The current Tracing version is not guaranteed to build on Rust
+version is 1.42. The current Tracing version is not guaranteed to build on Rust
 versions earlier than the minimum supported version.
 
 Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-flame/src/lib.rs
+++ b/tracing-flame/src/lib.rs
@@ -10,7 +10,7 @@
 //! issues bottlenecks in an application. For more details, see Brendan Gregg's [post]
 //! on flamegraphs.
 //!
-//! *Compiler support: [requires `rustc` 1.40+][msrv]*
+//! *Compiler support: [requires `rustc` 1.42+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
 //! [post]: http://www.brendangregg.com/flamegraphs.html
@@ -98,7 +98,7 @@
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported
-//! version is 1.40. The current Tracing version is not guaranteed to build on
+//! version is 1.42. The current Tracing version is not guaranteed to build on
 //! Rust versions earlier than the minimum supported version.
 //!
 //! Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-futures/README.md
+++ b/tracing-futures/README.md
@@ -51,14 +51,14 @@ The crate provides the following traits:
 [`Subscriber`]: https://docs.rs/tracing/latest/tracing/subscriber/index.html
 [`tracing`]: https://crates.io/tracing
 
-*Compiler support: [requires `rustc` 1.40+][msrv]*
+*Compiler support: [requires `rustc` 1.42+][msrv]*
 
 [msrv]: #supported-rust-versions
 
 ## Supported Rust Versions
 
 Tracing is built against the latest stable release. The minimum supported
-version is 1.40. The current Tracing version is not guaranteed to build on Rust
+version is 1.42. The current Tracing version is not guaranteed to build on Rust
 versions earlier than the minimum supported version.
 
 Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -15,7 +15,7 @@
 //! * [`WithSubscriber`] allows a `tracing` [`Subscriber`] to be attached to a
 //!   future, sink, stream, or executor.
 //!
-//! *Compiler support: [requires `rustc` 1.40+][msrv]*
+//! *Compiler support: [requires `rustc` 1.42+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
 //!
@@ -62,7 +62,7 @@
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported
-//! version is 1.40. The current Tracing version is not guaranteed to build on
+//! version is 1.42. The current Tracing version is not guaranteed to build on
 //! Rust versions earlier than the minimum supported version.
 //!
 //! Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-journald/README.md
+++ b/tracing-journald/README.md
@@ -28,7 +28,7 @@ scoped, structured, and async-aware diagnostics. `tracing-journald` provides a
 and events to [`systemd-journald`][journald], on Linux distributions that use
 `systemd`.
  
-*Compiler support: [requires `rustc` 1.40+][msrv]*
+*Compiler support: [requires `rustc` 1.42+][msrv]*
 
 [msrv]: #supported-rust-versions
 [`tracing`]: https://crates.io/crates/tracing
@@ -38,7 +38,7 @@ and events to [`systemd-journald`][journald], on Linux distributions that use
 ## Supported Rust Versions
 
 Tracing is built against the latest stable release. The minimum supported
-version is 1.40. The current Tracing version is not guaranteed to build on Rust
+version is 1.42. The current Tracing version is not guaranteed to build on Rust
 versions earlier than the minimum supported version.
 
 Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -11,7 +11,7 @@
 //! and events to [`systemd-journald`][journald], on Linux distributions that
 //! use `systemd`.
 //!  
-//! *Compiler support: [requires `rustc` 1.40+][msrv]*
+//! *Compiler support: [requires `rustc` 1.42+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
 //! [`tracing`]: https://crates.io/crates/tracing
@@ -21,7 +21,7 @@
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported
-//! version is 1.40. The current Tracing version is not guaranteed to build on
+//! version is 1.42. The current Tracing version is not guaranteed to build on
 //! Rust versions earlier than the minimum supported version.
 //!
 //! Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-log/README.md
+++ b/tracing-log/README.md
@@ -56,14 +56,14 @@ This crate provides:
 [`tracing::Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
 [`tracing::Event`]: https://docs.rs/tracing/latest/tracing/struct.Event.html
 
-*Compiler support: [requires `rustc` 1.40+][msrv]*
+*Compiler support: [requires `rustc` 1.42+][msrv]*
 
 [msrv]: #supported-rust-versions
 
 ## Supported Rust Versions
 
 Tracing is built against the latest stable release. The minimum supported
-version is 1.40. The current Tracing version is not guaranteed to build on Rust
+version is 1.42. The current Tracing version is not guaranteed to build on Rust
 versions earlier than the minimum supported version.
 
 Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -16,7 +16,7 @@
 //! - An [`env_logger`] module, with helpers for using the [`env_logger` crate]
 //!   with `tracing` (optional, enabled by the `env-logger` feature).
 //!
-//! *Compiler support: [requires `rustc` 1.40+][msrv]*
+//! *Compiler support: [requires `rustc` 1.42+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
 //!
@@ -78,7 +78,7 @@
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported
-//! version is 1.40. The current Tracing version is not guaranteed to build on
+//! version is 1.42. The current Tracing version is not guaranteed to build on
 //! Rust versions earlier than the minimum supported version.
 //!
 //! Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -50,7 +50,7 @@ The crate provides the following types:
 [`tracing`]: https://crates.io/crates/tracing
 [OpenTelemetry]: https://opentelemetry.io/
 
-*Compiler support: [requires `rustc` 1.40+][msrv]*
+*Compiler support: [requires `rustc` 1.42+][msrv]*
 
 [msrv]: #supported-rust-versions
 
@@ -101,7 +101,7 @@ $ firefox http://localhost:16686/
 ## Supported Rust Versions
 
 Tracing is built against the latest stable release. The minimum supported
-version is 1.40. The current Tracing version is not guaranteed to build on Rust
+version is 1.42. The current Tracing version is not guaranteed to build on Rust
 versions earlier than the minimum supported version.
 
 Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -9,7 +9,7 @@
 //! [OpenTelemetry]: https://opentelemetry.io
 //! [`tracing`]: https://github.com/tokio-rs/tracing
 //!
-//! *Compiler support: [requires `rustc` 1.40+][msrv]*
+//! *Compiler support: [requires `rustc` 1.42+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
 //!
@@ -77,7 +77,7 @@
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported
-//! version is 1.40. The current Tracing version is not guaranteed to build on
+//! version is 1.42. The current Tracing version is not guaranteed to build on
 //! Rust versions earlier than the minimum supported version.
 //!
 //! Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-serde/README.md
+++ b/tracing-serde/README.md
@@ -36,7 +36,7 @@ and tracing data to monitor your services in production.
 The `tracing` crate provides the APIs necessary for instrumenting
 libraries and applications to emit trace data.
 
-*Compiler support: [requires `rustc` 1.40+][msrv]*
+*Compiler support: [requires `rustc` 1.42+][msrv]*
 
 [msrv]: #supported-rust-versions
 
@@ -101,7 +101,7 @@ trace data.
 ## Supported Rust Versions
 
 Tracing is built against the latest stable release. The minimum supported
-version is 1.40. The current Tracing version is not guaranteed to build on Rust
+version is 1.42. The current Tracing version is not guaranteed to build on Rust
 versions earlier than the minimum supported version.
 
 Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-serde/src/lib.rs
+++ b/tracing-serde/src/lib.rs
@@ -32,7 +32,7 @@
 //! The `tracing` crate provides the APIs necessary for instrumenting
 //! libraries and applications to emit trace data.
 //!
-//! *Compiler support: [requires `rustc` 1.40+][msrv]*
+//! *Compiler support: [requires `rustc` 1.42+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
 //!
@@ -112,7 +112,7 @@
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported
-//! version is 1.40. The current Tracing version is not guaranteed to build on
+//! version is 1.42. The current Tracing version is not guaranteed to build on
 //! Rust versions earlier than the minimum supported version.
 //!
 //! Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -32,14 +32,14 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [discord-url]: https://discord.gg/EeF3cQw
 [maint-badge]: https://img.shields.io/badge/maintenance-experimental-blue.svg
 
-*Compiler support: [requires `rustc` 1.40+][msrv]*
+*Compiler support: [requires `rustc` 1.42+][msrv]*
 
 [msrv]: #supported-rust-versions
 
 ## Supported Rust Versions
 
 Tracing is built against the latest stable release. The minimum supported
-version is 1.40. The current Tracing version is not guaranteed to build on Rust
+version is 1.42. The current Tracing version is not guaranteed to build on Rust
 versions earlier than the minimum supported version.
 
 Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1052,22 +1052,13 @@ impl FmtSpanConfig {
         }
     }
     pub(super) fn trace_new(&self) -> bool {
-        match self.kind {
-            FmtSpan::FULL => true,
-            _ => false,
-        }
+        matches!(self.kind, FmtSpan::FULL)
     }
     pub(super) fn trace_active(&self) -> bool {
-        match self.kind {
-            FmtSpan::ACTIVE | FmtSpan::FULL => true,
-            _ => false,
-        }
+        matches!(self.kind, FmtSpan::ACTIVE | FmtSpan::FULL)
     }
     pub(super) fn trace_close(&self) -> bool {
-        match self.kind {
-            FmtSpan::CLOSE | FmtSpan::FULL => true,
-            _ => false,
-        }
+        matches!(self.kind, FmtSpan::CLOSE | FmtSpan::FULL)
     }
 }
 

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -10,7 +10,7 @@
 //! `tracing-subscriber` is intended for use by both `Subscriber` authors and
 //! application authors using `tracing` to instrument their applications.
 //!
-//! *Compiler support: [requires `rustc` 1.40+][msrv]*
+//! *Compiler support: [requires `rustc` 1.42+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
 //!
@@ -46,7 +46,7 @@
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported
-//! version is 1.40. The current Tracing version is not guaranteed to build on
+//! version is 1.42. The current Tracing version is not guaranteed to build on
 //! Rust versions earlier than the minimum supported version.
 //!
 //! Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -210,19 +210,13 @@ impl Error {
     /// Returns `true` if this error occurred because the layer was poisoned by
     /// a panic on another thread.
     pub fn is_poisoned(&self) -> bool {
-        match self.kind {
-            ErrorKind::Poisoned => true,
-            _ => false,
-        }
+        matches!(self.kind, ErrorKind::Poisoned)
     }
 
     /// Returns `true` if this error occurred because the `Subscriber`
     /// containing the reloadable layer was dropped.
     pub fn is_dropped(&self) -> bool {
-        match self.kind {
-            ErrorKind::SubscriberGone => true,
-            _ => false,
-        }
+        matches!(self.kind, ErrorKind::SubscriberGone)
     }
 }
 

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -47,7 +47,7 @@ data as well as textual messages.
 The `tracing` crate provides the APIs necessary for instrumenting libraries
 and applications to emit trace data.
 
-*Compiler support: [requires `rustc` 1.40+][msrv]*
+*Compiler support: [requires `rustc` 1.42+][msrv]*
 
 [msrv]: #supported-rust-versions
 
@@ -327,7 +327,7 @@ with a simple drop-in replacement.
 ## Supported Rust Versions
 
 Tracing is built against the latest stable release. The minimum supported
-version is 1.40. The current Tracing version is not guaranteed to build on Rust
+version is 1.42. The current Tracing version is not guaranteed to build on Rust
 versions earlier than the minimum supported version.
 
 Tracing follows the same compiler support policies as the rest of the Tokio
@@ -422,7 +422,7 @@ undergoing active development. They may be less stable than `tracing` and
 ## Supported Rust Versions
 
 Tracing is built against the latest stable release. The minimum supported
-version is 1.40. The current Tracing version is not guaranteed to build on Rust
+version is 1.42. The current Tracing version is not guaranteed to build on Rust
 versions earlier than the minimum supported version.
 
 Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -19,7 +19,7 @@
 //! The `tracing` crate provides the APIs necessary for instrumenting libraries
 //! and applications to emit trace data.
 //!
-//! *Compiler support: [requires `rustc` 1.40+][msrv]*
+//! *Compiler support: [requires `rustc` 1.42+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
 //! # Core Concepts
@@ -796,7 +796,7 @@
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported
-//! version is 1.40. The current Tracing version is not guaranteed to build on
+//! version is 1.42. The current Tracing version is not guaranteed to build on
 //! Rust versions earlier than the minimum supported version.
 //!
 //! Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tracing/tests/support/subscriber.rs
+++ b/tracing/tests/support/subscriber.rs
@@ -213,11 +213,7 @@ where
             "[{}] record: {}; id={:?}; values={:?};",
             self.name, span.name, id, values
         );
-        let was_expected = if let Some(Expect::Visit(_, _)) = expected.front() {
-            true
-        } else {
-            false
-        };
+        let was_expected = matches!(expected.front(), Some(Expect::Visit(_, _)));
         if was_expected {
             if let Expect::Visit(expected_span, mut expected_values) = expected.pop_front().unwrap()
             {
@@ -319,10 +315,7 @@ where
             id
         );
         let mut expected = self.expected.lock().unwrap();
-        let was_expected = match expected.front() {
-            Some(Expect::NewSpan(_)) => true,
-            _ => false,
-        };
+        let was_expected = matches!(expected.front(), Some(Expect::NewSpan(_)));
         let mut spans = self.spans.lock().unwrap();
         if was_expected {
             if let Expect::NewSpan(mut expected) = expected.pop_front().unwrap() {


### PR DESCRIPTION
This backports PR #991 to v0.1.x. This is primarily necessary for the MSRV
bump, since some dependencies no longer compile on Rust 1.40.0.

This has already been approved on `master`, in PR #991, so it should be 
fine to ship.

## Motivation

This will avoid breaking CI on new releases of clippy. It also makes the
code a little easier to read.

## Solution

- Convert `match val { pat => true, _ => false }` to `matches!(val, pat)`
- Remove unnecessary closures
- Convert `self: &mut Self` to `&mut self`

This bumps the MSRV to 1.42.0 for `matches!`.
The latest version of rust is 1.46.0, so as per
https://github.com/tokio-rs/tracing#supported-rust-versions this is not
considered a breaking change.

I didn't fix the following warning because the fix was not trivial/needed
a decision:

```
warning: you are deriving `Ord` but have implemented `PartialOrd` explicitly
   --> tracing-subscriber/src/filter/env/field.rs:16:32
    |
16  | #[derive(Debug, Eq, PartialEq, Ord)]
    |                                ^^^
    |
    = note: `#[warn(clippy::derive_ord_xor_partial_ord)]` on by default
note: `PartialOrd` implemented here
   --> tracing-subscriber/src/filter/env/field.rs:98:1
    |
98  | / impl PartialOrd for Match {
99  | |     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
100 | |         // Ordering for `Match` directives is based first on _whether_ a value
101 | |         // is matched or not. This is semantically meaningful --- we would
...   |
121 | |     }
122 | | }
    | |_^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derive_ord_xor_partial_ord
```

As a side note, this found a bug in clippy 😆 https://github.com/rust-lang/rust-clippy/issues/6089