### PR TITLE
tracing-subscriber api docs: Gotcha for the extensions(_mut) methods

### DIFF
--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -141,12 +141,21 @@ pub trait SpanData<'a> {
     ///
     /// The extensions may be used by `Subscriber`s to store additional data
     /// describing the span.
+    ///
+    /// This method acquires a read lock to the extensions that will be held as
+    /// long as the returned value lives. To prevent deadlocks, never acquire
+    /// extensions of multiple spans (e.g. of the parent and the active one) at
+    /// the same time.
     fn extensions(&self) -> Extensions<'_>;
 
     /// Returns a mutable reference to this span's `Extensions`.
     ///
     /// The extensions may be used by `Subscriber`s to store additional data
     /// describing the span.
+    ///
+    /// This method acquires a write lock to the extensions that will be held as
+    /// long as the returned value lives. To prevent deadlocks, never acquire
+    /// extensions of multiple spans (e.g. of the parent and the active one) at
     fn extensions_mut(&self) -> ExtensionsMut<'_>;
 }
 


### PR DESCRIPTION
## Motivation

While implementing [reqray](https://github.com/kolloch/reqray) based on `tracing-subscriber`, I noticed that the extension methods on `SpanRef`/`SpanData` acquire locks under the hood.

If any layer acquires multiple locks through these means in a different order, this could result in dead locks.

## Solution

 Therefore, I added documentation to this method, recommending to never hold more than one extension object at a time.