### PR TITLE
chore: backport "fix deprecation and clippy warnings"

### DIFF
--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -149,7 +149,10 @@ pub(crate) fn register_dispatch(dispatch: &Dispatch) {
 
 impl PartialEq for Identifier {
     fn eq(&self, other: &Identifier) -> bool {
-        self.0 as *const _ as *const () == other.0 as *const _ as *const ()
+        core::ptr::eq(
+            self.0 as *const _ as *const (),
+            other.0 as *const _ as *const (),
+        )
     }
 }
 

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -280,7 +280,16 @@ pub fn set_default(dispatcher: &Dispatch) -> DefaultGuard {
 /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
 /// [`Event`]: ../event/struct.Event.html
 pub fn set_global_default(dispatcher: Dispatch) -> Result<(), SetGlobalDefaultError> {
-    if GLOBAL_INIT.compare_and_swap(UNINITIALIZED, INITIALIZING, Ordering::SeqCst) == UNINITIALIZED
+    // if `compare_exchange` returns Result::Ok(_), then `new` has been set and
+    // `current`—now the prior value—has been returned in the `Ok()` branch.
+    if GLOBAL_INIT
+        .compare_exchange(
+            UNINITIALIZED,
+            INITIALIZING,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        )
+        .is_ok()
     {
         unsafe {
             GLOBAL_DISPATCH = Some(dispatcher);

--- a/tracing/tests/support/subscriber.rs
+++ b/tracing/tests/support/subscriber.rs
@@ -536,7 +536,7 @@ impl MockHandle {
 }
 
 impl Expect {
-    fn bad<'a>(&self, name: impl AsRef<str>, what: fmt::Arguments<'a>) {
+    fn bad(&self, name: impl AsRef<str>, what: fmt::Arguments<'_>) {
         let name = name.as_ref();
         match self {
             Expect::Event(e) => panic!("[{}] expected event {}, but {} instead", name, e, what,),


### PR DESCRIPTION
Backports #1195 to v0.1.x; unblocks #1205 and #1207.