### PR TITLE
examples: Fix echo by Reintroducing Concurrency

### DIFF
--- a/examples/examples/echo.rs
+++ b/examples/examples/echo.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         // Essentially here we're executing a new task to run concurrently,
         // which will allow all of our clients to be processed concurrently.
 
-        tokio::spawn(async move {
+        let fut = async move {
             let mut buf = [0; 1024];
 
             // In a loop, read data from the socket and write the data back.
@@ -115,8 +115,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
                 info!(message = "echo'd data", %peer_addr, size = n);
             }
-        })
-        .instrument(info_span!("echo", %peer_addr))
-        .await?;
+        }
+        .instrument(info_span!("echo", %peer_addr));
+        tokio::spawn(fut);
     }
 }


### PR DESCRIPTION
In #808, I've added an `.await?` to an instrumented `tokio::task::JoinHandle` since the `Instrument` future now has a `#[must_use]`. However, this caused the echo example to no longer accept multiple netcat connections but was only reported in #1097. This PR resolves this bug by instrumenting the spawned future, _not_ the `JoinHandle`.

More broadly, I think the interaction between `tokio::task::JoinHandle` (which _does not_ have the `#[must_use]` annotation) and the `tracing::Instrument` future (which _does_ have the `#[must_use]` annotation) is confusing and introduces performance footguns in refactors that even advanced users missed in code review.

Resolves #1097.