### PR TITLE
attributes: prepare to release v0.1.12

### DIFF
--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,3 +1,28 @@
+# 0.1.12 (February 4, 2021)
+
+### Fixed
+
+- Compiler error when using `#[instrument(err)]` on functions with mutable
+  parameters ([#1167])
+- Missing function visibility modifier when using `#[instrument]` with
+  `async-trait` ([#977])
+- Multiple documentation fixes and improvements ([#965], [#981], [#1215])
+
+### Changed
+
+- `tracing-futures` dependency is no longer required when using `#[instrument]`
+  on async functions ([#808])
+
+Thanks to @nagisa, @Txuritan, @TaKO8Ki, and @okready for contributing to this
+release!
+
+[#1167]: https://github.com/tokio-rs/tracing/pull/1167
+[#977]: https://github.com/tokio-rs/tracing/pull/977
+[#965]: https://github.com/tokio-rs/tracing/pull/965
+[#981]: https://github.com/tokio-rs/tracing/pull/981
+[#1215]: https://github.com/tokio-rs/tracing/pull/1215
+[#808]: https://github.com/tokio-rs/tracing/pull/808
+
 # 0.1.11 (August 18, 2020)
 
 ### Fixed
@@ -5,7 +30,7 @@
 - Corrected wrong minimum supported Rust version note in docs (#941)
 - Removed unused `syn` features (#928)
 
-Thanks to new contributor @jhpratt for contributing to this release!`
+Thanks to new contributor @jhpratt for contributing to this release!
 
 # 0.1.10 (August 10, 2020)
 

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-attributes"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.11"
+version = "0.1.12"
 authors = [
     "Tokio Contributors <team@tokio.rs>",
     "Eliza Weisman <eliza@buoyant.io>",

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -18,7 +18,7 @@ Macro attributes for application-level tracing.
 [crates-badge]: https://img.shields.io/crates/v/tracing-attributes.svg
 [crates-url]: https://crates.io/crates/tracing-attributes
 [docs-badge]: https://docs.rs/tracing-attributes/badge.svg
-[docs-url]: https://docs.rs/tracing-attributes/0.1.11
+[docs-url]: https://docs.rs/tracing-attributes/0.1.12
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_attributes
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -47,7 +47,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing-attributes = "0.1.11"
+tracing-attributes = "0.1.12"
 ```
 
 

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tracing-attributes = "0.1.11"
+//! tracing-attributes = "0.1.12"
 //! ```
 //!
 //! The [`#[instrument]`][instrument] attribute can now be added to a function
@@ -52,7 +52,7 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
-#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.11")]
+#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.12")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
### Fixed

- Compiler error when using `#[instrument(err)]` on functions with
  mutable parameters ([#1167])
- Missing function visibility modifier when using `#[instrument]` with
  `async-trait` ([#977])
- Multiple documentation fixes and improvements ([#965], [#981],
  [#1215])

 ### Changed

- `tracing-futures` dependency is no longer required when using
  `#[instrument]` on async functions ([#808])

Thanks to @nagisa, @Txuritan, @TaKO8Ki, and @okready for contributing to
this release!

[#1167]: https://github.com/tokio-rs/tracing/pull/1167
[#977]: https://github.com/tokio-rs/tracing/pull/977
[#965]: https://github.com/tokio-rs/tracing/pull/965
[#981]: https://github.com/tokio-rs/tracing/pull/981
[#1215]: https://github.com/tokio-rs/tracing/pull/1215
[#808]: https://github.com/tokio-rs/tracing/pull/808