### PR TITLE
chore: backport #1173

### DIFF
--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -21,7 +21,7 @@ edition = "2018"
 
 [dependencies]
 crossbeam-channel = "0.5.0"
-chrono = "0.4.11"
+chrono = { version = "0.4.16", default-features = false, features = ["clock", "std"] }
 
 [dependencies.tracing-subscriber]
 path = "../tracing-subscriber"

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -43,7 +43,7 @@ lazy_static = { optional = true, version = "1" }
 # fmt
 tracing-log = { path = "../tracing-log", version = "0.1", optional = true, default-features = false, features = ["log-tracer", "std"] }
 ansi_term = { version = "0.12", optional = true }
-chrono = { version = "0.4", optional = true }
+chrono = { version = "0.4.16", optional = true, default-features = false, features = ["clock", "std"] }
 
 # only required by the json feature
 serde_json = { version = "1.0", optional = true }


### PR DESCRIPTION
- this allows dropping the old time 0.1 dependency (see https://github.com/chronotope/chrono/blob/main/CHANGELOG.md#0416)

Co-authored-by: Eliza Weisman <eliza@buoyant.io>