### PR TITLE
attributes: fix #[instrument(err)] with mutable parameters

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -468,6 +468,7 @@ fn gen_body(
         quote_spanned!(block.span()=>
             let __tracing_attr_span = #span;
             let __tracing_attr_guard = __tracing_attr_span.enter();
+            #[allow(clippy::redundant_closure_call)]
             match (move || #return_type { #block })() {
                 Ok(x) => Ok(x),
                 Err(e) => {

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -469,7 +469,7 @@ fn gen_body(
             let __tracing_attr_span = #span;
             let __tracing_attr_guard = __tracing_attr_span.enter();
             #[allow(clippy::redundant_closure_call)]
-            match (move || #return_type { #block })() {
+            match (move || #return_type #block)() {
                 Ok(x) => Ok(x),
                 Err(e) => {
                     tracing::error!(error = %e);

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -446,6 +446,7 @@ fn gen_body(
                 let __tracing_attr_span = #span;
                 tracing::Instrument::instrument(async move {
                     match async move { #block }.await {
+                        #[allow(clippy::unit_arg)]
                         Ok(x) => Ok(x),
                         Err(e) => {
                             tracing::error!(error = %e);
@@ -468,8 +469,8 @@ fn gen_body(
         quote_spanned!(block.span()=>
             let __tracing_attr_span = #span;
             let __tracing_attr_guard = __tracing_attr_span.enter();
-            #[allow(clippy::redundant_closure_call)]
-            match (move || #return_type #block)() {
+            match move || #return_type #block () {
+                #[allow(clippy::unit_arg)]
                 Ok(x) => Ok(x),
                 Err(e) => {
                     tracing::error!(error = %e);

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -468,8 +468,7 @@ fn gen_body(
         quote_spanned!(block.span()=>
             let __tracing_attr_span = #span;
             let __tracing_attr_guard = __tracing_attr_span.enter();
-            let f = move || #return_type { #block };
-            match f() {
+            match move || #return_type { #block }() {
                 Ok(x) => Ok(x),
                 Err(e) => {
                     tracing::error!(error = %e);

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -468,7 +468,7 @@ fn gen_body(
         quote_spanned!(block.span()=>
             let __tracing_attr_span = #span;
             let __tracing_attr_guard = __tracing_attr_span.enter();
-            match move || #return_type { #block }() {
+            match (move || #return_type { #block })() {
                 Ok(x) => Ok(x),
                 Err(e) => {
                     tracing::error!(error = %e);


### PR DESCRIPTION
## Motivation

The closure generated by `#[instrument(err)]` for non-async functions is
not mutable, preventing any captured variables from being mutated. If a
function has any mutable parameters that are modified within the
function, adding the `#[instrument(err)]` attribute will result in a
compiler error.

## Solution

This change makes it so the closure is executed directly as a temporary
variable instead of storing it in a named variable prior to its use,
avoiding the need to explicitly declare it as mutable altogether or to
add an `#[allow(unused_mut)]` annotation on the closure declaration to
silence lint warnings for closures that do not need to be mutable.