### PR TITLE
opentelemetry: prepare for 0.9.0 release

### DIFF
--- a/tracing-opentelemetry/CHANGELOG.md
+++ b/tracing-opentelemetry/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.9.0 (November 13, 2020)
+
+### Added
+
+- Track busy/idle timings as attributes via `with_tracked_inactivity` (#1096)
+
+### Breaking Changes
+
+- Upgrade to `v0.10.0` of `opentelemetry` (#1049)
+  For list of breaking changes in OpenTelemetry, see the
+  [v0.10.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/master/opentelemetry/CHANGELOG.md#v0100).
+
 # 0.8.0 (October 13, 2020)
 
 ### Added

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-opentelemetry"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     "Julian Tescher <julian@tescher.me>",
     "Tokio Contributors <team@tokio.rs>"

--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -17,9 +17,9 @@ Utilities for adding [OpenTelemetry] interoperability to [`tracing`].
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-opentelemetry.svg
-[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.8.0
+[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.9.0
 [docs-badge]: https://docs.rs/tracing-opentelemetry/badge.svg
-[docs-url]: https://docs.rs/tracing-opentelemetry/0.8.0/tracing_opentelemetry
+[docs-url]: https://docs.rs/tracing-opentelemetry/0.9.0/tracing_opentelemetry
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_opentelemetry
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -92,7 +92,7 @@
 //!
 #![deny(unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.8.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.9.0")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     html_favicon_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/favicon.ico",


### PR DESCRIPTION
Changelog:

### Added

- Track busy/idle timings as attributes via `with_tracked_inactivity` (#1096)

### Breaking Changes

- Upgrade to `v0.10.0` of `opentelemetry` (#1049)
  For list of breaking changes in OpenTelemetry, see the [v0.10.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/master/opentelemetry/CHANGELOG.md#v0100).
