### PR TITLE
Allow disabling logging feature

### DIFF
--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -67,7 +67,8 @@ async-await = []
 
 alloc = ["tracing-core/alloc"]
 std = ["tracing-core/std", "alloc"]
-log-always = ["log"]
+logging = ["log"]
+log-always = ["logging"]
 attributes = ["tracing-attributes"]
 
 [[bench]]

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -910,7 +910,7 @@
 #[macro_use]
 extern crate cfg_if;
 
-#[cfg(feature = "log")]
+#[cfg(feature = "logging")]
 #[doc(hidden)]
 pub use log;
 
@@ -1049,13 +1049,13 @@ pub mod __macro_support {
         }
 
         #[inline]
-        #[cfg(feature = "log")]
+        #[cfg(feature = "logging")]
         pub fn disabled_span(&self) -> crate::Span {
             crate::Span::new_disabled(self.meta)
         }
 
         #[inline]
-        #[cfg(not(feature = "log"))]
+        #[cfg(not(feature = "logging"))]
         pub fn disabled_span(&self) -> crate::Span {
             crate::Span::none()
         }

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -2149,7 +2149,7 @@ macro_rules! fieldset {
 
 }
 
-#[cfg(feature = "log")]
+#[cfg(feature = "logging")]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! level_to_log {
@@ -2172,14 +2172,14 @@ macro_rules! __tracing_stringify {
     };
 }
 
-#[cfg(not(feature = "log"))]
+#[cfg(not(feature = "logging"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __tracing_log {
     (target: $target:expr, $level:expr, $($field:tt)+ ) => {};
 }
 
-#[cfg(feature = "log")]
+#[cfg(feature = "logging")]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __mk_format_string {
@@ -2227,7 +2227,7 @@ macro_rules! __mk_format_string {
     }
 }
 
-#[cfg(feature = "log")]
+#[cfg(feature = "logging")]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __mk_format_args {
@@ -2294,7 +2294,7 @@ macro_rules! __mk_format_args {
     };
 }
 
-#[cfg(feature = "log")]
+#[cfg(feature = "logging")]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __tracing_log {
@@ -2322,7 +2322,7 @@ macro_rules! __tracing_log {
     };
 }
 
-#[cfg(not(feature = "log"))]
+#[cfg(not(feature = "logging"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! if_log_enabled {
@@ -2337,7 +2337,7 @@ macro_rules! if_log_enabled {
     };
 }
 
-#[cfg(all(feature = "log", not(feature = "log-always")))]
+#[cfg(all(feature = "logging", not(feature = "log-always")))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! if_log_enabled {
@@ -2356,7 +2356,7 @@ macro_rules! if_log_enabled {
     };
 }
 
-#[cfg(all(feature = "log", feature = "log-always"))]
+#[cfg(all(feature = "logging", feature = "log-always"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! if_log_enabled {

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -383,10 +383,10 @@ pub struct Entered<'a> {
 }
 
 /// `log` target for all span lifecycle (creation/enter/exit/close) records.
-#[cfg(feature = "log")]
+#[cfg(feature = "logging")]
 const LIFECYCLE_LOG_TARGET: &str = "tracing::span";
 /// `log` target for span activity (enter/exit) records.
-#[cfg(feature = "log")]
+#[cfg(feature = "logging")]
 const ACTIVITY_LOG_TARGET: &str = "tracing::span::active";
 
 // ===== impl Span =====
@@ -1030,7 +1030,7 @@ impl Span {
         self.meta
     }
 
-    #[cfg(feature = "log")]
+    #[cfg(feature = "logging")]
     #[inline]
     fn log(&self, target: &str, level: log::Level, message: fmt::Arguments<'_>) {
         if let Some(ref meta) = self.meta {
@@ -1259,10 +1259,10 @@ impl<'a> Drop for Entered<'a> {
     }
 }
 
-#[cfg(feature = "log")]
+#[cfg(feature = "logging")]
 struct FmtValues<'a>(&'a Record<'a>);
 
-#[cfg(feature = "log")]
+#[cfg(feature = "logging")]
 impl<'a> fmt::Display for FmtValues<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut res = Ok(());
@@ -1275,10 +1275,10 @@ impl<'a> fmt::Display for FmtValues<'a> {
     }
 }
 
-#[cfg(feature = "log")]
+#[cfg(feature = "logging")]
 struct FmtAttrs<'a>(&'a Attributes<'a>);
 
-#[cfg(feature = "log")]
+#[cfg(feature = "logging")]
 impl<'a> fmt::Display for FmtAttrs<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut res = Ok(());


### PR DESCRIPTION
Logging macro `if_log_enabled` checks both `log` and `always-log` crate features to select which macro version to use. Unfortunately, `log` feature cannot be set by crate consumers in either existing form or if added to `Cargo.toml`, probably because of a name clash with `log` crate:

```diff
$ git diff Cargo.toml
diff --git a/tracing/Cargo.toml b/tracing/Cargo.toml
index 37bb61f..e030d27 100644
--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -63,7 +63,7 @@ release_max_level_trace = []
 async-await = []

 std = ["tracing-core/std"]
+log = ["log"]
 log-always = ["log"]
 attributes = ["tracing-attributes"]
 ```

```
Caused by:
  optional dependency `log` is not included in any feature
  Make sure that `dep:log` is included in one of features in the [features] table.
```

I'm renaming `log` feature to `logging` to work around that.

With the following code:

```rust
let now = std::time::Instant::now();

eprintln!("before span created us = {}", now.elapsed().as_micros());

let span = tracing::span!(tracing::Level::TRACE, "setup");

eprintln!("after span created us = {}", now.elapsed().as_micros());

let entered = span.enter();

eprintln!("after enter us = {}", now.elapsed().as_micros());

drop(entered);

eprintln!("after entered drop us = {}", now.elapsed().as_micros());

drop(span);

eprintln!("after span drop us = {}", now.elapsed().as_micros());
```

Typical timings with logging feature enabled (but not logging anything):

```
before span created us = 0
after span created us = 8
after enter us = 9
after entered drop us = 13
after span drop us = 14
```

Typical timings with logging disabled (this PR):

```
before span created us = 0
after span created us = 1
after enter us = 3
after entered drop us = 5
after span drop us = 6
```