### PR TITLE
attributes: remove default level for instrument attribute macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ use tracing::{debug, error, info, span, warn, Level};
 // the `#[tracing::instrument]` attribute creates and enters a span
 // every time the instrumented function is called. The span is named after the
 // the function or method. Parameters passed to the function are recorded as fields.
-#[tracing::instrument]
+#[tracing::instrument(level = "info")]
 pub fn shave(yak: usize) -> Result<(), Box<dyn Error + 'static>> {
     // this creates an event at the DEBUG level with two fields:
     // - `excitement`, with the key "excitement" and the value "yay!"
@@ -199,7 +199,7 @@ use tracing::{info, instrument};
 use tokio::{io::AsyncWriteExt, net::TcpStream};
 use std::io;
 
-#[instrument]
+#[instrument(level = "info")]
 async fn write(stream: &mut TcpStream) -> io::Result<usize> {
     let result = stream.write(b"hello world\n").await;
     info!("wrote to stream; success={:?}", result.is_ok());

--- a/examples/examples/async-fn.rs
+++ b/examples/examples/async-fn.rs
@@ -24,14 +24,14 @@ use tracing_attributes::instrument;
 
 use std::{error::Error, io, net::SocketAddr};
 
-#[instrument]
+#[instrument(level = "info")]
 async fn connect(addr: &SocketAddr) -> io::Result<TcpStream> {
     let stream = TcpStream::connect(&addr).await;
     tracing::info!("created stream");
     stream
 }
 
-#[instrument]
+#[instrument(level = "info")]
 async fn write(stream: &mut TcpStream) -> io::Result<usize> {
     let result = stream.write(b"hello world\n").await;
     info!("wrote to stream; success={:?}", result.is_ok());

--- a/examples/examples/attrs-args.rs
+++ b/examples/examples/attrs-args.rs
@@ -3,7 +3,7 @@
 use tracing::{debug, info};
 use tracing_attributes::instrument;
 
-#[instrument]
+#[instrument(level = "info")]
 fn nth_fibonacci(n: u64) -> u64 {
     if n == 0 || n == 1 {
         debug!("Base case");
@@ -14,7 +14,7 @@ fn nth_fibonacci(n: u64) -> u64 {
     }
 }
 
-#[instrument]
+#[instrument(level = "info")]
 fn fibonacci_seq(to: u64) -> Vec<u64> {
     let mut sequence = vec![];
 

--- a/examples/examples/attrs-basic.rs
+++ b/examples/examples/attrs-basic.rs
@@ -3,7 +3,7 @@
 use tracing::{debug, info, span, Level};
 use tracing_attributes::instrument;
 
-#[instrument]
+#[instrument(level = "info")]
 #[inline]
 fn suggest_band() -> String {
     debug!("Suggesting a band.");

--- a/examples/examples/attrs-literal-field-names.rs
+++ b/examples/examples/attrs-literal-field-names.rs
@@ -3,7 +3,7 @@
 use tracing::{debug, span, Level};
 use tracing_attributes::instrument;
 
-#[instrument]
+#[instrument(level = "info")]
 #[inline]
 fn suggest_band() -> String {
     debug!("Suggesting a band.");

--- a/examples/examples/custom-error.rs
+++ b/examples/examples/custom-error.rs
@@ -35,12 +35,12 @@ impl fmt::Display for FooError {
     }
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "info")]
 fn do_something(foo: &str) -> Result<&'static str, impl Error + Send + Sync + 'static> {
     do_another_thing(42, false)
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "info")]
 fn do_another_thing(
     answer: usize,
     will_succeed: bool,
@@ -48,7 +48,7 @@ fn do_another_thing(
     Err(FooError::new("something broke, lol"))
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "info")]
 fn main() {
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::subscriber())

--- a/examples/examples/fmt/yak_shave.rs
+++ b/examples/examples/fmt/yak_shave.rs
@@ -4,7 +4,7 @@ use tracing::{debug, error, info, span, trace, warn, Level};
 // the `#[tracing::instrument]` attribute creates and enters a span
 // every time the instrumented function is called. The span is named after the
 // the function or method. Paramaters passed to the function are recorded as fields.
-#[tracing::instrument]
+#[tracing::instrument(level = "info")]
 pub fn shave(yak: usize) -> Result<(), Box<dyn Error + 'static>> {
     // this creates an event at the TRACE log level with two fields:
     // - `excitement`, with the key "excitement" and the value "yay!"

--- a/examples/examples/futures-proxy-server.rs
+++ b/examples/examples/futures-proxy-server.rs
@@ -36,7 +36,7 @@ use tracing::{debug, debug_span, info, instrument, warn, Instrument as _};
 
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-#[instrument]
+#[instrument(level = "info")]
 async fn transfer(mut inbound: TcpStream, proxy_addr: SocketAddr) -> Result<(), Error> {
     let mut outbound = TcpStream::connect(&proxy_addr).await?;
 

--- a/examples/examples/instrumented-error.rs
+++ b/examples/examples/instrumented-error.rs
@@ -26,13 +26,13 @@ impl fmt::Display for FooError {
     }
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "info")]
 fn do_something(foo: &str) -> Result<&'static str, impl Error + Send + Sync + 'static> {
     // Results can be instrumented with a `SpanTrace` via the `InstrumentResult` trait
     do_another_thing(42, false).in_current_span()
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "info")]
 fn do_another_thing(
     answer: usize,
     will_succeed: bool,
@@ -41,7 +41,7 @@ fn do_another_thing(
     Err(FooError::new("something broke, lol").in_current_span())
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "info")]
 fn main() {
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::subscriber())

--- a/examples/examples/map-traced-error.rs
+++ b/examples/examples/map-traced-error.rs
@@ -37,12 +37,12 @@ fn print_extracted_spantraces(error: &(dyn Error + 'static)) {
     }
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "info")]
 fn do_something() -> Result<(), TracedError<OuterError>> {
     do_the_real_stuff().map_err(TracedError::err_into)
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "info")]
 fn do_the_real_stuff() -> Result<(), TracedError<InnerError>> {
     Err(InnerError).map_err(TracedError::from)
 }

