### PR TITLE
attributes: update & improve docs

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -183,7 +183,7 @@ use syn::{
 /// # use tracing_attributes::instrument;
 /// #[derive(Debug)]
 /// struct MyType {
-///    data: [u8; 4096]
+///    data: Vec<u8>, // Suppose this buffer is often quite long...
 /// }
 ///
 /// impl MyType {
@@ -262,7 +262,7 @@ use syn::{
 /// #[derive(Debug)]
 /// struct MyType {
 ///    name: &'static str,
-///    data: [u8; 4096]
+///    data: Vec<u8>,
 /// }
 ///
 /// impl MyType {

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -128,7 +128,7 @@ use syn::{
 ///
 /// ```
 /// pub mod my_module {
-///     # use tracing_attributes::Instrument;
+///     # use tracing_attributes::instrument;
 ///     // The generated span's target will be "my_crate::some_special_target",
 ///     // rather than "my_crate::my_module".
 ///     #[instrument(target = "my_crate::some_special_target")]
@@ -214,7 +214,7 @@ use syn::{
 /// Adding a new field based on the value of an argument:
 ///
 /// ```
-/// # use tracing::instrument;
+/// # use tracing_attributes::instrument;
 ///
 /// // This will record a field named "i" with the value of `i` *and* a field
 /// // named "next" with the value of `i` + 1.
@@ -229,13 +229,19 @@ use syn::{
 /// ```
 /// # mod http {
 /// #   pub struct Error;
-/// #   pub struct Response<B> { _b: std::marker::PhantomData<B> }
+/// #   pub struct Response<B> { pub(super) _b: std::marker::PhantomData<B> }
 /// #   pub struct Request<B> { _b: B }
-/// #   impl Request<B> {
+/// #   impl<B> std::fmt::Debug for Request<B> {
+/// #       fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+/// #           f.pad("request")
+/// #       }
+/// #   }
+/// #   impl<B> Request<B> {
 /// #       pub fn uri(&self) -> &str { "fake" }
 /// #       pub fn method(&self) -> &str { "GET" }
 /// #   }
 /// # }
+/// # use tracing_attributes::instrument;
 ///
 /// // This will record the request's URI and HTTP method as their own separate
 /// // fields.
@@ -286,8 +292,9 @@ use syn::{
 ///
 ///     // Now, the result will also be included on this event!
 ///     tracing::info!("calculation complete!");
-///     
+///
 ///     // ... etc ...
+///     # 0
 /// }
 /// ```
 ///

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -100,22 +100,22 @@ use syn::{
 /// Instruments a function to create and enter a `tracing` [span] every time
 /// the function is called.
 ///
-/// Unless overriden, a span with `info` level will be generated.
-/// The generated span's name will be the name of the function. Any arguments
-/// to that function will be recorded as fields using [`fmt::Debug`]. To skip
-/// recording a function's or method's argument, pass the argument's name
-/// to the `skip` argument on the `#[instrument]` macro. For example,
-/// `skip` can be used when an argument to an instrumented function does
-/// not implement [`fmt::Debug`], or to exclude an argument with a verbose
+/// By default, the generated span's name will be the name of the function, and
+/// the span's level will be [`INFO`], although these properties can be
+/// overridden. Any arguments to that function will be recorded as fields using
+/// [`fmt::Debug`]. To skip recording a function's or method's argument, pass
+/// the argument's name to the `skip` argument on the `#[instrument]` macro. For
+/// example, `skip` can be used when an argument to an instrumented function
+/// does not implement [`fmt::Debug`], or to exclude an argument with a verbose
 /// or costly Debug implementation. Note that:
 /// - multiple argument names can be passed to `skip`.
 /// - arguments passed to `skip` do _not_ need to implement `fmt::Debug`.
 ///
-/// You can also pass additional fields (key-value pairs with arbitrary data)
-/// to the generated span. This is achieved using the `fields` argument on the
-/// `#[instrument]` macro. You can use a string, integer or boolean literal as
-/// a value for each field. The name of the field must be a single valid Rust
-/// identifier, nested (dotted) field names are not supported.
+/// Additional fields (key-value pairs with arbitrary data) may be added to the
+/// generated span using the `fields` argument on the `#[instrument]` macro. Any
+/// Rust expression can be used as a field value in this manner. These
+/// expressions will be evaluated at the beginning of the function's body, sso
+/// arguments to the function may be used in these expressions.
 ///
 /// Note that overlap between the names of fields and (non-skipped) arguments
 /// will result in a compile error.
@@ -251,6 +251,7 @@ use syn::{
 /// which you implement the trait: `#[instrument(fields(tmp = std::any::type_name::<Bar>()))]`.
 ///
 /// [span]: https://docs.rs/tracing/latest/tracing/span/index.html
+/// [`INFO`]: https://docs.rs/tracing/latest/tracing//struct.Level.html#associatedconstant.INFO
 /// [`tracing`]: https://github.com/tokio-rs/tracing
 /// [`fmt::Debug`]: https://doc.rust-lang.org/std/fmt/trait.Debug.html
 #[proc_macro_attribute]


### PR DESCRIPTION
The `tracing-attributes` documentation for `instrument` is out of date
and could use some improvement. In particular, it doesn't mention that
empty fields can be created in `instrument`'s `fields` argument, and
states that dotted fields are forbidden and that field values must be
literals, both of which are no longer the case. See also #1210 and
#1211.

This branch updates the docs to correct the false statements, and also
fleshes out the usage examples a bit.

I wasn't sure what to do with the old examples --- some of them are now
redundant, but it's also useful to have a big list of examples for every
allowed form. Any thoughts?