### PR TITLE
opentelemetry: update to otel v0.11.x

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -53,5 +53,5 @@ inferno = "0.10.0"
 tempdir = "0.3.7"
 
 # opentelemetry example
-opentelemetry = { version = "0.10", default-features = false, features = ["trace"] }
-opentelemetry-jaeger = "0.9"
+opentelemetry = { version = "0.11", default-features = false, features = ["trace"] }
+opentelemetry-jaeger = "0.10"

--- a/examples/examples/opentelemetry-remote-context.rs
+++ b/examples/examples/opentelemetry-remote-context.rs
@@ -1,4 +1,4 @@
-use opentelemetry::sdk::propagation::B3Propagator;
+use opentelemetry::sdk::propagation::TraceContextPropagator;
 use opentelemetry::{global, Context};
 use std::collections::HashMap;
 use tracing::span;
@@ -15,8 +15,8 @@ fn make_request(_cx: Context) {
 fn build_example_carrier() -> HashMap<String, String> {
     let mut carrier = HashMap::new();
     carrier.insert(
-        "X-B3".to_string(),
-        "4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-1".to_string(),
+        "traceparent".to_string(),
+        "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01".to_string(),
     );
 
     carrier
@@ -24,7 +24,7 @@ fn build_example_carrier() -> HashMap<String, String> {
 
 fn main() {
     // Set a format for propagating context. This MUST be provided, as the default is a no-op.
-    global::set_text_map_propagator(B3Propagator::new());
+    global::set_text_map_propagator(TraceContextPropagator::new());
     let subscriber = Registry::default().with(tracing_opentelemetry::layer());
 
     tracing::collect::with_default(subscriber, || {
@@ -37,7 +37,7 @@ fn main() {
         let app_root = span!(tracing::Level::INFO, "app_start");
 
         // Assign parent trace from external context
-        app_root.set_parent(&parent_context);
+        app_root.set_parent(parent_context);
 
         // To include tracing context in client requests from _this_ app,
         // use `context` to extract the current OpenTelemetry context.

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -22,11 +22,12 @@ edition = "2018"
 default = ["tracing-log"]
 
 [dependencies]
-opentelemetry = { version = "0.10", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.11", default-features = false, features = ["trace"] }
 tracing = { path = "../tracing", version = "0.2", default-features = false, features = ["std"] }
 tracing-core = { path = "../tracing-core", version = "0.2" }
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry"] }
 tracing-log = { path = "../tracing-log", version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
-opentelemetry-jaeger = "0.9"
+async-trait = "0.1"
+opentelemetry-jaeger = "0.10"

--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -321,36 +321,35 @@ where
         }
     }
 
-    /// Retrieve the parent OpenTelemetry [`SpanContext`] from the current
-    /// tracing [`span`] through the [`Registry`]. This [`SpanContext`]
-    /// links spans to their parent for proper hierarchical visualization.
+    /// Retrieve the parent OpenTelemetry [`Context`] from the current tracing
+    /// [`span`] through the [`Registry`]. This [`Context`] links spans to their
+    /// parent for proper hierarchical visualization.
     ///
-    /// [`SpanContext`]: opentelemetry::trace::SpanContext
+    /// [`Context`]: opentelemetry::Context
     /// [`span`]: tracing::Span
     /// [`Registry`]: tracing_subscriber::Registry
-    fn parent_span_context(
-        &self,
-        attrs: &Attributes<'_>,
-        ctx: &Context<'_, S>,
-    ) -> Option<otel::SpanContext> {
+    fn parent_context(&self, attrs: &Attributes<'_>, ctx: &Context<'_, S>) -> OtelContext {
         // If a span is specified, it _should_ exist in the underlying `Registry`.
         if let Some(parent) = attrs.parent() {
             let span = ctx.span(parent).expect("Span not found, this is a bug");
             let mut extensions = span.extensions_mut();
             extensions
                 .get_mut::<otel::SpanBuilder>()
-                .map(|builder| self.tracer.sampled_span_context(builder))
+                .map(|builder| self.tracer.sampled_context(builder))
+                .unwrap_or_default()
         // Else if the span is inferred from context, look up any available current span.
         } else if attrs.is_contextual() {
-            ctx.lookup_current().and_then(|span| {
-                let mut extensions = span.extensions_mut();
-                extensions
-                    .get_mut::<otel::SpanBuilder>()
-                    .map(|builder| self.tracer.sampled_span_context(builder))
-            })
+            ctx.lookup_current()
+                .and_then(|span| {
+                    let mut extensions = span.extensions_mut();
+                    extensions
+                        .get_mut::<otel::SpanBuilder>()
+                        .map(|builder| self.tracer.sampled_context(builder))
+                })
+                .unwrap_or_else(OtelContext::current)
         // Explicit root spans should have no parent context.
         } else {
-            None
+            OtelContext::new()
         }
     }
 
@@ -401,17 +400,22 @@ where
             .with_span_id(self.tracer.new_span_id());
 
         // Set optional parent span context from attrs
-        builder.parent_context = self.parent_span_context(attrs, &ctx);
+        builder.parent_context = Some(self.parent_context(attrs, &ctx));
 
-        // Ensure trace id exists so children are matched properly.
-        if builder.parent_context.is_none() {
-            let cx = OtelContext::current();
-            let existing_otel_span_context = cx.span().span_context();
-            if existing_otel_span_context.is_valid() {
-                builder.trace_id = Some(existing_otel_span_context.trace_id());
-            } else {
-                builder.trace_id = Some(self.tracer.new_trace_id());
-            }
+        // Ensure trace id exists so spans are associated with the proper trace.
+        //
+        // Parent contexts are in 4 possible states, first two require a new
+        // trace ids, second two have existing trace ids:
+        //   * Empty - explicit new tracing root span, needs new id
+        //   * A parent context containing no active or remote span, needs new id
+        //   * A parent context containing an active span, defer to that span's trace
+        //   * A parent context containing a remote span context, defer to remote trace
+        let needs_trace_id = builder.parent_context.as_ref().map_or(true, |cx| {
+            !cx.has_active_span() && cx.remote_span_context().is_none()
+        });
+
+        if needs_trace_id {
+            builder.trace_id = Some(self.tracer.new_trace_id());
         }
 
         attrs.record(&mut SpanAttributeVisitor(&mut builder));
@@ -466,7 +470,12 @@ where
             .get_mut::<otel::SpanBuilder>()
             .expect("Missing SpanBuilder span extensions");
 
-        let follows_context = self.tracer.sampled_span_context(follows_builder);
+        let follows_context = self
+            .tracer
+            .sampled_context(follows_builder)
+            .span()
+            .span_context()
+            .clone();
         let follows_link = otel::Link::new(follows_context, Vec::new());
         if let Some(ref mut links) = builder.links {
             links.push(follows_link);
@@ -588,21 +597,21 @@ mod tests {
         fn invalid(&self) -> Self::Span {
             otel::NoopSpan::new()
         }
-        fn start_from_context(&self, _name: &str, _context: &OtelContext) -> Self::Span {
+        fn start_with_context(&self, _name: &str, _context: OtelContext) -> Self::Span {
             self.invalid()
         }
         fn span_builder(&self, name: &str) -> otel::SpanBuilder {
             otel::SpanBuilder::from_name(name.to_string())
         }
-        fn build_with_context(&self, builder: otel::SpanBuilder, _cx: &OtelContext) -> Self::Span {
+        fn build(&self, builder: otel::SpanBuilder) -> Self::Span {
             *self.0.lock().unwrap() = Some(builder);
             self.invalid()
         }
     }
 
     impl PreSampledTracer for TestTracer {
-        fn sampled_span_context(&self, _builder: &mut otel::SpanBuilder) -> otel::SpanContext {
-            otel::SpanContext::empty_context()
+        fn sampled_context(&self, _builder: &mut otel::SpanBuilder) -> OtelContext {
+            OtelContext::new()
         }
         fn new_trace_id(&self) -> otel::TraceId {
             otel::TraceId::invalid()
@@ -673,8 +682,19 @@ mod tests {
             tracing::debug_span!("request", otel.kind = "Server");
         });
 
-        let recorded_trace_id = tracer.0.lock().unwrap().as_ref().unwrap().trace_id;
-        assert_eq!(recorded_trace_id, Some(trace_id))
+        let recorded_trace_id = tracer
+            .0
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .parent_context
+            .as_ref()
+            .unwrap()
+            .span()
+            .span_context()
+            .trace_id();
+        assert_eq!(recorded_trace_id, trace_id)
     }
 
     #[test]

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -51,7 +51,7 @@
 //! ## Examples
 //!
 //! ```
-//! use opentelemetry::exporter::trace::stdout;
+//! use opentelemetry::sdk::export::trace::stdout;
 //! use tracing::{error, span};
 //! use tracing_subscriber::subscribe::CollectExt;
 //! use tracing_subscriber::Registry;

--- a/tracing-opentelemetry/src/span_ext.rs
+++ b/tracing-opentelemetry/src/span_ext.rs
@@ -1,6 +1,5 @@
 use crate::layer::WithContext;
-use opentelemetry::{trace as otel, trace::TraceContextExt, Context, KeyValue};
-use std::time::SystemTime;
+use opentelemetry::Context;
 
 /// Utility functions to allow tracing [`Span`]s to accept and return
 /// [OpenTelemetry] [`Context`]s.
@@ -18,7 +17,7 @@ pub trait OpenTelemetrySpanExt {
     ///
     /// ```rust
     /// use opentelemetry::{propagation::TextMapPropagator, trace::TraceContextExt};
-    /// use opentelemetry::sdk::propagation::B3Propagator;
+    /// use opentelemetry::sdk::propagation::TraceContextPropagator;
     /// use tracing_opentelemetry::OpenTelemetrySpanExt;
     /// use std::collections::HashMap;
     /// use tracing::Span;
@@ -26,8 +25,8 @@ pub trait OpenTelemetrySpanExt {
     /// // Example carrier, could be a framework header map that impls otel's `Extract`.
     /// let mut carrier = HashMap::new();
     ///
-    /// // Propagator can be swapped with trace context propagator, binary propagator, etc.
-    /// let propagator = B3Propagator::new();
+    /// // Propagator can be swapped with b3 propagator, jaeger propagator, etc.
+    /// let propagator = TraceContextPropagator::new();
     ///
     /// // Extract otel parent context via the chosen propagator
     /// let parent_context = propagator.extract(&carrier);
@@ -36,12 +35,12 @@ pub trait OpenTelemetrySpanExt {
     /// let app_root = tracing::span!(tracing::Level::INFO, "app_start");
     ///
     /// // Assign parent trace from external context
-    /// app_root.set_parent(&parent_context);
+    /// app_root.set_parent(parent_context.clone());
     ///
     /// // Or if the current span has been created elsewhere:
-    /// Span::current().set_parent(&parent_context);
+    /// Span::current().set_parent(parent_context);
     /// ```
-    fn set_parent(&self, cx: &Context);
+    fn set_parent(&self, cx: Context);
 
     /// Extracts an OpenTelemetry [`Context`] from `self`.
     ///
@@ -74,81 +73,27 @@ pub trait OpenTelemetrySpanExt {
 }
 
 impl OpenTelemetrySpanExt for tracing::Span {
-    fn set_parent(&self, cx: &Context) {
+    fn set_parent(&self, cx: Context) {
+        let mut cx = Some(cx);
         self.with_collector(move |(id, collector)| {
             if let Some(get_context) = collector.downcast_ref::<WithContext>() {
                 get_context.with_context(collector, id, move |builder, _tracer| {
-                    builder.parent_context = cx.remote_span_context().cloned()
+                    builder.parent_context = cx.take();
                 });
             }
         });
     }
 
     fn context(&self) -> Context {
-        let mut span_context = None;
+        let mut cx = None;
         self.with_collector(|(id, collector)| {
             if let Some(get_context) = collector.downcast_ref::<WithContext>() {
                 get_context.with_context(collector, id, |builder, tracer| {
-                    span_context = Some(tracer.sampled_span_context(builder));
+                    cx = Some(tracer.sampled_context(builder));
                 })
             }
         });
 
-        let span_context = span_context.unwrap_or_else(otel::SpanContext::empty_context);
-        let compat_span = CompatSpan(span_context);
-        Context::current_with_span(compat_span)
-    }
-}
-
-/// A compatibility wrapper for an injectable OpenTelemetry span context.
-#[derive(Debug)]
-struct CompatSpan(otel::SpanContext);
-impl otel::Span for CompatSpan {
-    fn add_event_with_timestamp(
-        &self,
-        _name: String,
-        _timestamp: std::time::SystemTime,
-        _attributes: Vec<KeyValue>,
-    ) {
-        #[cfg(debug_assertions)]
-        panic!(
-            "OpenTelemetry and tracing APIs cannot be mixed, use `tracing::event!` macro instead."
-        );
-    }
-
-    /// This method is used by OpenTelemetry propagators to inject span context
-    /// information into [`Injector`]s.
-    ///
-    /// [`Injector`]: opentelemetry::propagation::Injector
-    fn span_context(&self) -> &otel::SpanContext {
-        &self.0
-    }
-
-    fn is_recording(&self) -> bool {
-        #[cfg(debug_assertions)]
-        panic!("cannot record via OpenTelemetry API when using extracted span in tracing");
-
-        #[cfg(not(debug_assertions))]
-        false
-    }
-
-    fn set_attribute(&self, _attribute: KeyValue) {
-        #[cfg(debug_assertions)]
-        panic!("OpenTelemetry and tracing APIs cannot be mixed, use `tracing::span!` macro or `span.record()` instead.");
-    }
-
-    fn set_status(&self, _code: otel::StatusCode, _message: String) {
-        #[cfg(debug_assertions)]
-        panic!("OpenTelemetry and tracing APIs cannot be mixed, use `tracing::span!` macro or `span.record()` instead.");
-    }
-
-    fn update_name(&self, _new_name: String) {
-        #[cfg(debug_assertions)]
-        panic!("OpenTelemetry and tracing APIs cannot be mixed, span names are not mutable.");
-    }
-
-    fn end_with_timestamp(&self, _timestamp: SystemTime) {
-        #[cfg(debug_assertions)]
-        panic!("OpenTelemetry and tracing APIs cannot be mixed, span end times are set when the underlying tracing span closes.");
+        cx.unwrap_or_default()
     }
 }

--- a/tracing-opentelemetry/src/tracer.rs
+++ b/tracing-opentelemetry/src/tracer.rs
@@ -1,5 +1,13 @@
-use opentelemetry::sdk::trace::{SamplingDecision, Tracer};
-use opentelemetry::trace as otel;
+use opentelemetry::sdk::trace::{SamplingDecision, SamplingResult, Tracer, TracerProvider};
+use opentelemetry::{
+    trace as otel,
+    trace::{
+        SpanBuilder, SpanContext, SpanId, SpanKind, TraceContextExt, TraceId, TraceState,
+        TRACE_FLAG_SAMPLED,
+    },
+    Context as OtelContext, KeyValue,
+};
+use std::time::SystemTime;
 
 /// An interface for authors of OpenTelemetry SDKs to build pre-sampled tracers.
 ///
@@ -8,12 +16,12 @@ use opentelemetry::trace as otel;
 /// existing `tracing` spans, `tracing-opentelemetry` builds up otel span data
 /// using a [`SpanBuilder`] instead, and creates / exports full otel spans only
 /// when the associated `tracing` span is closed. However, in order to properly
-/// inject otel [`SpanContext`] information to downstream requests, the sampling
+/// inject otel [`Context`] information to downstream requests, the sampling
 /// state must now be known _before_ the otel span has been created.
 ///
 /// The logic for coming to a sampling decision and creating an injectable span
 /// context from a [`SpanBuilder`] is encapsulated in the
-/// [`PreSampledTracer::sampled_span_context`] method and has been implemented
+/// [`PreSampledTracer::sampled_context`] method and has been implemented
 /// for the standard OpenTelemetry SDK, but this trait may be implemented by
 /// authors of alternate OpenTelemetry SDK implementations if they wish to have
 /// `tracing` compatibility.
@@ -25,10 +33,14 @@ use opentelemetry::trace as otel;
 /// [`OpenTelemetrySpanExt::context`]: crate::OpenTelemetrySpanExt::context
 /// [`Tracer`]: opentelemetry::trace::Tracer
 /// [`SpanBuilder`]: opentelemetry::trace::SpanBuilder
-/// [`SpanContext`]: opentelemetry::trace::SpanContext
+/// [`Context`]: opentelemetry::Context
 pub trait PreSampledTracer {
-    /// Produce a pre-sampled span context for the given span builder.
-    fn sampled_span_context(&self, builder: &mut otel::SpanBuilder) -> otel::SpanContext;
+    /// Produce an otel context containing an active and pre-sampled span for
+    /// the given span builder data.
+    ///
+    /// The sampling decision, span context information, and parent context
+    /// values must match the values recorded when the tracing span is closed.
+    fn sampled_context(&self, builder: &mut otel::SpanBuilder) -> OtelContext;
 
     /// Generate a new trace id.
     fn new_trace_id(&self) -> otel::TraceId;
@@ -38,11 +50,11 @@ pub trait PreSampledTracer {
 }
 
 impl PreSampledTracer for otel::NoopTracer {
-    fn sampled_span_context(&self, builder: &mut otel::SpanBuilder) -> otel::SpanContext {
+    fn sampled_context(&self, builder: &mut otel::SpanBuilder) -> OtelContext {
         builder
             .parent_context
             .clone()
-            .unwrap_or_else(otel::SpanContext::empty_context)
+            .unwrap_or_else(OtelContext::new)
     }
 
     fn new_trace_id(&self) -> otel::TraceId {
@@ -55,62 +67,49 @@ impl PreSampledTracer for otel::NoopTracer {
 }
 
 impl PreSampledTracer for Tracer {
-    fn sampled_span_context(&self, builder: &mut otel::SpanBuilder) -> otel::SpanContext {
-        let span_id = builder.span_id.unwrap_or_else(|| {
-            self.provider()
-                .map(|provider| provider.config().id_generator.new_span_id())
-                .unwrap_or_else(otel::SpanId::invalid)
-        });
-        let (trace_id, trace_flags) = builder
-            .parent_context
-            .as_ref()
-            .filter(|parent_context| parent_context.is_valid())
-            .map(|parent_context| (parent_context.trace_id(), parent_context.trace_flags()))
-            .unwrap_or_else(|| {
-                let trace_id = builder.trace_id.unwrap_or_else(|| {
-                    self.provider()
-                        .map(|provider| provider.config().id_generator.new_trace_id())
-                        .unwrap_or_else(otel::TraceId::invalid)
-                });
+    fn sampled_context(&self, builder: &mut otel::SpanBuilder) -> OtelContext {
+        // Ensure tracing pipeline is still installed.
+        if self.provider().is_none() {
+            return OtelContext::new();
+        }
+        let provider = self.provider().unwrap();
 
-                // ensure sampling decision is recorded so all span context have consistent flags
-                let sampling_decision = if let Some(result) = builder.sampling_result.as_ref() {
-                    result.decision.clone()
-                } else if let Some(provider) = self.provider().as_ref() {
-                    let mut result = provider.config().default_sampler.should_sample(
-                        builder.parent_context.as_ref(),
-                        trace_id,
-                        &builder.name,
-                        builder
-                            .span_kind
-                            .as_ref()
-                            .unwrap_or(&otel::SpanKind::Internal),
-                        builder.attributes.as_ref().unwrap_or(&Vec::new()),
-                        builder.links.as_ref().unwrap_or(&Vec::new()),
-                    );
+        // Ensure parent context exists and contains data necessary for sampling
+        let parent_cx = build_parent_context(&builder);
 
-                    // Record additional attributes resulting from sampling
-                    if let Some(attributes) = &mut builder.attributes {
-                        attributes.append(&mut result.attributes)
-                    } else {
-                        builder.attributes = Some(result.attributes);
-                    }
+        // Gather trace state
+        let (no_parent, trace_id, remote_parent, parent_trace_flags) =
+            current_trace_state(&builder, &parent_cx, &provider);
 
-                    result.decision
-                } else {
-                    SamplingDecision::Drop
-                };
+        // Sample or defer to existing sampling decisions
+        let (flags, trace_state) = if let Some(result) = &builder.sampling_result {
+            process_sampling_result(result, parent_trace_flags)
+        } else if no_parent || remote_parent {
+            builder.sampling_result = Some(provider.config().default_sampler.should_sample(
+                Some(&parent_cx),
+                trace_id,
+                &builder.name,
+                builder.span_kind.as_ref().unwrap_or(&SpanKind::Internal),
+                builder.attributes.as_deref().unwrap_or(&[]),
+                builder.links.as_deref().unwrap_or(&[]),
+            ));
 
-                let trace_flags = if sampling_decision == SamplingDecision::RecordAndSample {
-                    otel::TRACE_FLAG_SAMPLED
-                } else {
-                    0
-                };
+            process_sampling_result(
+                builder.sampling_result.as_ref().unwrap(),
+                parent_trace_flags,
+            )
+        } else {
+            // has parent that is local
+            Some((
+                parent_trace_flags,
+                parent_cx.span().span_context().trace_state().clone(),
+            ))
+        }
+        .unwrap_or_default();
 
-                (trace_id, trace_flags)
-            });
-
-        otel::SpanContext::new(trace_id, span_id, trace_flags, false, Default::default())
+        let span_id = builder.span_id.unwrap_or_else(SpanId::invalid);
+        let span_context = SpanContext::new(trace_id, span_id, flags, false, trace_state);
+        parent_cx.with_span(CompatSpan(span_context))
     }
 
     fn new_trace_id(&self) -> otel::TraceId {
@@ -126,21 +125,188 @@ impl PreSampledTracer for Tracer {
     }
 }
 
+fn build_parent_context(builder: &SpanBuilder) -> OtelContext {
+    builder
+        .parent_context
+        .as_ref()
+        .map(|cx| {
+            // Sampling expects to be able to access the parent span via `span` so wrap remote span
+            // context in a wrapper span if necessary. Remote span contexts will be passed to
+            // subsequent context's, so wrapping is only necessary if there is no active span.
+            match cx.remote_span_context() {
+                Some(remote_sc) if !cx.has_active_span() => {
+                    cx.with_span(CompatSpan(remote_sc.clone()))
+                }
+                _ => cx.clone(),
+            }
+        })
+        .unwrap_or_default()
+}
+
+fn current_trace_state(
+    builder: &SpanBuilder,
+    parent_cx: &OtelContext,
+    provider: &TracerProvider,
+) -> (bool, TraceId, bool, u8) {
+    if parent_cx.has_active_span() {
+        let sc = parent_cx.span().span_context();
+        (false, sc.trace_id(), sc.is_remote(), sc.trace_flags())
+    } else {
+        (
+            true,
+            builder
+                .trace_id
+                .unwrap_or_else(|| provider.config().id_generator.new_trace_id()),
+            false,
+            0,
+        )
+    }
+}
+
+fn process_sampling_result(
+    sampling_result: &SamplingResult,
+    trace_flags: u8,
+) -> Option<(u8, TraceState)> {
+    match sampling_result {
+        SamplingResult {
+            decision: SamplingDecision::Drop,
+            ..
+        } => None,
+        SamplingResult {
+            decision: SamplingDecision::RecordOnly,
+            trace_state,
+            ..
+        } => Some((trace_flags & !TRACE_FLAG_SAMPLED, trace_state.clone())),
+        SamplingResult {
+            decision: SamplingDecision::RecordAndSample,
+            trace_state,
+            ..
+        } => Some((trace_flags | TRACE_FLAG_SAMPLED, trace_state.clone())),
+    }
+}
+
+#[derive(Debug)]
+struct CompatSpan(otel::SpanContext);
+impl otel::Span for CompatSpan {
+    fn add_event_with_timestamp(
+        &self,
+        _name: String,
+        _timestamp: std::time::SystemTime,
+        _attributes: Vec<KeyValue>,
+    ) {
+        #[cfg(debug_assertions)]
+        panic!(
+            "OpenTelemetry and tracing APIs cannot be mixed, use `tracing::event!` macro instead."
+        );
+    }
+
+    /// This method is used by OpenTelemetry propagators to inject span context
+    /// information into [`Injector`]s.
+    ///
+    /// [`Injector`]: opentelemetry::propagation::Injector
+    fn span_context(&self) -> &otel::SpanContext {
+        &self.0
+    }
+
+    fn is_recording(&self) -> bool {
+        #[cfg(debug_assertions)]
+        panic!("cannot record via OpenTelemetry API when using extracted span in tracing");
+
+        #[cfg(not(debug_assertions))]
+        false
+    }
+
+    fn set_attribute(&self, _attribute: KeyValue) {
+        #[cfg(debug_assertions)]
+        panic!("OpenTelemetry and tracing APIs cannot be mixed, use `tracing::span!` macro or `span.record()` instead.");
+    }
+
+    fn set_status(&self, _code: otel::StatusCode, _message: String) {
+        #[cfg(debug_assertions)]
+        panic!("OpenTelemetry and tracing APIs cannot be mixed, use `tracing::span!` macro or `span.record()` instead.");
+    }
+
+    fn update_name(&self, _new_name: String) {
+        #[cfg(debug_assertions)]
+        panic!("OpenTelemetry and tracing APIs cannot be mixed, use `span.record()` with `otel.name` instead.");
+    }
+
+    fn end_with_timestamp(&self, _timestamp: SystemTime) {
+        #[cfg(debug_assertions)]
+        panic!("OpenTelemetry and tracing APIs cannot be mixed, span end times are set when the underlying tracing span closes.");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opentelemetry::sdk;
-    use opentelemetry::trace::{SpanBuilder, TracerProvider};
+    use opentelemetry::sdk::trace::{config, Sampler, TracerProvider};
+    use opentelemetry::trace::{SpanBuilder, SpanId, TracerProvider as _, TRACE_FLAG_NOT_SAMPLED};
 
     #[test]
-    fn assigns_default_ids_if_missing() {
-        let provider = sdk::trace::TracerProvider::default();
+    fn assigns_default_trace_id_if_missing() {
+        let provider = TracerProvider::default();
         let tracer = provider.get_tracer("test", None);
         let mut builder = SpanBuilder::from_name("empty".to_string());
+        builder.span_id = Some(SpanId::from_u64(1));
         builder.trace_id = None;
-        builder.span_id = None;
-        let span_context = tracer.sampled_span_context(&mut builder);
+        let cx = tracer.sampled_context(&mut builder);
+        let span_context = cx.span().span_context();
 
         assert!(span_context.is_valid());
+    }
+
+    #[rustfmt::skip]
+    fn sampler_data() -> Vec<(&'static str, Sampler, OtelContext, Option<SamplingResult>, bool)> {
+        vec![
+            // No parent samples
+            ("empty_parent_cx_always_on", Sampler::AlwaysOn, OtelContext::new(), None, true),
+            ("empty_parent_cx_always_off", Sampler::AlwaysOff, OtelContext::new(), None, false),
+
+            // Remote parent samples
+            ("remote_parent_cx_always_on", Sampler::AlwaysOn, OtelContext::new().with_remote_span_context(span_context(TRACE_FLAG_SAMPLED, true)), None, true),
+            ("remote_parent_cx_always_off", Sampler::AlwaysOff, OtelContext::new().with_remote_span_context(span_context(TRACE_FLAG_SAMPLED, true)), None, false),
+            ("sampled_remote_parent_cx_parent_based", Sampler::ParentBased(Box::new(Sampler::AlwaysOff)), OtelContext::new().with_remote_span_context(span_context(TRACE_FLAG_SAMPLED, true)), None, true),
+            ("unsampled_remote_parent_cx_parent_based", Sampler::ParentBased(Box::new(Sampler::AlwaysOn)), OtelContext::new().with_remote_span_context(span_context(TRACE_FLAG_NOT_SAMPLED, true)), None, false),
+
+            // Existing sampling result defers
+            ("previous_drop_result_always_on", Sampler::AlwaysOn, OtelContext::new(), Some(SamplingResult { decision: SamplingDecision::Drop, attributes: vec![], trace_state: Default::default() }), false),
+            ("previous_record_and_sample_result_always_off", Sampler::AlwaysOff, OtelContext::new(), Some(SamplingResult { decision: SamplingDecision::RecordAndSample, attributes: vec![], trace_state: Default::default() }), true),
+            
+            // Existing local parent, defers
+            ("previous_drop_result_always_on", Sampler::AlwaysOn, OtelContext::new(), Some(SamplingResult { decision: SamplingDecision::Drop, attributes: vec![], trace_state: Default::default() }), false),
+            ("previous_record_and_sample_result_always_off", Sampler::AlwaysOff, OtelContext::new(), Some(SamplingResult { decision: SamplingDecision::RecordAndSample, attributes: vec![], trace_state: Default::default() }), true),
+        ]
+    }
+
+    #[test]
+    fn sampled_context() {
+        for (name, sampler, parent_cx, previous_sampling_result, is_sampled) in sampler_data() {
+            let provider = TracerProvider::builder()
+                .with_config(config().with_default_sampler(sampler))
+                .build();
+            let tracer = provider.get_tracer("test", None);
+            let mut builder = SpanBuilder::from_name("parent".to_string());
+            builder.parent_context = Some(parent_cx);
+            builder.sampling_result = previous_sampling_result;
+            let sampled = tracer.sampled_context(&mut builder);
+
+            assert_eq!(
+                sampled.span().span_context().is_sampled(),
+                is_sampled,
+                "{}",
+                name
+            )
+        }
+    }
+
+    fn span_context(trace_flags: u8, is_remote: bool) -> SpanContext {
+        SpanContext::new(
+            TraceId::from_u128(1),
+            SpanId::from_u64(1),
+            trace_flags,
+            is_remote,
+            Default::default(),
+        )
     }
 }

--- a/tracing-opentelemetry/tests/trace_state_propagation.rs
+++ b/tracing-opentelemetry/tests/trace_state_propagation.rs
@@ -1,0 +1,169 @@
+use async_trait::async_trait;
+use opentelemetry::{
+    propagation::TextMapPropagator,
+    sdk::{
+        export::trace::{SpanData, SpanExporter},
+        propagation::{BaggagePropagator, TextMapCompositePropagator, TraceContextPropagator},
+        trace::{Tracer, TracerProvider},
+    },
+    trace::{SpanContext, TraceContextExt, Tracer as _, TracerProvider as _},
+    Context,
+};
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+use tracing::Collect;
+use tracing_opentelemetry::{layer, OpenTelemetrySpanExt};
+use tracing_subscriber::prelude::*;
+
+#[test]
+fn trace_with_active_otel_context() {
+    let (cx, subscriber, exporter, _provider) = build_sampled_context();
+    let attached = cx.attach();
+
+    tracing::collect::with_default(subscriber, || {
+        tracing::debug_span!("child");
+    });
+
+    drop(attached); // end implicit parent
+
+    let spans = exporter.0.lock().unwrap();
+    assert_eq!(spans.len(), 2);
+    assert_shared_attrs_eq(&spans[0].span_context, &spans[1].span_context);
+}
+
+#[test]
+fn trace_with_assigned_otel_context() {
+    let (cx, subscriber, exporter, _provider) = build_sampled_context();
+
+    tracing::collect::with_default(subscriber, || {
+        let child = tracing::debug_span!("child");
+        child.set_parent(cx);
+    });
+
+    let spans = exporter.0.lock().unwrap();
+    assert_eq!(spans.len(), 2);
+    assert_shared_attrs_eq(&spans[0].span_context, &spans[1].span_context);
+}
+
+#[test]
+fn trace_root_with_children() {
+    let (_tracer, _provider, exporter, subscriber) = test_tracer();
+
+    tracing::collect::with_default(subscriber, || {
+        // Propagate trace information through tracing parent -> child
+        let root = tracing::debug_span!("root");
+        root.in_scope(|| tracing::debug_span!("child"));
+    });
+
+    let spans = exporter.0.lock().unwrap();
+    assert_eq!(spans.len(), 2);
+    assert_shared_attrs_eq(&spans[0].span_context, &spans[1].span_context);
+}
+
+#[test]
+fn inject_context_into_outgoing_requests() {
+    let (_tracer, _provider, _exporter, subscriber) = test_tracer();
+    let propagator = test_propagator();
+    let carrier = test_carrier();
+    let cx = propagator.extract(&carrier);
+    let mut outgoing_req_carrier = HashMap::new();
+
+    tracing::collect::with_default(subscriber, || {
+        let root = tracing::debug_span!("root");
+        root.set_parent(cx);
+        let _g = root.enter();
+        let child = tracing::debug_span!("child");
+        propagator.inject_context(&child.context(), &mut outgoing_req_carrier);
+    });
+
+    // Ensure all values that should be passed between services are preserved
+    assert_carrier_attrs_eq(&carrier, &outgoing_req_carrier);
+}
+
+fn assert_shared_attrs_eq(sc_a: &SpanContext, sc_b: &SpanContext) {
+    assert_eq!(sc_a.trace_id(), sc_b.trace_id());
+    assert_eq!(sc_a.trace_state(), sc_b.trace_state());
+}
+
+fn assert_carrier_attrs_eq(
+    carrier_a: &HashMap<String, String>,
+    carrier_b: &HashMap<String, String>,
+) {
+    // Match baggage unordered
+    assert_eq!(
+        carrier_a
+            .get("baggage")
+            .map(|b| b.split_terminator(',').collect::<HashSet<_>>()),
+        carrier_b
+            .get("baggage")
+            .map(|b| b.split_terminator(',').collect())
+    );
+    // match trace parent values, except span id
+    assert_eq!(
+        carrier_a.get("traceparent").unwrap()[0..36],
+        carrier_b.get("traceparent").unwrap()[0..36],
+    );
+    // match tracestate values
+    assert_eq!(carrier_a.get("tracestate"), carrier_b.get("tracestate"));
+}
+
+fn test_tracer() -> (Tracer, TracerProvider, TestExporter, impl Collect) {
+    let exporter = TestExporter::default();
+    let provider = TracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    let tracer = provider.get_tracer("test", None);
+    let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
+
+    (tracer, provider, exporter, subscriber)
+}
+
+fn test_propagator() -> TextMapCompositePropagator {
+    let baggage_propagator = BaggagePropagator::new();
+    let trace_context_propagator = TraceContextPropagator::new();
+
+    TextMapCompositePropagator::new(vec![
+        Box::new(baggage_propagator),
+        Box::new(trace_context_propagator),
+    ])
+}
+
+fn test_carrier() -> HashMap<String, String> {
+    let mut carrier = HashMap::new();
+    carrier.insert(
+        "baggage".to_string(),
+        "key2=value2,key1=value1;property1;property2,key3=value3;propertyKey=propertyValue"
+            .to_string(),
+    );
+    carrier.insert("tracestate".to_string(), "test1=test2".to_string());
+    carrier.insert(
+        "traceparent".to_string(),
+        "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01".to_string(),
+    );
+
+    carrier
+}
+
+fn build_sampled_context() -> (Context, impl Collect, TestExporter, TracerProvider) {
+    let (tracer, provider, exporter, subscriber) = test_tracer();
+    let span = tracer.start("sampled");
+    let cx = Context::current_with_span(span);
+
+    (cx, subscriber, exporter, provider)
+}
+
+#[derive(Clone, Default, Debug)]
+struct TestExporter(Arc<Mutex<Vec<SpanData>>>);
+
+#[async_trait]
+impl SpanExporter for TestExporter {
+    async fn export(
+        &mut self,
+        mut batch: Vec<SpanData>,
+    ) -> opentelemetry::sdk::export::trace::ExportResult {
+        if let Ok(mut inner) = self.0.lock() {
+            inner.append(&mut batch);
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Motivation

Support the latest OpenTelemetry specification

## Solution

In order to support the latest spec, this patch makes the following breaking API changes:

* Update `opentelemetry` to 0.11.x
* Update `OpenTelemetrySpanExt::set_parent` to take a context by value as it is now stored and propagated.
* Rename `PreSampledTracer::sampled_span_context` to `PreSampledTracer::sampled_context` as it now returns a full otel context

Additionally the following doc and example changes:

* Show w3c trace context propagator as recommendation in examples