### PR TITLE
chore: fix deprecation and clippy warnings

### DIFF
--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -235,7 +235,7 @@ mod inner {
 
 impl PartialEq for Identifier {
     fn eq(&self, other: &Identifier) -> bool {
-        core::ptr::eq(self.0, other.0)
+        core::ptr::eq(self.0 as *const _ as *const (), other.0 as *const _ as *const ())
     }
 }
 

--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -235,7 +235,7 @@ mod inner {
 
 impl PartialEq for Identifier {
     fn eq(&self, other: &Identifier) -> bool {
-        core::ptr::eq(self.0 as *const _, other.0 as *const _)
+        core::ptr::eq(self.0, other.0)
     }
 }
 

--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -235,7 +235,7 @@ mod inner {
 
 impl PartialEq for Identifier {
     fn eq(&self, other: &Identifier) -> bool {
-        std::ptr::eq(self.0 as *const _, other.0 as *const _)
+        core::ptr::eq(self.0 as *const _, other.0 as *const _)
     }
 }
 

--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -235,7 +235,7 @@ mod inner {
 
 impl PartialEq for Identifier {
     fn eq(&self, other: &Identifier) -> bool {
-        self.0 as *const _ as *const () == other.0 as *const _ as *const ()
+        std::ptr::eq(self.0 as *const _, other.0 as *const _)
     }
 }
 

--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -235,7 +235,10 @@ mod inner {
 
 impl PartialEq for Identifier {
     fn eq(&self, other: &Identifier) -> bool {
-        core::ptr::eq(self.0 as *const _ as *const (), other.0 as *const _ as *const ())
+        core::ptr::eq(
+            self.0 as *const _ as *const (),
+            other.0 as *const _ as *const (),
+        )
     }
 }
 

--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -310,12 +310,15 @@ pub fn set_default(dispatcher: &Dispatch) -> DefaultGuard {
 pub fn set_global_default(dispatcher: Dispatch) -> Result<(), SetGlobalDefaultError> {
     // if `compare_exchange` returns Result::Ok(_), then `new` has been set and
     // `current`—now the prior value—has been returned in the `Ok()` branch.
-    if let Ok(_) = GLOBAL_INIT.compare_exchange(
-        UNINITIALIZED,
-        INITIALIZING,
-        Ordering::SeqCst,
-        Ordering::SeqCst,
-    ) {
+    if GLOBAL_INIT
+        .compare_exchange(
+            UNINITIALIZED,
+            INITIALIZING,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        )
+        .is_ok()
+    {
         #[cfg(feature = "alloc")]
         let collector = {
             let collector = match dispatcher.collector {

--- a/tracing/tests/support/collector.rs
+++ b/tracing/tests/support/collector.rs
@@ -536,7 +536,7 @@ impl MockHandle {
 }
 
 impl Expect {
-    fn bad<'a>(&self, name: impl AsRef<str>, what: fmt::Arguments<'a>) {
+    fn bad(&self, name: impl AsRef<str>, what: fmt::Arguments<'_>) {
         let name = name.as_ref();
         match self {
             Expect::Event(e) => panic!("[{}] expected event {}, but {} instead", name, e, what,),


### PR DESCRIPTION
This branch fixes two known warnings.

The first fixed warning was in `tracing-core/src/callsite.rs`, where clippy suggested using `std::ptr::eq` to compare addresses instead of casting `&T` to a `*const T`, which `&T` coerces to _anyways_. Below is the warning:

```
error: use `std::ptr::eq` when comparing raw pointers
   --> tracing-core/src/callsite.rs:238:9
    |
238 |         self.0 as *const _ as *const () == other.0 as *const _ as *const ()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::eq(self.0 as *const _, other.0 as *const _)`
    |
    = note: `-D clippy::ptr-eq` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_eq
```

The second fixed warning is a bit more complex. As of Rust 1.50, [`AtomicUsize::compare_and_swap`](https://doc.rust-lang.org/nightly/std/sync/atomic/struct.AtomicUsize.html#method.compare_and_swap) has been deprecated in favor of [`AtomicUsize::compare_exchange`](https://doc.rust-lang.org/nightly/std/sync/atomic/struct.AtomicUsize.html#method.compare_exchange) and [`AtomicUsize::compare_exchange_weak`](https://doc.rust-lang.org/nightly/std/sync/atomic/struct.AtomicUsize.html#method.compare_exchange_weak). I've moved `tracing_core::dispatch::set_global_default` to use `AtomicUsize::compare_exchange` as `AtomicUsize::compare_exchange_weak` is designed for atomic loads in loops. Here are a few notes on the differences between `AtomicUsize::compare_and_swap` and `AtomicUsize::compare_exchange`:
- `AtomicUsize::compare_exchange` returns a result, where the `Result::Ok(_)` branch contains the prior value. This is equivalent to the now-deprecated [`AtomicUsize::compare_and_swap`](https://doc.rust-lang.org/nightly/std/sync/atomic/struct.AtomicUsize.html#method.compare_and_swap) returning the `current` parameter upon a successful compare-and-swap operation, but success is now established through a `Result`, not an equality operation.
- `AtomicUsize::compare_exchange` accepts an `Ordering` for the failure case of a compare-and-swap. The [migration guide suggests](https://doc.rust-lang.org/nightly/std/sync/atomic/struct.AtomicUsize.html#migrating-to-compare_exchange-and-compare_exchange_weak) using `Ordering::SeqCst` for both the success and failure cases and I saw no reason to depart from its guidance.

After this branch is approved, I'll backport these fixes to the `v0.1.0` branch.