### PR TITLE
appender: backport a bunch of changes

### DIFF
--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -20,7 +20,7 @@ keywords = ["logging", "tracing", "file-appender", "non-blocking-writer"]
 edition = "2018"
 
 [dependencies]
-crossbeam-channel = "0.4.2"
+crossbeam-channel = "0.5.0"
 chrono = "0.4.11"
 
 [dependencies.tracing-subscriber]

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -61,7 +61,7 @@ use tracing_subscriber::fmt::MakeWriter;
 /// The default maximum number of buffered log lines.
 ///
 /// If [`NonBlocking`][non-blocking] is lossy, it will drop spans/events at capacity.
-/// capacity. If [`NonBlocking`][non-blocking] is _not_ lossy,
+/// If [`NonBlocking`][non-blocking] is _not_ lossy,
 /// backpressure will be exerted on senders, causing them to block their
 /// respective threads until there is available capacity.
 ///

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -106,6 +106,7 @@ pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 pub struct WorkerGuard {
     guard: Option<JoinHandle<()>>,
     sender: Sender<Msg>,
+    shutdown: Sender<()>,
 }
 
 /// A non-blocking writer.
@@ -148,8 +149,11 @@ impl NonBlocking {
     ) -> (NonBlocking, WorkerGuard) {
         let (sender, receiver) = bounded(buffered_lines_limit);
 
-        let worker = Worker::new(receiver, writer);
-        let worker_guard = WorkerGuard::new(worker.worker_thread(), sender.clone());
+        let (shutdown_sender, shutdown_receiver) = bounded(0);
+
+        let worker = Worker::new(receiver, writer, shutdown_receiver);
+        let worker_guard =
+            WorkerGuard::new(worker.worker_thread(), sender.clone(), shutdown_sender);
 
         (
             Self {
@@ -245,10 +249,11 @@ impl MakeWriter for NonBlocking {
 }
 
 impl WorkerGuard {
-    fn new(handle: JoinHandle<()>, sender: Sender<Msg>) -> Self {
+    fn new(handle: JoinHandle<()>, sender: Sender<Msg>, shutdown: Sender<()>) -> Self {
         WorkerGuard {
             guard: Some(handle),
             sender,
+            shutdown,
         }
     }
 }
@@ -259,7 +264,14 @@ impl Drop for WorkerGuard {
             .sender
             .send_timeout(Msg::Shutdown, Duration::from_millis(100))
         {
-            Ok(_) | Err(SendTimeoutError::Disconnected(_)) => (),
+            Ok(_) => {
+                // Attempt to wait for `Worker` to flush all messages before dropping. This happens
+                // when the `Worker` calls `recv()` on a zero-capacity channel. Use `send_timeout`
+                // so that drop is not blocked indefinitely.
+                // TODO: Make timeout configurable.
+                let _ = self.shutdown.send_timeout((), Duration::from_millis(1000));
+            }
+            Err(SendTimeoutError::Disconnected(_)) => (),
             Err(SendTimeoutError::Timeout(e)) => println!(
                 "Failed to send shutdown signal to logging worker. Error: {:?}",
                 e

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -253,6 +253,14 @@ pub fn never(directory: impl AsRef<Path>, file_name: impl AsRef<Path>) -> Rollin
 ///
 /// To use a `Rotation`, pick one of the following options:
 ///
+/// ### Minutely Rotation
+/// ```rust
+/// # fn docs() {
+/// use tracing_appender::rolling::Rotation;
+/// let rotation = tracing_appender::rolling::Rotation::MINUTELY;
+/// # }
+/// ```
+///
 /// ### Hourly Rotation
 /// ```rust
 /// # fn docs() {


### PR DESCRIPTION
This backports a bunch of `tracing-appender` changes from v0.2.x.

This has all been approved already so I'll go ahead and merge it when CI passes.