### PR TITLE
subscriber: prepare to release 0.2.14

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 0.2.14 (October 22, 2020)
+
+### Fixed
+
+- **registry**: Fixed `Registry::new` allocating an excessively large amount of
+  memory, most of which would never be used ([#1064])
+
+### Changed
+
+- **registry**: Improved `new_span` performance by reusing `HashMap` allocations
+  for `Extensions` ([#1064])
+- **registry**: Significantly improved the performance of `Registry::enter` and
+  `Registry::exit` ([#1058])
+
+[#1064]: https://github.com/tokio-rs/tracing/pull/1064
+[#1058]: https://github.com/tokio-rs/tracing/pull/1058
+
 # 0.2.13 (October 7, 2020)
 
 ### Changed

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.13"
+version = "0.2.14"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -21,7 +21,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.2.13
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.14
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -67,7 +67,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.13")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.14")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
### Fixed

- **registry**: Fixed `Registry::new` allocating an excessively large
  amount of memory, most of which would never be used ([#1064])

### Changed

- **registry**: Improved `new_span` performance by reusing `HashMap`
  allocations for `Extensions` ([#1064])
- **registry**: Significantly improved the performance of
  `Registry::enter` and `Registry::exit` ([#1058])

[#1064]: https://github.com/tokio-rs/tracing/pull/1064
[#1058]: https://github.com/tokio-rs/tracing/pull/1058
