### PR TITLE
chore: big pile of backports

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ are not maintained by the `tokio` project. These include:
 - [`diesel-tracing`] provides integration with [`diesel`] database connections.
 - [`tracing-tracy`] provides a way to collect [Tracy] profiles in instrumented
   applications.
+- [`tracing-elastic-apm`] provides a layer for reporting traces to [Elastic APM].
 
 (if you're the maintainer of a `tracing` ecosystem crate not in this list,
 please let us know!)
@@ -426,6 +427,8 @@ please let us know!)
 [`diesel-tracing`]: https://crates.io/crates/diesel-tracing
 [`tracing-tracy`]: https://crates.io/crates/tracing-tracy
 [Tracy]: https://github.com/wolfpld/tracy
+[`tracing-elastic-apm`]: https://crates.io/crates/tracing-elastic-apm
+[Elastic APM]: https://www.elastic.co/apm
 
 **Note:** that some of the ecosystem crates are currently unreleased and
 undergoing active development. They may be less stable than `tracing` and

--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -39,7 +39,7 @@ traced-error = []
 
 [dependencies]
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.7", default-features = false, features = ["registry", "fmt"] }
-tracing = { path = "../tracing", version = "0.1.12"}
+tracing = { path = "../tracing", version = "0.1.12", default-features = false, features = ["std"] }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/tracing-flame/Cargo.toml
+++ b/tracing-flame/Cargo.toml
@@ -26,7 +26,7 @@ smallvec = ["tracing-subscriber/smallvec"]
 
 [dependencies]
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.2.3", default-features = false, features = ["registry", "fmt"] }
-tracing = { path = "../tracing", version = "0.1.12"}
+tracing = { path = "../tracing", version = "0.1.12", default-features = false, features = ["std"] }
 lazy_static = "1.3.0"
 
 [dev-dependencies]

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -28,7 +28,7 @@ std = ["tracing/std"]
 futures_01 = { package = "futures", version = "0.1", optional = true }
 futures = { version = "0.3.0", optional = true }
 futures-task = { version = "0.3", optional = true }
-pin-project = { version = "0.4", optional = true }
+pin-project = { version = "1.0", optional = true }
 tracing = { path = "../tracing", version = "0.1", default-features = false }
 tokio-executor = { version = "0.1", optional = true }
 tokio = { version = "0.1", optional = true }

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -23,7 +23,7 @@ default = ["tracing-log"]
 
 [dependencies]
 opentelemetry = { version = "0.12", default-features = false, features = ["trace"] }
-tracing = { path = "../tracing", version = "0.1" }
+tracing = { path = "../tracing", version = "0.1", default-features = false, features = ["std"] }
 tracing-core = { path = "../tracing-core", version = "0.1" }
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.2", default-features = false, features = ["registry"] }
 tracing-log = { path = "../tracing-log", version = "0.1", default-features = false, optional = true }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -34,7 +34,7 @@ json = ["tracing-serde", "serde", "serde_json"]
 tracing-core = { path = "../tracing-core", version = "0.1.17" }
 
 # only required by the filter feature
-tracing = { optional = true, path = "../tracing", version = "0.1" }
+tracing = { optional = true, path = "../tracing", version = "0.1", default-features = false, features = ["std"] }
 matchers = { optional = true, version = "0.0.1" }
 regex = { optional = true, version = "1", default-features = false, features = ["std"] }
 smallvec = { optional = true, version = "1" }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -45,6 +45,74 @@ use fmt::{Debug, Display};
 /// This trait is already implemented for function pointers with the same
 /// signature as `format_event`.
 ///
