### PR TITLE
subscriber: add `Pretty` formatter

### DIFF
--- a/examples/examples/fmt-json.rs
+++ b/examples/examples/fmt-json.rs
@@ -4,11 +4,9 @@ mod yak_shave;
 
 fn main() {
     tracing_subscriber::fmt()
-        .pretty()
-        .with_thread_names(true)
-        // enable everything
+        .json()
         .with_max_level(tracing::Level::TRACE)
-        // sets this to be the default, global collector for this application.
+        .with_current_span(false)
         .init();
 
     let number_of_yaks = 3;

--- a/examples/examples/fmt-pretty.rs
+++ b/examples/examples/fmt-pretty.rs
@@ -1,0 +1,38 @@
+#![deny(rust_2018_idioms)]
+
+use tracing::{debug, info, span, warn, Level};
+use tracing_subscriber::prelude::*;
+fn main() {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::subscriber().pretty())
+        .init();
+
+    let app_span = span!(Level::TRACE, "app", version = %5.0);
+    let _e = app_span.enter();
+
+    let server_span = span!(Level::TRACE, "server", host = "localhost", port = 8080);
+    let _e2 = server_span.enter();
+    info!("starting");
+    info!("listening");
+    let peer1 = span!(Level::TRACE, "conn", peer_addr = "82.9.9.9", port = 42381);
+    peer1.in_scope(|| {
+        debug!("connected");
+        debug!(length = 2, "message received");
+    });
+    let peer2 = span!(Level::TRACE, "conn", peer_addr = "8.8.8.8", port = 18230);
+    peer2.in_scope(|| {
+        debug!("connected");
+    });
+    peer1.in_scope(|| {
+        warn!(algo = "xor", "weak encryption requested");
+        debug!(length = 8, "response sent");
+        debug!("disconnected");
+    });
+    peer2.in_scope(|| {
+        debug!(length = 5, "message received");
+        debug!(length = 8, "response sent");
+        debug!("disconnected");
+    });
+    warn!("internal error");
+    info!("exit");
+}

--- a/examples/examples/fmt-pretty.rs
+++ b/examples/examples/fmt-pretty.rs
@@ -4,7 +4,13 @@ use tracing::{debug, info, span, warn, Level};
 use tracing_subscriber::prelude::*;
 fn main() {
     tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::subscriber().pretty())
+        .with(
+            tracing_subscriber::fmt::subscriber()
+                .pretty()
+                .with_thread_names(true)
+                .with_thread_ids(true)
+                .with_target(false),
+        )
         .init();
 
     let app_span = span!(Level::TRACE, "app", version = %5.0);

--- a/examples/examples/fmt.rs
+++ b/examples/examples/fmt.rs
@@ -1,23 +1,20 @@
 #![deny(rust_2018_idioms)]
-use tracing::{info, Level};
-
 #[path = "fmt/yak_shave.rs"]
 mod yak_shave;
 
 fn main() {
     tracing_subscriber::fmt()
-        // all spans/events with a level higher than DEBUG (e.g, info, warn, etc.)
-        // will be written to stdout.
-        .with_max_level(Level::DEBUG)
+        // enable everything
+        .with_max_level(tracing::Level::TRACE)
         // sets this to be the default, global collector for this application.
         .init();
 
     let number_of_yaks = 3;
     // this creates a new event, outside of any spans.
-    info!(number_of_yaks, "preparing to shave yaks");
+    tracing::info!(number_of_yaks, "preparing to shave yaks");
 
     let number_shaved = yak_shave::shave_all(number_of_yaks);
-    info!(
+    tracing::info!(
         all_yaks_shaved = number_shaved == number_of_yaks,
         "yak shaving completed."
     );

--- a/examples/examples/fmt/yak_shave.rs
+++ b/examples/examples/fmt/yak_shave.rs
@@ -1,38 +1,38 @@
 use std::{error::Error, io};
-use tracing::{debug, error, info, span, warn, Level};
+use tracing::{debug, error, info, span, trace, warn, Level};
 
 // the `#[tracing::instrument]` attribute creates and enters a span
 // every time the instrumented function is called. The span is named after the
 // the function or method. Paramaters passed to the function are recorded as fields.
 #[tracing::instrument]
 pub fn shave(yak: usize) -> Result<(), Box<dyn Error + 'static>> {
-    // this creates an event at the DEBUG log level with two fields:
+    // this creates an event at the TRACE log level with two fields:
     // - `excitement`, with the key "excitement" and the value "yay!"
     // - `message`, with the key "message" and the value "hello! I'm gonna shave a yak."
     //
     // unlike other fields, `message`'s shorthand initialization is just the string itself.
-    debug!(excitement = "yay!", "hello! I'm gonna shave a yak.");
+    trace!(excitement = "yay!", "hello! I'm gonna shave a yak");
     if yak == 3 {
-        warn!("could not locate yak!");
+        warn!("could not locate yak");
         // note that this is intended to demonstrate `tracing`'s features, not idiomatic
         // error handling! in a library or application, you should consider returning
         // a dedicated `YakError`. libraries like snafu or thiserror make this easy.
-        return Err(io::Error::new(io::ErrorKind::Other, "shaving yak failed!").into());
+        return Err(io::Error::new(io::ErrorKind::Other, "missing yak").into());
     } else {
-        debug!("yak shaved successfully");
+        trace!("yak shaved successfully");
     }
     Ok(())
 }
 
 pub fn shave_all(yaks: usize) -> usize {
-    // Constructs a new span named "shaving_yaks" at the TRACE level,
+    // Constructs a new span named "shaving_yaks" at the INFO level,
     // and a field whose key is "yaks". This is equivalent to writing:
     //
-    // let span = span!(Level::TRACE, "shaving_yaks", yaks = yaks);
+    // let span = span!(Level::INFO, "shaving_yaks", yaks = yaks);
     //
     // local variables (`yaks`) can be used as field values
     // without an assignment, similar to struct initializers.
-    let span = span!(Level::TRACE, "shaving_yaks", yaks);
+    let span = span!(Level::INFO, "shaving_yaks", yaks);
     let _enter = span.enter();
 
     info!("shaving yaks");
@@ -40,16 +40,16 @@ pub fn shave_all(yaks: usize) -> usize {
     let mut yaks_shaved = 0;
     for yak in 1..=yaks {
         let res = shave(yak);
-        debug!(yak, shaved = res.is_ok());
+        debug!(target: "yak_events", yak, shaved = res.is_ok());
 
         if let Err(ref error) = res {
             // Like spans, events can also use the field initialization shorthand.
             // In this instance, `yak` is the field being initalized.
-            error!(yak, error = error.as_ref(), "failed to shave yak!");
+            error!(yak, error = error.as_ref(), "failed to shave yak");
         } else {
             yaks_shaved += 1;
         }
-        debug!(yaks_shaved);
+        trace!(yaks_shaved);
     }
 
     yaks_shaved

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -343,6 +343,9 @@ where
         }
     }
 
+    /// Sets the subscriber being built to use an [excessively pretty, human-readable formatter](crate::fmt::format::Pretty).
+    #[cfg(feature = "ansi")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
     pub fn pretty(self) -> Subscriber<S, format::Pretty, format::Format<format::Pretty, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.pretty(),

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -346,7 +346,7 @@ where
     pub fn pretty(self) -> Subscriber<S, format::Pretty, format::Format<format::Pretty, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.pretty(),
-            fmt_fields: format::Pretty,
+            fmt_fields: format::Pretty::default(),
             fmt_span: self.fmt_span,
             make_writer: self.make_writer,
             _inner: self._inner,

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -343,8 +343,8 @@ where
         }
     }
 
