### PR TITLE
chore(deps): update pin-project-lite requirement from 0.1 to 0.2

### DIFF
--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -30,8 +30,8 @@ edition = "2018"
 tracing-core = { path = "../tracing-core", version = "0.1.17", default-features = false }
 log = { version = "0.4", optional = true }
 tracing-attributes = { path = "../tracing-attributes", version = "0.1.10", optional = true }
-cfg-if = "0.1.10"
-pin-project-lite = "0.1"
+cfg-if = "1.0.0"
+pin-project-lite = "0.2"
 
 [dev-dependencies]
 futures = "0.1"


### PR DESCRIPTION
This backports #1108 to v0.1.x. This was already approved on `master`,
so I'll just merge it pending CI.

Updates the requirements on [pin-project-lite](https://github.com/taiki-e/pin-project-lite) to permit the latest version.
- [Release notes](https://github.com/taiki-e/pin-project-lite/releases)
- [Changelog](https://github.com/taiki-e/pin-project-lite/blob/master/CHANGELOG.md)
- [Commits](https://github.com/taiki-e/pin-project-lite/compare/v0.1.0...v0.2.0)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

Co-authored-by: dependabot-preview[bot] <27856297+dependabot-preview[bot]@users.noreply.github.com>