### PR TITLE
subscriber: Remove Deprecated Type, Structs, and Methods

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -71,34 +71,7 @@ pub struct Subscriber<
     _inner: PhantomData<S>,
 }
 
-/// A builder for [`Subscriber`](struct.Subscriber.html) that logs formatted representations of `tracing`
-/// events and spans.
-///
-/// **Note**: As of `tracing-subscriber` 0.2.4, the separate builder type is now
-/// deprecated, as the `Subscriber` type itself supports all the builder's
-/// configuration methods. This is now an alias for `Subscriber`.
-#[deprecated(
-    since = "0.2.4",
-    note = "a separate layer builder type is not necessary, `Subscriber`s now support configuration"
-)]
-pub type LayerBuilder<
-    S,
-    N = format::DefaultFields,
-    E = format::Format<format::Full>,
-    W = fn() -> io::Stdout,
-> = Subscriber<S, N, E, W>;
-
 impl<S> Subscriber<S> {
-    /// Returns a new [`LayerBuilder`](type.LayerBuilder.html) for configuring a `Subscriber`.
-    #[deprecated(
-        since = "0.2.4",
-        note = "a separate layer builder is not necessary, use `Subscriber::new`/`Subscriber::default` instead"
-    )]
-    #[allow(deprecated)]
-    pub fn builder() -> LayerBuilder<S> {
-        Subscriber::default()
-    }
-
     /// Returns a new [`Subscriber`](struct.Subscriber.html) with the default configuration.
     pub fn new() -> Self {
         Self::default()
@@ -467,26 +440,6 @@ impl<S, N, E, W> Subscriber<S, N, E, W> {
             make_writer: self.make_writer,
             _inner: self._inner,
         }
-    }
-}
-
-#[allow(deprecated)]
-impl<S, N, E, W> LayerBuilder<S, N, E, W>
-where
-    S: Collect + for<'a> LookupSpan<'a>,
-    N: for<'writer> FormatFields<'writer> + 'static,
-    E: FormatEvent<S, N> + 'static,
-    W: MakeWriter + 'static,
-{
-    /// Builds a [`Subscriber`] with the provided configuration.
-    ///
-    /// [`Subscriber`]: struct.Subscriber.html
-    #[deprecated(
-        since = "0.2.4",
-        note = "`LayerBuilder` is no longer a separate type; this method is not necessary"
-    )]
-    pub fn finish(self) -> Subscriber<S, N, E, W> {
-        self
     }
 }
 

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -128,8 +128,6 @@ mod fmt_subscriber;
 pub mod format;
 pub mod time;
 pub mod writer;
-#[allow(deprecated)]
-pub use fmt_subscriber::LayerBuilder;
 pub use fmt_subscriber::{FmtContext, FormattedFields, Subscriber};
 
 use crate::subscribe::Subscribe as _;
@@ -848,26 +846,6 @@ impl<N, E, F, W> CollectorBuilder<N, E, F, W> {
             filter: self.filter,
             inner: self.inner.event_format(fmt_event),
         }
-    }
-
-    /// Sets whether or not spans inherit their parents' field values (disabled
-    /// by default).
-    #[deprecated(since = "0.2.0", note = "this no longer does anything")]
-    pub fn inherit_fields(self, inherit_fields: bool) -> Self {
-        let _ = inherit_fields;
-        self
-    }
-
-    /// Sets the function that the collector being built should use to format
-    /// events that occur.
-    #[deprecated(since = "0.2.0", note = "renamed to `event_format`.")]
-    pub fn on_event<E2>(self, fmt_event: E2) -> CollectorBuilder<N, E2, F, W>
-    where
-        E2: FormatEvent<Registry, N> + 'static,
-        N: for<'writer> FormatFields<'writer> + 'static,
-        W: MakeWriter + 'static,
-    {
-        self.event_format(fmt_event)
     }
 
     /// Sets the [`MakeWriter`] that the collector being built will use to write events.


### PR DESCRIPTION
This PR removes the deprecated items in `tracing-subscriber`. It _does not_ remove `Collector::drop_span` as that will happen in a separate PR. Note that branch builds atop of #1015, which means:
- #1015 needs to be merged first
- This PR will be rebased against the master branch containing #1015.
- _Then_ this can safely be merged.