+/// # Examples
+///
+/// ```rust
+/// use std::fmt::{self, Write};
+/// use tracing_core::{Subscriber, Event};
+/// use tracing_subscriber::fmt::{FormatEvent, FormatFields, FmtContext, FormattedFields};
+/// use tracing_subscriber::registry::LookupSpan;
+///
+/// struct MyFormatter;
+///
+/// impl<S, N> FormatEvent<S, N> for MyFormatter
+/// where
+///     S: Subscriber + for<'a> LookupSpan<'a>,
+///     N: for<'a> FormatFields<'a> + 'static,
+/// {
+///     fn format_event(
+///         &self,
+///         ctx: &FmtContext<'_, S, N>,
+///         writer: &mut dyn fmt::Write,
+///         event: &Event<'_>,
+///     ) -> fmt::Result {
+///         // Write level and target
+///         let level = *event.metadata().level();
+///         let target = event.metadata().target();
+///         write!(
+///             writer,
+///             "{} {}: ",
+///             level,
+///             target,
+///         )?;
+///
+///         // Write spans and fields of each span
+///         ctx.visit_spans(|span| {
+///             write!(writer, "{}", span.name())?;
+///
+///             let ext = span.extensions();
+///
+///             // `FormattedFields` is a a formatted representation of the span's
+///             // fields, which is stored in its extensions by the `fmt` layer's
+///             // `new_span` method. The fields will have been formatted
+///             // by the same field formatter that's provided to the event
+///             // formatter in the `FmtContext`.
+///             let fields = &ext
+///                 .get::<FormattedFields<N>>()
+///                 .expect("will never be `None`");
+///
+///             if !fields.is_empty() {
+///                 write!(writer, "{{{}}}", fields)?;
+///             }
+///             write!(writer, ": ")?;
+///
+///             Ok(())
+///         })?;
+///
+///         // Write fields on the event
+///         ctx.field_format().format_fields(writer, event)?;
+///
+///         writeln!(writer)
+///     }
+/// }
+/// ```
+///
+/// This formatter will print events like this:
+///
+/// ```text
+/// DEBUG yak_shaving::shaver: some-span{field-on-span=foo}: started shaving yak
+/// ```
+///
 /// [`fmt::Subscriber`]: ../struct.Subscriber.html
 /// [`fmt::Layer`]: ../struct.Layer.html
 pub trait FormatEvent<S, N>

--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -30,7 +30,7 @@ futures = "0.3"
 tower-service = "0.3"
 tower-layer = { version = "0.3", optional = true }
 tower_make = { package = "tower-make", version = "0.3", optional = true }
-pin-project = { version = "0.4", optional = true }
+pin-project = { version = "1.0", optional = true }
 http = { version = "0.2", optional = true }
 
 [badges]

--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -24,7 +24,7 @@ tower-make = [
 ]
 
 [dependencies]
-tracing = { path = "../tracing", version = "0.1"}
+tracing = { path = "../tracing", version = "0.1", default-features = false, features = ["std"] }
 tracing-futures = { version = "0.2.1", path = "../tracing-futures", features = ["std-future"] }
 futures = "0.3"
 tower-service = "0.3"

--- a/tracing/src/level_filters.rs
+++ b/tracing/src/level_filters.rs
@@ -33,10 +33,23 @@
 //! [dependencies]
 //! tracing = { version = "0.1", features = ["max_level_debug", "release_max_level_warn"] }
 //! ```
+//! ## Notes
 //!
-//! *Compiler support: requires rustc 1.39+*
+//! Please note that `tracing`'s static max level features do *not* control the
+//! [`log`] records that may be emitted when [`tracing`'s "log" feature flag][f] is
+//! enabled. This is to allow `tracing` to be disabled entirely at compile time
+//! while still emitting `log` records --- such as when a library using
+//! `tracing` is used by an application using `log` that doesn't want to
+//! generate any `tracing`-related code, but does want to collect `log` records.
 //!
-//! [`log` crate]: https://docs.rs/log/0.4.6/log/#compile-time-filters
+//! This means that if the "log" feature is in use, some code may be generated
+//! for `log` records emitted by disabled `tracing` events. If this is not
+//! desirable, `log` records may be disabled separately using [`log`'s static
+//! max level features][`log` crate].
+//!
+//! [`log`]: https://docs.rs/log/
+//! [`log` crate]: https://docs.rs/log/latest/log/#compile-time-filters
+//! [f]: : https://docs.rs/tracing/latest/tracing/#emitting-log-records
 pub use tracing_core::{metadata::ParseLevelFilterError, LevelFilter};
 
 /// The statically configured maximum trace level.

--- a/tracing/src/level_filters.rs
+++ b/tracing/src/level_filters.rs
@@ -49,7 +49,7 @@
 //!
 //! [`log`]: https://docs.rs/log/
 //! [`log` crate]: https://docs.rs/log/latest/log/#compile-time-filters
