### PR TITLE
Bubble up error for RollingFileAppender::new

### DIFF
--- a/examples/examples/fmt-multiple-writers.rs
+++ b/examples/examples/fmt-multiple-writers.rs
@@ -8,10 +8,10 @@ use std::io;
 use tempdir::TempDir;
 use tracing_subscriber::{fmt, subscribe::CollectExt, EnvFilter};
 
-fn main() {
+fn main() -> io::Result<()> {
     let dir = TempDir::new("directory").expect("Failed to create tempdir");
 
-    let file_appender = tracing_appender::rolling::hourly(dir, "example.log");
+    let file_appender = tracing_appender::rolling::hourly(dir, "example.log")?;
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
 
     let collector = tracing_subscriber::registry()
@@ -29,4 +29,5 @@ fn main() {
         all_yaks_shaved = number_shaved == number_of_yaks,
         "yak shaving completed."
     );
+    Ok(())
 }

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! ```rust
 //! # fn docs() {
-//! let file_appender = tracing_appender::rolling::hourly("/some/directory", "prefix.log");
+//! let file_appender = tracing_appender::rolling::hourly("/some/directory", "prefix.log").unwrap();
 //! # }
 //! ```
 //! This creates an hourly rotating file appender that writes to `/some/directory/prefix.log.YYYY-MM-DD-HH`.
@@ -99,7 +99,7 @@
 //!
 //! ```rust
 //! # fn docs() {
-//! let file_appender = tracing_appender::rolling::hourly("/some/directory", "prefix.log");
+//! let file_appender = tracing_appender::rolling::hourly("/some/directory", "prefix.log").unwrap();
 //! let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
 //! tracing_subscriber::fmt()
 //!     .with_writer(non_blocking)

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -74,23 +74,22 @@ impl RollingFileAppender {
     /// ```rust
     /// # fn docs() {
     /// use tracing_appender::rolling::{RollingFileAppender, Rotation};
-    /// let file_appender = RollingFileAppender::new(Rotation::HOURLY, "/some/directory", "prefix.log");
+    /// let file_appender = RollingFileAppender::new(Rotation::HOURLY, "/some/directory", "prefix.log").unwrap();
     /// # }
     /// ```
     pub fn new(
         rotation: Rotation,
         directory: impl AsRef<Path>,
         file_name_prefix: impl AsRef<Path>,
-    ) -> RollingFileAppender {
-        RollingFileAppender {
+    ) -> io::Result<RollingFileAppender> {
+        Ok(RollingFileAppender {
             inner: InnerAppender::new(
                 directory.as_ref(),
                 file_name_prefix.as_ref(),
                 rotation,
                 Utc::now(),
-            )
-            .expect("Failed to create appender"),
-        }
+            )?,
+        })
     }
 }
 