-    pub fn pretty(self) -> Layer<S, format::Pretty, format::Format<format::Pretty, T>, W> {
-        Layer {
+    pub fn pretty(self) -> Subscriber<S, format::Pretty, format::Format<format::Pretty, T>, W> {
+        Subscriber {
             fmt_event: self.fmt_event.pretty(),
             fmt_fields: format::Pretty,
             fmt_span: self.fmt_span,

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -343,6 +343,16 @@ where
         }
     }
 
+    pub fn pretty(self) -> Layer<S, format::Pretty, format::Format<format::Pretty, T>, W> {
+        Layer {
+            fmt_event: self.fmt_event.pretty(),
+            fmt_fields: format::Pretty,
+            fmt_span: self.fmt_span,
+            make_writer: self.make_writer,
+            _inner: self._inner,
+        }
+    }
+
     /// Sets the subscriber being built to use a [JSON formatter](../fmt/format/struct.Json.html).
     ///
     /// The full format includes fields from all entered spans.

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -24,11 +24,17 @@ use ansi_term::{Colour, Style};
 
 #[cfg(feature = "json")]
 mod json;
-
-use fmt::{Debug, Display};
 #[cfg(feature = "json")]
 #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 pub use json::*;
+
+#[cfg(feature = "ansi")]
+mod pretty;
+#[cfg(feature = "ansi")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
+pub use pretty::*;
+
+use fmt::{Debug, Display};
 
 /// A type that can format a tracing `Event` for a `fmt::Write`.
 ///
@@ -166,9 +172,6 @@ pub struct Compact;
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Full;
 
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
-pub struct Pretty;
-
 /// A pre-configured event formatter.
 ///
 /// You will usually want to use this as the `FormatEvent` for a `FmtSubscriber`.
@@ -219,7 +222,7 @@ impl<F, T> Format<F, T> {
 
     pub fn pretty(self) -> Format<Pretty, T> {
         Format {
-            format: Pretty,
+            format: Pretty::default(),
             timer: self.timer,
             ansi: self.ansi,
             display_target: self.display_target,
@@ -535,135 +538,6 @@ where
     }
 }
 
-#[cfg(feature = "ansi")]
-impl<C, N, T> FormatEvent<C, N> for Format<Pretty, T>
-where
-    C: Collect + for<'a> LookupSpan<'a>,
-    N: for<'a> FormatFields<'a> + 'static,
-    T: FormatTime,
-{
-    fn format_event(
-        &self,
-        ctx: &FmtContext<'_, C, N>,
-        writer: &mut dyn fmt::Write,
-        event: &Event<'_>,
-    ) -> fmt::Result {
-        fn style_for(level: &Level) -> Style {
-            match *level {
-                Level::TRACE => Style::new().fg(Colour::Purple),
-                Level::DEBUG => Style::new().fg(Colour::Blue),
-                Level::INFO => Style::new().fg(Colour::Green),
-                Level::WARN => Style::new().fg(Colour::Yellow),
-                Level::ERROR => Style::new().fg(Colour::Red),
-            }
-        }
-        #[cfg(feature = "tracing-log")]
-        let normalized_meta = event.normalized_metadata();
-        #[cfg(feature = "tracing-log")]
-        let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
-        #[cfg(not(feature = "tracing-log"))]
-        let meta = event.metadata();
-        write!(writer, "  ")?;
-        time::write(&self.timer, writer, self.ansi)?;
-
-        let style = if self.display_level {
-            style_for(meta.level())
-        } else {
-            Style::new()
-        };
-
-        if self.display_target {
-            write!(
-                writer,
-                "{}{}{}: ",
-                style.bold().prefix(),
-                meta.target(),
-                style.bold().infix(style)
-            )?;
-        }
-        let mut v = PrettyVisitor::new(writer, true).with_style(style);
-        event.record(&mut v);
-        v.finish()?;
-        writeln!(writer, "")?;
-        let thread = self.display_thread_name || self.display_thread_id;
-        let dimmed = Style::new().dimmed().italic();
-        if let (Some(file), Some(line)) = (meta.file(), meta.line()) {
-            write!(
-                writer,
-                "    {} {}:{}{}",
-                dimmed.paint("at"),
-                file,
-                line,
-                dimmed.paint(if thread { " " } else { "\n" })
-            )?;
-        } else if thread {
-            write!(writer, "    ")?;
-        }
-
-        if thread {
-            write!(writer, "{} ", dimmed.paint("on"))?;
-            let thread = std::thread::current();
-            if self.display_thread_name {
-                if let Some(name) = thread.name() {
-                    write!(writer, "{}", name)?;
-                    if self.display_thread_id {
-                        write!(writer, " ({:?})", thread.id())?;
-                    }
-                } else if !self.display_thread_id {
-                    write!(writer, " {:?}", thread.id())?;
-                }
-            } else if self.display_thread_id {
-                write!(writer, " {:?}", thread.id())?;
-            }
-            writer.write_char('\n')?;
-        }
-
-        let bold = Style::new().bold();
-        let span = event
-            .parent()
-            .and_then(|id| ctx.span(&id))
-            .or_else(|| ctx.lookup_current());
-
-        let scope = span.into_iter().flat_map(|span| {
-            let parents = span.parents();
-            iter::once(span).chain(parents)
-        });
-
-        for span in scope {
-            let meta = span.metadata();
-            if self.display_target {
-                write!(
-                    writer,
-                    "    {} {}::{}",
-                    dimmed.paint("in"),
-                    meta.target(),
-                    bold.paint(meta.name()),
-                )?;
-            } else {
-                write!(
-                    writer,
-                    "    {} {}",
-                    dimmed.paint("in"),
-                    bold.paint(meta.name()),
-                )?;
-            }
-
-            // seen = true;
-
-            let ext = span.extensions();
-            let fields = &ext
-                .get::<FormattedFields<N>>()
-                .expect("Unable to find FormattedFields in extensions; this is a bug");
-            if !fields.is_empty() {
-                write!(writer, " {} {}", dimmed.paint("with"), fields)?;
-            }
-            writer.write_char('\n')?;
-        }
-
-        writer.write_char('\n')
-    }
-}
-
 // === impl FormatFields ===
 
 impl<'writer, M> FormatFields<'writer> for M
@@ -699,18 +573,6 @@ pub struct DefaultFields {
 pub struct DefaultVisitor<'a> {
     writer: &'a mut dyn Write,
     is_empty: bool,
-    result: fmt::Result,
-}
-
-/// The [visitor] produced by [`Pretty`]'s [`MakeVisitor`] implementation.
-///
-/// [visitor]: ../../field/trait.Visit.html
-/// [`DefaultFields`]: struct.DefaultFields.html
-/// [`MakeVisitor`]: ../../field/trait.MakeVisitor.html
-pub struct PrettyVisitor<'a> {
-    writer: &'a mut dyn Write,
-    is_empty: bool,
-    style: Style,
     result: fmt::Result,
 }
 
@@ -821,123 +683,6 @@ impl<'a> fmt::Debug for DefaultVisitor<'a> {
             .field("is_empty", &self.is_empty)
             .field("result", &self.result)
             .finish()
-    }
-}
-// === PrettyFields ===
-
-impl<'a> MakeVisitor<&'a mut dyn Write> for Pretty {
-    type Visitor = PrettyVisitor<'a>;
-
-    #[inline]
-    fn make_visitor(&self, target: &'a mut dyn Write) -> Self::Visitor {
-        PrettyVisitor::new(target, true)
-    }
-}
-
-// === impl PrettyVisitor ===
-
-impl<'a> PrettyVisitor<'a> {
-    /// Returns a new default visitor that formats to the provided `writer`.
-    ///
-    /// # Arguments
-    /// - `writer`: the writer to format to.
-    /// - `is_empty`: whether or not any fields have been previously written to
-    ///   that writer.
-    pub fn new(writer: &'a mut dyn Write, is_empty: bool) -> Self {
-        Self {
-            writer,
-            is_empty,
-            style: Style::default(),
-            result: Ok(()),
-        }
-    }
-
-    pub fn with_style(self, style: Style) -> Self {
-        Self { style, ..self }
-    }
-
-    fn maybe_pad(&mut self) {
-        if self.is_empty {
-            self.is_empty = false;
-        } else {
-            self.result = write!(self.writer, ", ");
-        }
-    }
-}
-
-impl<'a> field::Visit for PrettyVisitor<'a> {
-    fn record_str(&mut self, field: &Field, value: &str) {
-        if self.result.is_err() {
-            return;
-        }
-
-        if field.name() == "message" {
-            self.record_debug(field, &format_args!("{}", value))
-        } else {
-            self.record_debug(field, &value)
-        }
-    }
-
-    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
-        if let Some(source) = value.source() {
-            let bold = self.style.bold();
-            self.record_debug(
-                field,
-                &format_args!(
-                    "{}, {}{}.source{}: {}",
-                    value,
-                    bold.prefix(),
-                    field,
-                    bold.infix(self.style),
-                    source,
-                ),
-            )
-        } else {
-            self.record_debug(field, &format_args!("{}", value))
-        }
-    }
-
-    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-        if self.result.is_err() {
-            return;
-        }
-        let bold = self.style.bold();
-        self.maybe_pad();
-        self.result = match field.name() {
-            "message" => write!(self.writer, "{}{:?}", self.style.prefix(), value,),
-            // Skip fields that are actually log metadata that have already been handled
-            #[cfg(feature = "tracing-log")]
-            name if name.starts_with("log.") => Ok(()),
-            name if name.starts_with("r#") => write!(
-                self.writer,
-                "{}{}{}: {:?}",
-                bold.prefix(),
-                &name[2..],
-                bold.infix(self.style),
-                value
-            ),
-            name => write!(
-                self.writer,
-                "{}{}{}: {:?}",
-                bold.prefix(),
-                name,
-                bold.infix(self.style),
-                value
-            ),
-        };
-    }
-}
-
-impl<'a> crate::field::VisitOutput<fmt::Result> for PrettyVisitor<'a> {
-    fn finish(self) -> fmt::Result {
-        write!(self.writer, "{}", self.style.suffix())?;
-        self.result
-    }
-}
-
-impl<'a> crate::field::VisitFmt for PrettyVisitor<'a> {
-    fn writer(&mut self) -> &mut dyn fmt::Write {
-        self.writer
     }
 }
 

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -220,6 +220,13 @@ impl<F, T> Format<F, T> {
         }
     }
 