-//! [f]: : https://docs.rs/tracing/latest/tracing/#emitting-log-records
+//! [f]: https://docs.rs/tracing/latest/tracing/#emitting-log-records
 pub use tracing_core::{metadata::ParseLevelFilterError, LevelFilter};
 
 /// The statically configured maximum trace level.

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -722,6 +722,7 @@
 //!  - [`diesel-tracing`] provides integration with [`diesel`] database connections.
 //!  - [`tracing-tracy`] provides a way to collect [Tracy] profiles in instrumented
 //!    applications.
+//!  - [`tracing-elastic-apm`] provides a layer for reporting traces to [Elastic APM].
 //!
 //! If you're the maintainer of a `tracing` ecosystem crate not listed above,
 //! please let us know! We'd love to add your project to the list!
@@ -747,6 +748,8 @@
 //! [`diesel-tracing`]: https://crates.io/crates/diesel-tracing
 //! [`tracing-tracy`]: https://crates.io/crates/tracing-tracy
 //! [Tracy]: https://github.com/wolfpld/tracy
+//! [`tracing-elastic-apm`]: https://crates.io/crates/tracing-elastic-apm
+//! [Elastic APM]: https://www.elastic.co/apm
 //!
 //! <div class="information">
 //!     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -45,7 +45,7 @@ macro_rules! span {
                 )
             } else {
                 let span = CALLSITE.disabled_span();
-                $crate::if_log_enabled! {{
+                $crate::if_log_enabled! { $lvl, {
                     span.record_all(&$crate::valueset!(CALLSITE.metadata().fields(), $($fields)*));
                 }};
                 span
@@ -75,7 +75,7 @@ macro_rules! span {
                 )
             } else {
                 let span = CALLSITE.disabled_span();
-                $crate::if_log_enabled! {{
+                $crate::if_log_enabled! { $lvl, {
                     span.record_all(&$crate::valueset!(CALLSITE.metadata().fields(), $($fields)*));
                 }};
                 span
@@ -2295,10 +2295,10 @@ macro_rules! __mk_format_args {
 #[macro_export]
 macro_rules! __tracing_log {
     (target: $target:expr, $level:expr, $($field:tt)+ ) => {
-        $crate::if_log_enabled! {{
+        $crate::if_log_enabled! { $level, {
             use $crate::log;
             let level = $crate::level_to_log!($level);
-            if level <= log::STATIC_MAX_LEVEL && level <= log::max_level() {
+            if level <= log::max_level() {
                 let log_meta = log::Metadata::builder()
                     .level(level)
                     .target($target)
@@ -2322,13 +2322,13 @@ macro_rules! __tracing_log {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! if_log_enabled {
-    ($e:expr;) => {
-        $crate::if_log_enabled! { $e }
+    ($lvl:expr, $e:expr;) => {
+        $crate::if_log_enabled! { $lvl, $e }
     };
-    ($if_log:block) => {
-        $crate::if_log_enabled! { $if_log else {} }
+    ($lvl:expr, $if_log:block) => {
+        $crate::if_log_enabled! { $lvl, $if_log else {} }
     };
-    ($if_log:block else $else_block:block) => {
+    ($lvl:expr, $if_log:block else $else_block:block) => {
         $else_block
     };
 }
@@ -2337,15 +2337,19 @@ macro_rules! if_log_enabled {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! if_log_enabled {
-    ($e:expr;) => {
-        $crate::if_log_enabled! { $e }
+    ($lvl:expr, $e:expr;) => {
+        $crate::if_log_enabled! { $lvl, $e }
     };
-    ($if_log:block) => {
-        $crate::if_log_enabled! { $if_log else {} }
+    ($lvl:expr, $if_log:block) => {
+        $crate::if_log_enabled! { $lvl, $if_log else {} }
     };
-    ($if_log:block else $else_block:block) => {
-        if !$crate::dispatcher::has_been_set() {
-            $if_log
+    ($lvl:expr, $if_log:block else $else_block:block) => {
+        if $crate::level_to_log!($lvl) <= $crate::log::STATIC_MAX_LEVEL {
+            if !$crate::dispatcher::has_been_set() {
+                $if_log
+            } else {
+                $else_block
+            }
         } else {
             $else_block
         }
@@ -2356,14 +2360,18 @@ macro_rules! if_log_enabled {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! if_log_enabled {
-    ($e:expr;) => {
-        $crate::if_log_enabled! { $e }
+    ($lvl:expr, $e:expr;) => {
+        $crate::if_log_enabled! { $lvl, $e }
     };
-    ($if_log:block) => {
-        $crate::if_log_enabled! { $if_log else {} }
+    ($lvl:expr, $if_log:block) => {
+        $crate::if_log_enabled! { $lvl, $if_log else {} }
     };
-    ($if_log:block else $else_block:block) => {
-        #[allow(unused_braces)]
-        $if_log
+    ($lvl:expr, $if_log:block else $else_block:block) => {
+        if $crate::level_to_log!($lvl) <= $crate::log::STATIC_MAX_LEVEL {
+            #[allow(unused_braces)]
+            $if_log
+        } else {
+            $else_block
+        }
     };
 }

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -544,7 +544,7 @@ impl Span {
             meta: Some(meta),
         };
 
-        if_log_enabled! {{
+        if_log_enabled! { *meta.level(), {
             let target = if attrs.is_empty() {
                 LIFECYCLE_LOG_TARGET
             } else {
@@ -555,6 +555,7 @@ impl Span {
 
         span
     }
+
     /// Enters this span, returning a guard that will exit the span when dropped.
     ///
     /// If this span is enabled by the current subscriber, then this function will
@@ -749,7 +750,7 @@ impl Span {
             inner.subscriber.enter(&inner.id);
         }
 
-        if_log_enabled! {{
+        if_log_enabled! { crate::Level::TRACE, {
             if let Some(ref meta) = self.meta {
                 self.log(ACTIVITY_LOG_TARGET, log::Level::Trace, format_args!("-> {}", meta.name()));
             }
@@ -916,16 +917,16 @@ impl Span {
             inner.record(&record);
         }
 
-        if_log_enabled! {{
-            if let Some(ref meta) = self.meta {
+        if let Some(ref _meta) = self.meta {
+            if_log_enabled! { *_meta.level(), {
                 let target = if record.is_empty() {
                     LIFECYCLE_LOG_TARGET
                 } else {
-                    meta.target()
+                    _meta.target()
                 };
-                self.log(target, level_to_log!(*meta.level()), format_args!("{}{}", meta.name(), FmtValues(&record)));
-            }
-        }}
+                self.log(target, level_to_log!(*_meta.level()), format_args!("{}{}", _meta.name(), FmtValues(&record)));
+            }}
+        }
 
         self
     }
@@ -1146,15 +1147,15 @@ impl Drop for Span {
             subscriber.try_close(id.clone());
         }
 
-        if_log_enabled!({
-            if let Some(ref meta) = self.meta {
+        if let Some(ref _meta) = self.meta {
+            if_log_enabled! { crate::Level::TRACE, {
                 self.log(
                     LIFECYCLE_LOG_TARGET,
                     log::Level::Trace,
-                    format_args!("-- {}", meta.name()),
+                    format_args!("-- {}", _meta.name()),
                 );
-            }
-        })
+            }}
+        }
     }
 }
 
@@ -1231,11 +1232,11 @@ impl<'a> Drop for Entered<'a> {
             inner.subscriber.exit(&inner.id);
         }
 
-        if_log_enabled! {{
-            if let Some(ref meta) = self.span.meta {
-                self.span.log(ACTIVITY_LOG_TARGET, log::Level::Trace, format_args!("<- {}", meta.name()));
-            }
-        }}
+        if let Some(ref _meta) = self.span.meta {
+            if_log_enabled! { crate::Level::TRACE, {
+                self.span.log(ACTIVITY_LOG_TARGET, log::Level::Trace, format_args!("<- {}", _meta.name()));
+            }}
+        }
     }
 }
 


### PR DESCRIPTION
This backports several changes from `master` to `v0.1.x`:

* 3b020ea2 chore(deps): update pin-project requirement from 0.4 to 1.0 (#1038)
* a0e9275a Add sample implementation of `FormatEvent` (#1189)
* e038d561 tracing: check `log` max level prior to dispatch check (#1175)
* ab631219 docs: add tracing-elastic-apm to related crates (#1146)
* cd7561e3 chore: disable default features of tracing dependencies (#1144)

Since these have all been approved on master, I'm going to just go ahead
and merge this when CI passes.