### PR TITLE
backport several non-breaking changes to v0.1.x

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: check
-        args: --all --bins --examples --tests --benches
+        args: --all --bins --tests --benches
 
   cargo-hack:
     runs-on: ubuntu-latest
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta, nightly, 1.42.0]
+        rust: [stable, beta, nightly]
     steps:
     - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
@@ -127,6 +127,32 @@ jobs:
       with:
         command: test
         args: --all
+
+  test-msrv:
+    # Test against the minimum supported Rust version
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@main
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.42.0
+        profile: minimal
+        override: true
+    # We can't use `cargo test --all`, as that will also compile the examples.
+    # We don't guarantee the examples will work on the MSRV, because they have
+    # external dependencies which may not comply with our MSRV policy, but don't
+    # actually impact users on our MSRV.
+    - name: Run tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --workspace --lib --tests
+    - name: Run doctests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --workspace --doc
 
   test-build-wasm:
     needs: check

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ attachment that `Future::instrument` does.
 
 [std-future]: https://doc.rust-lang.org/stable/std/future/trait.Future.html
 [`tracing-futures`]: https://docs.rs/tracing-futures
-[closing]: https://docs.rs/tracing/latest/span/index.html#closing-spans
+[closing]: https://docs.rs/tracing/latest/tracing/span/index.html#closing-spans
 [`Future::instrument`]: https://docs.rs/tracing/latest/tracing/trait.Instrument.html#method.instrument
 [`#[instrument]`]: https://docs.rs/tracing/0.1.11/tracing/attr.instrument.html
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,10 +1,7 @@
 [build]
-  command = """
-  curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly --profile minimal \
-  && source $HOME/.cargo/env \
-  && RUSTDOCFLAGS=\"--cfg docsrs\" cargo +nightly doc --no-deps
-  """
-  publish = "target/doc"
+  command = "rustup install nightly --profile minimal && cargo doc --no-deps && cp -r target/doc _netlify_out"
+  environment = { RUSTDOCFLAGS= "--cfg docsrs" }
+  publish = "_netlify_out"
 
 [[redirects]]
   from = "/"

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -106,6 +106,7 @@ pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 pub struct WorkerGuard {
     guard: Option<JoinHandle<()>>,
     sender: Sender<Msg>,
+    shutdown: Sender<()>,
 }
 
 /// A non-blocking writer.
