### PR TITLE
docs: fix typo causing CI doc check warnings

### DIFF
--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -150,7 +150,7 @@ pub struct TestWriter {
     _p: (),
 }
 
-/// A writer that erases the specific [`io::Write`] and [`Makewriter`] types being used.
+/// A writer that erases the specific [`io::Write`] and [`MakeWriter`] types being used.
 ///
 /// This is useful in cases where the concrete type of the writer cannot be known
 /// until runtime.


### PR DESCRIPTION
## Motivation

I noticed complaints in the doc checks upon CI deployments, and at first misread them as being the cause of some "Deployment failed" errors. It turns out that they were not the cause, but this PR does fix the doc check error.

There are several separate "Deploy failed" errors, all the same. From the deploy logs of one of them:

```console
    $   curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly --profile minimal && source $HOME/.cargo/env && RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --no-deps
    ...
    11:46:24 PM: warning: unresolved link to `Makewriter`
    11:46:24 PM:    --> tracing-subscriber/src/fmt/writer.rs:153:58
    11:46:24 PM:     |
    11:46:24 PM: 153 | /// A writer that erases the specific [`io::Write`] and [`Makewriter`] types being used.
    11:46:24 PM:     |                                                          ^^^^^^^^^^^^ no item named `Makewriter` in scope
    11:46:24 PM:     |
    11:46:24 PM:     = note: `#[warn(broken_intra_doc_links)]` on by default
    11:46:24 PM:     = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
    11:46:24 PM: warning: 1 warning emitted
    11:46:25 PM:  Documenting tracing-flame v0
    ...
```

## Solution

Fix single character typo: "Makewriter" => "MakeWriter".
