### PR TITLE
opentelemetry: rename Layer to Subscriber

### DIFF
--- a/examples/examples/opentelemetry-remote-context.rs
+++ b/examples/examples/opentelemetry-remote-context.rs
@@ -25,7 +25,7 @@ fn build_example_carrier() -> HashMap<String, String> {
 fn main() {
     // Set a format for propagating context. This MUST be provided, as the default is a no-op.
     global::set_text_map_propagator(TraceContextPropagator::new());
-    let subscriber = Registry::default().with(tracing_opentelemetry::layer());
+    let subscriber = Registry::default().with(tracing_opentelemetry::subscriber());
 
     tracing::collect::with_default(subscriber, || {
         // Extract context from request headers

--- a/examples/examples/opentelemetry.rs
+++ b/examples/examples/opentelemetry.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
         .with_service_name("report_example")
         .install()?;
-    let opentelemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+    let opentelemetry = tracing_opentelemetry::subscriber().with_tracer(tracer);
     tracing_subscriber::registry()
         .with(opentelemetry)
         .try_init()?;

--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -33,18 +33,18 @@ Utilities for adding [OpenTelemetry] interoperability to [`tracing`].
 ## Overview
 
 [`tracing`] is a framework for instrumenting Rust programs to collect
-structured, event-based diagnostic information. This crate provides a layer
-that connects spans from multiple systems into a trace and emits them to
-[OpenTelemetry]-compatible distributed tracing systems for processing and
-visualization.
+structured, event-based diagnostic information. This crate provides a 
+subscriber that connects spans from multiple systems into a trace and 
+emits them to [OpenTelemetry]-compatible distributed tracing systems 
+for processing and visualization.
 
 The crate provides the following types:
 
-* [`OpenTelemetryLayer`] adds OpenTelemetry context to all `tracing` [span]s.
+* [`OpenTelemetrySubscriber`] adds OpenTelemetry context to all `tracing` [span]s.
 * [`OpenTelemetrySpanExt`] allows OpenTelemetry parent trace information to be
   injected and extracted from a `tracing` [span].
 
-[`OpenTelemetryLayer`]: https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry/struct.OpenTelemetryLayer.html
+[`OpenTelemetrySubscriber`]: https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry/struct.OpenTelemetrySubscriber.html
 [`OpenTelemetrySpanExt`]: https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry/trait.OpenTelemetrySpanExt.html
 [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 [`tracing`]: https://crates.io/crates/tracing
@@ -61,22 +61,22 @@ The crate provides the following types:
 ```rust
 use opentelemetry::exporter::trace::stdout;
 use tracing::{error, span};
-use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::subscriber::SubscriberExt;
 use tracing_subscriber::Registry;
 
 fn main() {
     // Install a new OpenTelemetry trace pipeline
     let (tracer, _uninstall) = stdout::new_pipeline().install();
 
-    // Create a tracing layer with the configured tracer
-    let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+    // Create a tracing subscriber with the configured tracer
+    let telemetry = tracing_opentelemetry::subscriber().with_tracer(tracer);
 
     // Use the tracing subscriber `Registry`, or any other subscriber
     // that impls `LookupSpan`
-    let subscriber = Registry::default().with(telemetry);
+    let collector = Registry::default().with(telemetry);
 
     // Trace executed code
-    tracing::subscriber::with_default(subscriber, || {
+    tracing::collect::with_default(collector, || {
         // Spans will be sent to the configured OpenTelemetry exporter
         let root = span!(tracing::Level::TRACE, "app_start", work_units = 2);
         let _enter = root.enter();

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -57,7 +57,7 @@
 //! let (tracer, _uninstall) = stdout::new_pipeline().install();
 //!
 //! // Create a tracing layer with the configured tracer
-//! let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+//! let telemetry = tracing_opentelemetry::subscriber().with_tracer(tracer);
 //!
 //! // Use the tracing subscriber `Registry`, or any other subscriber
 //! // that impls `LookupSpan`
@@ -96,13 +96,13 @@
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
 )]
 
-/// Implementation of the trace::Subscriber as a source of OpenTelemetry data.
-mod layer;
 /// Span extension which enables OpenTelemetry context management.
 mod span_ext;
+/// Implementation of the trace::Subscriber as a source of OpenTelemetry data.
+mod subscriber;
 /// Protocols for OpenTelemetry Tracers that are compatible with Tracing
 mod tracer;
 
-pub use layer::{layer, OpenTelemetryLayer};
 pub use span_ext::OpenTelemetrySpanExt;
+pub use subscriber::{subscriber, OpenTelemetrySubscriber};
 pub use tracer::PreSampledTracer;

--- a/tracing-opentelemetry/src/span_ext.rs
+++ b/tracing-opentelemetry/src/span_ext.rs
@@ -1,4 +1,4 @@
-use crate::layer::WithContext;
+use crate::subscriber::WithContext;
 use opentelemetry::Context;
 
 /// Utility functions to allow tracing [`Span`]s to accept and return

--- a/tracing-opentelemetry/tests/trace_state_propagation.rs
+++ b/tracing-opentelemetry/tests/trace_state_propagation.rs
@@ -12,7 +12,7 @@ use opentelemetry::{
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use tracing::Collect;
-use tracing_opentelemetry::{layer, OpenTelemetrySpanExt};
+use tracing_opentelemetry::{subscriber, OpenTelemetrySpanExt};
 use tracing_subscriber::prelude::*;
 
 #[test]
@@ -113,7 +113,7 @@ fn test_tracer() -> (Tracer, TracerProvider, TestExporter, impl Collect) {
         .with_simple_exporter(exporter.clone())
         .build();
     let tracer = provider.get_tracer("test", None);
-    let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
+    let subscriber = tracing_subscriber::registry().with(subscriber().with_tracer(tracer.clone()));
 
     (tracer, provider, exporter, subscriber)
 }


### PR DESCRIPTION
This PR renames the following:

`tracing_opetelemetry::layer` to `tracing_opetelemetry::subscriber`
`tracing_opetelemetry::layer::layer()` to `tracing_opetelemetry::subscriber::subscriber()`
`tracing_opetelemetry::layer::OpenTelemetryLayer` to `tracing_opetelemetry::subscriber::OpenTelemetrySubscriber`

 Related PR: #1015