### PR TITLE
core: allow external construction of ParseLevelFilterError

### DIFF
--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -579,6 +579,13 @@ impl fmt::Display for ParseLevelFilterError {
 #[cfg(feature = "std")]
 impl std::error::Error for ParseLevelFilterError {}
 
+impl ParseLevelFilterError {
+    /// Constructor to create an empty [`ParseLevelFilterError`].
+    pub fn empty() -> Self {
+        ParseLevelFilterError(())
+    }
+}
+
 // ==== Level and LevelFilter comparisons ====
 
 // /!\ BIG, IMPORTANT WARNING /!\

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -870,4 +870,11 @@ mod tests {
             assert_eq!(expected, repr, "repr changed for {:?}", filter)
         }
     }
+
+    #[test]
+    fn parse_level_filter_error_ctor_empty() {
+        match ParseLevelFilterError::empty() {
+            ParseLevelFilterError(()) => (),
+        }
+    }
 }

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -581,6 +581,74 @@ impl std::error::Error for ParseLevelFilterError {}
 
 impl ParseLevelFilterError {
     /// Constructor to create an empty [`ParseLevelFilterError`].
+    ///
+    /// # Examples
+    ///
+    /// Constructing an empty [`ParseLevelFilterError`] may be useful in code
+    /// that instantiates [`LevelFilter`] from parsed string input, in order
+    /// to override the built-in default policy of how to treat empty string
+    /// input.
+    ///
+    /// By default, [`LevelFilter::from_str`] treats empty string input as
+    /// meaning "no default preference provided", so applies the default
+    /// policy of creating [`LevelFilter::ERROR`].
+    ///
+    /// In a context in which the available input is tightly controlled, an
+    /// empty string input may represent a misconfiguration. In such
+    /// situations, it may be desirable to override the built-in policy, but
+    /// still support roughly the same interface as [`LevelFilter::from_str`]
+    /// of emitting [`ParseLevelFilterError`] when rejecting the empty string
+    /// input.
+    ///
+    /// ```rust
+    /// use core::str::FromStr;
+    /// use tracing_core::metadata::{
+    ///     LevelFilter,
+    ///     ParseLevelFilterError,
+    /// };
+    ///
+    /// struct MyLevelFilterNewtype(LevelFilter);
+    ///
+    /// impl FromStr for MyLevelFilterNewtype {
+    ///     type Err = ParseLevelFilterError;
+    ///
+    ///     fn from_str(from: &str) -> Result<Self, Self::Err> {
+    ///
+    ///         // Override default policy: Reject empty string value
+    ///         // rather than defaulting to LevelFilter::ERROR
+    ///         if "" == from {
+    ///             return Err( ParseLevelFilterError::empty() );
+    ///         }
+    ///
+    ///         match LevelFilter::from_str(from) {
+    ///             Ok(level_filter) => Ok( MyLevelFilterNewtype(level_filter) ),
+    ///             Err(err) => Err(err),
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// # // When parsing legit level name strings, LevelFilter and MyLevelFilterNewtype
+    /// # // behave the same in that a LevelFilter of the specified level name is obtained...
+    /// # match LevelFilter::from_str("DEBUG") {
+    /// #     Ok(LevelFilter::DEBUG) => (),
+    /// #     Ok(_) | Err(_) => panic!("Expected LevelFilter::DEBUG from parsed \"DEBUG\" string"),
+    /// # }
+    /// # match MyLevelFilterNewtype::from_str("DEBUG") {
+    /// #     Ok( MyLevelFilterNewtype(LevelFilter::DEBUG) ) => (),
+    /// #     Ok(_) | Err(_) => panic!("Expected MyLevelFilterNewtype(LevelFilter::DEBUG) from parsed \"DEBUG\" string"),
+    /// # }
+    /// #
+    /// # // ...but when empty string input is provided, LevelFilter creates a LevelFilter::ERROR,
+    /// # // whereas MyLevelFilterNewtype rejects the empty string as invalid.
+    /// # match LevelFilter::from_str("") {
+    /// #     Ok(LevelFilter::ERROR) => (),
+    /// #     Ok(_) | Err(_) => panic!("Expected LevelFilter::ERROR due to default policy for empty string"),
+    /// # }
+    /// # match MyLevelFilterNewtype::from_str("") {
+    /// #     Err(_) => (), // empty string rejected
+    /// #     Ok(_) => panic!("Expected empty string to have been rejected with a ParseLevelFilterError(())"),
+    /// # }
+    /// ```
     pub fn empty() -> Self {
         ParseLevelFilterError(())
     }


### PR DESCRIPTION
## Motivation

External code using `tracing` is currently unable to directly instantiate `tracing_core::metadata::ParseLevelFilterError`. 

The current definition is this:
```rust
    pub struct ParseLevelFilterError(());
```

Because the single, empty member `()` is private, an attempt to create an instance of the error, of course, results in a compiler error such as this:

```console
    error[E0423]: expected function, tuple struct or tuple variant, found struct `ParseLevelFilterError`
       --> src/path/to/whatever.rs:399:31
        |
    399 | ...                   ParseLevelFilterError(()) )
        |                       ^^^^^^^^^^^^^^^^^^^^^ constructor is not visible here due to private fields
```

Having the ability to construct `ParseLevelFilterError` is useful behavior to have, for example, by external deserialization code that wraps the behavior of `LevelFilter::from_str()` to apply a different default policy than what `tracing` does internally when an empty string is parsed.

The built-in policy is to instantiate `LevelFilter::ERROR` when an empty string is parsed.

External deserialization code may wish to use a different default level, or reject empty string values altogether.

If the external code were able to construct `ParseLevelFilterError` instances directly, then it could provide the same interface as the `tracing` code. In particular, it could be made to be compatible with existing error handling code, but with a different policy behavior applied when an empty string is provided.


### Other approaches considered

#### Alt. approach 1: Piggyback on parsing by `Level`

*A.k.a. "`Level` already does (some of) what you want."*

One approach considered was to instead piggyback on the parsing by the lower-level `tracing_core::metadata::Level` type, and then use the parsed type to obtain the `LevelFilter`. And indeed, that parsing would reject empty strings, as desired.

The downside to it, though, is that special case handling would then be needed in the custom deserializer to add back in support for the `OFF` pseudo logging level. That's more intrusive, and also counter to the desire to have the supported logging levels type-checked at compile time against the symbols provided by `tracing` (the relevant `const` members of `LevelFilter`).


#### Alt. approach 2: Level of indirection via app-specific error

*A.k.a. "Get your own damn error type!"  :-)*