+    /// Use an excessively pretty, human-readable output format.
+    ///
+    /// See [`Pretty`].
+    ///
+    /// Note that this requires the "ansi" feature to be enabled.
+    #[cfg(feature = "ansi")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
     pub fn pretty(self) -> Format<Pretty, T> {
         Format {
             format: Pretty::default(),

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -585,14 +585,23 @@ where
         event.record(&mut v);
         v.finish()?;
         writeln!(writer, "")?;
-
+        let thread = self.display_thread_name || self.display_thread_id;
         let dimmed = Style::new().dimmed().italic();
         if let (Some(file), Some(line)) = (meta.file(), meta.line()) {
-            writeln!(writer, "    {} {}:{}", dimmed.paint("at"), file, line,)?;
+            write!(
+                writer,
+                "    {} {}:{}{}",
+                dimmed.paint("at"),
+                file,
+                line,
+                dimmed.paint(if thread { " " } else { "\n" })
+            )?;
+        } else if thread {
+            write!(writer, "    ")?;
         }
 
-        if self.display_thread_name || self.display_thread_id {
-            write!(writer, "    {} ", dimmed.paint("on"))?;
+        if thread {
+            write!(writer, "{} ", dimmed.paint("on"))?;
             let thread = std::thread::current();
             if self.display_thread_name {
                 if let Some(name) = thread.name() {

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -166,6 +166,9 @@ pub struct Compact;
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Full;
 
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Pretty;
+
 /// A pre-configured event formatter.
 ///
 /// You will usually want to use this as the `FormatEvent` for a `FmtSubscriber`.
@@ -205,6 +208,18 @@ impl<F, T> Format<F, T> {
     pub fn compact(self) -> Format<Compact, T> {
         Format {
             format: Compact,
+            timer: self.timer,
+            ansi: self.ansi,
+            display_target: self.display_target,
+            display_level: self.display_level,
+            display_thread_id: self.display_thread_id,
+            display_thread_name: self.display_thread_name,
+        }
+    }
+
+    pub fn pretty(self) -> Format<Pretty, T> {
+        Format {
+            format: Pretty,
             timer: self.timer,
             ansi: self.ansi,
             display_target: self.display_target,
@@ -520,7 +535,93 @@ where
     }
 }
 
+#[cfg(feature = "ansi")]
+impl<S, N, T> FormatEvent<S, N> for Format<Pretty, T>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+    T: FormatTime,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        writer: &mut dyn fmt::Write,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        fn style_for(level: &Level) -> Style {
+            match *level {
+                Level::TRACE => Style::new().fg(Colour::Purple),
+                Level::DEBUG => Style::new().fg(Colour::Blue),
+                Level::INFO => Style::new().fg(Colour::Green),
+                Level::WARN => Style::new().fg(Colour::Yellow),
+                Level::ERROR => Style::new().fg(Colour::Red),
+            }
+        }
+        #[cfg(feature = "tracing-log")]
+        let normalized_meta = event.normalized_metadata();
+        #[cfg(feature = "tracing-log")]
+        let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
+        #[cfg(not(feature = "tracing-log"))]
+        let meta = event.metadata();
+        write!(writer, "  ")?;
+        time::write(&self.timer, writer, self.ansi)?;
+        let style = style_for(meta.level());
+        write!(
+            writer,
+            "{}{}{}: ",
+            style.bold().prefix(),
+            meta.target(),
+            style.bold().infix(style)
+        )?;
+        let mut v = PrettyVisitor::new(writer, true).with_style(style);
+        event.record(&mut v);
+        v.finish()?;
+        writeln!(writer, "")?;
+        let dimmed = Style::new().dimmed().italic();
+        if let (Some(file), Some(line)) = (meta.file(), meta.line()) {
+            writeln!(writer, "    {} {}:{}", dimmed.paint("at"), file, line,)?;
+        }
+
+        let bold = Style::new().bold();
+        // let mut seen = false;
+
+        let span = event
+            .parent()
+            .and_then(|id| ctx.span(&id))
+            .or_else(|| ctx.lookup_current());
+
+        let scope = span.into_iter().flat_map(|span| {
+            let parents = span.parents();
+            iter::once(span).chain(parents)
+        });
+
+        for span in scope {
+            let meta = span.metadata();
+            write!(
+                writer,
+                "    {} {}::{}",
+                dimmed.paint("in"),
+                meta.target(),
+                bold.paint(meta.name()),
+            )?;
+            // seen = true;
+
+            let ext = span.extensions();
+            let fields = &ext
+                .get::<FormattedFields<N>>()
+                .expect("Unable to find FormattedFields in extensions; this is a bug");
+            if !fields.is_empty() {
+                write!(writer, " {} {}", dimmed.paint("with"), fields)?;
+            }
+            writer.write_char('\n')?;
+        }
+
+        writer.write_char('\n')
+    }
+}
+
 // === impl FormatFields ===
+
 impl<'writer, M> FormatFields<'writer> for M
 where
     M: MakeOutput<&'writer mut dyn fmt::Write, fmt::Result>,
@@ -554,6 +655,18 @@ pub struct DefaultFields {
 pub struct DefaultVisitor<'a> {
     writer: &'a mut dyn Write,
     is_empty: bool,
+    result: fmt::Result,
+}
+
+/// The [visitor] produced by [`Pretty`]'s [`MakeVisitor`] implementation.
+///
+/// [visitor]: ../../field/trait.Visit.html
+/// [`DefaultFields`]: struct.DefaultFields.html
+/// [`MakeVisitor`]: ../../field/trait.MakeVisitor.html
+pub struct PrettyVisitor<'a> {
+    writer: &'a mut dyn Write,
+    is_empty: bool,
+    style: Style,
     result: fmt::Result,
 }
 
@@ -622,10 +735,7 @@ impl<'a> field::Visit for DefaultVisitor<'a> {
 
     fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
         if let Some(source) = value.source() {
-            self.record_debug(
-                field,
-                &format_args!("{} {}.source={}", value, field, source),
-            )
+            self.record_debug(field, &format_args!("{}, {}: {}", value, field, source))
         } else {
             self.record_debug(field, &format_args!("{}", value))
         }
@@ -667,6 +777,123 @@ impl<'a> fmt::Debug for DefaultVisitor<'a> {
             .field("is_empty", &self.is_empty)
             .field("result", &self.result)
             .finish()
+    }
+}
+// === PrettyFields ===
+
+impl<'a> MakeVisitor<&'a mut dyn Write> for Pretty {
+    type Visitor = PrettyVisitor<'a>;
+
+    #[inline]
+    fn make_visitor(&self, target: &'a mut dyn Write) -> Self::Visitor {
+        PrettyVisitor::new(target, true)
+    }
+}
+
+// === impl PrettyVisitor ===
+
+impl<'a> PrettyVisitor<'a> {
+    /// Returns a new default visitor that formats to the provided `writer`.
+    ///
+    /// # Arguments
+    /// - `writer`: the writer to format to.
+    /// - `is_empty`: whether or not any fields have been previously written to
+    ///   that writer.
+    pub fn new(writer: &'a mut dyn Write, is_empty: bool) -> Self {
+        Self {
+            writer,
+            is_empty,
+            style: Style::default(),
+            result: Ok(()),
+        }
+    }
+
+    pub fn with_style(self, style: Style) -> Self {
+        Self { style, ..self }
+    }
+
+    fn maybe_pad(&mut self) {
+        if self.is_empty {
+            self.is_empty = false;
+        } else {
+            self.result = write!(self.writer, ", ");
+        }
+    }
+}
+
+impl<'a> field::Visit for PrettyVisitor<'a> {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if self.result.is_err() {
+            return;
+        }
+
+        if field.name() == "message" {
+            self.record_debug(field, &format_args!("{}", value))
+        } else {
+            self.record_debug(field, &value)
+        }
+    }
+
+    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+        if let Some(source) = value.source() {
+            let bold = self.style.bold();
+            self.record_debug(
+                field,
+                &format_args!(
+                    "{}, {}{}.source{}: {}",
+                    value,
+                    bold.prefix(),
+                    field,
+                    bold.infix(self.style),
+                    source,
+                ),
+            )
+        } else {
+            self.record_debug(field, &format_args!("{}", value))
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if self.result.is_err() {
+            return;
+        }
+        let bold = self.style.bold();
+        self.maybe_pad();
+        self.result = match field.name() {
+            "message" => write!(self.writer, "{}{:?}", self.style.prefix(), value,),
+            // Skip fields that are actually log metadata that have already been handled
+            #[cfg(feature = "tracing-log")]
+            name if name.starts_with("log.") => Ok(()),
+            name if name.starts_with("r#") => write!(
+                self.writer,
+                "{}{}{}: {:?}",
+                bold.prefix(),
+                &name[2..],
+                bold.infix(self.style),
+                value
+            ),
+            name => write!(
+                self.writer,
+                "{}{}{}: {:?}",
+                bold.prefix(),
+                name,
+                bold.infix(self.style),
+                value
+            ),
+        };
+    }
+}
+
+impl<'a> crate::field::VisitOutput<fmt::Result> for PrettyVisitor<'a> {
+    fn finish(self) -> fmt::Result {
+        write!(self.writer, "{}", self.style.suffix())?;
+        self.result
+    }
+}
+
+impl<'a> crate::field::VisitFmt for PrettyVisitor<'a> {
+    fn writer(&mut self) -> &mut dyn fmt::Write {
+        self.writer
     }
 }
 

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -565,7 +565,13 @@ where
         let meta = event.metadata();
         write!(writer, "  ")?;
         time::write(&self.timer, writer, self.ansi)?;
-        let style = style_for(meta.level());
+
+        let style = if self.display_level {
+            style_for(meta.level())
+        } else {
+            Style::new()
+        };
+
         if self.display_target {
             write!(
                 writer,

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -121,7 +121,7 @@ where
         let mut v = PrettyVisitor::new(writer, true).with_style(style);
         event.record(&mut v);
         v.finish()?;
-        writeln!(writer, "")?;
+        writer.write_char('\n')?;
 
         let dimmed = Style::new().dimmed().italic();
         let thread = self.display_thread_name || self.display_thread_id;

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -187,7 +187,6 @@ where
                 )?;
             }
 
-
             let ext = span.extensions();
             let fields = &ext
                 .get::<FormattedFields<N>>()

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -1,0 +1,285 @@
+use super::*;
+use crate::{
+    field::{MakeVisitor, VisitOutput},
+    fmt::fmt_subscriber::FmtContext,
+    fmt::fmt_subscriber::FormattedFields,
+    registry::LookupSpan,
+};
+
+use std::{
+    fmt::{self, Write},
+    iter,
+};
+use tracing_core::{
+    field::{self, Field},
+    Collect, Event, Level,
+};
+
+#[cfg(feature = "tracing-log")]
+use tracing_log::NormalizeEvent;
+
+#[cfg(feature = "ansi")]
+use ansi_term::{Colour, Style};
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Pretty {
+    display_location: bool,
+}
+
+/// The [visitor] produced by [`Pretty`]'s [`MakeVisitor`] implementation.
+///
+/// [visitor]: ../../field/trait.Visit.html
+/// [`DefaultFields`]: struct.DefaultFields.html
+/// [`MakeVisitor`]: ../../field/trait.MakeVisitor.html
+pub struct PrettyVisitor<'a> {
+    writer: &'a mut dyn Write,
+    is_empty: bool,
+    style: Style,
+    result: fmt::Result,
+}
+
+impl<C, N, T> FormatEvent<C, N> for Format<Pretty, T>
+where
+    C: Collect + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+    T: FormatTime,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, C, N>,
+        writer: &mut dyn fmt::Write,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        fn style_for(level: &Level) -> Style {
+            match *level {
+                Level::TRACE => Style::new().fg(Colour::Purple),
+                Level::DEBUG => Style::new().fg(Colour::Blue),
+                Level::INFO => Style::new().fg(Colour::Green),
+                Level::WARN => Style::new().fg(Colour::Yellow),
+                Level::ERROR => Style::new().fg(Colour::Red),
+            }
+        }
+        #[cfg(feature = "tracing-log")]
+        let normalized_meta = event.normalized_metadata();
+        #[cfg(feature = "tracing-log")]
+        let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
+        #[cfg(not(feature = "tracing-log"))]
+        let meta = event.metadata();
+        write!(writer, "  ")?;
+        time::write(&self.timer, writer, self.ansi)?;
+
+        let style = if self.display_level {
+            style_for(meta.level())
+        } else {
+            Style::new()
+        };
+
+        if self.display_target {
+            write!(
+                writer,
+                "{}{}{}: ",
+                style.bold().prefix(),
+                meta.target(),
+                style.bold().infix(style)
+            )?;
+        }
+        let mut v = PrettyVisitor::new(writer, true).with_style(style);
+        event.record(&mut v);
+        v.finish()?;
+        writeln!(writer, "")?;
+        let thread = self.display_thread_name || self.display_thread_id;
+        let dimmed = Style::new().dimmed().italic();
+        if let (Some(file), Some(line)) = (meta.file(), meta.line()) {
+            write!(
+                writer,
+                "    {} {}:{}{}",
+                dimmed.paint("at"),
+                file,
+                line,
+                dimmed.paint(if thread { " " } else { "\n" })
+            )?;
+        } else if thread {
+            write!(writer, "    ")?;
+        }
+
+        if thread {
+            write!(writer, "{} ", dimmed.paint("on"))?;
+            let thread = std::thread::current();
+            if self.display_thread_name {
+                if let Some(name) = thread.name() {
+                    write!(writer, "{}", name)?;
+                    if self.display_thread_id {
+                        write!(writer, " ({:?})", thread.id())?;
+                    }
+                } else if !self.display_thread_id {
+                    write!(writer, " {:?}", thread.id())?;
+                }
+            } else if self.display_thread_id {
+                write!(writer, " {:?}", thread.id())?;
+            }
+            writer.write_char('\n')?;
+        }
+
+        let bold = Style::new().bold();
+        let span = event
+            .parent()
+            .and_then(|id| ctx.span(&id))
+            .or_else(|| ctx.lookup_current());
+
+        let scope = span.into_iter().flat_map(|span| {
+            let parents = span.parents();
+            iter::once(span).chain(parents)
+        });
+
+        for span in scope {
+            let meta = span.metadata();
+            if self.display_target {
+                write!(
+                    writer,
+                    "    {} {}::{}",
+                    dimmed.paint("in"),
+                    meta.target(),
+                    bold.paint(meta.name()),
+                )?;
+            } else {
+                write!(
+                    writer,
+                    "    {} {}",
+                    dimmed.paint("in"),
+                    bold.paint(meta.name()),
+                )?;
+            }
+
+            // seen = true;
+
+            let ext = span.extensions();
+            let fields = &ext
+                .get::<FormattedFields<N>>()
+                .expect("Unable to find FormattedFields in extensions; this is a bug");
+            if !fields.is_empty() {
+                write!(writer, " {} {}", dimmed.paint("with"), fields)?;
+            }
+            writer.write_char('\n')?;
+        }
+
+        writer.write_char('\n')
+    }
+}
+
+// === PrettyFields ===
+
+impl<'a> MakeVisitor<&'a mut dyn Write> for Pretty {
+    type Visitor = PrettyVisitor<'a>;
+
+    #[inline]
+    fn make_visitor(&self, target: &'a mut dyn Write) -> Self::Visitor {
+        PrettyVisitor::new(target, true)
+    }
+}
+
+// === impl PrettyVisitor ===
+
+impl<'a> PrettyVisitor<'a> {
+    /// Returns a new default visitor that formats to the provided `writer`.
+    ///
+    /// # Arguments
+    /// - `writer`: the writer to format to.
+    /// - `is_empty`: whether or not any fields have been previously written to
+    ///   that writer.
+    pub fn new(writer: &'a mut dyn Write, is_empty: bool) -> Self {
+        Self {
+            writer,
+            is_empty,
+            style: Style::default(),
+            result: Ok(()),
+        }
+    }
+
+    pub fn with_style(self, style: Style) -> Self {
+        Self { style, ..self }
+    }
+
+    fn maybe_pad(&mut self) {
+        if self.is_empty {
+            self.is_empty = false;
+        } else {
+            self.result = write!(self.writer, ", ");
+        }
+    }
+}
+
+impl<'a> field::Visit for PrettyVisitor<'a> {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if self.result.is_err() {
+            return;
+        }
+
+        if field.name() == "message" {
+            self.record_debug(field, &format_args!("{}", value))
+        } else {
+            self.record_debug(field, &value)
+        }
+    }
+
+    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+        if let Some(source) = value.source() {
+            let bold = self.style.bold();
+            self.record_debug(
+                field,
+                &format_args!(
+                    "{}, {}{}.source{}: {}",
+                    value,
+                    bold.prefix(),
+                    field,
+                    bold.infix(self.style),
+                    source,
+                ),
+            )
+        } else {
+            self.record_debug(field, &format_args!("{}", value))
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if self.result.is_err() {
+            return;
+        }
+        let bold = self.style.bold();
+        self.maybe_pad();
+        self.result = match field.name() {
+            "message" => write!(self.writer, "{}{:?}", self.style.prefix(), value,),
+            // Skip fields that are actually log metadata that have already been handled
+            #[cfg(feature = "tracing-log")]
+            name if name.starts_with("log.") => Ok(()),
+            name if name.starts_with("r#") => write!(
+                self.writer,
+                "{}{}{}: {:?}",
+                bold.prefix(),
+                &name[2..],
+                bold.infix(self.style),
+                value
+            ),
+            name => write!(
+                self.writer,
+                "{}{}{}: {:?}",
+                bold.prefix(),
+                name,
+                bold.infix(self.style),
+                value
+            ),
+        };
+    }
+}
+
+impl<'a> crate::field::VisitOutput<fmt::Result> for PrettyVisitor<'a> {
+    fn finish(self) -> fmt::Result {
+        write!(self.writer, "{}", self.style.suffix())?;
+        self.result
+    }
+}
+
+impl<'a> crate::field::VisitFmt for PrettyVisitor<'a> {
+    fn writer(&mut self) -> &mut dyn fmt::Write {
+        self.writer
+    }
+}

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -58,8 +58,7 @@ impl Pretty {
         }
     }
 
