### PR TITLE
opentelemetry: update to otel v0.12.x

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -53,5 +53,5 @@ inferno = "0.10.0"
 tempdir = "0.3.7"
 
 # opentelemetry example
-opentelemetry = { version = "0.11", default-features = false, features = ["trace"] }
-opentelemetry-jaeger = "0.10"
+opentelemetry = { version = "0.12", default-features = false, features = ["trace"] }
+opentelemetry-jaeger = "0.11"

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2018"
 default = ["tracing-log"]
 
 [dependencies]
-opentelemetry = { version = "0.11", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.12", default-features = false, features = ["trace"] }
 tracing = { path = "../tracing", version = "0.2", default-features = false, features = ["std"] }
 tracing-core = { path = "../tracing-core", version = "0.2" }
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry"] }
@@ -30,4 +30,4 @@ tracing-log = { path = "../tracing-log", version = "0.2", default-features = fal
 
 [dev-dependencies]
 async-trait = "0.1"
-opentelemetry-jaeger = "0.10"
+opentelemetry-jaeger = "0.11"


### PR DESCRIPTION
No additional changes needed to support the latest release, the changes on the otel side can be seen in [the changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/master/opentelemetry/CHANGELOG.md#v0120).