### PR TITLE
Use macros for module declarations on registry

### DIFF
--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -66,18 +66,16 @@ use tracing_core::{field::FieldSet, span::Id, Metadata};
 
 /// A module containing a type map of span extensions.
 mod extensions;
-#[cfg(feature = "registry")]
-mod sharded;
-#[cfg(feature = "registry")]
-mod stack;
+
+cfg_feature!("registry", {
+    mod sharded;
+    mod stack;
+
+    pub use sharded::Data;
+    pub use sharded::Registry;
+});
 
 pub use extensions::{Extensions, ExtensionsMut};
-#[cfg(feature = "registry")]
-#[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
-pub use sharded::Data;
-#[cfg(feature = "registry")]
-#[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
-pub use sharded::Registry;
 
 /// Provides access to stored span data.
 ///

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -19,55 +19,53 @@ use tracing_core::{
     Collect, Event, Interest, Metadata,
 };
 
-/// A shared, reusable store for spans.
-///
-/// A `Registry` is a [`Collect`] around which multiple subscribers
-/// implementing various behaviors may be [added]. Unlike other types
-/// implementing `Collect`, `Registry` does not actually record traces itself:
-/// instead, it collects and stores span data that is exposed to any `Subscriber`s
-/// wrapping it through implementations of the [`LookupSpan`] trait.
-/// The `Registry` is responsible for storing span metadata, recording
-/// relationships between spans, and tracking which spans are active and whicb
-/// are closed. In addition, it provides a mechanism for `Subscriber`s to store
-/// user-defined per-span data, called [extensions], in the registry. This
-/// allows `Subscriber`-specific data to benefit from the `Registry`'s
-/// high-performance concurrent storage.
-///
-/// This registry is implemented using a [lock-free sharded slab][slab], and is
-/// highly optimized for concurrent access.
-///
-/// [slab]: https://docs.rs/crate/sharded-slab/
-/// [`Collect`]:
-///     https://docs.rs/crate/tracing-core/latest/tracing_core/collect/trait.Collect.html
-/// [`Subscriber`]: ../trait.Subscriber.html
-/// [added]: ../trait.Subscriber.html#method.with_subscriber
-/// [`LookupSpan`]: trait.LookupSpan.html
-/// [extensions]: extensions/index.html
-#[cfg(feature = "registry")]
-#[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
-#[derive(Debug)]
-pub struct Registry {
-    spans: Pool<DataInner>,
-    current_spans: ThreadLocal<RefCell<SpanStack>>,
-}
+cfg_feature!("registry", {
+    /// A shared, reusable store for spans.
+    ///
+    /// A `Registry` is a [`Collect`] around which multiple subscribers
+    /// implementing various behaviors may be [added]. Unlike other types
+    /// implementing `Collect`, `Registry` does not actually record traces itself:
+    /// instead, it collects and stores span data that is exposed to any `Subscriber`s
+    /// wrapping it through implementations of the [`LookupSpan`] trait.
+    /// The `Registry` is responsible for storing span metadata, recording
+    /// relationships between spans, and tracking which spans are active and whicb
+    /// are closed. In addition, it provides a mechanism for `Subscriber`s to store
+    /// user-defined per-span data, called [extensions], in the registry. This
+    /// allows `Subscriber`-specific data to benefit from the `Registry`'s
+    /// high-performance concurrent storage.
+    ///
+    /// This registry is implemented using a [lock-free sharded slab][slab], and is
+    /// highly optimized for concurrent access.
+    ///
+    /// [slab]: https://docs.rs/crate/sharded-slab/
+    /// [`Collect`]:
+    ///     https://docs.rs/crate/tracing-core/latest/tracing_core/collect/trait.Collect.html
+    /// [`Subscriber`]: ../trait.Subscriber.html
+    /// [added]: ../trait.Subscriber.html#method.with_subscriber
+    /// [`LookupSpan`]: trait.LookupSpan.html
+    /// [extensions]: extensions/index.html
+    #[derive(Debug)]
+    pub struct Registry {
+        spans: Pool<DataInner>,
+        current_spans: ThreadLocal<RefCell<SpanStack>>,
+    }
 
-/// Span data stored in a [`Registry`].
-///
-/// The registry stores well-known data defined by tracing: span relationships,
-/// metadata and reference counts. Additional user-defined data provided by
-/// [`Subscriber`s], such as formatted fields, metrics, or distributed traces should
-/// be stored in the [extensions] typemap.
-///
-/// [`Registry`]: struct.Registry.html
-/// [`Subscriber`s]: ../layer/trait.Subscriber.html
-/// [extensions]: struct.Extensions.html
-#[cfg(feature = "registry")]
-#[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
-#[derive(Debug)]
-pub struct Data<'a> {
-    /// Immutable reference to the pooled `DataInner` entry.
-    inner: Ref<'a, DataInner>,
-}
+    /// Span data stored in a [`Registry`].
+    ///
+    /// The registry stores well-known data defined by tracing: span relationships,
+    /// metadata and reference counts. Additional user-defined data provided by
+    /// [`Subscriber`s], such as formatted fields, metrics, or distributed traces should
+    /// be stored in the [extensions] typemap.
+    ///
+    /// [`Registry`]: struct.Registry.html
+    /// [`Subscriber`s]: ../layer/trait.Subscriber.html
+    /// [extensions]: struct.Extensions.html
+    #[derive(Debug)]
+    pub struct Data<'a> {
+        /// Immutable reference to the pooled `DataInner` entry.
+        inner: Ref<'a, DataInner>,
+    }
+});
 
 /// Stored data associated with a span.
 ///


### PR DESCRIPTION
## Motivation

ref: https://github.com/tokio-rs/tracing/pull/1009

This is code refactoring. Currently, there is a lot of code that declares modules as follows:

```rust
#[cfg(feature = "registry")]
#[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
pub use registry::Registry;

#[cfg(feature = "registry")]
#[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
pub fn registry() -> Registry {
    Registry::default()
}
```

It is verbose to write a module declaration multiple times using the feature attribute. Also, if the definition for the same feature spans multiple places, it will be a little harder to read the code.

## Solution

You can combine features attributes in one place by writing as follows. It also eliminates the need to write the same code over and over again.

```rust
cfg_feature!("feature" ,{
    pub use registry::Registry;

    pub fn registry() -> Registry {
        Registry::default()
    }
});

```
