### PR TITLE
subscriber: fix accessing the field formatter from `FmtContext`

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -738,14 +738,14 @@ impl<'a, S, N> fmt::Debug for FmtContext<'a, S, N> {
     }
 }
 
-impl<'a, S, N> FormatFields<'a> for FmtContext<'a, S, N>
+impl<'cx, 'writer, S, N> FormatFields<'writer> for FmtContext<'cx, S, N>
 where
     S: Collect + for<'lookup> LookupSpan<'lookup>,
-    N: for<'writer> FormatFields<'writer> + 'static,
+    N: FormatFields<'writer> + 'static,
 {
     fn format_fields<R: RecordFields>(
         &self,
-        writer: &'a mut dyn fmt::Write,
+        writer: &'writer mut dyn fmt::Write,
         fields: R,
     ) -> fmt::Result {
         self.fmt_fields.format_fields(writer, fields)
@@ -832,6 +832,17 @@ where
         S: for<'lookup> LookupSpan<'lookup>,
     {
         self.ctx.scope()
+    }
+
+    /// Returns the [field formatter] configured by the subscriber invoking
+    /// `format_event`.
+    ///
+    /// The event formatter may use the returned field formatter to format the
+    /// fields of any events it records.
+    ///
+    /// [field formatter]: FormatFields
+    pub fn field_format(&self) -> &N {
+        self.fmt_fields
     }
 }
 


### PR DESCRIPTION
## Motivation

Currently, the `FmtContext` type implements `FormatFields` using the
subscriber's field formatter. However, this is difficult to use. The
`FmtContext` may _not_ be passed to functions expecting a `for<'writer>
FormatFields<'writer>`, because it only implements `FormatFields` for
its _own_ lifetime. This means the writer must have the same lifetime as
the context, which is not correct.

## Solution

This branch fixes this by changing the impl of `FormatFields` for
`FmtContext` to be generic over both the vontext's lifetime _and_ the
field formatter's lifetime. Additionally, I've added a method for
borrowing the actual field formatter as its concrete type, in case the
`FormatEvent` impl puts additional constraints on its type or is only
implemented for a specific named type, and wants to actually _use_ that
type.

I'd like to backport this to v0.1.x as soon as it lands.