### PR TITLE
appender(docs): add missing entry for Rotation::MINUTELY

### DIFF
--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -245,6 +245,14 @@ pub fn never(directory: impl AsRef<Path>, file_name: impl AsRef<Path>) -> Rollin
 ///
 /// To use a `Rotation`, pick one of the following options:
 ///
+/// ### Minutely Rotation
+/// ```rust
+/// # fn docs() {
+/// use tracing_appender::rolling::Rotation;
+/// let rotation = tracing_appender::rolling::Rotation::MINUTELY;
+/// # }
+/// ```
+///
 /// ### Hourly Rotation
 /// ```rust
 /// # fn docs() {


### PR DESCRIPTION
The list introduced by:

    "To use a Rotation, pick one of the following options:"

had en entry for all variations of Rotation except for Rotation::MINUTELY. This PR completes this list, with the doc test structured the same as the others in the list.

The newly added entry heading is "Minutely Rotation".

**Side-note:** I had to look up "minutely" in several dictionaries to convince myself that it is actually a legit English word that means "minute by minute" (in addition to the more familiar definition meaning "careful examination"), and was not just a cute symbol name in the code. It turns out that that usage of the word *is* legit!  (But you folks already knew that)  :-)

I performed both positive and negative tests to ensure that `'cargo test --doc'` is correctly testing the change.
