### PR TITLE
attributes: add #[instrument(parent = ...)] for specifying parent span.

### DIFF
--- a/tracing-attributes/tests/parent.rs
+++ b/tracing-attributes/tests/parent.rs
@@ -1,0 +1,23 @@
+use tracing::Span;
+use tracing_attributes::instrument;
+
+#[derive(Debug)]
+struct WithSpan {
+    span: Span,
+}
+
+impl WithSpan {
+    fn new(span: Span) -> Self {
+        Self { span }
+    }
+
+    #[instrument(parent = &self.span)]
+    fn foo(&self) {}
+}
+
+#[test]
+fn test() {
+    let span = Span::current();
+    let with_span = WithSpan::new(span);
+    with_span.foo();
+}


### PR DESCRIPTION
## Motivation

Resolves part of #879.

## Solution

This change adds `parent` parameter that takes an arbitrary expression to the `#[instrument]` attribute.
If specified, it overrides the parent span of the span made by `#[instrument]`

## Questions

I'm creating this as a draft PR because there are some unclear things. Any ideas and suggestions are welcome.

1. I couldn't decipher how the integration tests are written😅 Currently, the new test just checks whether it compiles.
2. I'm not sure what to put as [the default parent](https://github.com/tokio-rs/tracing/compare/master...pandaman64:parent?expand=1#diff-f05c3ad567dbbebdd8aaacb7a49922d5b060b9ddb836991490d4374e933dd83cR570). Leaving `parent` field blank when unspecified might be better.