### PR TITLE
Remove deprecated add-path from CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,7 +82,7 @@ jobs:
       with:
         path: ${{ runner.tool_cache }}/cargo-hack/bin
         key: cargo-hack-bin-${{ hashFiles('.github/caching/cargo-hack.lock') }}
-    - run: echo "::add-path::${{ runner.tool_cache }}/cargo-hack/bin"
+    - run: echo "${{ runner.tool_cache }}/cargo-hack/bin" >> $GITHUB_PATH
     # if `cargo-hack` somehow doesn't exist after loading it from the cache,
     # make *sure* it's there.
     - run: cargo hack --help || { cargo install --force cargo-hack; }
@@ -303,5 +303,5 @@ jobs:
       with:
         command: install
         args: --root ${{ runner.tool_cache }}/cargo-audit --force cargo-audit
-    - run: echo "::add-path::${{ runner.tool_cache }}/cargo-audit/bin"
+    - run: echo "${{ runner.tool_cache }}/cargo-audit/bin" >> $GITHUB_PATH
     - run: cargo audit


### PR DESCRIPTION
This PR just removes the use of the deprecated `add-path` from the CI workflow. See [here](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) for details. Specifically, note:

> Starting today runner version 2.273.5 will begin to warn you if you use the add-path or set-env commands. We are monitoring telemetry for the usage of these commands and plan to fully disable them in the future.