### PR TITLE
tracing: prepare to release v0.1.23

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,40 @@
+# 0.1.23 (February 4, 2021)
+
+### Fixed
+
+- **attributes**: Compiler error when using `#[instrument(err)]` on functions
+  with mutable parameters ([#1167])
+- **attributes**: Missing function visibility modifier when using
+  `#[instrument]` with `async-trait` ([#977])
+- **attributes** Removed unused `syn` features ([#928])
+- **log**: Fixed an issue where the `tracing` macros would generate code for
+  events whose levels are disabled statically by the `log` crate's
+  `static_max_level_XXX` features ([#1175])
+- Fixed deprecations and clippy lints ([#1195])
+- Several documentation fixes and improvements ([#941], [#965], [#981], [#1146],
+  [#1215])
+  
+### Changed
+
+- **attributes**: `tracing-futures` dependency is no longer required when using
+  `#[instrument]` on async functions ([#808])
+- **attributes**: Updated `tracing-attributes` minimum dependency to v0.1.12
+  ([#1222])
+
+Thanks to @nagisa, @Txuritan, @TaKO8Ki, @okready, and @krojew for contributing
+to this release!
+
+[#1167]: https://github.com/tokio-rs/tracing/pull/1167
+[#977]: https://github.com/tokio-rs/tracing/pull/977
+[#965]: https://github.com/tokio-rs/tracing/pull/965
+[#981]: https://github.com/tokio-rs/tracing/pull/981
+[#1215]: https://github.com/tokio-rs/tracing/pull/1215
+[#808]: https://github.com/tokio-rs/tracing/pull/808
+[#941]: https://github.com/tokio-rs/tracing/pull/941
+[#1146]: https://github.com/tokio-rs/tracing/pull/1146
+[#1175]: : https://github.com/tokio-rs/tracing/pull/1175
+[#1195]: https://github.com/tokio-rs/tracing/pull/1195
+[#1222]: https://github.com/tokio-rs/tracing/pull/1222
 # 0.1.22 (November 23, 2020)
 
 ### Changed

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.22"
+version = "0.1.23"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -16,9 +16,9 @@ Application-level tracing for Rust.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.22
+[crates-url]: https://crates.io/crates/tracing/0.1.23
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.22
+[docs-url]: https://docs.rs/tracing/0.1.23
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -246,7 +246,7 @@ my_future
 is as long as the future's.
 
 The second, and preferred, option is through the
-[`#[instrument]`](https://docs.rs/tracing/0.1.22/tracing/attr.instrument.html)
+[`#[instrument]`](https://docs.rs/tracing/0.1.23/tracing/attr.instrument.html)
 attribute:
 
 ```rust
@@ -293,7 +293,7 @@ span.in_scope(|| {
 // Dropping the span will close it, indicating that it has ended.
 ```
 
-The [`#[instrument]`](https://docs.rs/tracing/0.1.22/tracing/attr.instrument.html) attribute macro
+The [`#[instrument]`](https://docs.rs/tracing/0.1.23/tracing/attr.instrument.html) attribute macro
 can reduce some of this boilerplate:
 
 ```rust

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -784,7 +784,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing = { version = "0.1.22", default-features = false }
+//!   tracing = { version = "0.1.23", default-features = false }
 //!   ```
 //!
 //! <div class="information">
@@ -840,7 +840,7 @@
 //! [flags]: #crate-feature-flags
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.22")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.23")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
### Fixed

- **attributes**: Compiler error when using `#[instrument(err)]` on
  functions with mutable parameters ([#1167])
- **attributes**: Missing function visibility modifier when using
  `#[instrument]` with `async-trait` ([#977])
- **attributes** Removed unused `syn` features ([#928])
- **log**: Fixed an issue where the `tracing` macros would generate code
  for events whose levels are disabled statically by the `log` crate's
  `static_max_level_XXX` features ([#1175])
- Fixed deprecations and clippy lints ([#1195])
- Several documentation fixes and improvements ([#941], [#965], [#981],
  [#1146], [#1215])

### Changed

- **attributes**: `tracing-futures` dependency is no longer required
  when using `#[instrument]` on async functions ([#808])
- **attributes**: Updated `tracing-attributes` minimum dependency to
  v0.1.12 ([#1222])

Thanks to @nagisa, @Txuritan, @TaKO8Ki, @okready, and @krojew for
contributing to this release!