@@ -119,7 +118,7 @@ impl io::Write for RollingFileAppender {
 /// # #[clippy::allow(needless_doctest_main)]
 /// fn main () {
 /// # fn doc() {
-///     let appender = tracing_appender::rolling::minutely("/some/path", "rolling.log");
+///     let appender = tracing_appender::rolling::minutely("/some/path", "rolling.log").unwrap();
 ///     let (non_blocking_appender, _guard) = tracing_appender::non_blocking(appender);
 ///
 ///     let collector = tracing_subscriber::fmt().with_writer(non_blocking_appender);
@@ -135,7 +134,7 @@ impl io::Write for RollingFileAppender {
 pub fn minutely(
     directory: impl AsRef<Path>,
     file_name_prefix: impl AsRef<Path>,
-) -> RollingFileAppender {
+) -> io::Result<RollingFileAppender> {
     RollingFileAppender::new(Rotation::MINUTELY, directory, file_name_prefix)
 }
 
@@ -154,7 +153,7 @@ pub fn minutely(
 /// # #[clippy::allow(needless_doctest_main)]
 /// fn main () {
 /// # fn doc() {
-///     let appender = tracing_appender::rolling::hourly("/some/path", "rolling.log");
+///     let appender = tracing_appender::rolling::hourly("/some/path", "rolling.log").unwrap();
 ///     let (non_blocking_appender, _guard) = tracing_appender::non_blocking(appender);
 ///
 ///     let collector = tracing_subscriber::fmt().with_writer(non_blocking_appender);
@@ -170,7 +169,7 @@ pub fn minutely(
 pub fn hourly(
     directory: impl AsRef<Path>,
     file_name_prefix: impl AsRef<Path>,
-) -> RollingFileAppender {
+) -> io::Result<RollingFileAppender> {
     RollingFileAppender::new(Rotation::HOURLY, directory, file_name_prefix)
 }
 
@@ -190,7 +189,7 @@ pub fn hourly(
 /// # #[clippy::allow(needless_doctest_main)]
 /// fn main () {
 /// # fn doc() {
-///     let appender = tracing_appender::rolling::daily("/some/path", "rolling.log");
+///     let appender = tracing_appender::rolling::daily("/some/path", "rolling.log").unwrap();
 ///     let (non_blocking_appender, _guard) = tracing_appender::non_blocking(appender);
 ///
 ///     let collector = tracing_subscriber::fmt().with_writer(non_blocking_appender);
@@ -206,7 +205,7 @@ pub fn hourly(
 pub fn daily(
     directory: impl AsRef<Path>,
     file_name_prefix: impl AsRef<Path>,
-) -> RollingFileAppender {
+) -> io::Result<RollingFileAppender> {
     RollingFileAppender::new(Rotation::DAILY, directory, file_name_prefix)
 }
 
@@ -224,7 +223,7 @@ pub fn daily(
 /// # #[clippy::allow(needless_doctest_main)]
 /// fn main () {
 /// # fn doc() {
-///     let appender = tracing_appender::rolling::never("/some/path", "non-rolling.log");
+///     let appender = tracing_appender::rolling::never("/some/path", "non-rolling.log").unwrap();
 ///     let (non_blocking_appender, _guard) = tracing_appender::non_blocking(appender);
 ///
 ///     let collector = tracing_subscriber::fmt().with_writer(non_blocking_appender);
@@ -237,7 +236,7 @@ pub fn daily(
 /// ```
 ///
 /// This will result in a log file located at `/some/path/non-rolling.log`.
-pub fn never(directory: impl AsRef<Path>, file_name: impl AsRef<Path>) -> RollingFileAppender {
+pub fn never(directory: impl AsRef<Path>, file_name: impl AsRef<Path>) -> io::Result<RollingFileAppender> {
     RollingFileAppender::new(Rotation::NEVER, directory, file_name)
 }
 
@@ -368,7 +367,7 @@ mod test {
     }
 
     fn test_appender(rotation: Rotation, directory: TempDir, file_prefix: &str) {
-        let mut appender = RollingFileAppender::new(rotation, directory.path(), file_prefix);
+        let mut appender = RollingFileAppender::new(rotation, directory.path(), file_prefix).expect("Failed to initialize appender");
 
         let expected_value = "Hello";
         write_to_log(&mut appender, expected_value);


### PR DESCRIPTION
## Motivation

`RollingAppender::new` uses `expect` to handle any `InnerAppender` error:
```rust
RollingFileAppender {
    inner: InnerAppender::new(
        directory.as_ref(),
        file_name_prefix.as_ref(),
        rotation,
        Utc::now(),
    ).expect("Failed to create appender"),
}
```

I found it may be annoying to get a **panic** and not being able to handle it for outer error handling systems API users may have.

In specific I have been using it when bootstrapping a server. We have some specific return codes depending on what bootstrapping error happened.  For solving it I had to manually check some file-related data (like if the path is malformed) before using any `RollingAppender` related call.


## Solution

Bubble-up the derivated error and handle in the most outer scope.
```rust
pub fn new(
        rotation: Rotation,
        directory: impl AsRef<Path>,
        file_name_prefix: impl AsRef<Path>,
    ) -> io::Result<RollingFileAppender> {
        Ok(RollingFileAppender {
            inner: InnerAppender::new(
                directory.as_ref(),
                file_name_prefix.as_ref(),
                rotation,
                Utc::now(),
            )?,
        })
    }
```