### PR TITLE
appender(docs): fix minor typo for DEFAULT_BUFFERED_LINES_LIMIT

### DIFF
--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -61,7 +61,7 @@ use tracing_subscriber::fmt::MakeWriter;
 /// The default maximum number of buffered log lines.
 ///
 /// If [`NonBlocking`][non-blocking] is lossy, it will drop spans/events at capacity.
-/// capacity. If [`NonBlocking`][non-blocking] is _not_ lossy,
+/// If [`NonBlocking`][non-blocking] is _not_ lossy,
 /// backpressure will be exerted on senders, causing them to block their
 /// respective threads until there is available capacity.
 ///


### PR DESCRIPTION
Remove duplication in "...at capacity. capacity." in doc comment for:

    tracing_appender::non_blocking::DEFAULT_BUFFERED_LINES_LIMIT