-    /// Sets whether or not the source code location from which an event
-    /// originated is displayed.
+    /// Sets whether the event's source code location is displayed.
     ///
     /// This defaults to `true`.
     pub fn with_source_location(self, display_location: bool) -> Self {
@@ -188,7 +187,6 @@ where
                 )?;
             }
 
-            // seen = true;
 
             let ext = span.extensions();
             let fields = &ext

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -571,7 +571,7 @@ where
 
     /// Sets the collector being built to use a less verbose formatter.
     ///
-    /// See [`format::Compact`](../fmt/format/struct.Compact.html).
+    /// See [`format::Compact`].
     pub fn compact(self) -> CollectorBuilder<N, format::Format<format::Compact, T>, F, W>
     where
         N: for<'writer> FormatFields<'writer> + 'static,
@@ -582,6 +582,9 @@ where
         }
     }
 
+    /// Sets the collector being built to use an [excessively pretty, human-readable formatter](crate::fmt::format::Pretty).
+    #[cfg(feature = "ansi")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
     pub fn pretty(
         self,
     ) -> CollectorBuilder<format::Pretty, format::Format<format::Pretty, T>, F, W> {

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -171,7 +171,7 @@
 //!
 //! * [`format::Json`]: Outputs newline-delimited JSON logs. This is intended
 //!   for production use with systems where structured logs are consumed as JSON
-//!   by analysis and viewing tools. The JSON output, as seen below, is *not* 
+//!   by analysis and viewing tools. The JSON output, as seen below, is *not*
 //!   optimized for human readability.
 //!
 //!   For example:

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -582,6 +582,15 @@ where
         }
     }
 
