### PR TITLE
tracing: prepare to release v0.1.22

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.22 (November 23, 2020)
+
+### Changed
+
+- Updated `pin-project-lite` dependency to 0.2 ([#1108])
+
+[#1108]: https://github.com/tokio-rs/tracing/pull/1108
+
 # 0.1.21 (September 28, 2020)
 
 ### Fixed
@@ -24,7 +32,7 @@ Thanks to @nagisa, and new contributors @SecurityInsanity, @froydnj, @jyn514 and
 
 [#994]: https://github.com/tokio-rs/tracing/pull/994
 [#992]: https://github.com/tokio-rs/tracing/pull/992
-[#987]: https://github.com/tokio-rs/tracing/pull/987 
+[#987]: https://github.com/tokio-rs/tracing/pull/987
 [#980]: https://github.com/tokio-rs/tracing/pull/980
 [#981]: https://github.com/tokio-rs/tracing/pull/981
 [#964]: https://github.com/tokio-rs/tracing/pull/964

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.21"
+version = "0.1.22"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -16,9 +16,9 @@ Application-level tracing for Rust.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.21
+[crates-url]: https://crates.io/crates/tracing/0.1.22
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.21
+[docs-url]: https://docs.rs/tracing/0.1.22
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -246,7 +246,7 @@ my_future
 is as long as the future's.
 
 The second, and preferred, option is through the
-[`#[instrument]`](https://docs.rs/tracing/0.1.21/tracing/attr.instrument.html)
+[`#[instrument]`](https://docs.rs/tracing/0.1.22/tracing/attr.instrument.html)
 attribute:
 
 ```rust
@@ -293,7 +293,7 @@ span.in_scope(|| {
 // Dropping the span will close it, indicating that it has ended.
 ```
 
-The [`#[instrument]`](https://docs.rs/tracing/0.1.21/tracing/attr.instrument.html) attribute macro
+The [`#[instrument]`](https://docs.rs/tracing/0.1.22/tracing/attr.instrument.html) attribute macro
 can reduce some of this boilerplate:
 
 ```rust

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -781,7 +781,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing = { version = "0.1.21", default-features = false }
+//!   tracing = { version = "0.1.22", default-features = false }
 //!   ```
 //!
 //! <div class="information">
@@ -837,7 +837,7 @@
 //! [flags]: #crate-feature-flags
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.21")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.22")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
### Changed

- Updated `pin-project-lite` dependency to 0.2 ([#1108])

[#1108]: https://github.com/tokio-rs/tracing/pull/1108