### PR TITLE
Fix a few renames missed in #1015

### DIFF
--- a/examples/examples/custom-error.rs
+++ b/examples/examples/custom-error.rs
@@ -3,7 +3,7 @@
 #![deny(rust_2018_idioms)]
 use std::error::Error;
 use std::fmt;
-use tracing_error::{ErrorLayer, SpanTrace};
+use tracing_error::{ErrorSubscriber, SpanTrace};
 use tracing_subscriber::prelude::*;
 #[derive(Debug)]
 struct FooError {
@@ -52,8 +52,8 @@ fn do_another_thing(
 fn main() {
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::subscriber())
-        // The `ErrorLayer` subscriber layer enables the use of `SpanTrace`.
-        .with(ErrorLayer::default())
+        // The `ErrorSubscriber` subscriber layer enables the use of `SpanTrace`.
+        .with(ErrorSubscriber::default())
         .init();
     match do_something("hello world") {
         Ok(result) => println!("did something successfully: {}", result),

--- a/examples/examples/instrumented-error.rs
+++ b/examples/examples/instrumented-error.rs
@@ -3,7 +3,7 @@
 #![deny(rust_2018_idioms)]
 use std::error::Error;
 use std::fmt;
-use tracing_error::{prelude::*, ErrorLayer};
+use tracing_error::{prelude::*, ErrorSubscriber};
 use tracing_subscriber::prelude::*;
 
 #[derive(Debug)]
@@ -45,8 +45,8 @@ fn do_another_thing(
 fn main() {
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::subscriber())
-        // The `ErrorLayer` subscriber layer enables the use of `SpanTrace`.
-        .with(ErrorLayer::default())
+        // The `ErrorSubscriber` subscriber layer enables the use of `SpanTrace`.
+        .with(ErrorSubscriber::default())
         .init();
 
     match do_something("hello world") {

--- a/tracing-error/README.md
+++ b/tracing-error/README.md
@@ -44,7 +44,7 @@ The crate provides the following:
 
 * [`SpanTrace`], a captured trace of the current `tracing` [span] context
 
-* [`ErrorLayer`], a [subscriber layer] which enables capturing `SpanTrace`s
+* [`ErrorSubscriber`], a [subscriber layer] which enables capturing `SpanTrace`s
 
 **Note**: This crate is currently experimental.
 
@@ -156,18 +156,18 @@ fn print_naive_spantraces(error: &(dyn Error + 'static)) {
 ```
 
 Applications that wish to use `tracing-error`-enabled errors should
-construct an [`ErrorLayer`] and add it to their [`Subscriber`] in order to
+construct an [`ErrorSubscriber`] and add it to their [`Subscriber`] in order to
 enable capturing [`SpanTrace`]s. For example:
 
 ```rust
-use tracing_error::ErrorLayer;
+use tracing_error::ErrorSubscriber;
 use tracing_subscriber::prelude::*;
 
 fn main() {
     let subscriber = tracing_subscriber::Registry::default()
         // any number of other subscriber layers may be added before or
-        // after the `ErrorLayer`...
-        .with(ErrorLayer::default());
+        // after the `ErrorSubscriber`...
+        .with(ErrorSubscriber::default());
 
     // set the subscriber as the default for the application
     tracing::subscriber::set_global_default(subscriber);
@@ -222,7 +222,7 @@ for inclusion in Tracing by you, shall be licensed as MIT, without any additiona
 terms or conditions.
 
 [`SpanTrace`]: https://docs.rs/tracing-error/*/tracing_error/struct.SpanTrace.html
-[`ErrorLayer`]: https://docs.rs/tracing-error/*/tracing_error/struct.ErrorLayer.html
+[`ErrorSubscriber`]: https://docs.rs/tracing-error/*/tracing_error/struct.ErrorSubscriber.html
 [`TracedError`]: https://docs.rs/tracing-error/*/tracing_error/struct.TracedError.html
 [`InstrumentResult`]: https://docs.rs/tracing-error/*/tracing_error/trait.InstrumentResult.html
 [`InstrumentError`]: https://docs.rs/tracing-error/*/tracing_error/trait.InstrumentError.html
@@ -235,4 +235,4 @@ terms or conditions.
 [`tracing`]: https://docs.rs/tracing
 [`std::error::Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
 [`SpanTrace`]: https://docs.rs/tracing-error/0.1.2/tracing_error/struct.SpanTrace.html
-[`ErrorLayer`]: https://docs.rs/tracing-error/0.1.2/tracing_error/struct.ErrorLayer.html
+[`ErrorSubscriber`]: https://docs.rs/tracing-error/0.1.2/tracing_error/struct.ErrorSubscriber.html

--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -152,7 +152,7 @@ pub struct SpanTraceStatus(SpanTraceStatusInner);
 
 impl SpanTraceStatus {
     /// Formatting a SpanTrace is not supported, likely because there is no
-    /// ErrorLayer or the ErrorLayer is from a different version of
+    /// ErrorSubscriber or the ErrorSubscriber is from a different version of
     /// tracing_error
     pub const UNSUPPORTED: SpanTraceStatus = SpanTraceStatus(SpanTraceStatusInner::Unsupported);
 
@@ -265,14 +265,14 @@ impl fmt::Debug for SpanTrace {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ErrorLayer;
+    use crate::ErrorSubscriber;
     use tracing::collect::with_default;
     use tracing::{span, Level};
     use tracing_subscriber::{prelude::*, registry::Registry};
 
     #[test]
     fn capture_supported() {
-        let collector = Registry::default().with(ErrorLayer::default());
+        let collector = Registry::default().with(ErrorSubscriber::default());
 
         with_default(collector, || {
             let span = span!(Level::ERROR, "test span");
@@ -288,7 +288,7 @@ mod tests {
 
     #[test]
     fn capture_empty() {
-        let collector = Registry::default().with(ErrorLayer::default());
+        let collector = Registry::default().with(ErrorSubscriber::default());
 
         with_default(collector, || {
             let span_trace = SpanTrace::capture();

--- a/tracing-error/src/layer.rs
+++ b/tracing-error/src/layer.rs
@@ -19,7 +19,7 @@ use tracing_subscriber::{
 /// [`SpanTrace`]: ../struct.SpanTrace.html
 /// [field formatter]: https://docs.rs/tracing-subscriber/0.2.10/tracing_subscriber/fmt/trait.FormatFields.html
 /// [default format]: https://docs.rs/tracing-subscriber/0.2.10/tracing_subscriber/fmt/format/struct.DefaultFields.html
-pub struct ErrorLayer<S, F = DefaultFields> {
+pub struct ErrorSubscriber<S, F = DefaultFields> {
     format: F,
 
     get_context: WithContext,
@@ -33,7 +33,7 @@ pub(crate) struct WithContext(
     fn(&Dispatch, &span::Id, f: &mut dyn FnMut(&'static Metadata<'static>, &str) -> bool),
 );
 
-impl<S, F> Subscribe<S> for ErrorLayer<S, F>
+impl<S, F> Subscribe<S> for ErrorSubscriber<S, F>
 where
     S: Collect + for<'span> LookupSpan<'span>,
     F: for<'writer> FormatFields<'writer> + 'static,
@@ -68,12 +68,12 @@ where
     }
 }
 
-impl<S, F> ErrorLayer<S, F>
+impl<S, F> ErrorSubscriber<S, F>
 where
     F: for<'writer> FormatFields<'writer> + 'static,
     S: Collect + for<'span> LookupSpan<'span>,
 {
-    /// Returns a new `ErrorLayer` with the provided [field formatter].
+    /// Returns a new `ErrorSubscriber` with the provided [field formatter].
     ///
     /// [field formatter]: https://docs.rs/tracing-subscriber/0.2.10/tracing_subscriber/fmt/trait.FormatFields.html
     pub fn new(format: F) -> Self {
@@ -120,7 +120,7 @@ impl WithContext {
     }
 }
 
-impl<S> Default for ErrorLayer<S>
+impl<S> Default for ErrorSubscriber<S>
 where
     S: Collect + for<'span> LookupSpan<'span>,
 {
@@ -129,9 +129,9 @@ where
     }
 }
 
-impl<S, F: fmt::Debug> fmt::Debug for ErrorLayer<S, F> {
+impl<S, F: fmt::Debug> fmt::Debug for ErrorSubscriber<S, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ErrorLayer")
+        f.debug_struct("ErrorSubscriber")
             .field("format", &self.format)
             .field("subscriber", &format_args!("{}", type_name::<S>()))
             .finish()

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -139,7 +139,7 @@
 //! ```
 //!
 //! Applications that wish to use `tracing-error`-enabled errors should
-//! construct an [`ErrorSubscriber`] and add it to their [collector` in order to
+//! construct an [`ErrorSubscriber`] and add it to their [`collector`] in order to
 //! enable capturing [`SpanTrace`]s. For example:
 //!
 //! ```rust
@@ -148,7 +148,7 @@
 //!
 //! fn main() {
 //!     let subscriber = tracing_subscriber::Registry::default()
-//!         // any number of other subscriber layers may be added before or
+//!         // any number of other collector subscribers may be added before or
 //!         // after the `ErrorSubscriber`...
 //!         .with(ErrorSubscriber::default());
 //!

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! * [`SpanTrace`], a captured trace of the current `tracing` [span] context
 //!
-//! * [`ErrorLayer`], a [subscriber layer] which enables capturing `SpanTrace`s
+//! * [`ErrorSubscriber`], a [subscriber layer] which enables capturing `SpanTrace`s
 //!
 //! **Note**: This crate is currently experimental.
 //!
@@ -139,18 +139,18 @@
 //! ```
 //!
 //! Applications that wish to use `tracing-error`-enabled errors should
-//! construct an [`ErrorLayer`] and add it to their [collector` in order to
+//! construct an [`ErrorSubscriber`] and add it to their [collector` in order to
 //! enable capturing [`SpanTrace`]s. For example:
 //!
 //! ```rust
-//! use tracing_error::ErrorLayer;
+//! use tracing_error::ErrorSubscriber;
 //! use tracing_subscriber::prelude::*;
 //!
 //! fn main() {
 //!     let subscriber = tracing_subscriber::Registry::default()
 //!         // any number of other subscriber layers may be added before or
-//!         // after the `ErrorLayer`...
-//!         .with(ErrorLayer::default());
+//!         // after the `ErrorSubscriber`...
+//!         .with(ErrorSubscriber::default());
 //!
 //!     // set the subscriber as the default for the application
 //!     tracing::collect::set_global_default(subscriber);
@@ -158,7 +158,7 @@
 //! ```
 //!
 //! [`SpanTrace`]: struct.SpanTrace.html
-//! [`ErrorLayer`]: struct.ErrorLayer.html
+//! [`ErrorSubscriber`]: struct.ErrorSubscriber.html
 //! [`TracedError`]: struct.TracedError.html
 //! [`InstrumentResult`]: trait.InstrumentResult.html
 //! [`InstrumentError`]: trait.InstrumentError.html
@@ -222,7 +222,7 @@ mod layer;
 pub use self::backtrace::{SpanTrace, SpanTraceStatus};
 #[cfg(feature = "traced-error")]
 pub use self::error::{ExtractSpanTrace, InstrumentError, InstrumentResult, TracedError};
-pub use self::layer::ErrorLayer;
+pub use self::layer::ErrorSubscriber;
 
 #[cfg(feature = "traced-error")]
 #[cfg_attr(docsrs, doc(cfg(feature = "traced-error")))]

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -139,7 +139,7 @@
 //! ```
 //!
 //! Applications that wish to use `tracing-error`-enabled errors should
-//! construct an [`ErrorSubscriber`] and add it to their [`collector`] in order to
+//! construct an [`ErrorSubscriber`] and add it to their [collector] in order to
 //! enable capturing [`SpanTrace`]s. For example:
 //!
 //! ```rust

--- a/tracing-subscriber/tests/reload.rs
+++ b/tracing-subscriber/tests/reload.rs
@@ -6,9 +6,9 @@ use tracing_core::{
 };
 use tracing_subscriber::{prelude::*, reload::*, subscribe};
 
-pub struct NopSubscriber;
+pub struct NopCollector;
 
-impl Collect for NopSubscriber {
+impl Collect for NopCollector {
     fn register_callsite(&self, _: &'static Metadata<'static>) -> Interest {
         Interest::never()
     }
@@ -57,11 +57,11 @@ fn reload_handle() {
         tracing::trace!("my event");
     }
 
-    let (layer, handle) = Subscriber::new(Filter::One);
+    let (subscriber, handle) = Subscriber::new(Filter::One);
 
-    let subscriber = tracing_core::dispatch::Dispatch::new(layer.with_collector(NopSubscriber));
+    let dispatcher = tracing_core::dispatch::Dispatch::new(subscriber.with_collector(NopCollector));
 
-    tracing_core::dispatch::with_default(&subscriber, || {
+    tracing_core::dispatch::with_default(&dispatcher, || {
         assert_eq!(FILTER1_CALLS.load(Ordering::SeqCst), 0);
         assert_eq!(FILTER2_CALLS.load(Ordering::SeqCst), 0);
 

--- a/tracing/benches/subscriber.rs
+++ b/tracing/benches/subscriber.rs
@@ -97,9 +97,7 @@ const N_SPANS: usize = 100;
 fn criterion_benchmark(c: &mut Criterion) {
     let mut c = c.benchmark_group("scoped/subscriber");
     c.bench_function("span_no_fields", |b| {
-        tracing::collect::with_default(EnabledCollector, || {
-            b.iter(|| span!(Level::TRACE, "span"))
-        });
+        tracing::collect::with_default(EnabledCollector, || b.iter(|| span!(Level::TRACE, "span")));
     });
 
     c.bench_function("enter_span", |b| {

--- a/tracing/benches/subscriber.rs
+++ b/tracing/benches/subscriber.rs
@@ -10,10 +10,10 @@ use std::{
 };
 use tracing::{field, span, Event, Id, Metadata};
 
-/// A subscriber that is enabled but otherwise does nothing.
-struct EnabledSubscriber;
+/// A collector that is enabled but otherwise does nothing.
+struct EnabledCollector;
 
-impl tracing::Collect for EnabledSubscriber {
+impl tracing::Collect for EnabledCollector {
     fn new_span(&self, span: &span::Attributes<'_>) -> Id {
         let _ = span;
         Id::from_u64(0xDEAD_FACE)
@@ -45,8 +45,8 @@ impl tracing::Collect for EnabledSubscriber {
     }
 }
 
-/// Simulates a subscriber that records span data.
-struct VisitingSubscriber(Mutex<String>);
+/// Simulates a collector that records span data.
+struct VisitingCollector(Mutex<String>);
 
 struct Visitor<'a>(MutexGuard<'a, String>);
 
@@ -57,7 +57,7 @@ impl<'a> field::Visit for Visitor<'a> {
     }
 }
 
-impl tracing::Collect for VisitingSubscriber {
+impl tracing::Collect for VisitingCollector {
     fn new_span(&self, span: &span::Attributes<'_>) -> Id {
         let mut visitor = Visitor(self.0.lock().unwrap());
         span.record(&mut visitor);
@@ -97,13 +97,13 @@ const N_SPANS: usize = 100;
 fn criterion_benchmark(c: &mut Criterion) {
     let mut c = c.benchmark_group("scoped/subscriber");
     c.bench_function("span_no_fields", |b| {
-        tracing::collect::with_default(EnabledSubscriber, || {
+        tracing::collect::with_default(EnabledCollector, || {
             b.iter(|| span!(Level::TRACE, "span"))
         });
     });
 
     c.bench_function("enter_span", |b| {
-        tracing::collect::with_default(EnabledSubscriber, || {
+        tracing::collect::with_default(EnabledCollector, || {
             let span = span!(Level::TRACE, "span");
             #[allow(clippy::unit_arg)]
             b.iter(|| black_box(span.in_scope(|| {})))
@@ -111,7 +111,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("event", |b| {
-        tracing::collect::with_default(EnabledSubscriber, || {
+        tracing::collect::with_default(EnabledCollector, || {
             b.iter(|| {
                 tracing::event!(Level::TRACE, "hello");
             });
@@ -125,13 +125,13 @@ fn criterion_benchmark(c: &mut Criterion) {
         }
 
         let n = black_box(N_SPANS);
-        tracing::collect::with_default(EnabledSubscriber, || {
+        tracing::collect::with_default(EnabledCollector, || {
             b.iter(|| (0..n).fold(mk_span(0), |_, i| mk_span(i as u64)))
         });
     });
 
     c.bench_function("span_with_fields", |b| {
-        tracing::collect::with_default(EnabledSubscriber, || {
+        tracing::collect::with_default(EnabledCollector, || {
             b.iter(|| {
                 span!(
                     Level::TRACE,
@@ -146,7 +146,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("span_with_fields_record", |b| {
-        let subscriber = VisitingSubscriber(Mutex::new(String::from("")));
+        let subscriber = VisitingCollector(Mutex::new(String::from("")));
         tracing::collect::with_default(subscriber, || {
             b.iter(|| {
                 span!(
@@ -183,7 +183,7 @@ fn bench_dispatch(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("scoped/dispatch");
     group.bench_function("get_ref", |b| {
-        tracing::collect::with_default(EnabledSubscriber, || {
+        tracing::collect::with_default(EnabledCollector, || {
             b.iter(|| {
                 tracing::dispatch::get_default(|current| {
                     black_box(&current);
@@ -192,7 +192,7 @@ fn bench_dispatch(c: &mut Criterion) {
         })
     });
     group.bench_function("get_clone", |b| {
-        tracing::collect::with_default(EnabledSubscriber, || {
+        tracing::collect::with_default(EnabledCollector, || {
             b.iter(|| {
                 let current = tracing::dispatch::get_default(|current| current.clone());
                 black_box(current);

--- a/tracing/tests/collector.rs
+++ b/tracing/tests/collector.rs
@@ -16,10 +16,10 @@ use tracing::{
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn event_macros_dont_infinite_loop() {
-    // This test ensures that an event macro within a subscriber
+    // This test ensures that an event macro within a collector
     // won't cause an infinite loop of events.
-    struct TestSubscriber;
-    impl Collect for TestSubscriber {
+    struct TestCollector;
+    impl Collect for TestCollector {
         fn register_callsite(&self, _: &Metadata<'_>) -> Interest {
             // Always return sometimes so that `enabled` will be called
             // (which can loop).
@@ -50,7 +50,7 @@ fn event_macros_dont_infinite_loop() {
         fn exit(&self, _: &span::Id) {}
     }
 
-    with_default(TestSubscriber, || {
+    with_default(TestCollector, || {
         event!(Level::TRACE, foo = false);
     })
 }


### PR DESCRIPTION
A few minor things left over from #1015. There are possibly a few more (`ErrorLayer` in `tracing-error`?).