+    pub fn pretty(
+        self,
+    ) -> CollectorBuilder<format::Pretty, format::Format<format::Pretty, T>, F, W> {
+        CollectorBuilder {
+            filter: self.filter,
+            inner: self.inner.pretty(),
+        }
+    }
+
     /// Sets the collector being built to use a JSON formatter.
     ///
     /// See [`format::Json`](../fmt/format/struct.Json.html)

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -57,7 +57,143 @@
 //!     .finish();
 //! ```
 //!
-//! You can find the configuration methods for [`FmtCollector`] in [`fmtBuilder`].
+//! You can find the configuration methods for [`FmtCollector`] in
+//! [`fmtBuilder`].
+//!
+//! ### Formatters
+//!
+//! The output format used by the subscriber and collector in this module is
+//! represented by implementing the [`FormatEvent`] trait, and can be
+//! customized. This module provides a number of formatter implementations:
+//!
+//! * [`format::Full`]: The default formatter. This emits human-readable,
+//!   single-line logs for each event that occurs, with the current span context
+//!   displayed before the formatted representation of the event.
+//!
+//!   For example:
+//!   <pre><font color="#4E9A06"><b>    Finished</b></font> dev [unoptimized + debuginfo] target(s) in 1.59s
+//!   <font color="#4E9A06"><b>     Running</b></font> `target/debug/examples/fmt`
+//!   <font color="#AAAAAA">Oct 24 12:55:47.814 </font><font color="#4E9A06"> INFO</font> fmt: preparing to shave yaks number_of_yaks=3
+//!   <font color="#AAAAAA">Oct 24 12:55:47.814 </font><font color="#4E9A06"> INFO</font> <b>shaving_yaks{</b>yaks=3<b>}</b>: fmt::yak_shave: shaving yaks
+//!   <font color="#AAAAAA">Oct 24 12:55:47.814 </font><font color="#75507B">TRACE</font> <b>shaving_yaks{</b>yaks=3<b>}</b>:<b>shave{</b>yak=1<b>}</b>: fmt::yak_shave: hello! I&apos;m gonna shave a yak excitement=&quot;yay!&quot;
+//!   <font color="#AAAAAA">Oct 24 12:55:47.814 </font><font color="#75507B">TRACE</font> <b>shaving_yaks{</b>yaks=3<b>}</b>:<b>shave{</b>yak=1<b>}</b>: fmt::yak_shave: yak shaved successfully
+//!   <font color="#AAAAAA">Oct 24 12:55:47.814 </font><font color="#3465A4">DEBUG</font> <b>shaving_yaks{</b>yaks=3<b>}</b>: yak_events: yak=1 shaved=true
+//!   <font color="#AAAAAA">Oct 24 12:55:47.814 </font><font color="#75507B">TRACE</font> <b>shaving_yaks{</b>yaks=3<b>}</b>: fmt::yak_shave: yaks_shaved=1
+//!   <font color="#AAAAAA">Oct 24 12:55:47.815 </font><font color="#75507B">TRACE</font> <b>shaving_yaks{</b>yaks=3<b>}</b>:<b>shave{</b>yak=2<b>}</b>: fmt::yak_shave: hello! I&apos;m gonna shave a yak excitement=&quot;yay!&quot;
+//!   <font color="#AAAAAA">Oct 24 12:55:47.815 </font><font color="#75507B">TRACE</font> <b>shaving_yaks{</b>yaks=3<b>}</b>:<b>shave{</b>yak=2<b>}</b>: fmt::yak_shave: yak shaved successfully
+//!   <font color="#AAAAAA">Oct 24 12:55:47.815 </font><font color="#3465A4">DEBUG</font> <b>shaving_yaks{</b>yaks=3<b>}</b>: yak_events: yak=2 shaved=true
+//!   <font color="#AAAAAA">Oct 24 12:55:47.815 </font><font color="#75507B">TRACE</font> <b>shaving_yaks{</b>yaks=3<b>}</b>: fmt::yak_shave: yaks_shaved=2
+//!   <font color="#AAAAAA">Oct 24 12:55:47.815 </font><font color="#75507B">TRACE</font> <b>shaving_yaks{</b>yaks=3<b>}</b>:<b>shave{</b>yak=3<b>}</b>: fmt::yak_shave: hello! I&apos;m gonna shave a yak excitement=&quot;yay!&quot;
+//!   <font color="#AAAAAA">Oct 24 12:55:47.815 </font><font color="#C4A000"> WARN</font> <b>shaving_yaks{</b>yaks=3<b>}</b>:<b>shave{</b>yak=3<b>}</b>: fmt::yak_shave: could not locate yak
+//!   <font color="#AAAAAA">Oct 24 12:55:47.815 </font><font color="#3465A4">DEBUG</font> <b>shaving_yaks{</b>yaks=3<b>}</b>: yak_events: yak=3 shaved=false
+//!   <font color="#AAAAAA">Oct 24 12:55:47.815 </font><font color="#CC0000">ERROR</font> <b>shaving_yaks{</b>yaks=3<b>}</b>: fmt::yak_shave: failed to shave yak yak=3 error=missing yak
+//!   <font color="#AAAAAA">Oct 24 12:55:47.815 </font><font color="#75507B">TRACE</font> <b>shaving_yaks{</b>yaks=3<b>}</b>: fmt::yak_shave: yaks_shaved=2
+//!   <font color="#AAAAAA">Oct 24 12:55:47.815 </font><font color="#4E9A06"> INFO</font> fmt: yak shaving completed all_yaks_shaved=false
+//!   </pre>
+//!
+//! * [`format::Pretty`]: Emits excessively pretty, multi-line logs, optimized
+//!   for human readability. This is primarily intended to be used in local
+//!   development and debugging, or for command-line applications, where
+//!   automated analysis and compact storage of logs is less of a priority than
+//!   readability and visual appeal.
+//!
+//!   For example:
+//!   <pre><font color="#4E9A06"><b>    Finished</b></font> dev [unoptimized + debuginfo] target(s) in 1.61s
+//!   <font color="#4E9A06"><b>     Running</b></font> `target/debug/examples/fmt-pretty`
+//!   Oct 24 12:57:29.386 <font color="#4E9A06"><b>fmt_pretty</b></font><font color="#4E9A06">: preparing to shave yaks, </font><font color="#4E9A06"><b>number_of_yaks</b></font><font color="#4E9A06">: 3</font>
+//!     <font color="#AAAAAA"><i>at</i></font> examples/examples/fmt-pretty.rs:16<font color="#AAAAAA"><i> on</i></font> main
+//!
+//!   Oct 24 12:57:29.386 <font color="#4E9A06"><b>fmt_pretty::yak_shave</b></font><font color="#4E9A06">: shaving yaks</font>
+//!     <font color="#AAAAAA"><i>at</i></font> examples/examples/fmt/yak_shave.rs:38<font color="#AAAAAA"><i> on</i></font> main
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shaving_yaks</b> <font color="#AAAAAA"><i>with</i></font> <b>yaks</b>: 3
+//!
+//!   Oct 24 12:57:29.387 <font color="#75507B"><b>fmt_pretty::yak_shave</b></font><font color="#75507B">: hello! I&apos;m gonna shave a yak, </font><font color="#75507B"><b>excitement</b></font><font color="#75507B">: &quot;yay!&quot;</font>
+//!     <font color="#AAAAAA"><i>at</i></font> examples/examples/fmt/yak_shave.rs:14<font color="#AAAAAA"><i> on</i></font> main
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shave</b> <font color="#AAAAAA"><i>with</i></font> <b>yak</b>: 1
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shaving_yaks</b> <font color="#AAAAAA"><i>with</i></font> <b>yaks</b>: 3
+//!
+//!   Oct 24 12:57:29.387 <font color="#75507B"><b>fmt_pretty::yak_shave</b></font><font color="#75507B">: yak shaved successfully</font>
+//!     <font color="#AAAAAA"><i>at</i></font> examples/examples/fmt/yak_shave.rs:22<font color="#AAAAAA"><i> on</i></font> main
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shave</b> <font color="#AAAAAA"><i>with</i></font> <b>yak</b>: 1
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shaving_yaks</b> <font color="#AAAAAA"><i>with</i></font> <b>yaks</b>: 3
+//!
+//!   Oct 24 12:57:29.387 <font color="#3465A4"><b>yak_events</b></font><font color="#3465A4">: </font><font color="#3465A4"><b>yak</b></font><font color="#3465A4">: 1, </font><font color="#3465A4"><b>shaved</b></font><font color="#3465A4">: true</font>
+//!     <font color="#AAAAAA"><i>at</i></font> examples/examples/fmt/yak_shave.rs:43<font color="#AAAAAA"><i> on</i></font> main
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shaving_yaks</b> <font color="#AAAAAA"><i>with</i></font> <b>yaks</b>: 3
+//!
+//!   Oct 24 12:57:29.387 <font color="#75507B"><b>fmt_pretty::yak_shave</b></font><font color="#75507B">: </font><font color="#75507B"><b>yaks_shaved</b></font><font color="#75507B">: 1</font>
+//!     <font color="#AAAAAA"><i>at</i></font> examples/examples/fmt/yak_shave.rs:52<font color="#AAAAAA"><i> on</i></font> main
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shaving_yaks</b> <font color="#AAAAAA"><i>with</i></font> <b>yaks</b>: 3
+//!
+//!   Oct 24 12:57:29.387 <font color="#75507B"><b>fmt_pretty::yak_shave</b></font><font color="#75507B">: hello! I&apos;m gonna shave a yak, </font><font color="#75507B"><b>excitement</b></font><font color="#75507B">: &quot;yay!&quot;</font>
+//!     <font color="#AAAAAA"><i>at</i></font> examples/examples/fmt/yak_shave.rs:14<font color="#AAAAAA"><i> on</i></font> main
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shave</b> <font color="#AAAAAA"><i>with</i></font> <b>yak</b>: 2
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shaving_yaks</b> <font color="#AAAAAA"><i>with</i></font> <b>yaks</b>: 3
+//!
+//!   Oct 24 12:57:29.387 <font color="#75507B"><b>fmt_pretty::yak_shave</b></font><font color="#75507B">: yak shaved successfully</font>
+//!     <font color="#AAAAAA"><i>at</i></font> examples/examples/fmt/yak_shave.rs:22<font color="#AAAAAA"><i> on</i></font> main
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shave</b> <font color="#AAAAAA"><i>with</i></font> <b>yak</b>: 2
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shaving_yaks</b> <font color="#AAAAAA"><i>with</i></font> <b>yaks</b>: 3
+//!
+//!   Oct 24 12:57:29.387 <font color="#3465A4"><b>yak_events</b></font><font color="#3465A4">: </font><font color="#3465A4"><b>yak</b></font><font color="#3465A4">: 2, </font><font color="#3465A4"><b>shaved</b></font><font color="#3465A4">: true</font>
+//!     <font color="#AAAAAA"><i>at</i></font> examples/examples/fmt/yak_shave.rs:43<font color="#AAAAAA"><i> on</i></font> main
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shaving_yaks</b> <font color="#AAAAAA"><i>with</i></font> <b>yaks</b>: 3
+//!
+//!   Oct 24 12:57:29.387 <font color="#75507B"><b>fmt_pretty::yak_shave</b></font><font color="#75507B">: </font><font color="#75507B"><b>yaks_shaved</b></font><font color="#75507B">: 2</font>
+//!     <font color="#AAAAAA"><i>at</i></font> examples/examples/fmt/yak_shave.rs:52<font color="#AAAAAA"><i> on</i></font> main
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shaving_yaks</b> <font color="#AAAAAA"><i>with</i></font> <b>yaks</b>: 3
+//!
+//!   Oct 24 12:57:29.387 <font color="#75507B"><b>fmt_pretty::yak_shave</b></font><font color="#75507B">: hello! I&apos;m gonna shave a yak, </font><font color="#75507B"><b>excitement</b></font><font color="#75507B">: &quot;yay!&quot;</font>
+//!     <font color="#AAAAAA"><i>at</i></font> examples/examples/fmt/yak_shave.rs:14<font color="#AAAAAA"><i> on</i></font> main
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shave</b> <font color="#AAAAAA"><i>with</i></font> <b>yak</b>: 3
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shaving_yaks</b> <font color="#AAAAAA"><i>with</i></font> <b>yaks</b>: 3
+//!
+//!   Oct 24 12:57:29.387 <font color="#C4A000"><b>fmt_pretty::yak_shave</b></font><font color="#C4A000">: could not locate yak</font>
+//!     <font color="#AAAAAA"><i>at</i></font> examples/examples/fmt/yak_shave.rs:16<font color="#AAAAAA"><i> on</i></font> main
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shave</b> <font color="#AAAAAA"><i>with</i></font> <b>yak</b>: 3
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shaving_yaks</b> <font color="#AAAAAA"><i>with</i></font> <b>yaks</b>: 3
+//!
+//!   Oct 24 12:57:29.387 <font color="#3465A4"><b>yak_events</b></font><font color="#3465A4">: </font><font color="#3465A4"><b>yak</b></font><font color="#3465A4">: 3, </font><font color="#3465A4"><b>shaved</b></font><font color="#3465A4">: false</font>
+//!     <font color="#AAAAAA"><i>at</i></font> examples/examples/fmt/yak_shave.rs:43<font color="#AAAAAA"><i> on</i></font> main
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shaving_yaks</b> <font color="#AAAAAA"><i>with</i></font> <b>yaks</b>: 3
+//!
+//!   Oct 24 12:57:29.387 <font color="#CC0000"><b>fmt_pretty::yak_shave</b></font><font color="#CC0000">: failed to shave yak, </font><font color="#CC0000"><b>yak</b></font><font color="#CC0000">: 3, </font><font color="#CC0000"><b>error</b></font><font color="#CC0000">: missing yak</font>
+//!     <font color="#AAAAAA"><i>at</i></font> examples/examples/fmt/yak_shave.rs:48<font color="#AAAAAA"><i> on</i></font> main
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shaving_yaks</b> <font color="#AAAAAA"><i>with</i></font> <b>yaks</b>: 3
+//!
+//!   Oct 24 12:57:29.387 <font color="#75507B"><b>fmt_pretty::yak_shave</b></font><font color="#75507B">: </font><font color="#75507B"><b>yaks_shaved</b></font><font color="#75507B">: 2</font>
+//!     <font color="#AAAAAA"><i>at</i></font> examples/examples/fmt/yak_shave.rs:52<font color="#AAAAAA"><i> on</i></font> main
+//!     <font color="#AAAAAA"><i>in</i></font> fmt_pretty::yak_shave::<b>shaving_yaks</b> <font color="#AAAAAA"><i>with</i></font> <b>yaks</b>: 3
+//!
+//!   Oct 24 12:57:29.387 <font color="#4E9A06"><b>fmt_pretty</b></font><font color="#4E9A06">: yak shaving completed, </font><font color="#4E9A06"><b>all_yaks_shaved</b></font><font color="#4E9A06">: false</font>
+//!     <font color="#AAAAAA"><i>at</i></font> examples/examples/fmt-pretty.rs:19<font color="#AAAAAA"><i> on</i></font> main
+//!   </pre>
+//!
+//! * [`format::Json`]: Outputs newline-delimited JSON logs. This is intended
+//!   for production use with systems where structured logs are consumed as JSON
+//!   by analysis and viewing tools. The JSON output is *not* pretty-printed for
+//!   human readability.
+//!
+//!   For example:
+//!   <pre><font color="#4E9A06"><b>    Finished</b></font> dev [unoptimized + debuginfo] target(s) in 1.58s
+//!   <font color="#4E9A06"><b>     Running</b></font> `target/debug/examples/fmt-json`
+//!   {&quot;timestamp&quot;:&quot;Oct 24 13:00:00.873&quot;,&quot;level&quot;:&quot;INFO&quot;,&quot;fields&quot;:{&quot;message&quot;:&quot;preparing to shave yaks&quot;,&quot;number_of_yaks&quot;:3},&quot;target&quot;:&quot;fmt_json&quot;}
+//!   {&quot;timestamp&quot;:&quot;Oct 24 13:00:00.874&quot;,&quot;level&quot;:&quot;INFO&quot;,&quot;fields&quot;:{&quot;message&quot;:&quot;shaving yaks&quot;},&quot;target&quot;:&quot;fmt_json::yak_shave&quot;,&quot;spans&quot;:[{&quot;yaks&quot;:3,&quot;name&quot;:&quot;shaving_yaks&quot;}]}
+//!   {&quot;timestamp&quot;:&quot;Oct 24 13:00:00.874&quot;,&quot;level&quot;:&quot;TRACE&quot;,&quot;fields&quot;:{&quot;message&quot;:&quot;hello! I&apos;m gonna shave a yak&quot;,&quot;excitement&quot;:&quot;yay!&quot;},&quot;target&quot;:&quot;fmt_json::yak_shave&quot;,&quot;spans&quot;:[{&quot;yaks&quot;:3,&quot;name&quot;:&quot;shaving_yaks&quot;},{&quot;yak&quot;:&quot;1&quot;,&quot;name&quot;:&quot;shave&quot;}]}
+//!   {&quot;timestamp&quot;:&quot;Oct 24 13:00:00.874&quot;,&quot;level&quot;:&quot;TRACE&quot;,&quot;fields&quot;:{&quot;message&quot;:&quot;yak shaved successfully&quot;},&quot;target&quot;:&quot;fmt_json::yak_shave&quot;,&quot;spans&quot;:[{&quot;yaks&quot;:3,&quot;name&quot;:&quot;shaving_yaks&quot;},{&quot;yak&quot;:&quot;1&quot;,&quot;name&quot;:&quot;shave&quot;}]}
+//!   {&quot;timestamp&quot;:&quot;Oct 24 13:00:00.874&quot;,&quot;level&quot;:&quot;DEBUG&quot;,&quot;fields&quot;:{&quot;yak&quot;:1,&quot;shaved&quot;:true},&quot;target&quot;:&quot;yak_events&quot;,&quot;spans&quot;:[{&quot;yaks&quot;:3,&quot;name&quot;:&quot;shaving_yaks&quot;}]}
+//!   {&quot;timestamp&quot;:&quot;Oct 24 13:00:00.874&quot;,&quot;level&quot;:&quot;TRACE&quot;,&quot;fields&quot;:{&quot;yaks_shaved&quot;:1},&quot;target&quot;:&quot;fmt_json::yak_shave&quot;,&quot;spans&quot;:[{&quot;yaks&quot;:3,&quot;name&quot;:&quot;shaving_yaks&quot;}]}
+//!   {&quot;timestamp&quot;:&quot;Oct 24 13:00:00.874&quot;,&quot;level&quot;:&quot;TRACE&quot;,&quot;fields&quot;:{&quot;message&quot;:&quot;hello! I&apos;m gonna shave a yak&quot;,&quot;excitement&quot;:&quot;yay!&quot;},&quot;target&quot;:&quot;fmt_json::yak_shave&quot;,&quot;spans&quot;:[{&quot;yaks&quot;:3,&quot;name&quot;:&quot;shaving_yaks&quot;},{&quot;yak&quot;:&quot;2&quot;,&quot;name&quot;:&quot;shave&quot;}]}
+//!   {&quot;timestamp&quot;:&quot;Oct 24 13:00:00.874&quot;,&quot;level&quot;:&quot;TRACE&quot;,&quot;fields&quot;:{&quot;message&quot;:&quot;yak shaved successfully&quot;},&quot;target&quot;:&quot;fmt_json::yak_shave&quot;,&quot;spans&quot;:[{&quot;yaks&quot;:3,&quot;name&quot;:&quot;shaving_yaks&quot;},{&quot;yak&quot;:&quot;2&quot;,&quot;name&quot;:&quot;shave&quot;}]}
+//!   {&quot;timestamp&quot;:&quot;Oct 24 13:00:00.874&quot;,&quot;level&quot;:&quot;DEBUG&quot;,&quot;fields&quot;:{&quot;yak&quot;:2,&quot;shaved&quot;:true},&quot;target&quot;:&quot;yak_events&quot;,&quot;spans&quot;:[{&quot;yaks&quot;:3,&quot;name&quot;:&quot;shaving_yaks&quot;}]}
+//!   {&quot;timestamp&quot;:&quot;Oct 24 13:00:00.874&quot;,&quot;level&quot;:&quot;TRACE&quot;,&quot;fields&quot;:{&quot;yaks_shaved&quot;:2},&quot;target&quot;:&quot;fmt_json::yak_shave&quot;,&quot;spans&quot;:[{&quot;yaks&quot;:3,&quot;name&quot;:&quot;shaving_yaks&quot;}]}
+//!   {&quot;timestamp&quot;:&quot;Oct 24 13:00:00.874&quot;,&quot;level&quot;:&quot;TRACE&quot;,&quot;fields&quot;:{&quot;message&quot;:&quot;hello! I&apos;m gonna shave a yak&quot;,&quot;excitement&quot;:&quot;yay!&quot;},&quot;target&quot;:&quot;fmt_json::yak_shave&quot;,&quot;spans&quot;:[{&quot;yaks&quot;:3,&quot;name&quot;:&quot;shaving_yaks&quot;},{&quot;yak&quot;:&quot;3&quot;,&quot;name&quot;:&quot;shave&quot;}]}
+//!   {&quot;timestamp&quot;:&quot;Oct 24 13:00:00.875&quot;,&quot;level&quot;:&quot;WARN&quot;,&quot;fields&quot;:{&quot;message&quot;:&quot;could not locate yak&quot;},&quot;target&quot;:&quot;fmt_json::yak_shave&quot;,&quot;spans&quot;:[{&quot;yaks&quot;:3,&quot;name&quot;:&quot;shaving_yaks&quot;},{&quot;yak&quot;:&quot;3&quot;,&quot;name&quot;:&quot;shave&quot;}]}
+//!   {&quot;timestamp&quot;:&quot;Oct 24 13:00:00.875&quot;,&quot;level&quot;:&quot;DEBUG&quot;,&quot;fields&quot;:{&quot;yak&quot;:3,&quot;shaved&quot;:false},&quot;target&quot;:&quot;yak_events&quot;,&quot;spans&quot;:[{&quot;yaks&quot;:3,&quot;name&quot;:&quot;shaving_yaks&quot;}]}
+//!   {&quot;timestamp&quot;:&quot;Oct 24 13:00:00.875&quot;,&quot;level&quot;:&quot;ERROR&quot;,&quot;fields&quot;:{&quot;message&quot;:&quot;failed to shave yak&quot;,&quot;yak&quot;:3,&quot;error&quot;:&quot;missing yak&quot;},&quot;target&quot;:&quot;fmt_json::yak_shave&quot;,&quot;spans&quot;:[{&quot;yaks&quot;:3,&quot;name&quot;:&quot;shaving_yaks&quot;}]}
+//!   {&quot;timestamp&quot;:&quot;Oct 24 13:00:00.875&quot;,&quot;level&quot;:&quot;TRACE&quot;,&quot;fields&quot;:{&quot;yaks_shaved&quot;:2},&quot;target&quot;:&quot;fmt_json::yak_shave&quot;,&quot;spans&quot;:[{&quot;yaks&quot;:3,&quot;name&quot;:&quot;shaving_yaks&quot;}]}
+//!   {&quot;timestamp&quot;:&quot;Oct 24 13:00:00.875&quot;,&quot;level&quot;:&quot;INFO&quot;,&quot;fields&quot;:{&quot;message&quot;:&quot;yak shaving completed&quot;,&quot;all_yaks_shaved&quot;:false},&quot;target&quot;:&quot;fmt_json&quot;}
+//!   </pre>
 //!
 //! ### Filters
 //!

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -57,7 +57,7 @@
 //!     .finish();
 //! ```
 //!
