### PR TITLE
Convert even more intra-doc links

### DIFF
--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -91,9 +91,9 @@
 //! [write]: https://doc.rust-lang.org/std/io/trait.Write.html
 //! [non_blocking]: mod@non_blocking
 //! [guard]: non_blocking::WorkerGuard
-//! [make_writer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/trait.MakeWriter.html
+//! [make_writer]: tracing_subscriber::fmt::MakeWriter
 //! [`RollingFileAppender`]: rolling::RollingFileAppender
-//! [fmt_subscriber]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Subscriber.html
+//! [fmt_subscriber]: tracing_subscriber::fmt::Subscriber
 //!
 //! ## Non-Blocking Rolling File Appender
 //!

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -120,7 +120,7 @@ pub struct WorkerGuard {
 /// or with any other subscriber/layer implementation that uses the `MakeWriter` trait.
 ///
 /// [make_writer]: tracing_subscriber::fmt::MakeWriter
-/// [fmt]: tracing_subscriber::fmt
+/// [fmt]: mod@tracing_subscriber::fmt
 #[derive(Clone, Debug)]
 pub struct NonBlocking {
     error_counter: Arc<AtomicU64>,

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -119,8 +119,8 @@ pub struct WorkerGuard {
 /// crate. Therefore, it can be used with the [`tracing_subscriber::fmt`][fmt] module
 /// or with any other subscriber/layer implementation that uses the `MakeWriter` trait.
 ///
-/// [make_writer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/trait.MakeWriter.html
-/// [fmt]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/index.html
+/// [make_writer]: tracing_subscriber::fmt::MakeWriter
+/// [fmt]: tracing_subscriber::fmt
 #[derive(Clone, Debug)]
 pub struct NonBlocking {
     error_counter: Arc<AtomicU64>,

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -35,8 +35,7 @@
 //! ```
 //!
 //! [`tracing`]: https://crates.io/crates/tracing
-//! [instrument]: macro@instrument
-//! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
+//! [span]: tracing::span
 //!
 //! ## Supported Rust Versions
 //!
@@ -251,7 +250,7 @@ use syn::{
 /// Instead, you should manually rewrite any `Self` types as the type for
 /// which you implement the trait: `#[instrument(fields(tmp = std::any::type_name::<Bar>()))]`.
 ///
-/// [span]: https://docs.rs/tracing/latest/tracing/span/index.html
+/// [span]: tracing::span
 /// [`tracing`]: https://github.com/tokio-rs/tracing
 /// [`fmt::Debug`]: https://doc.rust-lang.org/std/fmt/trait.Debug.html
 #[proc_macro_attribute]

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -35,7 +35,8 @@
 //! ```
 //!
 //! [`tracing`]: https://crates.io/crates/tracing
-//! [span]: tracing::span
+//! [instrument]: macro@instrument
+//! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 //!
 //! ## Supported Rust Versions
 //!
@@ -250,7 +251,7 @@ use syn::{
 /// Instead, you should manually rewrite any `Self` types as the type for
 /// which you implement the trait: `#[instrument(fields(tmp = std::any::type_name::<Bar>()))]`.
 ///
-/// [span]: tracing::span
+/// [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 /// [`tracing`]: https://github.com/tokio-rs/tracing
 /// [`fmt::Debug`]: https://doc.rust-lang.org/std/fmt/trait.Debug.html
 #[proc_macro_attribute]

--- a/tracing-core/src/collect.rs
+++ b/tracing-core/src/collect.rs
@@ -388,7 +388,7 @@ pub trait Collect: 'static {
     /// inside of a `try_close` function may cause a double panic, if the span
     /// was dropped due to a thread unwinding.
     ///
-    /// [span ID]: super::span::Id
+    /// [`span ID`]: super::span::Id
     /// [`clone_span`]: Collect::clone_span
     /// [`drop_span`]: Collect::drop_span
     fn try_close(&self, id: span::Id) -> bool {

--- a/tracing-core/src/collect.rs
+++ b/tracing-core/src/collect.rs
@@ -440,7 +440,7 @@ pub trait Collect: 'static {
     /// with the provided `TypeId`. Failure to ensure this will result in
     /// undefined behaviour, so implementing `downcast_raw` is unsafe.
     ///
-    /// [`downcast_ref`]: #method.downcast_ref
+    /// [`downcast_ref`]: Collect::downcast_ref()
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
         if id == TypeId::of::<Self>() {
             Some(self as *const Self as *const ())

--- a/tracing-core/src/collect.rs
+++ b/tracing-core/src/collect.rs
@@ -440,7 +440,7 @@ pub trait Collect: 'static {
     /// with the provided `TypeId`. Failure to ensure this will result in
     /// undefined behaviour, so implementing `downcast_raw` is unsafe.
     ///
-    /// [`downcast_ref`]: Collect::downcast_ref()
+    /// [`downcast_ref`]: #method.downcast_ref
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
         if id == TypeId::of::<Self>() {
             Some(self as *const Self as *const ())

--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -55,9 +55,9 @@ use tracing::{Metadata, Span};
 ///
 /// [`tracing`]: https://docs.rs/tracing
 /// [`Backtrace`]: https://doc.rust-lang.org/std/backtrace/struct.Backtrace.html
-/// [span]: https://docs.rs/tracing/latest/tracing/span/index.html
-/// [parents]: https://docs.rs/tracing/latest/tracing/span/index.html#span-relationships
-/// [fields]: https://docs.rs/tracing/latest/tracing/field/index.html
+/// [span]: tracing::span
+/// [parents]: tracing::span#span-relationships
+/// [fields]: tracing::field
 /// [futures]: https://doc.rust-lang.org/std/future/trait.Future.html
 /// [`tracing-futures`]: https://docs.rs/tracing-futures/
 /// [`with_spans`]: SpanTrace::with_spans()
@@ -111,8 +111,8 @@ impl SpanTrace {
     /// indicate whether to continue iterating over spans; if it returns
     /// `false`, no additional spans will be visited.
     ///
-    /// [fields]: https://docs.rs/tracing/latest/tracing/field/index.html
-    /// [`Metadata`]: https://docs.rs/tracing/latest/tracing/struct.Metadata.html
+    /// [fields]: tracing::field
+    /// [`Metadata`]: tracing::Metadata
     pub fn with_spans(&self, f: impl FnMut(&'static Metadata<'static>, &str) -> bool) {
         self.span.with_collector(|(id, s)| {
             if let Some(getcx) = s.downcast_ref::<WithContext>() {

--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -55,8 +55,8 @@ use tracing::{Metadata, Span};
 ///
 /// [`tracing`]: https://docs.rs/tracing
 /// [`Backtrace`]: https://doc.rust-lang.org/std/backtrace/struct.Backtrace.html
-/// [span]: tracing::span
-/// [parents]: tracing::span#span-relationships
+/// [span]: mod@tracing::span
+/// [parents]: mod@tracing::span#span-relationships
 /// [fields]: tracing::field
 /// [futures]: https://doc.rust-lang.org/std/future/trait.Future.html
 /// [`tracing-futures`]: https://docs.rs/tracing-futures/

--- a/tracing-error/src/layer.rs
+++ b/tracing-error/src/layer.rs
@@ -15,7 +15,7 @@ use tracing_subscriber::{
 /// when formatting the fields of each span in a trace. When no formatter is
 /// provided, the [default format] is used instead.
 ///
-/// [subscriber]: tracing_subscriber::subscriber::Subscribe
+/// [subscriber]: tracing_subscriber::subscribe::Subscribe
 /// [`SpanTrace`]: super::SpanTrace
 /// [field formatter]: tracing_subscriber::fmt::FormatFields
 /// [default format]: tracing_subscriber::fmt::format::DefaultFields

--- a/tracing-error/src/layer.rs
+++ b/tracing-error/src/layer.rs
@@ -15,10 +15,10 @@ use tracing_subscriber::{
 /// when formatting the fields of each span in a trace. When no formatter is
 /// provided, the [default format] is used instead.
 ///
-/// [subscriber]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/subscriber/trait.Subscribe.html
+/// [subscriber]: tracing_subscriber::subscriber::Subscribe
 /// [`SpanTrace`]: super::SpanTrace
-/// [field formatter]: https://docs.rs/tracing-subscriber/0.2.10/tracing_subscriber/fmt/trait.FormatFields.html
-/// [default format]: https://docs.rs/tracing-subscriber/0.2.10/tracing_subscriber/fmt/format/struct.DefaultFields.html
+/// [field formatter]: tracing_subscriber::fmt::FormatFields
+/// [default format]: tracing_subscriber::fmt::format::DefaultFields
 pub struct ErrorSubscriber<S, F = DefaultFields> {
     format: F,
 
@@ -75,7 +75,7 @@ where
 {
     /// Returns a new `ErrorSubscriber` with the provided [field formatter].
     ///
-    /// [field formatter]: https://docs.rs/tracing-subscriber/0.2.10/tracing_subscriber/fmt/trait.FormatFields.html
+    /// [field formatter]: tracing_subscriber::fmt::FormatFields
     pub fn new(format: F) -> Self {
         Self {
             format,

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -158,10 +158,10 @@
 //! ```
 //!
 //! [`in_current_span()`]: InstrumentResult::in_current_span
-//! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
-//! [events]: https://docs.rs/tracing/latest/tracing/struct.Event.html
-//! [collector]: https://docs.rs/tracing/latest/tracing/trait.Collect.html
-//! [subscriber layer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/trait.Layer.html
+//! [span]: tracing::span
+//! [events]: tracing::Event
+//! [collector]: tracing::Collect
+//! [subscriber layer]: tracing_subscriber::layer::Layer
 //! [`tracing`]: https://docs.rs/tracing
 //! [`std::error::Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
 //!

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -158,10 +158,10 @@
 //! ```
 //!
 //! [`in_current_span()`]: InstrumentResult::in_current_span
-//! [span]: tracing::span
+//! [span]: mod@tracing::span
 //! [events]: tracing::Event
 //! [collector]: tracing::Collect
-//! [subscriber layer]: tracing_subscriber::layer::Layer
+//! [subscriber layer]: tracing_subscriber::subscribe::Subscribe
 //! [`tracing`]: https://docs.rs/tracing
 //! [`std::error::Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
 //!

--- a/tracing-flame/src/lib.rs
+++ b/tracing-flame/src/lib.rs
@@ -91,7 +91,7 @@
 //!
 //! [`tracing`]: https://docs.rs/tracing
 //! [`inferno`]: https://docs.rs/inferno
-//! [`inferno-flamegraph`]: https://docs.rs/inferno/0.9.5/inferno/index.html#producing-a-flame-graph
+//! [`inferno-flamegraph`]: inferno#producing-a-flame-graph
 //!
 //! ## Supported Rust Versions
 //!

--- a/tracing-flame/src/lib.rs
+++ b/tracing-flame/src/lib.rs
@@ -91,7 +91,7 @@
 //!
 //! [`tracing`]: https://docs.rs/tracing
 //! [`inferno`]: https://docs.rs/inferno
-//! [`inferno-flamegraph`]: inferno#producing-a-flame-graph
+//! [`inferno-flamegraph`]: https://docs.rs/inferno/0.9.5/inferno/index.html#producing-a-flame-graph
 //!
 //! ## Supported Rust Versions
 //!

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -53,8 +53,8 @@
 //! The `tokio`, `std-future` and `std` features are enabled by default.
 //!
 //! [`tracing`]: https://crates.io/crates/tracing
-//! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
-//! [collector]: https://docs.rs/tracing/latest/tracing/collect/index.html
+//! [span]: tracing::span
+//! [collector]: tracing::collect
 //! [`futures`]: https://crates.io/crates/futures
 //!
 //! ## Supported Rust Versions
@@ -118,7 +118,7 @@ pub mod executor;
 /// Extension trait allowing futures, streams, sinks, and executors to be
 /// instrumented with a `tracing` [span].
 ///
-/// [span]: https://docs.rs/tracing/latest/tracing/span/index.html
+/// [span]: tracing::span
 pub trait Instrument: Sized {
     /// Instruments this type with the provided `Span`, returning an
     /// `Instrumented` wrapper.
@@ -147,7 +147,7 @@ pub trait Instrument: Sized {
     /// # }
     /// ```
     ///
-    /// [entered]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.enter
+    /// [entered]: tracing::span::Span::enter()
     fn instrument(self, span: Span) -> Instrumented<Self> {
         Instrumented { inner: self, span }
     }
@@ -182,8 +182,8 @@ pub trait Instrument: Sized {
     /// # }
     /// ```
     ///
-    /// [current]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.current
-    /// [entered]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.enter
+    /// [current]: tracing::span::Span::current()
+    /// [entered]: tracing::span::Span::enter()
     #[inline]
     fn in_current_span(self) -> Instrumented<Self> {
         self.instrument(Span::current())
@@ -193,7 +193,7 @@ pub trait Instrument: Sized {
 /// Extension trait allowing futures, streams, and sinks to be instrumented with
 /// a `tracing` [collector].
 ///
-/// [collector]: https://docs.rs/tracing/latest/tracing/collect/trait.Collect.html
+/// [collector]: tracing::collect::Collect
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub trait WithCollector: Sized {
@@ -205,8 +205,8 @@ pub trait WithCollector: Sized {
     /// When the wrapped type is an executor, the subscriber will be set as the
     /// default for any futures spawned on that executor.
     ///
-    /// [collector]: https://docs.rs/tracing/latest/tracing/collect/trait.Collect.html
-    /// [default]: https://docs.rs/tracing/latest/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [collector]: tracing::collect::Collect
+    /// [default]: tracing::dispatcher#setting-the-default-subscriber
     fn with_collector<S>(self, collector: S) -> WithDispatch<Self>
     where
         S: Into<Dispatch>,
@@ -228,8 +228,8 @@ pub trait WithCollector: Sized {
     /// This can be used to propagate the current dispatcher context when
     /// spawning a new future.
     ///
-    /// [collector]: https://docs.rs/tracing/latest/tracing/collect/trait.Collect.html
-    /// [default]: https://docs.rs/tracing/latest/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [collector]: tracing::collect::Collect
+    /// [default]: tracing::dispatcher#setting-the-default-subscriber
     #[inline]
     fn with_current_collector(self) -> WithDispatch<Self> {
         WithDispatch {

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -53,7 +53,7 @@
 //! The `tokio`, `std-future` and `std` features are enabled by default.
 //!
 //! [`tracing`]: https://crates.io/crates/tracing
-//! [span]: tracing::span
+//! [span]: mod@tracing::span
 //! [collector]: tracing::collect
 //! [`futures`]: https://crates.io/crates/futures
 //!
@@ -118,7 +118,7 @@ pub mod executor;
 /// Extension trait allowing futures, streams, sinks, and executors to be
 /// instrumented with a `tracing` [span].
 ///
-/// [span]: tracing::span
+/// [span]: mod@tracing::span
 pub trait Instrument: Sized {
     /// Instruments this type with the provided `Span`, returning an
     /// `Instrumented` wrapper.
@@ -206,7 +206,7 @@ pub trait WithCollector: Sized {
     /// default for any futures spawned on that executor.
     ///
     /// [collector]: tracing::collect::Collect
-    /// [default]: tracing::dispatcher#setting-the-default-subscriber
+    /// [default]: tracing::dispatch#setting-the-default-collector
     fn with_collector<S>(self, collector: S) -> WithDispatch<Self>
     where
         S: Into<Dispatch>,
@@ -229,7 +229,7 @@ pub trait WithCollector: Sized {
     /// spawning a new future.
     ///
     /// [collector]: tracing::collect::Collect
-    /// [default]: tracing::dispatcher#setting-the-default-subscriber
+    /// [default]: tracing::dispatch#setting-the-default-collector
     #[inline]
     fn with_current_collector(self) -> WithDispatch<Self> {
         WithDispatch {

--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! [msrv]: #supported-rust-versions
 //! [`tracing`]: https://crates.io/crates/tracing
-//! [subscriber]: tracing_subscriber::subscriber::Subscriber
+//! [subscriber]: tracing_subscriber::subscribe::Subscribe
 //! [journald]: https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html
 //!
 //! ## Supported Rust Versions

--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! [msrv]: #supported-rust-versions
 //! [`tracing`]: https://crates.io/crates/tracing
-//! [subscriber]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/subscriber/trait.Subscriber.html
+//! [subscriber]: tracing_subscriber::subscriber::Subscriber
 //! [journald]: https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html
 //!
 //! ## Supported Rust Versions

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -92,8 +92,9 @@
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [`log`]: https://crates.io/crates/log
 //! [`env_logger` crate]: https://crates.io/crates/env-logger
-//! [`tracing::Collector`]: tracing::Collect
-//! [`Collect`]: tracing::Collect
+//! [`tracing::Collector`]: https://docs.rs/tracing/latest/tracing/trait.Collect.html
+//! [`Collect`]: https://docs.rs/tracing/latest/tracing/trait.Collect.html
+//! [`tracing::Event`]: https://docs.rs/tracing/latest/tracing/struct.Event.html
 //! [flags]: https://docs.rs/tracing/latest/tracing/#crate-feature-flags
 #![doc(html_root_url = "https://docs.rs/tracing-log/0.1.1")]
 #![doc(

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -92,11 +92,8 @@
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [`log`]: https://crates.io/crates/log
 //! [`env_logger` crate]: https://crates.io/crates/env-logger
-//! [`log::Log`]: https://docs.rs/log/latest/log/trait.Log.html
-//! [`log::Record`]: https://docs.rs/log/latest/log/struct.Record.html
-//! [`tracing::Collector`]: https://docs.rs/tracing/latest/tracing/trait.Collect.html
-//! [`Collect`]: https://docs.rs/tracing/latest/tracing/trait.Collect.html
-//! [`tracing::Event`]: https://docs.rs/tracing/latest/tracing/struct.Event.html
+//! [`tracing::Collector`]: tracing::Collect
+//! [`Collect`]: tracing::Collect
 //! [flags]: https://docs.rs/tracing/latest/tracing/#crate-feature-flags
 #![doc(html_root_url = "https://docs.rs/tracing-log/0.1.1")]
 #![doc(
@@ -376,7 +373,6 @@ impl AsTrace for log::Level {
 /// regardless of the source of its source.
 ///
 /// [`normalized_metadata`]: trait.NormalizeEvent.html#normalized_metadata
-/// [`log::Record`]: https://docs.rs/log/0.4.7/log/struct.Record.html
 pub trait NormalizeEvent<'a>: crate::sealed::Sealed {
     /// If this `Event` comes from a `log`, this method provides a new
     /// normalized `Metadata` which has all available attributes

--- a/tracing-log/src/log_tracer.rs
+++ b/tracing-log/src/log_tracer.rs
@@ -20,7 +20,7 @@
 //! default.
 //!
 //! [`log`]: https://docs.rs/log/0.4.8/log/
-//! [logger interface]: https://docs.rs/log/0.4.8/log/trait.Log.html
+//! [logger interface]: log::Log
 //! [`init`]: LogTracer.html#method.init
 //! [`init_with_filter`]: LogTracer.html#method.init_with_filter
 //! [builder]: LogTracer::builder()

--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -105,7 +105,7 @@ struct SpanEventVisitor<'a>(&'a mut api::Event);
 impl<'a> field::Visit for SpanEventVisitor<'a> {
     /// Record events on the underlying OpenTelemetry [`Span`] from `bool` values.
     ///
-    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    /// [`Span`]: opentelemetry::api::trace::span::Span
     fn record_bool(&mut self, field: &field::Field, value: bool) {
         match field.name() {
             "message" => self.0.name = value.to_string(),
@@ -120,7 +120,7 @@ impl<'a> field::Visit for SpanEventVisitor<'a> {
 
     /// Record events on the underlying OpenTelemetry [`Span`] from `i64` values.
     ///
-    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    /// [`Span`]: opentelemetry::api::trace::span::Span
     fn record_i64(&mut self, field: &field::Field, value: i64) {
         match field.name() {
             "message" => self.0.name = value.to_string(),
@@ -135,7 +135,7 @@ impl<'a> field::Visit for SpanEventVisitor<'a> {
 
     /// Record events on the underlying OpenTelemetry [`Span`] from `u64` values.
     ///
-    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    /// [`Span`]: opentelemetry::api::trace::span::Span
     fn record_u64(&mut self, field: &field::Field, value: u64) {
         match field.name() {
             "message" => self.0.name = value.to_string(),
@@ -150,7 +150,7 @@ impl<'a> field::Visit for SpanEventVisitor<'a> {
 
     /// Record events on the underlying OpenTelemetry [`Span`] from `&str` values.
     ///
-    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    /// [`Span`]: opentelemetry::api::trace::span::Span
     fn record_str(&mut self, field: &field::Field, value: &str) {
         match field.name() {
             "message" => self.0.name = value.to_string(),
@@ -166,7 +166,7 @@ impl<'a> field::Visit for SpanEventVisitor<'a> {
     /// Record events on the underlying OpenTelemetry [`Span`] from values that
     /// implement Debug.
     ///
-    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    /// [`Span`]: opentelemetry::api::trace::span::Span
     fn record_debug(&mut self, field: &field::Field, value: &dyn fmt::Debug) {
         match field.name() {
             "message" => self.0.name = format!("{:?}", value),
@@ -187,7 +187,7 @@ struct SpanAttributeVisitor<'a>(&'a mut api::SpanBuilder);
 impl<'a> field::Visit for SpanAttributeVisitor<'a> {
     /// Set attributes on the underlying OpenTelemetry [`Span`] from `bool` values.
     ///
-    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    /// [`Span`]: opentelemetry::api::trace::span::Span
     fn record_bool(&mut self, field: &field::Field, value: bool) {
         let attribute = api::KeyValue::new(field.name(), value);
         if let Some(attributes) = &mut self.0.attributes {
@@ -199,7 +199,7 @@ impl<'a> field::Visit for SpanAttributeVisitor<'a> {
 
     /// Set attributes on the underlying OpenTelemetry [`Span`] from `i64` values.
     ///
-    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    /// [`Span`]: opentelemetry::api::trace::span::Span
     fn record_i64(&mut self, field: &field::Field, value: i64) {
         let attribute = api::KeyValue::new(field.name(), value);
         if let Some(attributes) = &mut self.0.attributes {
@@ -211,7 +211,7 @@ impl<'a> field::Visit for SpanAttributeVisitor<'a> {
 
     /// Set attributes on the underlying OpenTelemetry [`Span`] from `u64` values.
     ///
-    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    /// [`Span`]: opentelemetry::api::trace::span::Span
     fn record_u64(&mut self, field: &field::Field, value: u64) {
         let attribute = api::KeyValue::new(field.name(), value);
         if let Some(attributes) = &mut self.0.attributes {
@@ -223,7 +223,7 @@ impl<'a> field::Visit for SpanAttributeVisitor<'a> {
 
     /// Set attributes on the underlying OpenTelemetry [`Span`] from `&str` values.
     ///
-    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    /// [`Span`]: opentelemetry::api::trace::span::Span
     fn record_str(&mut self, field: &field::Field, value: &str) {
         if field.name() == SPAN_NAME_FIELD {
             self.0.name = value.to_string();
@@ -242,7 +242,7 @@ impl<'a> field::Visit for SpanAttributeVisitor<'a> {
     /// Set attributes on the underlying OpenTelemetry [`Span`] from values that
     /// implement Debug.
     ///
-    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    /// [`Span`]: opentelemetry::api::trace::span::Span
     fn record_debug(&mut self, field: &field::Field, value: &dyn fmt::Debug) {
         if field.name() == SPAN_NAME_FIELD {
             self.0.name = format!("{:?}", value);
@@ -267,8 +267,8 @@ where
     /// Set the [`Tracer`] that this layer will use to produce and track
     /// OpenTelemetry [`Span`]s.
     ///
-    /// [`Tracer`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/tracer/trait.Tracer.html
-    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    /// [`Tracer`]: opentelemetry::api::trace::tracer::Tracer
+    /// [`Span`]: opentelemetry::api::trace::span::Span
     ///
     /// # Examples
     ///
@@ -318,8 +318,8 @@ where
     /// Set the [`Tracer`] that this layer will use to produce and track
     /// OpenTelemetry [`Span`]s.
     ///
-    /// [`Tracer`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/tracer/trait.Tracer.html
-    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    /// [`Tracer`]: opentelemetry::api::trace::tracer::Tracer
+    /// [`Span`]: opentelemetry::api::trace::span::Span
     ///
     /// # Examples
     ///
@@ -373,9 +373,9 @@ where
     /// tracing [`span`] through the [`Registry`]. This [`SpanContext`]
     /// links spans to their parent for proper hierarchical visualization.
     ///
-    /// [`SpanContext`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span_context/struct.SpanContext.html
-    /// [`span`]: https://docs.rs/tracing/latest/tracing/struct.Span.html
-    /// [`Registry`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.Registry.html
+    /// [`SpanContext`]: opentelemetry::api::trace::span_context::SpanContext
+    /// [`span`]: tracing::Span
+    /// [`Registry`]: tracing_subscriber::Registry
     fn parent_span_context(
         &self,
         attrs: &Attributes<'_>,
@@ -431,8 +431,8 @@ where
 {
     /// Creates an [OpenTelemetry `Span`] for the corresponding [tracing `Span`].
     ///
-    /// [OpenTelemetry `Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
-    /// [tracing `Span`]: https://docs.rs/tracing/latest/tracing/struct.Span.html
+    /// [OpenTelemetry `Span`]: opentelemetry::api::trace::span::Span
+    /// [tracing `Span`]: tracing::Span
     fn new_span(&self, attrs: &Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
         let span = ctx.span(id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
@@ -463,7 +463,7 @@ where
 
     /// Record OpenTelemetry [`attributes`] for the given values.
     ///
-    /// [`attributes`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/tracer/struct.SpanBuilder.html#structfield.attributes
+    /// [`attributes`]: opentelemetry::api::trace::tracer::SpanBuilder::attributes
     fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
         let span = ctx.span(id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
@@ -501,9 +501,9 @@ where
     /// Note: an [`ERROR`]-level event will also set the OpenTelemetry span status code to
     /// [`Unknown`], signaling that an error has occurred.
     ///
-    /// [`Event`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/event/struct.Event.html
-    /// [`ERROR`]: https://docs.rs/tracing/latest/tracing/struct.Level.html#associatedconstant.ERROR
-    /// [`Unknown`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/enum.StatusCode.html#variant.Unknown
+    /// [`Event`]: opentelemetry::api::trace::event::Event
+    /// [`ERROR`]: tracing::Level::ERROR
+    /// [`Unknown`]: opentelemetry::api::trace::span::StatusCode::Unknown
     fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
         // Ignore events that are not in the context of a span
         if let Some(span) = ctx.lookup_current() {
@@ -542,7 +542,7 @@ where
 
     /// Exports an OpenTelemetry [`Span`] on close.
     ///
-    /// [`Span`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span/trait.Span.html
+    /// [`Span`]: opentelemetry::api::trace::span::Span
     fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
         let span = ctx.span(&id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();

--- a/tracing-opentelemetry/src/span_ext.rs
+++ b/tracing-opentelemetry/src/span_ext.rs
@@ -5,14 +5,14 @@ use opentelemetry::api::TraceContextExt;
 /// Utility functions to allow tracing [`Span`]s to accept and return
 /// [OpenTelemetry] [`Context`]s.
 ///
-/// [`Span`]: https://docs.rs/tracing/latest/tracing/struct.Span.html
+/// [`Span`]: tracing::Span
 /// [OpenTelemetry]: https://opentelemetry.io
-/// [`Context`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/context/struct.Context.html
+/// [`Context`]: opentelemetry::api::context::Context
 pub trait OpenTelemetrySpanExt {
     /// Associates `self` with a given OpenTelemetry trace, using the provided
     /// parent [`Context`].
     ///
-    /// [`Context`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/context/struct.Context.html
+    /// [`Context`]: opentelemetry::api::context::Context
     ///
     /// # Examples
     ///
@@ -44,7 +44,7 @@ pub trait OpenTelemetrySpanExt {
 
     /// Extracts an OpenTelemetry [`Context`] from `self`.
     ///
-    /// [`Context`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/context/struct.Context.html
+    /// [`Context`]: opentelemetry::api::context::Context
     ///
     /// # Examples
     ///
@@ -117,7 +117,7 @@ impl api::Span for CompatSpan {
     /// This method is used by OpenTelemetry propagators to inject span context
     /// information into [`Carrier`]s.
     ///
-    /// [`Carrier`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/context/propagation/trait.Carrier.html
+    /// [`Carrier`]: opentelemetry::api::context::propagation::Carrier
     fn span_context(&self) -> api::SpanContext {
         self.0.clone()
     }

--- a/tracing-opentelemetry/src/tracer.rs
+++ b/tracing-opentelemetry/src/tracer.rs
@@ -22,9 +22,9 @@ use opentelemetry::{api, sdk};
 ///
 /// [`OpenTelemetrySpanExt::set_parent`]: crate::OpenTelemetrySpanExt::set_parent
 /// [`OpenTelemetrySpanExt::context`]: crate::OpenTelemetrySpanExt::context
-/// [`Tracer`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/tracer/trait.Tracer.html
-/// [`SpanBuilder`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/tracer/struct.SpanBuilder.html
-/// [`SpanContext`]: https://docs.rs/opentelemetry/latest/opentelemetry/api/trace/span_context/struct.SpanContext.html
+/// [`Tracer`]: opentelemetry::api::trace::tracer::Tracer
+/// [`SpanBuilder`]: opentelemetry::api::trace::tracer::SpanBuilder
+/// [`SpanContext`]: opentelemetry::api::trace::span_context::SpanContext
 pub trait PreSampledTracer {
     /// Produce a pre-sampled span context for the given span builder.
     fn sampled_span_context(&self, builder: &mut api::SpanBuilder) -> api::SpanContext;

--- a/tracing-subscriber/src/field/delimited.rs
+++ b/tracing-subscriber/src/field/delimited.rs
@@ -53,7 +53,7 @@ impl<D, V> VisitDelimited<D, V> {
     /// Returns a new [`Visit`] implementation that wraps `inner` so that
     /// each formatted field is separated by the provided `delimiter`.
     ///
-    /// [`Visit`]: https://docs.rs/tracing-core/0.1.6/tracing_core/field/trait.Visit.html
+    /// [`Visit`]: tracing_core::field::Visit
     pub fn new(delimiter: D, inner: V) -> Self {
         Self {
             delimiter,

--- a/tracing-subscriber/src/field/mod.rs
+++ b/tracing-subscriber/src/field/mod.rs
@@ -1,7 +1,7 @@
 //! Utilities for working with [fields] and [field visitors].
 //!
-//! [fields]: https://docs.rs/tracing-core/latest/tracing_core/field/index.html
-//! [field visitors]: https://docs.rs/tracing-core/latest/tracing_core/field/trait.Visit.html
+//! [fields]: tracing_core::field
+//! [field visitors]: tracing_core::field::Visit
 use std::{fmt, io};
 pub use tracing_core::field::Visit;
 use tracing_core::{
@@ -22,7 +22,7 @@ pub mod display;
 /// data to, configuration variables that determine the visitor's behavior, or
 /// `()` when no input is required to produce a visitor.
 ///
-/// [visitors]: https://docs.rs/tracing-core/latest/tracing_core/field/trait.Visit.html
+/// [visitors]: tracing_core::field::Visit
 pub trait MakeVisitor<T> {
     /// The visitor type produced by this `MakeVisitor`.
     type Visitor: Visit;
@@ -33,7 +33,7 @@ pub trait MakeVisitor<T> {
 
 /// A [visitor] that produces output once it has visited a set of fields.
 ///
-/// [visitor]: https://docs.rs/tracing-core/latest/tracing_core/field/trait.Visit.html
+/// [visitor]: tracing_core::field::Visit
 pub trait VisitOutput<Out>: Visit {
     /// Completes the visitor, returning any output.
     ///
@@ -82,10 +82,10 @@ pub trait VisitOutput<Out>: Visit {
 ///     r.record(&mut visitor);
 /// }
 /// ```
-/// [visitor]: https://docs.rs/tracing-core/latest/tracing_core/field/trait.Visit.html
-/// [attr]: https://docs.rs/tracing-core/latest/tracing_core/span/struct.Attributes.html
-/// [rec]: https://docs.rs/tracing-core/latest/tracing_core/span/struct.Record.html
-/// [event]: https://docs.rs/tracing-core/latest/tracing_core/event/struct.Event.html
+/// [visitor]: tracing_core::field::Visit
+/// [attr]: tracing_core::span::Attributes
+/// [rec]: tracing_core::span::Record
+/// [event]: tracing_core::event::Event
 pub trait RecordFields: crate::sealed::Sealed<RecordFieldsMarker> {
     /// Record all the fields in `self` with the provided `visitor`.
     fn record(&self, visitor: &mut dyn Visit);

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -89,11 +89,11 @@ use tracing_core::{
 ///
 /// [`Subscriber`]: Subscribe
 /// [`env_logger`]: https://docs.rs/env_logger/0.7.1/env_logger/#enabling-logging
-/// [`Span`]: https://docs.rs/tracing-core/latest/tracing_core/span/index.html
-/// [fields]: https://docs.rs/tracing-core/latest/tracing_core/struct.Field.html
-/// [`Event`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Event.html
-/// [`level`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Level.html
-/// [`Metadata`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Metadata.html
+/// [`Span`]: tracing_core::span
+/// [fields]: tracing_core::Field
+/// [`Event`]: tracing_core::Event
+/// [`level`]: tracing_core::Level
+/// [`Metadata`]: tracing_core::Metadata
 #[cfg(feature = "env-filter")]
 #[cfg_attr(docsrs, doc(cfg(feature = "env-filter")))]
 #[derive(Debug)]
@@ -199,7 +199,7 @@ impl EnvFilter {
     /// and events as a previous filter, but sets a different level for those
     /// spans and events, the previous directive is overwritten.
     ///
-    /// [`Level`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Level.html
+    /// [`Level`]: tracing_core::Level
     ///
     /// # Examples
     ///

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -105,7 +105,7 @@ where
     /// # let _ = layer.with_collector(tracing_subscriber::registry::Registry::default());
     /// ```
     /// [`FormatEvent`]: format::FormatEvent
-    /// [`Event`]: https://docs.rs/tracing/latest/tracing/struct.Event.html
+    /// [`Event`]: tracing::Event
     pub fn event_format<E2>(self, e: E2) -> Subscriber<S, N, E2, W>
     where
         E2: FormatEvent<S, N> + 'static,
@@ -247,7 +247,7 @@ where
     /// this formatter; they will not be recorded by other `Collector`s or by
     /// `Subscriber`s added to this subscriber.
     ///
-    /// [lifecycle]: https://docs.rs/tracing/latest/tracing/span/index.html#the-span-lifecycle
+    /// [lifecycle]: tracing::span#the-span-lifecycle
     /// [time]: Subscriber::without_time()
     pub fn with_span_events(self, kind: FmtSpan) -> Self {
         Subscriber {

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -247,7 +247,7 @@ where
     /// this formatter; they will not be recorded by other `Collector`s or by
     /// `Subscriber`s added to this subscriber.
     ///
-    /// [lifecycle]: tracing::span#the-span-lifecycle
+    /// [lifecycle]: mod@tracing::span#the-span-lifecycle
     /// [time]: Subscriber::without_time()
     pub fn with_span_events(self, kind: FmtSpan) -> Self {
         Subscriber {

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -27,8 +27,8 @@ pub struct Pretty {
 
 /// The [visitor] produced by [`Pretty`]'s [`MakeVisitor`] implementation.
 ///
-/// [visitor]: super::super::field::Visit
-/// [`MakeVisitor`]: super::super::field::MakeVisitor
+/// [visitor]: field::Visit
+/// [`MakeVisitor`]: crate::field::MakeVisitor
 pub struct PrettyVisitor<'a> {
     writer: &'a mut dyn Write,
     is_empty: bool,

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -27,9 +27,8 @@ pub struct Pretty {
 
 /// The [visitor] produced by [`Pretty`]'s [`MakeVisitor`] implementation.
 ///
-/// [visitor]: ../../field/trait.Visit.html
-/// [`DefaultFields`]: struct.DefaultFields.html
-/// [`MakeVisitor`]: ../../field/trait.MakeVisitor.html
+/// [visitor]: super::super::field::Visit
+/// [`MakeVisitor`]: super::super::field::MakeVisitor
 pub struct PrettyVisitor<'a> {
     writer: &'a mut dyn Write,
     is_empty: bool,

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -616,6 +616,7 @@ where
     /// Note that using the `chrono` feature flag enables the
     /// additional time formatters [`ChronoUtc`] and [`ChronoLocal`].
     ///
+    /// [`time`]: mod@time
     /// [`timer`]: time::FormatTime
     /// [`ChronoUtc`]: time::ChronoUtc
     /// [`ChronoLocal`]: time::ChronoLocal
@@ -658,7 +659,7 @@ where
     /// this formatter; they will not be recorded by other `Collector`s or by
     /// `Subscriber`s added to this subscriber.
     ///
-    /// [lifecycle]: tracing::span#the-span-lifecycle
+    /// [lifecycle]: mod@tracing::span#the-span-lifecycle
     /// [time]: CollectorBuilder::without_time()
     pub fn with_span_events(self, kind: format::FmtSpan) -> Self {
         CollectorBuilder {

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -423,7 +423,7 @@ impl Collector {
     ///
     /// This can be overridden with the [`CollectorBuilder::with_max_level`] method.
     ///
-    /// [verbosity level]: https://docs.rs/tracing-core/0.1.5/tracing_core/struct.Level.html
+    /// [verbosity level]: tracing_core::Level
     pub const DEFAULT_MAX_LEVEL: LevelFilter = LevelFilter::INFO;
 
     /// Returns a new `CollectorBuilder` for configuring a format subscriber.
@@ -616,7 +616,6 @@ where
     /// Note that using the `chrono` feature flag enables the
     /// additional time formatters [`ChronoUtc`] and [`ChronoLocal`].
     ///
-    /// [`time`]: mod@time
     /// [`timer`]: time::FormatTime
     /// [`ChronoUtc`]: time::ChronoUtc
     /// [`ChronoLocal`]: time::ChronoLocal
@@ -659,7 +658,7 @@ where
     /// this formatter; they will not be recorded by other `Collector`s or by
     /// `Subscriber`s added to this subscriber.
     ///
-    /// [lifecycle]: https://docs.rs/tracing/latest/tracing/span/index.html#the-span-lifecycle
+    /// [lifecycle]: tracing::span#the-span-lifecycle
     /// [time]: CollectorBuilder::without_time()
     pub fn with_span_events(self, kind: format::FmtSpan) -> Self {
         CollectorBuilder {
@@ -945,7 +944,7 @@ impl<N, E, F, W> CollectorBuilder<N, E, F, W> {
     ///     .with_max_level(LevelFilter::OFF)
     ///     .finish();
     /// ```
-    /// [verbosity level]: https://docs.rs/tracing-core/0.1.5/tracing_core/struct.Level.html
+    /// [verbosity level]: tracing_core::Level
     /// [`EnvFilter`]: super::filter::EnvFilter
     pub fn with_max_level(
         self,

--- a/tracing-subscriber/src/fmt/time/mod.rs
+++ b/tracing-subscriber/src/fmt/time/mod.rs
@@ -180,7 +180,6 @@ impl ChronoUtc {
     /// See [`chrono::format::strftime`]
     /// for details on the supported syntax.
     ///
-    /// [`chrono::format::strftime`]: https://docs.rs/chrono/0.4.9/chrono/format/strftime/index.html
     pub fn with_format(format_string: String) -> Self {
         ChronoUtc {
             format: ChronoFmtType::Custom(format_string),
@@ -227,7 +226,6 @@ impl ChronoLocal {
     /// See [`chrono::format::strftime`]
     /// for details on the supported syntax.
     ///
-    /// [`chrono::format::strftime`]: https://docs.rs/chrono/0.4.9/chrono/format/strftime/index.html
     pub fn with_format(format_string: String) -> Self {
         ChronoLocal {
             format: ChronoFmtType::Custom(format_string),

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -16,7 +16,7 @@ use std::{fmt::Debug, io};
 /// [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 /// [`fmt::Collector`]: super::super::fmt::Collector
 /// [`fmt::Subscriber`]: super::super::fmt::Subscriber
-/// [`Event`]: https://docs.rs/tracing-core/0.1.5/tracing_core/event/struct.Event.html
+/// [`Event`]: tracing_core::event::Event
 /// [`io::stdout`]: https://doc.rust-lang.org/std/io/fn.stdout.html
 /// [`io::stderr`]: https://doc.rust-lang.org/std/io/fn.stderr.html
 pub trait MakeWriter {
@@ -127,7 +127,7 @@ impl MakeWriter for TestWriter {
 /// }
 /// ```
 ///
-/// [`Collect`]: https://docs.rs/tracing/latest/tracing/trait.Collect.html
+/// [`Collect`]: tracing::Collect
 /// [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 pub struct BoxMakeWriter {
     inner: Box<dyn MakeWriter<Writer = Box<dyn Write>> + Send + Sync>,

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -57,6 +57,8 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
+//! [`fmt`]: mod@fmt
+//! [`registry`]: mod@registry
 //! [`tracing`]: https://docs.rs/tracing/latest/tracing/
 //! [`Collect`]: tracing_core::collect::Collect
 //! [`EnvFilter`]: filter::EnvFilter

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -57,10 +57,8 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
-//! [`fmt`]: mod@fmt
-//! [`registry`]: mod@registry
 //! [`tracing`]: https://docs.rs/tracing/latest/tracing/
-//! [`Collect`]: https://docs.rs/tracing-core/latest/tracing_core/collect/trait.Collect.html
+//! [`Collect`]: tracing_core::collect::Collect
 //! [`EnvFilter`]: filter::EnvFilter
 //! [`tracing-log`]: https://crates.io/crates/tracing-log
 //! [`smallvec`]: https://crates.io/crates/smallvec
@@ -159,7 +157,7 @@ impl CurrentSpan {
     /// executing, or `None` if it is not inside of a span.
     ///
     ///
-    /// [`Id`]: https://docs.rs/tracing/latest/tracing/span/struct.Id.html
+    /// [`Id`]: tracing::span::Id
     pub fn id(&self) -> Option<Id> {
         self.current.with(|current| current.last().cloned())?
     }

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -211,7 +211,7 @@ where
 
     /// Returns a list of [fields] defined by the span.
     ///
-    /// [fields]: https://docs.rs/tracing-core/latest/tracing_core/field/index.html
+    /// [fields]: tracing_core::field
     pub fn fields(&self) -> &FieldSet {
         self.data.metadata().fields()
     }

--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -187,13 +187,13 @@ use std::{any::TypeId, marker::PhantomData};
 /// [`Interest::never()`] from its [`register_callsite`] method, filter
 /// evaluation will short-circuit and the span or event will be disabled.
 ///
-/// [`Collect`]: https://docs.rs/tracing-core/latest/tracing_core/collect/trait.Collect.html
-/// [span IDs]: https://docs.rs/tracing-core/latest/tracing_core/span/struct.Id.html
+/// [`Collect`]: tracing_core::collect::Collect
+/// [span IDs]: tracing_core::span::Id
 /// [the current span]: Context::current_span()
 /// [`register_callsite`]: Subscribe::register_callsite()
 /// [`enabled`]: Subscribe::enabled()
 /// [`on_enter`]: Subscribe::on_enter()
-/// [`Interest::never()`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/struct.Interest.html#method.never
+/// [`Interest::never()`]: tracing_core::subscriber::Interest::never()
 pub trait Subscribe<C>
 where
     C: Collect,
@@ -233,10 +233,10 @@ where
     /// globally enable or disable those callsites, it should always return
     /// [`Interest::always()`].
     ///
-    /// [`Interest`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Interest.html
-    /// [`Collector::register_callsite`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html#method.register_callsite
-    /// [`Interest::never()`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/struct.Interest.html#method.never
-    /// [`Interest::always()`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/struct.Interest.html#method.always
+    /// [`Interest`]: tracing_core::Interest
+    /// [`Collector::register_callsite`]: tracing_core::Subscriber::register_callsite()
+    /// [`Interest::never()`]: tracing_core::subscriber::Interest::never()
+    /// [`Interest::always()`]: tracing_core::subscriber::Interest::always()
     /// [`self.enabled`]: Subscribe::enabled()
     /// [`Subscriber::enabled`]: Subscribe::enabled()
     /// [`on_event`]: Subscribe::on_event()
@@ -280,7 +280,7 @@ where
     /// See [the trait-level documentation] for more information on filtering
     /// with `Subscriber`s.
     ///
-    /// [`Interest`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Interest.html
+    /// [`Interest`]: tracing_core::Interest
     /// [`on_event`]: Layer::on_event()
     /// [`on_enter`]: Layer::on_enter()
     /// [`on_exit`]: Layer::on_exit()
@@ -485,7 +485,7 @@ where
     ///     .with_collector(MyCollector::new());
     ///```
     ///
-    /// [`Collect`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Collect.html
+    /// [`Collect`]: tracing_core::Collect
     fn with_collector(self, inner: C) -> Layered<Self, C>
     where
         Self: Sized,
@@ -552,7 +552,7 @@ pub struct Context<'a, S> {
 /// [subscriber]s.
 ///
 /// [subscriber]: super::subscribe::Subscribe
-/// [collector]: https://docs.rs/tracing-core/latest/tracing_core/trait.Collect.html
+/// [collector]: tracing_core::Collect
 #[derive(Clone, Debug)]
 pub struct Layered<S, I, C = I> {
     subscriber: S,
@@ -976,8 +976,8 @@ where
     ///   check whether the event would be enabled. This allows `Collectors`s to
     ///   elide constructing the event if it would not be recorded.
     ///
-    /// [register]: https://docs.rs/tracing-core/latest/tracing_core/collect/trait.Collect.html#method.register_callsite
-    /// [`enabled`]: https://docs.rs/tracing-core/latest/tracing_core/collect/trait.Collect.html#method.enabled
+    /// [register]: tracing_core::collect::Collect::register_callsite()
+    /// [`enabled`]: tracing_core::collect::Collect::enabled()
     /// [`Context::enabled`]: Layered::enabled()
     #[inline]
     pub fn event(&self, event: &Event<'_>) {

--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -193,7 +193,6 @@ use std::{any::TypeId, marker::PhantomData};
 /// [`register_callsite`]: Subscribe::register_callsite()
 /// [`enabled`]: Subscribe::enabled()
 /// [`on_enter`]: Subscribe::on_enter()
-/// [`Interest::never()`]: tracing_core::subscriber::Interest::never()
 pub trait Subscribe<C>
 where
     C: Collect,
@@ -201,7 +200,7 @@ where
 {
     /// Registers a new callsite with this subscriber, returning whether or not
     /// the subscriber is interested in being notified about the callsite, similarly
-    /// to [`Collector::register_callsite`].
+    /// to [`Collect::register_callsite`].
     ///
     /// By default, this returns [`Interest::always()`] if [`self.enabled`] returns
     /// true, or [`Interest::never()`] if it returns false.
@@ -212,7 +211,7 @@ where
     /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: This method (and <a href="#method.enabled">
-    /// <code>Subscriber::enabled</code></a>) determine whether a span or event is
+    /// <code>Subscribe::enabled</code></a>) determine whether a span or event is
     /// globally enabled, <em>not</em> whether the individual subscriber will be
     /// notified about that span or event. This is intended to be used
     /// by subscribers that implement filtering for the entire stack. Subscribers which do
@@ -234,11 +233,8 @@ where
     /// [`Interest::always()`].
     ///
     /// [`Interest`]: tracing_core::Interest
-    /// [`Collector::register_callsite`]: tracing_core::Subscriber::register_callsite()
-    /// [`Interest::never()`]: tracing_core::subscriber::Interest::never()
-    /// [`Interest::always()`]: tracing_core::subscriber::Interest::always()
+    /// [`Collect::register_callsite`]: tracing_core::Collect::register_callsite()
     /// [`self.enabled`]: Subscribe::enabled()
-    /// [`Subscriber::enabled`]: Subscribe::enabled()
     /// [`on_event`]: Subscribe::on_event()
     /// [`on_enter`]: Subscribe::on_enter()
     /// [`on_exit`]: Subscribe::on_exit()

--- a/tracing-subscriber/src/util.rs
+++ b/tracing-subscriber/src/util.rs
@@ -14,8 +14,8 @@ use tracing_core::dispatch::{self, Dispatch};
 /// `Collector`, may implement `Into<Dispatch>`, and will also receive an
 /// implementation of this trait.
 ///
-/// [default subscriber]: https://docs.rs/tracing/0.1.21/tracing/dispatcher/index.html#setting-the-default-subscriber
-/// [trace dispatcher]: https://docs.rs/tracing/0.1.21/tracing/dispatcher/index.html
+/// [default subscriber]: tracing::dispatcher#setting-the-default-subscriber
+/// [trace dispatcher]: tracing::dispatcher
 pub trait SubscriberInitExt
 where
     Self: Into<Dispatch>,
@@ -27,7 +27,7 @@ where
     /// a [`log`] compatibility layer. This allows the subscriber to consume
     /// `log::Record`s as though they were `tracing` `Event`s.
     ///
-    /// [default subscriber]: https://docs.rs/tracing/0.1.21/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [default subscriber]: tracing::dispatcher#setting-the-default-subscriber
     /// [`log`]: https://crates.io/log
     fn set_default(self) -> dispatch::DefaultGuard {
         #[cfg(feature = "tracing-log")]
@@ -47,7 +47,7 @@ where
     /// been set, or if a `log` logger has already been set (when the
     /// "tracing-log" feature is enabled).
     ///
-    /// [global default subscriber]: https://docs.rs/tracing/0.1.21/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [global default subscriber]: tracing::dispatcher#setting-the-default-subscriber
     /// [`log`]: https://crates.io/log
     fn try_init(self) -> Result<(), TryInitError> {
         #[cfg(feature = "tracing-log")]
@@ -69,7 +69,7 @@ where
     /// or if a `log` logger has already been set (when the "tracing-log"
     /// feature is enabled).
     ///
-    /// [global default subscriber]: https://docs.rs/tracing/0.1.21/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [global default subscriber]: tracing::dispatcher#setting-the-default-subscriber
     /// [`log`]: https://crates.io/log
     fn init(self) {
         self.try_init()

--- a/tracing-subscriber/src/util.rs
+++ b/tracing-subscriber/src/util.rs
@@ -14,8 +14,8 @@ use tracing_core::dispatch::{self, Dispatch};
 /// `Collector`, may implement `Into<Dispatch>`, and will also receive an
 /// implementation of this trait.
 ///
-/// [default subscriber]: tracing::dispatcher#setting-the-default-subscriber
-/// [trace dispatcher]: tracing::dispatcher
+/// [default subscriber]: tracing::dispatch#setting-the-default-collector
+/// [trace dispatcher]: tracing::dispatch
 pub trait SubscriberInitExt
 where
     Self: Into<Dispatch>,
@@ -27,7 +27,7 @@ where
     /// a [`log`] compatibility layer. This allows the subscriber to consume
     /// `log::Record`s as though they were `tracing` `Event`s.
     ///
-    /// [default subscriber]: tracing::dispatcher#setting-the-default-subscriber
+    /// [default subscriber]: tracing::dispatch#setting-the-default-collector
     /// [`log`]: https://crates.io/log
     fn set_default(self) -> dispatch::DefaultGuard {
         #[cfg(feature = "tracing-log")]
@@ -47,7 +47,7 @@ where
     /// been set, or if a `log` logger has already been set (when the
     /// "tracing-log" feature is enabled).
     ///
-    /// [global default subscriber]: tracing::dispatcher#setting-the-default-subscriber
+    /// [global default subscriber]: tracing::dispatch#setting-the-default-collector
     /// [`log`]: https://crates.io/log
     fn try_init(self) -> Result<(), TryInitError> {
         #[cfg(feature = "tracing-log")]
@@ -69,7 +69,7 @@ where
     /// or if a `log` logger has already been set (when the "tracing-log"
     /// feature is enabled).
     ///
-    /// [global default subscriber]: tracing::dispatcher#setting-the-default-subscriber
+    /// [global default subscriber]: tracing::dispatch#setting-the-default-collector
     /// [`log`]: https://crates.io/log
     fn init(self) {
         self.try_init()

--- a/tracing/src/collect.rs
+++ b/tracing/src/collect.rs
@@ -12,8 +12,8 @@ pub use tracing_core::dispatch::DefaultGuard;
 /// executing, new spans or events are dispatched to the collector that
 /// tagged that span, instead.
 ///
-/// [`Span`]: ../span/struct.Span.html
-/// [`Collect`]: ../collect/trait.Collect.html
+/// [`Span`]: super::span::Span
+/// [`Collect`]: super::collect::Collect
 /// [`Event`]: :../event/struct.Event.html
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
@@ -33,8 +33,8 @@ where
 /// Note: Libraries should *NOT* call `set_global_default()`! That will cause conflicts when
 /// executables try to set them later.
 ///
-/// [span]: ../span/index.html
-/// [`Event`]: ../event/struct.Event.html
+/// [span]: super::span
+/// [`Event`]: super::event::Event
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "std", feature = "alloc"))))]
 pub fn set_global_default<S>(collector: S) -> Result<(), SetGlobalDefaultError>
@@ -52,9 +52,9 @@ where
 /// executing, new spans or events are dispatched to the collector that
 /// tagged that span, instead.
 ///
-/// [`Span`]: ../span/struct.Span.html
+/// [`Span`]: super::span::Span
 /// [`Event`]: :../event/struct.Event.html
-/// [`DefaultGuard`]: ../dispatcher/struct.DefaultGuard.html
+/// [`DefaultGuard`]: super::dispatcher::DefaultGuard
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[must_use = "Dropping the guard unregisters the collector."]

--- a/tracing/src/collect.rs
+++ b/tracing/src/collect.rs
@@ -54,7 +54,6 @@ where
 ///
 /// [`Span`]: super::span::Span
 /// [`Event`]: :../event/struct.Event.html
-/// [`DefaultGuard`]: super::dispatcher::DefaultGuard
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[must_use = "Dropping the guard unregisters the collector."]

--- a/tracing/src/collect.rs
+++ b/tracing/src/collect.rs
@@ -14,7 +14,7 @@ pub use tracing_core::dispatch::DefaultGuard;
 ///
 /// [`Span`]: super::span::Span
 /// [`Collect`]: super::collect::Collect
-/// [`Event`]: :../event/struct.Event.html
+/// [`Event`]: tracing_core::Event
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn with_default<T, S>(collector: S, f: impl FnOnce() -> T) -> T
@@ -34,7 +34,6 @@ where
 /// executables try to set them later.
 ///
 /// [span]: super::span
-/// [`Event`]: super::event::Event
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "std", feature = "alloc"))))]
 pub fn set_global_default<S>(collector: S) -> Result<(), SetGlobalDefaultError>
@@ -53,7 +52,7 @@ where
 /// tagged that span, instead.
 ///
 /// [`Span`]: super::span::Span
-/// [`Event`]: :../event/struct.Event.html
+/// [`Event`]: tracing_core::Event
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[must_use = "Dropping the guard unregisters the collector."]

--- a/tracing/src/dispatch.rs
+++ b/tracing/src/dispatch.rs
@@ -133,11 +133,6 @@
 //! currently default `Dispatch`. This is used primarily by `tracing`
 //! instrumentation.
 //!
-//! [`Collect`]: struct.Collect.html
-//! [`with_default`]: fn.with_default.html
-//! [`set_global_default`]: fn.set_global_default.html
-//! [`get_default`]: fn.get_default.html
-//! [`Dispatch`]: struct.Dispatch.html
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use tracing_core::dispatch::set_default;

--- a/tracing/src/dispatch.rs
+++ b/tracing/src/dispatch.rs
@@ -133,6 +133,7 @@
 //! currently default `Dispatch`. This is used primarily by `tracing`
 //! instrumentation.
 //!
+//! [`Collect`]: tracing_core::Collect
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use tracing_core::dispatch::set_default;

--- a/tracing/src/instrument.rs
+++ b/tracing/src/instrument.rs
@@ -34,7 +34,7 @@ pub trait Instrument: Sized {
     /// # }
     /// ```
     ///
-    /// [entered]: ../struct.Span.html#method.enter
+    /// [entered]: super::Span::enter()
     fn instrument(self, span: Span) -> Instrumented<Self> {
         Instrumented { inner: self, span }
     }
@@ -68,8 +68,8 @@ pub trait Instrument: Sized {
     /// # }
     /// ```
     ///
-    /// [current]: ../struct.Span.html#method.current
-    /// [entered]: ../struct.Span.html#method.enter
+    /// [current]: super::Span::current()
+    /// [entered]: super::Span::enter()
     #[inline]
     fn in_current_span(self) -> Instrumented<Self> {
         self.instrument(Span::current())
@@ -85,8 +85,8 @@ pub trait WithCollector: Sized {
     ///
     /// The attached collector will be set as the [default] when the returned `Future` is polled.
     ///
-    /// [`Collect`]: ../trait.Collect.html
-    /// [default]: https://docs.rs/tracing/latest/tracing/dispatch/index.html#setting-the-default-collector
+    /// [`Collect`]: super::Collect
+    /// [default]: crate::dispatch#setting-the-default-collector
     fn with_collector<S>(self, collector: S) -> WithDispatch<Self>
     where
         S: Into<Dispatch>,
@@ -108,7 +108,7 @@ pub trait WithCollector: Sized {
     /// This can be used to propagate the current dispatcher context when
     /// spawning a new future.
     ///
-    /// [default]: https://docs.rs/tracing/latest/tracing/dispatch/index.html#setting-the-default-collector
+    /// [default]: crate::dispatch#setting-the-default-collector
     #[inline]
     fn with_current_collector(self) -> WithDispatch<Self> {
         WithDispatch {

--- a/tracing/src/level_filters.rs
+++ b/tracing/src/level_filters.rs
@@ -49,7 +49,7 @@ pub use tracing_core::{metadata::ParseLevelFilterError, LevelFilter};
 /// `Span` constructors should compare the level against this value to
 /// determine if those spans or events are enabled.
 ///
-/// [module-level documentation]: ../index.html#compile-time-filters
+/// [module-level documentation]: super#compile-time-filters
 pub const STATIC_MAX_LEVEL: LevelFilter = MAX_LEVEL;
 
 cfg_if! {

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -49,7 +49,7 @@
 //! # }
 //!```
 //!
-//! The [`span` module][span]'s documentation provides further details on how to
+//! The [`span` module][mod@span]'s documentation provides further details on how to
 //! use spans.
 //!
 //! <div class="information">
@@ -868,7 +868,7 @@
 //! [`tracing-timing`]: https://crates.io/crates/tracing-timing
 //! [`tracing-appender`]: https://crates.io/crates/tracing-appender
 //! [`env_logger`]: https://crates.io/crates/env_logger
-//! [`FmtSubscriber`]: tracing_subscriber::fmt::Subscriber
+//! [`FmtSubscriber`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Subscriber.html
 //! [static verbosity level]: level_filters#compile-time-filters
 //! [instrument]: tracing_attributes::instrument
 //! [flags]: #crate-feature-flags

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -416,13 +416,13 @@
 //! Specifying a formatted message in this manner does not allocate by default.
 //!
 //! [struct initializers]: https://doc.rust-lang.org/book/ch05-01-defining-structs.html#using-the-field-init-shorthand-when-variables-and-fields-have-the-same-name
-//! [target]: struct.Metadata.html#method.target
-//! [parent span]: span/struct.Attributes.html#method.parent
-//! [determined contextually]: span/struct.Attributes.html#method.is_contextual
+//! [target]: Metadata::target()
+//! [parent span]: span::Attributes::parent()
+//! [determined contextually]: span::Attributes::is_contextual()
 //! [`fmt::Debug`]: https://doc.rust-lang.org/std/fmt/trait.Debug.html
 //! [`fmt::Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
 //! [fmt]: https://doc.rust-lang.org/std/fmt/#usage
-//! [`Empty`]: field/struct.Empty.html
+//! [`Empty`]: field::Empty
 //!
 //! ### Shorthand Macros
 //!
@@ -436,19 +436,18 @@
 //! These are intended both as a shorthand, and for compatibility with the [`log`]
 //! crate (see the next section).
 //!
-//! [`span!`]: macro.span.html
-//! [`event!`]: macro.event.html
-//! [`trace!`]: macro.trace.html
-//! [`debug!`]: macro.debug.html
-//! [`info!`]: macro.info.html
-//! [`warn!`]: macro.warn.html
-//! [`error!`]: macro.error.html
-//! [`trace_span!`]: macro.trace_span.html
-//! [`debug_span!`]: macro.debug_span.html
-//! [`info_span!`]: macro.info_span.html
-//! [`warn_span!`]: macro.warn_span.html
-//! [`error_span!`]: macro.error_span.html
-//! [`Level`]: struct.Level.html
+//! [`span!`]: span!
+//! [`event!`]: event!
+//! [`trace!`]: trace!
+//! [`debug!`]: debug!
+//! [`info!`]: info!
+//! [`warn!`]: warn!
+//! [`error!`]: error!
+//! [`trace_span!`]: trace_span!
+//! [`debug_span!`]: debug_span!
+//! [`info_span!`]: info_span!
+//! [`warn_span!`]: warn_span!
+//! [`error_span!`]: error_span!
 //!
 //! ### For `log` Users
 //!
@@ -849,7 +848,6 @@
 //! long as doing so complies with this policy.
 //!
 //! [`log`]: https://docs.rs/log/0.4.6/log/
-//! [span]: mod@span
 //! [spans]: mod@span
 //! [`Span`]: span::Span
 //! [`in_scope`]: span::Span::in_scope
@@ -861,8 +859,6 @@
 //! [`exit`]: collect::Collect::exit
 //! [`enabled`]: collect::Collect::enabled
 //! [metadata]: Metadata
-//! [`field::display`]: field::display
-//! [`field::debug`]: field::debug
 //! [`set_global_default`]: collect::set_global_default
 //! [`with_default`]: collect::with_default
 //! [`tokio-rs/tracing`]: https://github.com/tokio-rs/tracing
@@ -872,9 +868,9 @@
 //! [`tracing-timing`]: https://crates.io/crates/tracing-timing
 //! [`tracing-appender`]: https://crates.io/crates/tracing-appender
 //! [`env_logger`]: https://crates.io/crates/env_logger
-//! [`FmtSubscriber`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Subscriber.html
-//! [static verbosity level]: level_filters/index.html#compile-time-filters
-//! [instrument]: https://docs.rs/tracing-attributes/latest/tracing_attributes/attr.instrument.html
+//! [`FmtSubscriber`]: tracing_subscriber::fmt::Subscriber
+//! [static verbosity level]: level_filters#compile-time-filters
+//! [instrument]: tracing_attributes::instrument
 //! [flags]: #crate-feature-flags
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -3,7 +3,7 @@
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: self#using-the-macros
+/// [lib]: crate#using-the-macros
 ///
 /// # Examples
 ///
@@ -139,9 +139,9 @@ macro_rules! span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: self#using-the-macros
-/// [attributes]: self#configuring-attributes
-/// [Fields]: self#recording-fields
+/// [lib]: crate#using-the-macros
+/// [attributes]: crate#configuring-attributes
+/// [Fields]: crate#recording-fields
 /// [`span!`]: span!
 ///
 /// # Examples
@@ -220,9 +220,9 @@ macro_rules! trace_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: self#using-the-macros
-/// [attributes]: self#configuring-attributes
-/// [Fields]: self#recording-fields
+/// [lib]: crate#using-the-macros
+/// [attributes]: crate#configuring-attributes
+/// [Fields]: crate#recording-fields
 /// [`span!`]: span!
 ///
 /// # Examples
@@ -301,9 +301,9 @@ macro_rules! debug_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: self#using-the-macros
-/// [attributes]: self#configuring-attributes
-/// [Fields]: self#recording-fields
+/// [lib]: crate#using-the-macros
+/// [attributes]: crate#configuring-attributes
+/// [Fields]: crate#recording-fields
 /// [`span!`]: span!
 ///
 /// # Examples
@@ -382,9 +382,9 @@ macro_rules! info_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: self#using-the-macros
-/// [attributes]: self#configuring-attributes
-/// [Fields]: self#recording-fields
+/// [lib]: crate#using-the-macros
+/// [attributes]: crate#configuring-attributes
+/// [Fields]: crate#recording-fields
 /// [`span!`]: span!
 ///
 /// # Examples
@@ -462,9 +462,9 @@ macro_rules! warn_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: self#using-the-macros
-/// [attributes]: self#configuring-attributes
-/// [Fields]: self#recording-fields
+/// [lib]: crate#using-the-macros
+/// [attributes]: crate#configuring-attributes
+/// [Fields]: crate#recording-fields
 /// [`span!`]: span!
 ///
 /// # Examples
@@ -544,7 +544,7 @@ macro_rules! error_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: self#using-the-macros
+/// [lib]: crate#using-the-macros
 ///
 /// # Examples
 ///
@@ -807,7 +807,7 @@ macro_rules! event {
 /// this macro.
 ///
 /// [`event!`]: event!
-/// [lib]: self#using-the-macros
+/// [lib]: crate#using-the-macros
 ///
 /// # Examples
 ///
@@ -1007,7 +1007,7 @@ macro_rules! trace {
 /// this macro.
 ///
 /// [`event!`]: event!
-/// [lib]: self#using-the-macros
+/// [lib]: crate#using-the-macros
 ///
 /// # Examples
 ///
@@ -1208,7 +1208,7 @@ macro_rules! debug {
 /// this macro.
 ///
 /// [`event!`]: event!
-/// [lib]: self#using-the-macros
+/// [lib]: crate#using-the-macros
 ///
 /// # Examples
 ///
@@ -1420,7 +1420,7 @@ macro_rules! info {
 /// this macro.
 ///
 /// [`event!`]: event!
-/// [lib]: self#using-the-macros
+/// [lib]: crate#using-the-macros
 ///
 /// # Examples
 ///
@@ -1625,7 +1625,7 @@ macro_rules! warn {
 /// this macro.
 ///
 /// [`event!`]: event!
-/// [lib]: self#using-the-macros
+/// [lib]: crate#using-the-macros
 ///
 /// # Examples
 ///

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -3,7 +3,7 @@
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: index.html#using-the-macros
+/// [lib]: self#using-the-macros
 ///
 /// # Examples
 ///
@@ -139,10 +139,10 @@ macro_rules! span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: index.html#using-the-macros
-/// [attributes]: index.html#configuring-attributes
-/// [Fields]: index.html#recording-fields
-/// [`span!`]: macro.span.html
+/// [lib]: self#using-the-macros
+/// [attributes]: self#configuring-attributes
+/// [Fields]: self#recording-fields
+/// [`span!`]: span!
 ///
 /// # Examples
 ///
@@ -220,10 +220,10 @@ macro_rules! trace_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: index.html#using-the-macros
-/// [attributes]: index.html#configuring-attributes
-/// [Fields]: index.html#recording-fields
-/// [`span!`]: macro.span.html
+/// [lib]: self#using-the-macros
+/// [attributes]: self#configuring-attributes
+/// [Fields]: self#recording-fields
+/// [`span!`]: span!
 ///
 /// # Examples
 ///
@@ -301,10 +301,10 @@ macro_rules! debug_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: index.html#using-the-macros
-/// [attributes]: index.html#configuring-attributes
-/// [Fields]: index.html#recording-fields
-/// [`span!`]: macro.span.html
+/// [lib]: self#using-the-macros
+/// [attributes]: self#configuring-attributes
+/// [Fields]: self#recording-fields
+/// [`span!`]: span!
 ///
 /// # Examples
 ///
@@ -382,10 +382,10 @@ macro_rules! info_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: index.html#using-the-macros
-/// [attributes]: index.html#configuring-attributes
-/// [Fields]: index.html#recording-fields
-/// [`span!`]: macro.span.html
+/// [lib]: self#using-the-macros
+/// [attributes]: self#configuring-attributes
+/// [Fields]: self#recording-fields
+/// [`span!`]: span!
 ///
 /// # Examples
 ///
@@ -462,10 +462,10 @@ macro_rules! warn_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: index.html#using-the-macros
-/// [attributes]: index.html#configuring-attributes
-/// [Fields]: index.html#recording-fields
-/// [`span!`]: macro.span.html
+/// [lib]: self#using-the-macros
+/// [attributes]: self#configuring-attributes
+/// [Fields]: self#recording-fields
+/// [`span!`]: span!
 ///
 /// # Examples
 ///
@@ -544,7 +544,7 @@ macro_rules! error_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: index.html#using-the-macros
+/// [lib]: self#using-the-macros
 ///
 /// # Examples
 ///
@@ -806,8 +806,8 @@ macro_rules! event {
 /// documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [`event!`]: macro.event.html
-/// [lib]: index.html#using-the-macros
+/// [`event!`]: event!
+/// [lib]: self#using-the-macros
 ///
 /// # Examples
 ///
@@ -1006,8 +1006,8 @@ macro_rules! trace {
 /// documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [`event!`]: macro.event.html
-/// [lib]: index.html#using-the-macros
+/// [`event!`]: event!
+/// [lib]: self#using-the-macros
 ///
 /// # Examples
 ///
@@ -1207,8 +1207,8 @@ macro_rules! debug {
 /// documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [`event!`]: macro.event.html
-/// [lib]: index.html#using-the-macros
+/// [`event!`]: event!
+/// [lib]: self#using-the-macros
 ///
 /// # Examples
 ///
@@ -1419,8 +1419,8 @@ macro_rules! info {
 /// documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [`event!`]: macro.event.html
-/// [lib]: index.html#using-the-macros
+/// [`event!`]: event!
+/// [lib]: self#using-the-macros
 ///
 /// # Examples
 ///
@@ -1624,8 +1624,8 @@ macro_rules! warn {
 /// documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [`event!`]: macro.event.html
-/// [lib]: index.html#using-the-macros
+/// [`event!`]: event!
+/// [lib]: self#using-the-macros
 ///
 /// # Examples
 ///

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -515,7 +515,7 @@ impl Span {
     /// that the thread from which this function is called is not currently
     /// inside a span, the returned span will be disabled.
     ///
-    /// [considered by the `Collector`]: super::collector::Collector::current()
+    /// [considered by the `Collector`]: super::collect::Collect::current_span()
     pub fn current() -> Span {
         dispatch::get_default(|dispatch| {
             if let Some((id, meta)) = dispatch.current_span().into_inner() {
@@ -558,8 +558,8 @@ impl Span {
     /// Enters this span, returning a guard that will exit the span when dropped.
     ///
     /// If this span is enabled by the current collector, then this function will
-    /// call [`Collector::enter`] with the span's [`Id`], and dropping the guard
-    /// will call [`Collector::exit`]. If the span is disabled, this does
+    /// call [`Collect::enter`] with the span's [`Id`], and dropping the guard
+    /// will call [`Collect::exit`]. If the span is disabled, this does
     /// nothing.
     ///
     /// <div class="information">
@@ -691,7 +691,7 @@ impl Span {
     ///
     /// [syntax]: https://rust-lang.github.io/async-book/01_getting_started/04_async_await_primer.html
     /// [instrument]: crate::Instrument
-    /// [attr]: super::super::instrument
+    /// [attr]: macro@crate::instrument
     ///
     /// # Examples
     ///
@@ -750,8 +750,8 @@ impl Span {
     /// info!("i'm outside the span!")
     /// ```
     ///
-    /// [`Collector::enter`]: super::collector::Collector::enter()
-    /// [`Collector::exit`]: super::collector::Collector::exit()
+    /// [`Collect::enter`]: super::collect::Collect::enter()
+    /// [`Collect::exit`]: super::collect::Collect::exit()
     /// [`Id`]: super::Id
     pub fn enter(&self) -> Entered<'_> {
         if let Some(ref inner) = self.inner.as_ref() {

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -24,7 +24,7 @@
 //! - A string literal providing the span's name.
 //! - Finally, between zero and 32 arbitrary key/value fields.
 //!
-//! [`target`]: ../struct.Metadata.html#method.target
+//! [`target`]: super::Metadata::target()
 //!
 //! For example:
 //! ```rust
@@ -293,25 +293,23 @@
 //! much time was spent in each individual iteration, we would enter a new span
 //! on every iteration.
 //!
-//! [fields]: ../field/index.html
-//! [Metadata]: ../struct.Metadata.html
-//! [`Id`]: struct.Id.html
-//! [verbosity level]: ../struct.Level.html
-//! [`span!`]: ../macro.span.html
-//! [`trace_span!`]: ../macro.trace_span.html
-//! [`debug_span!`]: ../macro.debug_span.html
-//! [`info_span!`]: ../macro.info_span.html
-//! [`warn_span!`]: ../macro.warn_span.html
-//! [`error_span!`]: ../macro.error_span.html
-//! [`clone_span`]: ../collect/trait.Collect.html#method.clone_span
-//! [`drop_span`]: ../collect/trait.Collect.html#method.drop_span
-//! [`exit`]: ../collect/trait.Collect.html#tymethod.exit
-//! [collector]: ../collect/trait.Collect.html
-//! [`Attributes`]: struct.Attributes.html
-//! [`enter`]: struct.Span.html#method.enter
-//! [`in_scope`]: struct.Span.html#method.in_scope
-//! [`follows_from`]: struct.Span.html#method.follows_from
-//! [guard]: struct.Entered.html
+//! [fields]: super::field
+//! [Metadata]: super::Metadata
+//! [verbosity level]: super::Level
+//! [`span!`]: super::span!
+//! [`trace_span!`]: super::trace_span!
+//! [`debug_span!`]: super::debug_span!
+//! [`info_span!`]: super::info_span!
+//! [`warn_span!`]: super::warn_span!
+//! [`error_span!`]: super::error_span!
+//! [`clone_span`]: super::collect::Collect::clone_span()
+//! [`drop_span`]: super::collect::Collect::drop_span()
+//! [`exit`]: super::collect::Collect::exit
+//! [collector]: super::collect::Collect
+//! [`enter`]: Span::enter()
+//! [`in_scope`]: Span::in_scope()
+//! [`follows_from`]: Span::follows_from()
+//! [guard]: Entered
 //! [parent]: #span-relationships
 pub use tracing_core::span::{Attributes, Id, Record};
 
@@ -375,7 +373,7 @@ pub(crate) struct Inner {
 ///
 /// This is returned by the [`Span::enter`] function.
 ///
-/// [`Span::enter`]: ../struct.Span.html#method.enter
+/// [`Span::enter`]: super::Span::enter()
 #[derive(Debug)]
 #[must_use = "once a span has been entered, it should be exited"]
 pub struct Entered<'a> {
@@ -403,9 +401,9 @@ impl Span {
     /// annotations may be added to it.
     ///
     /// [metadata]: ../metadata
-    /// [collector]: ../collect/trait.Collect.html
-    /// [field values]: ../field/struct.ValueSet.html
-    /// [`follows_from`]: ../struct.Span.html#method.follows_from
+    /// [collector]: super::collect::Collect
+    /// [field values]: super::field::ValueSet
+    /// [`follows_from`]: super::Span::follows_from()
     pub fn new(meta: &'static Metadata<'static>, values: &field::ValueSet<'_>) -> Span {
         dispatch::get_default(|dispatch| Self::new_with(meta, values, dispatch))
     }
@@ -428,8 +426,8 @@ impl Span {
     /// annotations may be added to it.
     ///
     /// [metadata]: ../metadata
-    /// [field values]: ../field/struct.ValueSet.html
-    /// [`follows_from`]: ../struct.Span.html#method.follows_from
+    /// [field values]: super::field::ValueSet
+    /// [`follows_from`]: super::Span::follows_from()
     pub fn new_root(meta: &'static Metadata<'static>, values: &field::ValueSet<'_>) -> Span {
         dispatch::get_default(|dispatch| Self::new_root_with(meta, values, dispatch))
     }
@@ -452,8 +450,8 @@ impl Span {
     /// annotations may be added to it.
     ///
     /// [metadata]: ../metadata
-    /// [field values]: ../field/struct.ValueSet.html
-    /// [`follows_from`]: ../struct.Span.html#method.follows_from
+    /// [field values]: super::field::ValueSet
+    /// [`follows_from`]: super::Span::follows_from()
     pub fn child_of(
         parent: impl Into<Option<Id>>,
         meta: &'static Metadata<'static>,
@@ -517,7 +515,7 @@ impl Span {
     /// that the thread from which this function is called is not currently
     /// inside a span, the returned span will be disabled.
     ///
-    /// [considered by the `Collector`]: ../collector/trait.Collector.html#method.current
+    /// [considered by the `Collector`]: super::collector::Collector::current()
     pub fn current() -> Span {
         dispatch::get_default(|dispatch| {
             if let Some((id, meta)) = dispatch.current_span().into_inner() {
@@ -625,7 +623,7 @@ impl Span {
     ///       // This is okay! The span has already been exited before we reach
     ///       // the await point.
     ///       some_other_async_function(some_value).await;
-    ///  
+    ///
     ///       // ...
     ///   }
     ///   ```
@@ -634,7 +632,7 @@ impl Span {
     ///   attaching a span to a future (async function or block). This will
     ///   enter the span _every_ time the future is polled, and exit it whenever
     ///   the future yields.
-    ///   
+    ///
     ///   `Instrument` can be used with an async block inside an async function:
     ///   ```ignore
     ///   # use tracing::info_span;
@@ -681,20 +679,19 @@ impl Span {
     ///   # async fn some_other_async_function() {}
     ///   #[tracing::instrument(level = "info")]
     ///   async fn my_async_function() {
-    ///   
+    ///
     ///       // This is correct! If we yield here, the span will be exited,
     ///       // and re-entered when we resume.
     ///       some_other_async_function().await;
     ///
     ///       // ...
-    ///    
+    ///
     ///   }
     ///   ```
     ///
     /// [syntax]: https://rust-lang.github.io/async-book/01_getting_started/04_async_await_primer.html
-    /// [`Span::in_scope`]: #method.in_scope
-    /// [instrument]: https://docs.rs/tracing/latest/tracing/trait.Instrument.html
-    /// [attr]: ../../attr.instrument.html
+    /// [instrument]: crate::Instrument
+    /// [attr]: super::super::instrument
     ///
     /// # Examples
     ///
@@ -753,9 +750,9 @@ impl Span {
     /// info!("i'm outside the span!")
     /// ```
     ///
-    /// [`Collector::enter`]: ../collector/trait.Collector.html#method.enter
-    /// [`Collector::exit`]: ../collector/trait.Collector.html#method.exit
-    /// [`Id`]: ../struct.Id.html
+    /// [`Collector::enter`]: super::collector::Collector::enter()
+    /// [`Collector::exit`]: super::collector::Collector::exit()
+    /// [`Id`]: super::Id
     pub fn enter(&self) -> Entered<'_> {
         if let Some(ref inner) = self.inner.as_ref() {
             inner.collector.enter(&inner.id);
@@ -904,8 +901,8 @@ impl Span {
     /// span.record("parting", &"you will be remembered");
     /// ```
     ///
-    /// [`field::Empty`]: ../field/struct.Empty.html
-    /// [`Metadata`]: ../struct.Metadata.html
+    /// [`field::Empty`]: super::field::Empty
+    /// [`Metadata`]: super::Metadata
     pub fn record<Q: ?Sized, V>(&self, field: &Q, value: &V) -> &Self
     where
         Q: field::AsField,
@@ -950,7 +947,7 @@ impl Span {
     ///
     /// See also [`is_none`].
     ///
-    /// [`is_none`]: #method.is_none
+    /// [`is_none`]: Span::is_none()
     #[inline]
     pub fn is_disabled(&self) -> bool {
         self.inner.is_none()
@@ -964,8 +961,7 @@ impl Span {
     /// rather than constructed by `Span::none`, this method will return
     /// `false`, while `is_disabled` will return `true`.
     ///
-    /// [`Span::none`]: #method.none
-    /// [`is_disabled`]: #method.is_disabled
+    /// [`is_disabled`]: Span::is_disabled()
     #[inline]
     pub fn is_none(&self) -> bool {
         self.is_disabled() && self.meta.is_none()

--- a/tracing/src/subscribe.rs
+++ b/tracing/src/subscribe.rs
@@ -12,8 +12,8 @@ pub use tracing_core::dispatch::DefaultGuard;
 /// executing, new spans or events are dispatched to the subscriber that
 /// tagged that span, instead.
 ///
-/// [`Span`]: ../span/struct.Span.html
-/// [`Collect`]: ../collect/trait.Collect.html
+/// [`Span`]: super::span::Span
+/// [`Collect`]: super::collect::Collect
 // /// [`Event`]: :../event/struct.Event.html
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
@@ -33,9 +33,9 @@ where
 /// Note: Libraries should *NOT* call `set_global_default()`! That will cause conflicts when
 /// executables try to set them later.
 ///
-/// [span]: ../span/index.html
-/// [`Collect`]: ../collect/trait.Collect.html
-/// [`Event`]: ../event/struct.Event.html
+/// [span]: super::span
+/// [`Collect`]: super::collect::Collect
+/// [`Event`]: super::event::Event
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "std", feature = "alloc"))))]
 pub fn set_global_default<S>(collector: S) -> Result<(), SetGlobalDefaultError>
@@ -53,10 +53,10 @@ where
 /// executing, new spans or events are dispatched to the collector that
 /// tagged that span, instead.
 ///
-/// [`Span`]: ../span/struct.Span.html
-/// [`Collect`]: ../collect/trait.Collect.html
+/// [`Span`]: super::span::Span
+/// [`Collect`]: super::collect::Collect
 /// [`Event`]: :../event/struct.Event.html
-/// [`DefaultGuard`]: ../dispatch/struct.DefaultGuard.html
+/// [`DefaultGuard`]: super::dispatch::DefaultGuard
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[must_use = "Dropping the guard unregisters the collector."]


### PR DESCRIPTION
## Motivation

#940

## Solution

This changes the docs.rs links, many of which were broken (or would have been broken on the next release). It also converts some links I missed the first time (maybe they were added after I opened the PR?).