### PR TITLE
appender: prepare to release v0.1.2

### DIFF
--- a/tracing-appender/CHANGELOG.md
+++ b/tracing-appender/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.1.2 (December 28, 2020)
+
+### Changed
+
+- **non_blocking**: Updated `crossbeam-channel` dependency to 0.5 (#1031)
+
+### Fixed
+
+- **non_blocking**: Fixed a race condition when logging on shutdown (#1125)
+- Several documentation improvements (#1109, #1110, #941, #953)
+
 # 0.1.1 (July 20, 2020)
 
 ### Added

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-appender"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     "Zeki Sherif <zekshi@amazon.com>",
     "Tokio Contributors <team@tokio.rs>"

--- a/tracing-appender/README.md
+++ b/tracing-appender/README.md
@@ -16,9 +16,9 @@ Writers for logging events and spans
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-appender.svg
-[crates-url]: https://crates.io/crates/tracing-appender/0.1.1
+[crates-url]: https://crates.io/crates/tracing-appender/0.1.2
 [docs-badge]: https://docs.rs/tracing-appender/badge.svg
-[docs-url]: https://docs.rs/tracing-appender/0.1.1
+[docs-url]: https://docs.rs/tracing-appender/0.1.2
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing.rs/tracing-appender
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -122,7 +122,7 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
-#![doc(html_root_url = "https://docs.rs/tracing-appender/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/tracing-appender/0.1.2")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
Changed

- **non_blocking**: Updated `crossbeam-channel` dependency to 0.5
  (#1031)

Fixed
- **non_blocking**: Fixed a race condition when logging on shutdown
  (#1125)
- Several documentation improvements (#1109, #1110, #941, #953)