-//! You can find the configuration methods for [`FmtCollector`] in
+//! The configuration methods for [`FmtCollector`] can be found in
 //! [`fmtBuilder`].
 //!
 //! ### Formatters
@@ -171,8 +171,8 @@
 //!
 //! * [`format::Json`]: Outputs newline-delimited JSON logs. This is intended
 //!   for production use with systems where structured logs are consumed as JSON
-//!   by analysis and viewing tools. The JSON output is *not* pretty-printed for
-//!   human readability.
+//!   by analysis and viewing tools. The JSON output, as seen below, is *not* 
+//!   optimized for human readability.
 //!
 //!   For example:
 //!   <pre><font color="#4E9A06"><b>    Finished</b></font> dev [unoptimized + debuginfo] target(s) in 1.58s

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -27,7 +27,7 @@
 //!
 //! ## Filtering Events with Environment Variables
 //!
-//! The default subscriber installed by `init` enables you to filter events
+//! The default collector installed by `init` enables you to filter events
 //! at runtime using environment variables (using the [`EnvFilter`]).
 //!
 //! The filter syntax is a superset of the [`env_logger`] syntax.
@@ -52,7 +52,7 @@
 //! You can create one by calling:
 //!
 //! ```rust
-//! let subscriber = tracing_subscriber::fmt()
+//! let collector = tracing_subscriber::fmt()
 //!     // ... add configuration
 //!     .finish();
 //! ```
