### PR TITLE
examples: update Tokio to 1.0

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -28,7 +28,8 @@ tracing-journald = { path = "../tracing-journald" }
 serde_json = "1.0"
 
 futures = "0.3"
-tokio = { version = "0.2.12", features = ["full"] }
+tokio = { version = "1.1", features = ["full"] }
+tokio-stream = "0.1"
 
 # env-logger example
 env_logger = "0.8"
@@ -38,9 +39,9 @@ tower = "0.3"
 tower-util = "0.3.1"
 tower-make = "0.3"
 http = "0.2"
-hyper = "0.13.2"
+hyper = { version = "0.14", features = ["full"] }
 rand = "0.7"
-bytes = "0.5"
+bytes = "1"
 clap = "2.33"
 
 # sloggish example

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -35,9 +35,7 @@ tokio-stream = "0.1"
 env_logger = "0.8"
 
 # tower examples
-tower = "0.3"
-tower-util = "0.3.1"
-tower-make = "0.3"
+tower = { version = "0.4.4", features = ["full"] }
 http = "0.2"
 hyper = { version = "0.14", features = ["full"] }
 rand = "0.7"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -29,7 +29,6 @@ serde_json = "1.0"
 
 futures = "0.3"
 tokio = { version = "1.1", features = ["full"] }
-tokio-stream = "0.1"
 
 # env-logger example
 env_logger = "0.8"

--- a/examples/examples/echo.rs
+++ b/examples/examples/echo.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Next up we create a TCP listener which will listen for incoming
     // connections. This TCP listener is bound to the address we determined
     // above and must be associated with an event loop.
-    let mut listener = TcpListener::bind(&addr).await?;
+    let listener = TcpListener::bind(&addr).await?;
     // Use `fmt::Debug` impl for `addr` using the `%` symbol
     info!(message = "Listening on", %addr);
 

--- a/examples/examples/futures-proxy-server.rs
+++ b/examples/examples/futures-proxy-server.rs
@@ -116,7 +116,7 @@ async fn main() -> Result<(), Error> {
     let server_addr = matches.value_of("server_addr").unwrap_or("127.0.0.1:3000");
     let server_addr = server_addr.parse::<SocketAddr>()?;
 
-    let mut listener = TcpListener::bind(&listen_addr).await?;
+    let listener = TcpListener::bind(&listen_addr).await?;
 
     info!("Listening on: {}", listen_addr);
     info!("Proxying to: {}", server_addr);

--- a/examples/examples/tower-load.rs
+++ b/examples/examples/tower-load.rs
@@ -309,9 +309,9 @@ async fn load_gen(addr: SocketAddr) -> Result<(), Err> {
         .timeout(Duration::from_millis(200))
         .service(Client::new());
     let interval = tokio::time::interval(Duration::from_millis(50));
-    let mut interval = tokio_stream::wrappers::IntervalStream::new(interval);
 
-    while interval.next().await.is_some() {
+    loop {
+        interval.tick().await;
         let authority = format!("{}", addr);
         let mut svc = svc.clone().ready_oneshot().await?;
 

--- a/examples/examples/tower-load.rs
+++ b/examples/examples/tower-load.rs
@@ -26,7 +26,6 @@
 use bytes::Bytes;
 use futures::{
     future::{self, Ready},
-    stream::StreamExt,
     Future,
 };
 use http::{header, Method, Request, Response, StatusCode};
@@ -308,7 +307,7 @@ async fn load_gen(addr: SocketAddr) -> Result<(), Err> {
         .layer(request_span::layer(req_span))
         .timeout(Duration::from_millis(200))
         .service(Client::new());
-    let interval = tokio::time::interval(Duration::from_millis(50));
+    let mut interval = tokio::time::interval(Duration::from_millis(50));
 
     loop {
         interval.tick().await;
@@ -363,8 +362,6 @@ async fn load_gen(addr: SocketAddr) -> Result<(), Err> {
         .instrument(span!(target: "gen", Level::INFO, "generated_request", remote.addr=%addr));
         tokio::spawn(f);
     }
-
-    Ok(())
 }
 
 fn req_span<A>(req: &Request<A>) -> Span {


### PR DESCRIPTION
Not sure that there's a issue tracking this, but anyways. Here's an
update to Tokio 1.0!

This closes the various Dependabot dependency update PRs that we can't
just merge due to breaking changes.

Closes #1149
Closes #1164
Closes #1177