### PR TITLE
attributes: remove the duplicated pattern of event macro

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -751,13 +751,6 @@ macro_rules! event {
             { message = format_args!($($arg)+), $($fields)* }
         )
     );
-    ( $lvl:expr, { $($fields:tt)* }, $($arg:tt)+ ) => (
-        $crate::event!(
-            target: module_path!(),
-            $lvl,
-            { message = format_args!($($arg)+), $($fields)* }
-        )
-    );
     ($lvl:expr, $($k:ident).+ = $($field:tt)*) => (
         $crate::event!(
             target: module_path!(),


### PR DESCRIPTION
Line [747 to 753](https://github.com/tokio-rs/tracing/blob/70ee64a96f84b90fb50aaf4a44af241df5ce284e/tracing/src/macros.rs#L747-L753) is identical with line [754 to 760](https://github.com/tokio-rs/tracing/blob/70ee64a96f84b90fb50aaf4a44af241df5ce284e/tracing/src/macros.rs#L754-L760) in `tracing/src/macros.rs`. 

This PR simply remove one of the duplicated patterns.