### PR TITLE
Fix rustdoc warning

### DIFF
--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -27,7 +27,7 @@ use tracing_log::NormalizeEvent;
 ///
 /// # Example Output
 ///
-/// ```ignore,json
+/// ```json
 /// {
 ///     "timestamp":"Feb 20 11:28:15.096",
 ///     "level":"INFO",


### PR DESCRIPTION
I've been seeing this warning from `tracing-subscriber` for quite a long time.
Running `cargo doc` gives this:
```
warning: could not parse code block as Rust code
  --> /home/veetaha/.cargo/registry/src/github.com-1ecc6299db9ec823/tracing-subscriber-0.2.13/src/fmt/format/json.rs:30:5
   |
30 |   /// ```ignore,json
   |  _____^
31 | | /// {
32 | | ///     "timestamp":"Feb 20 11:28:15.096",
33 | | ///     "level":"INFO",
...  |
38 | | /// }
39 | | /// ```
   | |_______^
   |
   = note: error from rustc: unterminated double quote string
```

I guess it's me who dares fix this then :D