### PR TITLE
examples: backport `fmt-multiple-writers.rs` example to v0.1.0

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -22,6 +22,7 @@ tracing-log = { path = "../tracing-log", version = "0.1.1", features = ["env_log
 tracing-serde = { path = "../tracing-serde" }
 tracing-opentelemetry = { path = "../tracing-opentelemetry" }
 tracing-journald = { path = "../tracing-journald" }
+tracing-appender = { path = "../tracing-appender", version = "0.1.2" }
 
 # serde example
 serde_json = "1.0"

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,8 @@ This directory contains a collection of examples that demonstrate the use of the
     fields on spans and events.
   + `fmt-custom-event`: Demonstrates overriding how the `fmt` subscriber formats
     events.
+  + `fmt-multiple-writers.rs`: demonstrates how `fmt::Layer` can write
+    to multiple destinations (in this instance, stdout and a file) simultaneously.
   + `subscriber-filter`: Demonstrates the `tracing-subscriber::filter` module,
     which provides a layer which adds configurable filtering to a subscriber
     implementation.

--- a/examples/examples/fmt-multiple-writers.rs
+++ b/examples/examples/fmt-multiple-writers.rs
@@ -1,0 +1,32 @@
+//! An example demonstrating how `fmt::Layer` can write to multiple
+//! destinations (in this instance, `stdout` and a file) simultaneously.
+
+#[path = "fmt/yak_shave.rs"]
+mod yak_shave;
+
+use std::io;
+use tempdir::TempDir;
+use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter};
+
+fn main() {
+    let dir = TempDir::new("directory").expect("Failed to create tempdir");
+
+    let file_appender = tracing_appender::rolling::hourly(dir, "example.log");
+    let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
+
+    let subscriber = tracing_subscriber::registry()
+        .with(EnvFilter::from_default_env().add_directive(tracing::Level::TRACE.into()))
+        .with(fmt::Layer::new().with_writer(io::stdout))
+        .with(fmt::Layer::new().with_writer(non_blocking));
+    tracing::subscriber::set_global_default(subscriber).expect("Unable to set a global collector");
+
+    let number_of_yaks = 3;
+    // this creates a new event, outside of any spans.
+    tracing::info!(number_of_yaks, "preparing to shave yaks");
+
+    let number_shaved = yak_shave::shave_all(number_of_yaks);
+    tracing::info!(
+        all_yaks_shaved = number_shaved == number_of_yaks,
+        "yak shaving completed."
+    );
+}


### PR DESCRIPTION
It turns out that this example never existed on v0.1.x, which is my bad.

Resolves https://github.com/tokio-rs/tracing/issues/1179.