### PR TITLE
Format has default value for all type params

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -61,7 +61,7 @@ use tracing_core::{
 pub struct Subscriber<
     S,
     N = format::DefaultFields,
-    E = format::Format<format::Full>,
+    E = format::Format,
     W = fn() -> io::Stdout,
 > {
     make_writer: W,

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -58,12 +58,7 @@ use tracing_core::{
 ///
 /// [`Subscriber`]: ../layer/trait.Subscriber.html
 #[derive(Debug)]
-pub struct Subscriber<
-    S,
-    N = format::DefaultFields,
-    E = format::Format,
-    W = fn() -> io::Stdout,
-> {
+pub struct Subscriber<S, N = format::DefaultFields, E = format::Format, W = fn() -> io::Stdout> {
     make_writer: W,
     fmt_fields: N,
     fmt_event: E,

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -150,7 +150,7 @@ pub use self::{
 #[derive(Debug)]
 pub struct Collector<
     N = format::DefaultFields,
-    E = format::Format<format::Full>,
+    E = format::Format,
     F = LevelFilter,
     W = fn() -> io::Stdout,
 > {
@@ -161,7 +161,7 @@ pub struct Collector<
 /// This type only logs formatted events; it does not perform any filtering.
 pub type Formatter<
     N = format::DefaultFields,
-    E = format::Format<format::Full>,
+    E = format::Format,
     W = fn() -> io::Stdout,
 > = subscribe::Layered<fmt_subscriber::Subscriber<Registry, N, E, W>, Registry>;
 
@@ -169,7 +169,7 @@ pub type Formatter<
 #[derive(Debug)]
 pub struct CollectorBuilder<
     N = format::DefaultFields,
-    E = format::Format<format::Full>,
+    E = format::Format,
     F = LevelFilter,
     W = fn() -> io::Stdout,
 > {

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -159,11 +159,8 @@ pub struct Collector<
 
 /// A collector that logs formatted representations of `tracing` events.
 /// This type only logs formatted events; it does not perform any filtering.
-pub type Formatter<
-    N = format::DefaultFields,
-    E = format::Format,
-    W = fn() -> io::Stdout,
-> = subscribe::Layered<fmt_subscriber::Subscriber<Registry, N, E, W>, Registry>;
+pub type Formatter<N = format::DefaultFields, E = format::Format, W = fn() -> io::Stdout> =
+    subscribe::Layered<fmt_subscriber::Subscriber<Registry, N, E, W>, Registry>;
 
 /// Configures and constructs `Collector`s.
 #[derive(Debug)]


### PR DESCRIPTION
`format::Format` already has [default values for the log forma](https://github.com/dvdplm/tracing/blob/95463b8ac2fe43f51f89ae3f98006930bbfd2874/tracing-subscriber/src/fmt/format/mod.rs#L177)t (`Full`) as well as time measuring gizmo (`SystemTime`) so no need to plug those in.
