### PR TITLE
Disable default features of tracing dependency

### DIFF
--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -39,7 +39,7 @@ traced-error = []
 
 [dependencies]
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry", "fmt"] }
-tracing = { path = "../tracing", version = "0.2" }
+tracing = { path = "../tracing", version = "0.2", default-features = false, features = ["std"] }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/tracing-flame/Cargo.toml
+++ b/tracing-flame/Cargo.toml
@@ -26,7 +26,7 @@ smallvec = ["tracing-subscriber/smallvec"]
 
 [dependencies]
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry", "fmt"] }
-tracing = { path = "../tracing", version = "0.2"}
+tracing = { path = "../tracing", version = "0.2", default-features = false, features = ["std"] }
 lazy_static = "1.3.0"
 
 [dev-dependencies]

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -23,7 +23,7 @@ default = ["tracing-log"]
 
 [dependencies]
 opentelemetry = { version = "0.10", default-features = false, features = ["trace"] }
-tracing = { path = "../tracing", version = "0.2" }
+tracing = { path = "../tracing", version = "0.2", default-features = false, features = ["std"] }
 tracing-core = { path = "../tracing-core", version = "0.2" }
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry"] }
 tracing-log = { path = "../tracing-log", version = "0.2", default-features = false, optional = true }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -34,7 +34,7 @@ json = ["tracing-serde", "serde", "serde_json"]
 tracing-core = { path = "../tracing-core", version = "0.2" }
 
 # only required by the filter feature
-tracing = { optional = true, path = "../tracing", version = "0.2" }
+tracing = { optional = true, path = "../tracing", version = "0.2", default-features = false, features = ["std"] }
 matchers = { optional = true, version = "0.0.1" }
 regex = { optional = true, version = "1", default-features = false, features = ["std"] }
 smallvec = { optional = true, version = "1" }

--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -24,7 +24,7 @@ tower-make = [
 ]
 
 [dependencies]
-tracing = { path = "../tracing", version = "0.2"}
+tracing = { path = "../tracing", version = "0.2", default-features = false, features = ["std"] }
 tracing-futures = { version = "0.3", path = "../tracing-futures", features = ["std-future"] }
 futures = "0.3"
 tower-service = "0.3"


### PR DESCRIPTION
This avoids relatively heavy dependencies (tracing-attributes, syn, etc.) in some cases.