### PR TITLE
tracing: rename the last dispatch -> dispatcher

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -2348,7 +2348,7 @@ macro_rules! if_log_enabled {
         $crate::if_log_enabled! { $if_log else {} }
     };
     ($if_log:block else $else_block:block) => {
-        if !$crate::dispatcher::has_been_set() {
+        if !$crate::dispatch::has_been_set() {
             $if_log
         } else {
             $else_block


### PR DESCRIPTION
It was renamed everywhere in #1015, but until #1190 it wasn't possible to enter this macro branch. Now it fails with the following:

```
   Compiling tracing v0.2.0 (/Users/ivan/projects/tracing/tracing)
error[E0433]: failed to resolve: maybe a missing crate `dispatcher`?
    --> /Users/ivan/projects/tracing/tracing/src/macros.rs:2351:21
     |
2351 |           if !$crate::dispatcher::has_been_set() {
     |                       ^^^^^^^^^^ maybe a missing crate `dispatcher`?
```