### PR TITLE
core: make clippy happy about ptr comparison

### DIFF
--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -235,7 +235,10 @@ mod inner {
 
 impl PartialEq for Identifier {
     fn eq(&self, other: &Identifier) -> bool {
-        self.0 as *const _ as *const () == other.0 as *const _ as *const ()
+        core::ptr::eq(
+            self.0 as *const _ as *const (),
+            other.0 as *const _ as *const (),
+        )
     }
 }
 


### PR DESCRIPTION
This fixes a clippy lint about address comparisons without `ptr::eq`.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>