### PR TITLE
chore: don't check examples on MSRV

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta, nightly, 1.42.0]
+        rust: [stable, beta, nightly]
     steps:
     - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
@@ -127,6 +127,32 @@ jobs:
       with:
         command: test
         args: --all
+
+  test-msrv:
+    # Test against the minimum supported Rust version
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@main
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.42.0
+        profile: minimal
+        override: true
+    # We can't use `cargo test --all`, as that will also compile the examples.
+    # We don't guarantee the examples will work on the MSRV, because they have
+    # external dependencies which may not comply with our MSRV policy, but don't
+    # actually impact users on our MSRV.
+    - name: Run tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --workspace --lib --tests
+    - name: Run doctests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --workspace --doc
 
   test-build-wasm:
     needs: check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: check
-        args: --all --bins --examples --tests --benches
+        args: --all --bins --tests --benches
 
   cargo-hack:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

Tracing's examples depend on a number of external crates that the core
`tracing` crates don't depend on. Sometimes, crates that we only depend
on for examples will break compatibility with our MSRV. It's not ideal
to bump our supported MSRV just for an example, since the actual
`tracing` crates will still build fine.

## Solution

Instead, this PR updates the CI config to exclude examples from the
MSRV check. This way, we don't have to bump MSRV for examples-only
dependencies.