@@ -213,7 +213,7 @@
 //!
 //! ### Using Your Collector
 //!
-//! Finally, once you have configured your `Collector`, you need to
+//! Finally, once you have configured your `Collect`, you need to
 //! configure your executable to use it.
 //!
 //! A collector can be installed globally using:
@@ -221,31 +221,31 @@
 //! use tracing;
 //! use tracing_subscriber::fmt;
 //!
-//! let subscriber = fmt::Collector::new();
+//! let collector = fmt::Collector::new();
 //!
-//! tracing::collect::set_global_default(subscriber)
-//!     .map_err(|_err| eprintln!("Unable to set global default subscriber"));
+//! tracing::collect::set_global_default(collector)
+//!     .map_err(|_err| eprintln!("Unable to set global default collector"));
 //! // Note this will only fail if you try to set the global default
-//! // subscriber multiple times
+//! // collector multiple times
 //! ```
 //!
-//! ### Composing Layers
+//! ### Composing Subscribers
 //!
-//! Composing an [`EnvFilter`] `Subscriber` and a [format `Subscriber`](../fmt/struct.Subscriber.html):
+//! Composing an [`EnvFilter`] `Subscribe` and a [format `Subscribe`](../fmt/struct.Subscriber.html):
 //!
 //! ```rust
 //! use tracing_subscriber::{fmt, EnvFilter};
 //! use tracing_subscriber::prelude::*;
 //!
