### PR TITLE
ci: switch to `audit-check` GitHub Action for `cargo audit`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -251,26 +251,3 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         args: --all --bins --examples --tests --benches -- -D warnings
-
-  cargo-audit:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@main
-    - name: Fetch latest release version of cargo-audit
-      run: |
-        mkdir -p .github/caching
-        cargo search cargo-audit | grep '^cargo-audit' | awk '{gsub(/"/,"",$3); print $3}' > .github/caching/cargo-audit.lock
-    - name: Cache cargo-audit/bin
-      id: cache-cargo-audit
-      uses: actions/cache@v1
-      with:
-        path: ${{ runner.tool_cache }}/cargo-audit/bin
-        key: cargo-audit-bin-${{ hashFiles('.github/caching/cargo-audit.lock') }}
-    - name: Install cargo-audit
-      if: "steps.cache-cargo-audit.outputs.cache-hit != 'true'"
-      uses: actions-rs/cargo@v1
-      with:
-        command: install
-        args: --root ${{ runner.tool_cache }}/cargo-audit --force cargo-audit
-    - run: echo "${{ runner.tool_cache }}/cargo-audit/bin" >> $GITHUB_PATH
-    - run: cargo audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,14 @@
+name: Security audit
+on:
+  push:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

Currently, we are building and caching `cargo-audit` on CI. The GitHub
Actions configuration we use for caching the `cargo-audit` binary is now
deprecated and is [breaking our CI builds][2].

## Solution

This PR switches to the [`actions-rs/audit-check` action][3]. This ought
to fix CI.

[1]: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
[2]: https://github.com/tokio-rs/tracing/pull/1116/checks?check_run_id=1444562432
[3]: https://github.com/actions-rs/audit-check