--- a/examples/examples/opentelemetry.rs
+++ b/examples/examples/opentelemetry.rs
@@ -5,7 +5,7 @@ use tracing::{span, trace, warn};
 use tracing_attributes::instrument;
 use tracing_subscriber::prelude::*;
 
-#[instrument]
+#[instrument(level = "info")]
 #[inline]
 fn expensive_work() -> &'static str {
     span!(tracing::Level::INFO, "expensive_step_1")

--- a/examples/examples/spawny-thing.rs
+++ b/examples/examples/spawny-thing.rs
@@ -12,7 +12,7 @@ use std::error::Error;
 use tracing::{debug, info};
 use tracing_attributes::instrument;
 
-#[instrument]
+#[instrument(level = "info")]
 async fn parent_task(subtasks: usize) {
     info!("spawning subtasks...");
     let subtasks = (1..=subtasks)
@@ -29,7 +29,7 @@ async fn parent_task(subtasks: usize) {
     info!(sum);
 }
 
-#[instrument]
+#[instrument(level = "info")]
 async fn subtask(number: usize) -> usize {
     info!("polling subtask...");
     number

--- a/examples/examples/tokio-spawny-thing.rs
+++ b/examples/examples/tokio-spawny-thing.rs
@@ -12,7 +12,7 @@ use tracing::{debug, info, instrument, span, Instrument as _, Level};
 
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-#[instrument]
+#[instrument(level = "info")]
 async fn parent_task(subtasks: usize) -> Result<(), Error> {
     info!("spawning subtasks...");
     let subtasks = (1..=subtasks)

--- a/examples/examples/tower-load.rs
+++ b/examples/examples/tower-load.rs
@@ -301,7 +301,7 @@ fn gen_uri(authority: &str) -> (usize, String) {
     (len, format!("http://{}/{}", authority, letter))
 }
 
-#[tracing::instrument(target = "gen", "load_gen")]
+#[tracing::instrument(target = "gen", "load_gen", level = "info")]
 async fn load_gen(addr: SocketAddr) -> Result<(), Err> {
     let svc = ServiceBuilder::new()
         .buffer(5)

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -57,7 +57,7 @@ with a `tracing` [span]. For example:
 ```rust
 use tracing_attributes::instrument;
 
-#[instrument]
+#[instrument(level = "info")]
 pub fn my_function(my_arg: usize) {
     // ...
 }

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -26,7 +26,7 @@
 //! ```
 //! use tracing_attributes::instrument;
 //!
-//! #[instrument]
+//! #[instrument(level = "info")]
 //! pub fn my_function(my_arg: usize) {
 //!     // ...
 //! }
@@ -101,7 +101,6 @@ use syn::{
 /// Instruments a function to create and enter a `tracing` [span] every time
 /// the function is called.
 ///
-/// Unless overriden, a span with `info` level will be generated.
 /// The generated span's name will be the name of the function. Any arguments
 /// to that function will be recorded as fields using [`fmt::Debug`]. To skip
 /// recording a function's or method's argument, pass the argument's name
@@ -125,7 +124,7 @@ use syn::{
 /// Instrumenting a function:
 /// ```
 /// # use tracing_attributes::instrument;
-/// #[instrument]
+/// #[instrument(level = "info")]
 /// pub fn my_function(my_arg: usize) {
 ///     // This event will be recorded inside a span named `my_function` with the
 ///     // field `my_arg`.
@@ -133,18 +132,10 @@ use syn::{
 ///     // ...
 /// }
 /// ```
-/// Setting the level for the generated span:
-/// ```
-/// # use tracing_attributes::instrument;
-/// #[instrument(level = "debug")]
-/// pub fn my_function() {
-///     // ...
-/// }
-/// ```
 /// Overriding the generated span's name:
 /// ```
 /// # use tracing_attributes::instrument;
-/// #[instrument(name = "my_name")]
+/// #[instrument(name = "my_name", level = "info")]
 /// pub fn my_function() {
 ///     // ...
 /// }
@@ -152,7 +143,7 @@ use syn::{
 /// Overriding the generated span's target:
 /// ```
 /// # use tracing_attributes::instrument;
-/// #[instrument(target = "my_target")]
+/// #[instrument(target = "my_target", "new_load", level = "info")]
 /// pub fn my_function() {
 ///     // ...
 /// }
@@ -164,7 +155,7 @@ use syn::{
 /// # use tracing_attributes::instrument;
 /// struct NonDebug;
 ///
-/// #[instrument(skip(non_debug))]
+/// #[instrument(skip(non_debug), level = "info")]
 /// fn my_function(arg: usize, non_debug: NonDebug) {
 ///     // ...
 /// }
@@ -174,7 +165,7 @@ use syn::{
 ///
 /// ```
 /// # use tracing_attributes::instrument;
-/// #[instrument(fields(foo="bar", id=1, show=true))]
+/// #[instrument(fields(foo="bar", id=1, show=true), level = "info")]
 /// fn my_function(arg: usize) {
 ///     // ...
 /// }
@@ -185,7 +176,7 @@ use syn::{
 ///
 /// ```
 /// # use tracing_attributes::instrument;
-/// #[instrument(err)]
+/// #[instrument(err, level = "info")]
 /// fn my_function(arg: usize) -> Result<(), std::io::Error> {
 ///     Ok(())
 /// }
@@ -195,7 +186,7 @@ use syn::{
 ///
 /// ```
 /// # use tracing_attributes::instrument;
-/// #[instrument]
+/// #[instrument(level = "info")]
 /// pub async fn my_function() -> Result<(), ()> {
 ///     // ...
 ///     # Ok(())
@@ -221,7 +212,7 @@ use syn::{
 ///
 /// #[async_trait]
 /// impl Foo for FooImpl {
-///     #[instrument(fields(value = self.0, tmp = std::any::type_name::<Self>()))]
+///     #[instrument(fields(value = self.0, tmp = std::any::type_name::<Self>()), level = "debug")]
 ///     async fn foo(&self, arg: usize) {}
 /// }
 /// ```
@@ -244,7 +235,7 @@ use syn::{
 ///
 /// #[async_trait]
 /// impl Bar for BarImpl {
-///     #[instrument(fields(tmp = std::any::type_name::<Self>()))]
+///     #[instrument(fields(tmp = std::any::type_name::<Self>()), level = "debug")]
 ///     async fn bar() {}
 /// }
 /// ```
@@ -546,7 +537,12 @@ impl InstrumentArgs {
                      \"debug\", \"info\", \"warn\", or \"error\", or a number 1-5"
                 )
             },
-            None => quote!(tracing::Level::INFO),
+            None => quote! {
+                compile_error!(
+                    "no verbosity level specified, expected one of \"trace\", \
+                     \"debug\", \"info\", \"warn\", or \"error\", or a number 1-5"
+                )
+            },
         }
     }
 

--- a/tracing-attributes/tests/async_fn.rs
+++ b/tracing-attributes/tests/async_fn.rs
@@ -7,7 +7,7 @@ use support::*;
 use tracing::collect::with_default;
 use tracing_attributes::instrument;
 
-#[instrument]
+#[instrument(level = "info")]
 async fn test_async_fn(polls: usize) -> Result<(), ()> {
     let future = PollN::new_ok(polls);
     tracing::trace!(awaiting = true);
@@ -34,12 +34,12 @@ fn async_fn_only_enters_for_polls() {
 
 #[test]
 fn async_fn_nested() {
-    #[instrument]
+    #[instrument(level = "info")]
     async fn test_async_fns_nested() {
         test_async_fns_nested_other().await
     }
 
-    #[instrument]
+    #[instrument(level = "info")]
     async fn test_async_fns_nested_other() {
         tracing::trace!(nested = true);
     }
@@ -94,7 +94,7 @@ fn async_fn_with_async_trait() {
 
     #[async_trait]
     impl TestA for TestImpl {
-        #[instrument]
+        #[instrument(level = "info")]
         async fn foo(&mut self, v: usize) {
             self.baz().await;
             self.0 = v;
@@ -104,7 +104,7 @@ fn async_fn_with_async_trait() {
 
     #[async_trait]
     impl TestB for TestImpl {
-        #[instrument]
+        #[instrument(level = "info")]
         async fn bar(&self) {
             tracing::trace!(val = self.0);
         }
@@ -112,7 +112,7 @@ fn async_fn_with_async_trait() {
 
     #[async_trait]
     impl TestC for TestImpl {
-        #[instrument(skip(self))]
+        #[instrument(skip(self), level = "info")]
         async fn baz(&self) {
             tracing::trace!(val = self.0);
         }
@@ -172,7 +172,7 @@ fn async_fn_with_async_trait_and_fields_expressions() {
     #[async_trait]
     impl Test for TestImpl {
         // check that self is correctly handled, even when using async_trait
-        #[instrument(fields(val=self.foo(), test=%v+5))]
+        #[instrument(fields(val=self.foo(), test=%v+5), level = "info")]
         async fn call(&mut self, v: usize) {}
     }
 
@@ -216,13 +216,13 @@ fn async_fn_with_async_trait_and_fields_expressions_with_generic_parameter() {
     #[async_trait]
     impl Test for TestImpl {
         // instrumenting this is currently not possible, see https://github.com/tokio-rs/tracing/issues/864#issuecomment-667508801
-        //#[instrument(fields(Self=std::any::type_name::<Self>()))]
+        //#[instrument(fields(Self=std::any::type_name::<Self>()), level = "info")]
         async fn call() {}
 
-        #[instrument(fields(Self=std::any::type_name::<Self>()))]
+        #[instrument(fields(Self=std::any::type_name::<Self>()), level = "info")]
         async fn call_with_self(&self) {}
 
-        #[instrument(fields(Self=std::any::type_name::<Self>()))]
+        #[instrument(fields(Self=std::any::type_name::<Self>()), level = "info")]
         async fn call_with_mut_self(&mut self) {}
     }
 

--- a/tracing-attributes/tests/destructuring.rs
+++ b/tracing-attributes/tests/destructuring.rs
@@ -6,7 +6,7 @@ use tracing_attributes::instrument;
 
 #[test]
 fn destructure_tuples() {
-    #[instrument]
+    #[instrument(level = "info")]
     fn my_fn((arg1, arg2): (usize, usize)) {}
 
     let span = span::mock().named("my_fn");
@@ -35,7 +35,7 @@ fn destructure_tuples() {
 
 #[test]
 fn destructure_nested_tuples() {
-    #[instrument]
+    #[instrument(level = "info")]
     fn my_fn(((arg1, arg2), (arg3, arg4)): ((usize, usize), (usize, usize))) {}
 
     let span = span::mock().named("my_fn");
@@ -66,7 +66,7 @@ fn destructure_nested_tuples() {
 
 #[test]
 fn destructure_refs() {
-    #[instrument]
+    #[instrument(level = "info")]
     fn my_fn(&arg1: &usize) {}
 
     let span = span::mock().named("my_fn");
@@ -93,7 +93,7 @@ fn destructure_refs() {
 fn destructure_tuple_structs() {
     struct Foo(usize, usize);
 
-    #[instrument]
+    #[instrument(level = "info")]
     fn my_fn(Foo(arg1, arg2): Foo) {}
 
     let span = span::mock().named("my_fn");
@@ -127,7 +127,7 @@ fn destructure_structs() {
         baz: usize,
     }
 
-    #[instrument]
+    #[instrument(level = "info")]
     fn my_fn(
         Foo {
             bar: arg1,
@@ -171,7 +171,7 @@ fn destructure_everything() {
     struct Bar((usize, usize));
     struct NoDebug;
 
-    #[instrument]
+    #[instrument(level = "info")]
     fn my_fn(
         &Foo {
             bar: Bar((arg1, arg2)),

--- a/tracing-attributes/tests/err.rs
+++ b/tracing-attributes/tests/err.rs
@@ -11,7 +11,7 @@ use tracing_attributes::instrument;
 use std::convert::TryFrom;
 use std::num::TryFromIntError;
 
-#[instrument(err)]
+#[instrument(err, level = "info")]
 fn err() -> Result<u8, TryFromIntError> {
     u8::try_from(1234)
 }
@@ -31,7 +31,7 @@ fn test() {
     handle.assert_finished();
 }
 
-#[instrument(err)]
+#[instrument(err, level = "info")]
 fn err_early_return() -> Result<u8, TryFromIntError> {
     u8::try_from(1234)?;
     Ok(5)
@@ -52,7 +52,7 @@ fn test_early_return() {
     handle.assert_finished();
 }
 
-#[instrument(err)]
+#[instrument(err, level = "info")]
 async fn err_async(polls: usize) -> Result<u8, TryFromIntError> {
     let future = PollN::new_ok(polls);
     tracing::trace!(awaiting = true);

--- a/tracing-attributes/tests/fields.rs
+++ b/tracing-attributes/tests/fields.rs
@@ -6,29 +6,29 @@ use crate::support::span::NewSpan;
 use tracing::collect::with_default;
 use tracing_attributes::instrument;
 
-#[instrument(fields(foo = "bar", dsa = true, num = 1))]
+#[instrument(fields(foo = "bar", dsa = true, num = 1), level = "info")]
 fn fn_no_param() {}
 
-#[instrument(fields(foo = "bar"))]
+#[instrument(fields(foo = "bar"), level = "info")]
 fn fn_param(param: u32) {}
 
-#[instrument(fields(foo = "bar", empty))]
+#[instrument(fields(foo = "bar", empty), level = "info")]
 fn fn_empty_field() {}
 
-#[instrument(fields(len = s.len()))]
+#[instrument(fields(len = s.len()), level = "info")]
 fn fn_expr_field(s: &str) {}
 
-#[instrument(fields(s.len = s.len(), s.is_empty = s.is_empty()))]
+#[instrument(fields(s.len = s.len(), s.is_empty = s.is_empty()), level = "info")]
 fn fn_two_expr_fields(s: &str) {
     let _ = s;
 }
 
-#[instrument(fields(%s, s.len = s.len()))]
+#[instrument(fields(%s, s.len = s.len()), level = "info")]
 fn fn_clashy_expr_field(s: &str) {
     let _ = s;
 }
 
-#[instrument(fields(s = "s"))]
+#[instrument(fields(s = "s"), level = "info")]
 fn fn_clashy_expr_field2(s: &str) {
     let _ = s;
 }
@@ -39,7 +39,7 @@ struct HasField {
 }
 
 impl HasField {
-    #[instrument(fields(my_field = self.my_field), skip(self))]
+    #[instrument(fields(my_field = self.my_field), skip(self), level = "info")]
     fn self_expr_field(&self) {}
 }
 

--- a/tracing-attributes/tests/instrument.rs
+++ b/tracing-attributes/tests/instrument.rs
@@ -137,7 +137,7 @@ fn generics() {
     #[derive(Debug)]
     struct Foo;
 
-    #[instrument]
+    #[instrument(level = "info")]
     fn my_fn<S, T: std::fmt::Debug>(arg1: S, arg2: T)
     where
         S: std::fmt::Debug,
@@ -173,7 +173,7 @@ fn methods() {
     struct Foo;
 
     impl Foo {
-        #[instrument]
+        #[instrument(level = "info")]
         fn my_fn(&self, arg1: usize) {}
     }
 

--- a/tracing-attributes/tests/names.rs
+++ b/tracing-attributes/tests/names.rs
@@ -4,16 +4,16 @@ use support::*;
 use tracing::collect::with_default;
 use tracing_attributes::instrument;
 
-#[instrument]
+#[instrument(level = "info")]
 fn default_name() {}
 
-#[instrument(name = "my_name")]
+#[instrument(name = "my_name", level = "info")]
 fn custom_name() {}
 
 // XXX: it's weird that we support both of these forms, but apparently we
 // managed to release a version that accepts both syntax, so now we have to
 // support it! yay!
-#[instrument("my_other_name")]
+#[instrument("my_other_name", level = "info")]
 fn custom_name_no_equals() {}
 
 #[test]

--- a/tracing-attributes/tests/targets.rs
+++ b/tracing-attributes/tests/targets.rs
@@ -4,10 +4,10 @@ use support::*;
 use tracing::collect::with_default;
 use tracing_attributes::instrument;
 
-#[instrument]
+#[instrument(level = "info")]
 fn default_target() {}
 
-#[instrument(target = "my_target")]
+#[instrument(target = "my_target", level = "info")]
 fn custom_target() {}
 
 mod my_mod {
@@ -15,10 +15,10 @@ mod my_mod {
 
     pub const MODULE_PATH: &str = module_path!();
 
-    #[instrument]
+    #[instrument(level = "info")]
     pub fn default_target() {}
 
-    #[instrument(target = "my_other_target")]
+    #[instrument(target = "my_other_target", level = "info")]
     pub fn custom_target() {}
 }
 

--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -82,7 +82,7 @@ impl SpanTrace {
     ///
     /// # fn some_error_condition() -> bool { true }
     ///
-    /// #[tracing::instrument]
+    /// #[tracing::instrument(level = "info")]
     /// pub fn my_function(arg: &str) -> Result<(), MyError> {
     ///     if some_error_condition() {
     ///         return Err(MyError {

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -146,7 +146,7 @@ use tracing::{debug, error, info, span, warn, Level};
 // the `#[tracing::instrument]` attribute creates and enters a span
 // every time the instrumented function is called. The span is named after the
 // the function or method. Paramaters passed to the function are recorded as fields.
-#[tracing::instrument]
+#[tracing::instrument(level = "info")]
 pub fn shave(yak: usize) -> Result<(), Box<dyn Error + 'static>> {
     // this creates an event at the DEBUG level with two fields:
     // - `excitement`, with the key "excitement" and the value "yay!"
@@ -254,7 +254,7 @@ use tracing::{info, instrument};
 use tokio::{io::AsyncWriteExt, net::TcpStream};
 use std::io;
 
-#[instrument]
+#[instrument(level = "info")]
 async fn write(stream: &mut TcpStream) -> io::Result<usize> {
     let result = stream.write(b"hello world\n").await;
     info!("wrote to stream; success={:?}", result.is_ok());
@@ -299,7 +299,7 @@ can reduce some of this boilerplate:
 ```rust
 use tracing::{instrument};
 
-#[instrument]
+#[instrument(level = "info")]
 pub fn my_function(my_arg: usize) {
     // This event will be recorded inside a span named `my_function` with the
     // field `my_arg`.

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -163,7 +163,7 @@
 //! # // that it should only be run with cfg(feature = "attributes")
 //! use tracing::{Level, event, instrument};
 //!
-//! #[instrument]
+//! #[instrument(level = "info")]
 //! pub fn my_function(my_arg: usize) {
 //!     // This event will be recorded inside a span named `my_function` with the
 //!     // field `my_arg`.
@@ -466,7 +466,7 @@
 //! // the `#[tracing::instrument]` attribute creates and enters a span
 //! // every time the instrumented function is called. The span is named after the
 //! // the function or method. Parameters passed to the function are recorded as fields.
-//! #[tracing::instrument]
+//! #[tracing::instrument(level = "info")]
 //! pub fn shave(yak: usize) -> Result<(), Box<dyn Error + 'static>> {
 //!     // this creates an event at the DEBUG level with two fields:
 //!     // - `excitement`, with the key "excitement" and the value "yay!"


### PR DESCRIPTION
This PR removes the default level for the #[instrument] attribute
macro, forcing the user to explicitly specify the logging level.

Fixes #1070 

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
As mentioned in the associated issue, the default value of the tracing level might have performance and users should be aware of the tracing level they are opting for the performance impact it can have. Whatever default we pick might not work for some and might surprise some people. Making the level explicit allows users to make a conscious choice.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
This PR adds a `complie_error` in case no tracing level is specified by the user. 

I have made most of the documentation and test changes required. Please let me know if I missed some.