### PR TITLE
Fix logging macros

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -914,14 +914,14 @@ macro_rules! trace {
     (target: $target:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(target: $target, $crate::Level::TRACE, { $($field)* }, $($arg)*)
     );
-    (target: $target:expr, $($k:ident).+ $($field:tt)+ ) => (
-        $crate::event!(target: $target, $crate::Level::TRACE, { $($k).+ $($field)+ })
+    (target: $target:expr, $($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::TRACE, { $($k).+ $($field)* })
     );
-    (target: $target:expr, ?$($k:ident).+ $($field:tt)+ ) => (
-        $crate::event!(target: $target, $crate::Level::TRACE, { $($k).+ $($field)+ })
+    (target: $target:expr, ?$($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::TRACE, { ?$($k).+ $($field)* })
     );
-    (target: $target:expr, %$($k:ident).+ $($field:tt)+ ) => (
-        $crate::event!(target: $target, $crate::Level::TRACE, { $($k).+ $($field)+ })
+    (target: $target:expr, %$($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::TRACE, { %$($k).+ $($field)* })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
         $crate::event!(target: $target, $crate::Level::TRACE, {}, $($arg)+)
@@ -1101,14 +1101,14 @@ macro_rules! debug {
     (target: $target:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(target: $target, $crate::Level::DEBUG, { $($field)* }, $($arg)*)
     );
-    (target: $target:expr, $($k:ident).+ $($field:tt)+ ) => (
-        $crate::event!(target: $target, $crate::Level::DEBUG, { $($k).+ $($field)+ })
+    (target: $target:expr, $($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::DEBUG, { $($k).+ $($field)* })
     );
-    (target: $target:expr, ?$($k:ident).+ $($field:tt)+ ) => (
-        $crate::event!(target: $target, $crate::Level::DEBUG, { $($k).+ $($field)+ })
+    (target: $target:expr, ?$($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::DEBUG, { ?$($k).+ $($field)* })
     );
-    (target: $target:expr, %$($k:ident).+ $($field:tt)+ ) => (
-        $crate::event!(target: $target, $crate::Level::DEBUG, { $($k).+ $($field)+ })
+    (target: $target:expr, %$($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::DEBUG, { %$($k).+ $($field)* })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
         $crate::event!(target: $target, $crate::Level::DEBUG, {}, $($arg)+)
@@ -1313,14 +1313,14 @@ macro_rules! info {
     (target: $target:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(target: $target, $crate::Level::INFO, { $($field)* }, $($arg)*)
     );
-    (target: $target:expr, $($k:ident).+ $($field:tt)+ ) => (
-        $crate::event!(target: $target, $crate::Level::INFO, { $($k).+ $($field)+ })
+    (target: $target:expr, $($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::INFO, { $($k).+ $($field)* })
     );
-    (target: $target:expr, ?$($k:ident).+ $($field:tt)+ ) => (
-        $crate::event!(target: $target, $crate::Level::INFO, { $($k).+ $($field)+ })
+    (target: $target:expr, ?$($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::INFO, { ?$($k).+ $($field)* })
     );
-    (target: $target:expr, %$($k:ident).+ $($field:tt)+ ) => (
-        $crate::event!(target: $target, $crate::Level::INFO, { $($k).+ $($field)+ })
+    (target: $target:expr, %$($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::INFO, { $($k).+ $($field)* })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
         $crate::event!(target: $target, $crate::Level::INFO, {}, $($arg)+)
@@ -1350,7 +1350,7 @@ macro_rules! info {
     (%$($k:ident).+ = $($field:tt)*) => (
         $crate::event!(
             target: module_path!(),
-            $crate::Level::TRACE,
+            $crate::Level::INFO,
             { %$($k).+ = $($field)*}
         )
     );
@@ -1518,14 +1518,14 @@ macro_rules! warn {
     (target: $target:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(target: $target, $crate::Level::WARN, { $($field)* }, $($arg)*)
     );
-    (target: $target:expr, $($k:ident).+ $($field:tt)+ ) => (
-        $crate::event!(target: $target, $crate::Level::WARN, { $($k).+ $($field)+ })
+    (target: $target:expr, $($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::WARN, { $($k).+ $($field)* })
     );
-    (target: $target:expr, ?$($k:ident).+ $($field:tt)+ ) => (
-        $crate::event!(target: $target, $crate::Level::WARN, { $($k).+ $($field)+ })
+    (target: $target:expr, ?$($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::WARN, { ?$($k).+ $($field)* })
     );
-    (target: $target:expr, %$($k:ident).+ $($field:tt)+ ) => (
-        $crate::event!(target: $target, $crate::Level::WARN, { $($k).+ $($field)+ })
+    (target: $target:expr, %$($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::WARN, { %$($k).+ $($field)* })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
         $crate::event!(target: $target, $crate::Level::WARN, {}, $($arg)+)
@@ -1719,14 +1719,14 @@ macro_rules! error {
     (target: $target:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(target: $target, $crate::Level::ERROR, { $($field)* }, $($arg)*)
     );
-    (target: $target:expr, $($k:ident).+ $($field:tt)+ ) => (
-        $crate::event!(target: $target, $crate::Level::ERROR, { $($k).+ $($field)+ })
+    (target: $target:expr, $($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::ERROR, { $($k).+ $($field)* })
     );
-    (target: $target:expr, ?$($k:ident).+ $($field:tt)+ ) => (
-        $crate::event!(target: $target, $crate::Level::ERROR, { $($k).+ $($field)+ })
+    (target: $target:expr, ?$($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::ERROR, { ?$($k).+ $($field)* })
     );
-    (target: $target:expr, %$($k:ident).+ $($field:tt)+ ) => (
-        $crate::event!(target: $target, $crate::Level::ERROR, { $($k).+ $($field)+ })
+    (target: $target:expr, %$($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::ERROR, { %$($k).+ $($field)* })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
         $crate::event!(target: $target, $crate::Level::ERROR, {}, $($arg)+)
@@ -1756,7 +1756,7 @@ macro_rules! error {
     (%$($k:ident).+ = $($field:tt)*) => (
         $crate::event!(
             target: module_path!(),
-            $crate::Level::TRACE,
+            $crate::Level::ERROR,
             { %$($k).+ = $($field)*}
         )
     );

--- a/tracing/tests/macros.rs
+++ b/tracing/tests/macros.rs
@@ -407,6 +407,12 @@ fn trace() {
     trace!(?foo);
     trace!(%foo);
     trace!(foo);
+    trace!(target: "foo_events", ?foo);
+    trace!(target: "foo_events", %foo);
+    trace!(target: "foo_events", foo);
+    trace!(target: "foo_events", ?foo, true, "message");
+    trace!(target: "foo_events", %foo, true, "message");
+    trace!(target: "foo_events", foo, true, "message");
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -437,6 +443,12 @@ fn debug() {
     debug!(?foo);
     debug!(%foo);
     debug!(foo);
+    debug!(target: "foo_events", ?foo);
+    debug!(target: "foo_events", %foo);
+    debug!(target: "foo_events", foo);
+    debug!(target: "foo_events", ?foo, true, "message");
+    debug!(target: "foo_events", %foo, true, "message");
+    debug!(target: "foo_events", foo, true, "message");
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -467,6 +479,12 @@ fn info() {
     info!(?foo);
     info!(%foo);
     info!(foo);
+    info!(target: "foo_events", ?foo);
+    info!(target: "foo_events", %foo);
+    info!(target: "foo_events", foo);
+    info!(target: "foo_events", ?foo, true, "message");
+    info!(target: "foo_events", %foo, true, "message");
+    info!(target: "foo_events", foo, true, "message");
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -497,6 +515,12 @@ fn warn() {
     warn!(?foo);
     warn!(%foo);
     warn!(foo);
+    warn!(target: "foo_events", ?foo);
+    warn!(target: "foo_events", %foo);
+    warn!(target: "foo_events", foo);
+    warn!(target: "foo_events", ?foo, true, "message");
+    warn!(target: "foo_events", %foo, true, "message");
+    warn!(target: "foo_events", foo, true, "message");
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -527,6 +551,12 @@ fn error() {
     error!(?foo);
     error!(%foo);
     error!(foo);
+    error!(target: "foo_events", ?foo);
+    error!(target: "foo_events", %foo);
+    error!(target: "foo_events", foo);
+    error!(target: "foo_events", ?foo, true, "message");
+    error!(target: "foo_events", %foo, true, "message");
+    error!(target: "foo_events", foo, true, "message");
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]


### PR DESCRIPTION
This pr fixes the logging macros to accept syntax like
`info!(target: "test", ?value)`. While this works without the explicit
`target`, it did not worked with the `target` up to now. Besides that
the macros also used from wrong levels in certain branches.

