### PR TITLE
Add sample implementation of `FormatEvent`

### DIFF
--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -46,7 +46,7 @@ use fmt::{Debug, Display};
 /// This trait is already implemented for function pointers with the same
 /// signature as `format_event`.
 ///
-/// # Example implementation
+/// # Examples
 ///
 /// ```rust
 /// use std::fmt::{self, Write};
@@ -101,7 +101,7 @@ use fmt::{Debug, Display};
 /// }
 /// ```
 ///
-/// That will result in events printed like so:
+/// This formatter will print events like this:
 ///
 /// ```text
 /// DEBUG yak_shaving::shaver: some-span{field-on-span=foo}: started shaving yak

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -86,7 +86,7 @@ use fmt::{Debug, Display};
 ///             // `FormattedFields` is a a formatted representation of the span's
 ///             // fields, which is stored in its extensions by the `fmt` layer's
 ///             // `new_span` method. The fields will have been formatted
-///             // by the same field formatter that's provided to the event 
+///             // by the same field formatter that's provided to the event
 ///             // formatter in the `FmtContext`.
 ///             let fields = &ext
 ///                 .get::<FormattedFields<N>>()

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -82,9 +82,13 @@ use fmt::{Debug, Display};
 ///             write!(writer, "{}", span.name())?;
 ///
 ///             let ext = span.extensions();
+///
+///             // `FormattedFields` is a a formatted representation of the span's
+///             // fields which are stored in its extensions
 ///             let fields = &ext
 ///                 .get::<FormattedFields<N>>()
 ///                 .expect("will never be `None`");
+///
 ///             if !fields.is_empty() {
 ///                 write!(writer, "{{{}}}", fields)?;
 ///             }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -84,7 +84,10 @@ use fmt::{Debug, Display};
 ///             let ext = span.extensions();
 ///
 ///             // `FormattedFields` is a a formatted representation of the span's
-///             // fields which are stored in its extensions
+///             // fields, which is stored in its extensions by the `fmt` layer's
+///             // `new_span` method. The fields will have been formatted
+///             // by the same field formatter that's provided to the event 
+///             // formatter in the `FmtContext`.
 ///             let fields = &ext
 ///                 .get::<FormattedFields<N>>()
 ///                 .expect("will never be `None`");


### PR DESCRIPTION
## Motivation

I recently had to write a custom `FormatEvent` implementation. Most things were straight forward but I struggled with how to print the values of fields on the span. Through the context you can get `SpanRef`s but those don't include field values, only field names. I had to dig around in the code to discover `FormattedFields` which made things easy. I think an example implementation in the docs would be helpful to others.

## Solution

A sample implementation of `FormatEvent` in the docs that prints level, span name and fields, and event.