@@ -148,8 +149,11 @@ impl NonBlocking {
     ) -> (NonBlocking, WorkerGuard) {
         let (sender, receiver) = bounded(buffered_lines_limit);
 
-        let worker = Worker::new(receiver, writer);
-        let worker_guard = WorkerGuard::new(worker.worker_thread(), sender.clone());
+        let (shutdown_sender, shutdown_receiver) = bounded(0);
+
+        let worker = Worker::new(receiver, writer, shutdown_receiver);
+        let worker_guard =
+            WorkerGuard::new(worker.worker_thread(), sender.clone(), shutdown_sender);
 
         (
             Self {
@@ -245,10 +249,11 @@ impl MakeWriter for NonBlocking {
 }
 
 impl WorkerGuard {
-    fn new(handle: JoinHandle<()>, sender: Sender<Msg>) -> Self {
+    fn new(handle: JoinHandle<()>, sender: Sender<Msg>, shutdown: Sender<()>) -> Self {
         WorkerGuard {
             guard: Some(handle),
             sender,
+            shutdown,
         }
     }
 }
@@ -259,7 +264,14 @@ impl Drop for WorkerGuard {
             .sender
             .send_timeout(Msg::Shutdown, Duration::from_millis(100))
         {
-            Ok(_) | Err(SendTimeoutError::Disconnected(_)) => (),
+            Ok(_) => {
+                // Attempt to wait for `Worker` to flush all messages before dropping. This happens
+                // when the `Worker` calls `recv()` on a zero-capacity channel. Use `send_timeout`
+                // so that drop is not blocked indefinitely.
+                // TODO: Make timeout configurable.
+                let _ = self.shutdown.send_timeout((), Duration::from_millis(1000));
+            }
+            Err(SendTimeoutError::Disconnected(_)) => (),
             Err(SendTimeoutError::Timeout(e)) => println!(
                 "Failed to send shutdown signal to logging worker. Error: {:?}",
                 e

--- a/tracing-subscriber/src/filter/env/directive.rs
+++ b/tracing-subscriber/src/filter/env/directive.rs
@@ -178,13 +178,17 @@ impl FromStr for Directive {
         lazy_static! {
             static ref DIRECTIVE_RE: Regex = Regex::new(
                 r"(?x)
-                ^(?P<global_level>trace|TRACE|debug|DEBUG|info|INFO|warn|WARN|error|ERROR|off|OFF|[0-5])$ |
+                ^(?P<global_level>(?i:trace|debug|info|warn|error|off|[0-5]))$ |
+                 #                 ^^^.
+                 #                     `note: we match log level names case-insensitively
                 ^
                 (?: # target name or span name
                     (?P<target>[\w:-]+)|(?P<span>\[[^\]]*\])
                 ){1,2}
                 (?: # level or nothing
-                    =(?P<level>trace|TRACE|debug|DEBUG|info|INFO|warn|WARN|error|ERROR|off|OFF|[0-5])?
+                    =(?P<level>(?i:trace|debug|info|warn|error|off|[0-5]))?
+                     #          ^^^.
+                     #              `note: we match log level names case-insensitively
                 )?
                 $
                 "
@@ -832,6 +836,32 @@ mod test {
     }
 
     #[test]
+    fn parse_directives_ralith_uc() {
+        let dirs = parse_directives("common=INFO,server=DEBUG");
+        assert_eq!(dirs.len(), 2, "\nparsed: {:#?}", dirs);
+        assert_eq!(dirs[0].target, Some("common".to_string()));
+        assert_eq!(dirs[0].level, LevelFilter::INFO);
+        assert_eq!(dirs[0].in_span, None);
+
+        assert_eq!(dirs[1].target, Some("server".to_string()));
+        assert_eq!(dirs[1].level, LevelFilter::DEBUG);
+        assert_eq!(dirs[1].in_span, None);
+    }
+
+    #[test]
+    fn parse_directives_ralith_mixed() {
+        let dirs = parse_directives("common=iNfo,server=dEbUg");
+        assert_eq!(dirs.len(), 2, "\nparsed: {:#?}", dirs);
+        assert_eq!(dirs[0].target, Some("common".to_string()));
+        assert_eq!(dirs[0].level, LevelFilter::INFO);
+        assert_eq!(dirs[0].in_span, None);
+
+        assert_eq!(dirs[1].target, Some("server".to_string()));
+        assert_eq!(dirs[1].level, LevelFilter::DEBUG);
+        assert_eq!(dirs[1].in_span, None);
+    }
+
+    #[test]
     fn parse_directives_valid() {
         let dirs = parse_directives("crate1::mod1=error,crate1::mod2,crate2=debug,crate3=off");
         assert_eq!(dirs.len(), 4, "\nparsed: {:#?}", dirs);
@@ -1001,6 +1031,39 @@ mod test {
         assert_eq!(dirs[1].target, Some("crate2".to_string()));
         assert_eq!(dirs[1].level, LevelFilter::DEBUG);
         assert_eq!(dirs[1].in_span, None);
+    }
+
+    // helper function for tests below
+    fn test_parse_bare_level(directive_to_test: &str, level_expected: LevelFilter) {
+        let dirs = parse_directives(directive_to_test);
+        assert_eq!(
+            dirs.len(),
+            1,
+            "\ninput: \"{}\"; parsed: {:#?}",
+            directive_to_test,
+            dirs
+        );
+        assert_eq!(dirs[0].target, None);
+        assert_eq!(dirs[0].level, level_expected);
+        assert_eq!(dirs[0].in_span, None);
+    }
+
+    #[test]
+    fn parse_directives_global_bare_warn_lc() {
+        // test parse_directives with no crate, in isolation, all lowercase
+        test_parse_bare_level("warn", LevelFilter::WARN);
+    }
+
+    #[test]
+    fn parse_directives_global_bare_warn_uc() {
+        // test parse_directives with no crate, in isolation, all uppercase
+        test_parse_bare_level("WARN", LevelFilter::WARN);
+    }
+
+    #[test]
+    fn parse_directives_global_bare_warn_mixed() {
+        // test parse_directives with no crate, in isolation, mixed case
+        test_parse_bare_level("wArN", LevelFilter::WARN);
     }
 
     #[test]


### PR DESCRIPTION
This branch backports a number of non-breaking changes from `master` to
`v0.1.x`:

* 27b28773 tracing-flame: add module_path and file_and_line configs (#1134)
* 4f93a6e0 docs: update README.md (#1133)
* ade54898 appender: fix race condition when logging on shutdown (#1125)
* aa2bae09 subscriber: directives: accept legit log level names in mixed case (env_logger compat) (#1126)
* d59f4bc4 chore: fix netlify build (#1131)
* 2e81818f chore: don't check examples on MSRV (#1128)

These changes have already been approved on `master`, so I'll just go
ahead and merge this once CI passes.

I'll rebase merge this so all the commits land individually.
