### PR TITLE
opentelemetry: prepare for 0.8.0 release

### DIFF
--- a/tracing-opentelemetry/CHANGELOG.md
+++ b/tracing-opentelemetry/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 0.8.0 (October 13, 2020)
+
+### Added
+
+- Implement additional record types (bool, i64, u64) (#1007)
+
+### Breaking changes
+
+- Add `PreSampledTracer` interface, removes need to specify sampler (#962)
+
+### Fixed
+
+- Connect external traces (#956)
+- Assign default ids if missing (#1027)
+
 # 0.7.0 (August 14, 2020)
 
 ### Breaking Changes

--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -17,9 +17,9 @@ Utilities for adding [OpenTelemetry] interoperability to [`tracing`].
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-opentelemetry.svg
-[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.7.0
+[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.8.0
 [docs-badge]: https://docs.rs/tracing-opentelemetry/badge.svg
-[docs-url]: https://docs.rs/tracing-opentelemetry/0.7.0/tracing_opentelemetry
+[docs-url]: https://docs.rs/tracing-opentelemetry/0.8.0/tracing_opentelemetry
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_opentelemetry
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -90,7 +90,7 @@
 //!
 #![deny(unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.7.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.8.0")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
The intention is to backport this and release against v0.1.x branch. Changelog:

### Added

- Implement additional record types (bool, i64, u64) (#1007)

### Breaking changes

- Add `PreSampledTracer` interface, removes need to specify sampler (#962)

### Fixed

- Connect external traces (#956)
- Assign default ids if missing (#1027)
