### PR TITLE
examples: tracing-macros - updates factorial example to tracing 0.2

### DIFF
--- a/tracing-macros/Cargo.toml
+++ b/tracing-macros/Cargo.toml
@@ -17,10 +17,10 @@ keywords = ["logging", "tracing"]
 license = "MIT"
 
 [dependencies]
-tracing = "0.1.20"
+tracing = { path = "../tracing", version = "0.2", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-tracing-subscriber = "0.2"
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.3" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/tracing-macros/examples/factorial.rs
+++ b/tracing-macros/examples/factorial.rs
@@ -12,7 +12,9 @@ fn factorial(n: u32) -> u32 {
 }
 
 fn main() {
-    let subscriber = tracing_subscriber::fmt().finish();
+    let collector = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .finish();
 
-    tracing::subscriber::with_default(subscriber, || dbg!(factorial(4)));
+    tracing::collect::with_default(collector, || dbg!(factorial(4)));
 }


### PR DESCRIPTION

## Motivation

factorial dbg! example doesn't produce any stdout & is referencing tracing 0.1 crate

## Solution

update to path reference & set fmt max level DEBUG:

```
$ cargo run --example factorial
Jan 10 21:17:47.574 DEBUG factorial: n <= 1 value=false
Jan 10 21:17:47.575 DEBUG factorial: n <= 1 value=false
...
```
