### PR TITLE
attributes: remove closure type annotation in `#[instrument(err)]`

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -469,7 +469,7 @@ fn gen_body(
         quote_spanned!(block.span()=>
             let __tracing_attr_span = #span;
             let __tracing_attr_guard = __tracing_attr_span.enter();
-            match move || #return_type #block () {
+            match (move || #block)() {
                 #[allow(clippy::unit_arg)]
                 Ok(x) => Ok(x),
                 Err(e) => {

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -469,6 +469,7 @@ fn gen_body(
         quote_spanned!(block.span()=>
             let __tracing_attr_span = #span;
             let __tracing_attr_guard = __tracing_attr_span.enter();
+            #[allow(clippy::redundant_closure_call)]
             match (move || #block)() {
                 #[allow(clippy::unit_arg)]
                 Ok(x) => Ok(x),

--- a/tracing-attributes/tests/instrument.rs
+++ b/tracing-attributes/tests/instrument.rs
@@ -200,3 +200,32 @@ fn methods() {
 
     handle.assert_finished();
 }
+
+#[test]
+fn impl_trait_return_type() {
+    #[instrument]
+    fn returns_impl_trait(x: usize) -> impl Iterator<Item = usize> {
+        0..x
+    }
+
+    let span = span::mock().named("returns_impl_trait");
+
+    let (collector, handle) = collector::mock()
+        .new_span(
+            span.clone()
+                .with_field(field::mock("x").with_value(&format_args!("10")).only()),
+        )
+        .enter(span.clone())
+        .exit(span.clone())
+        .drop_span(span)
+        .done()
+        .run_with_handle();
+
+    with_default(collector, || {
+        for _ in returns_impl_trait(10) {
+            // nop
+        }
+    });
+
+    handle.assert_finished();
+}


### PR DESCRIPTION
## Motivation

Currently, using `#[instrument(err)]` on a function returning a `Result`
with an `impl Trait` in it results in a compiler error. This is because
we generate a type annotation on the closure in the function body that
contains the user function's actual body, and `impl Trait` isn't allowed
on types in local bindings, only on function parameters and return
types.

## Solution

This branch fixes the issue by simply removing the return type
annotation from the closure. I've also added tests that break on master
for functions returning `impl Trait`, both with and without the `err`
argument.

Fixes #1227

Signed-off-by: Eliza Weisman <eliza@buoyant.io>