### PR TITLE
opentelemetry: Backport update to otel v0.12.x (#1200)

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -53,5 +53,5 @@ inferno = "0.10.0"
 tempdir = "0.3.7"
 
 # opentelemetry example
-opentelemetry = { version = "0.11", default-features = false, features = ["trace"] }
-opentelemetry-jaeger = "0.10"
+opentelemetry = { version = "0.12", default-features = false, features = ["trace"] }
+opentelemetry-jaeger = "0.11"

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2018"
 default = ["tracing-log"]
 
 [dependencies]
-opentelemetry = { version = "0.11", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.12", default-features = false, features = ["trace"] }
 tracing = { path = "../tracing", version = "0.1" }
 tracing-core = { path = "../tracing-core", version = "0.1" }
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.2", default-features = false, features = ["registry"] }
@@ -30,4 +30,4 @@ tracing-log = { path = "../tracing-log", version = "0.1", default-features = fal
 
 [dev-dependencies]
 async-trait = "0.1"
-opentelemetry-jaeger = "0.10"
+opentelemetry-jaeger = "0.11"


### PR DESCRIPTION
Backport #1200 into `v0.1.x`