The custom deserializer code in my system could  also introduce an application-specific error that is always the top-level thing emitted for these types of parse conditions. When applying the local empty string policy, it would not have a member `ParseLevelFilterError`.

This is arguably the cleaner approach, as it helps isolate the code from some of the details of the `tracing` implementation.

However, the entire point of the module in which this deserialization code lives in my codebase is to be an integration point specifically coupled to `tracing`. The code knows internally about `ParseLevelFilterError`, but any errors emitted across the app's module API boundary *already are* application-specific errors. So decoupling at this specific area of the code does not seem to buy much.


## Solution

*[ **EDITED** (based on [feedback](https://github.com/tokio-rs/tracing/pull/1132#issuecomment-742839741) from @hawkw in the PR comments below) ]*

~~Flag empty `()` member of `tracing_core::metadata::ParseLevelFilterError` as 'pub' to allow instantiation by external code:~~

<pre>
    <strike>pub struct ParseLevelFilterError(pub ());</strike>
</pre>

Provide a pub "constructor" function to allow instantiation by external code.

Please feel free to reject this proposal; there may be downsides to it that haven't occurred to me. But since there does not seem to be much of an obvious downside to allowing external code to instantiate `ParseLevelFilterError` itself, I figured I'd float this PR for some feedback before going down the road of Alt. approach 2.