-//! let fmt_layer = fmt::subscriber()
+//! let fmt_subscriber = fmt::subscriber()
 //!     .with_target(false);
-//! let filter_layer = EnvFilter::try_from_default_env()
+//! let filter_subscriber = EnvFilter::try_from_default_env()
 //!     .or_else(|_| EnvFilter::try_new("info"))
 //!     .unwrap();
 //!
 //! tracing_subscriber::registry()
-//!     .with(filter_layer)
-//!     .with(fmt_layer)
+//!     .with(filter_subscriber)
+//!     .with(fmt_subscriber)
 //!     .init();
 //! ```
 //!
@@ -334,7 +334,7 @@ pub struct CollectorBuilder<
 ///     .with_target(false)
 ///     .with_timer(tracing_subscriber::fmt::time::uptime())
 ///     .with_level(true)
-///     // Set the subscriber as the default.
+///     // Set the collector as the default.
 ///     .init();
 /// ```
 ///
@@ -345,18 +345,18 @@ pub struct CollectorBuilder<
 ///
 /// fn init_subscriber() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 ///     tracing_subscriber::fmt()
-///         // Configure the subscriber to emit logs in JSON format.
+///         // Configure the collector to emit logs in JSON format.
 ///         .json()
-///         // Configure the subscriber to flatten event fields in the output JSON objects.
+///         // Configure the collector to flatten event fields in the output JSON objects.
 ///         .flatten_event(true)
-///         // Set the subscriber as the default, returning an error if this fails.
+///         // Set the collector as the default, returning an error if this fails.
 ///         .try_init()?;
 ///
 ///     Ok(())
 /// }
 /// ```
 ///
-/// Rather than setting the subscriber as the default, [`finish`] _returns_ the
+/// Rather than setting the collector as the default, [`finish`] _returns_ the
 /// constructed collector, which may then be passed to other functions:
 ///
 /// ```rust
@@ -387,7 +387,7 @@ pub fn fmt() -> CollectorBuilder {
 /// This is a shorthand for the equivalent [`Subscriber::default`] function.
 ///
 /// [formatting subscriber]: struct.Subscriber.html
-/// [composed]: ../layer/index.html
+/// [composed]: ../subscribe/index.html
 /// [`Subscriber::default`]: struct.Subscriber.html#method.default
 pub fn subscriber<S>() -> Subscriber<S> {
     Subscriber::default()
@@ -762,7 +762,7 @@ impl<T, F, W> CollectorBuilder<format::JsonFields, format::Format<format::Json, 
         }
     }
 
-    /// Sets whether or not the JSON layer being built will include the current span
+    /// Sets whether or not the JSON subscriber being built will include the current span
     /// in formatted events.
     ///
     /// See [`format::Json`](../fmt/format/struct.Json.html)
@@ -776,7 +776,7 @@ impl<T, F, W> CollectorBuilder<format::JsonFields, format::Format<format::Json, 
         }
     }
 
-    /// Sets whether or not the JSON layer being built will include a list (from
+    /// Sets whether or not the JSON subscriber being built will include a list (from
     /// root to leaf) of all currently entered spans in formatted events.
     ///
     /// See [`format::Json`](../fmt/format/struct.Json.html)

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -96,6 +96,12 @@
     unused_parens,
     while_true
 )]
+// Using struct update syntax when a struct has no additional fields avoids
+// a potential source change if additional fields are added to the struct in the
+// future, reducing diff noise. Allow this even though clippy considers it
+// "needless".
+#![allow(clippy::needless_update)]
+
 use tracing_core::span::Id;
 
 #[macro_use]


### PR DESCRIPTION
## Motivation

Currently, the `tracing_subscriber::fmt` module contains only
single-line event formatters. Some users have requested a
human-readable, pretty-printing event formatter optimized for
aesthetics.

## Solution

This branch adds a new `Pretty` formatter which uses an _excessively_
pretty output format. It's neither compact, single-line oriented, nor
easily machine-readable, but it looks _quite_ nice, in my opinion. This
is well suited for local development or potentially for user-facing logs
in a CLI application.

Additionally, I tried to improve the docs for the different formatters
currently provided, including example output. Check out [the Netlify
preview][1]!

[1]: https://deploy-preview-1067--tracing-rs.netlify.app/tracing_subscriber/fmt/index.html#formatters