### PR TITLE
subscriber: update pretty formatter for no ansi

### DIFF
--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -297,9 +297,10 @@ impl<F, T> Format<F, T> {
     ///
     /// # Options
     ///
-    /// [`Format::with_ansi`] can be used to disable ANSI formatting in event formatting. However,
-    /// a field formatter must be manually provided to avoid ANSI in the formatting of parent
-    /// spans, like so:
+    /// [`Format::with_ansi`] can be used to disable ANSI terminal escape codes (which enable
+    /// formatting such as colors, bold, italic, etc) in event formatting. However, a field
+    /// formatter must be manually provided to avoid ANSI in the formatting of parent spans, like
+    /// so:
     ///
     /// ```
     /// tracing_subscriber::fmt()

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -935,6 +935,7 @@ trait LevelNames {
     }
 }
 
+#[cfg(feature = "ansi")]
 impl LevelNames for Pretty {
     const TRACE_STR: &'static str = "TRACE";
     const DEBUG_STR: &'static str = "DEBUG";

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -935,6 +935,13 @@ trait LevelNames {
     }
 }
 
+impl LevelNames for Pretty {
+    const TRACE_STR: &'static str = "TRACE";
+    const DEBUG_STR: &'static str = "DEBUG";
+    const INFO_STR: &'static str = " INFO";
+    const WARN_STR: &'static str = " WARN";
+    const ERROR_STR: &'static str = "ERROR";
+}
 impl LevelNames for Full {
     const TRACE_STR: &'static str = "TRACE";
     const DEBUG_STR: &'static str = "DEBUG";

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -294,6 +294,21 @@ impl<F, T> Format<F, T> {
     /// See [`Pretty`].
     ///
     /// Note that this requires the "ansi" feature to be enabled.
+    ///
+    /// # Options
+    ///
+    /// [`Format::with_ansi`] can be used to disable ANSI formatting in event formatting. However,
+    /// a field formatter must be manually provided to avoid ANSI in the formatting of parent
+    /// spans, like so:
+    ///
+    /// ```
+    /// tracing_subscriber::fmt()
+    ///    .pretty()
+    ///    .with_ansi(false)
+    ///    .fmt_fields(format::PrettyFields::new().with_ansi(false))
+    ///    // ... other settings ...
+    ///    .init();
+    /// ```
     #[cfg(feature = "ansi")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
     pub fn pretty(self) -> Format<Pretty, T> {

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -303,6 +303,7 @@ impl<F, T> Format<F, T> {
     /// so:
     ///
     /// ```
+    /// # use tracing_subscriber::fmt::format;
     /// tracing_subscriber::fmt()
     ///    .pretty()
     ///    .with_ansi(false)

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -959,6 +959,7 @@ impl LevelNames for Pretty {
     const WARN_STR: &'static str = " WARN";
     const ERROR_STR: &'static str = "ERROR";
 }
+
 impl LevelNames for Full {
     const TRACE_STR: &'static str = "TRACE";
     const DEBUG_STR: &'static str = "DEBUG";

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -270,6 +270,14 @@ impl<'a> PrettyVisitor<'a> {
         };
         self.result = write!(self.writer, "{}{:?}", padding, value);
     }
+
+    fn bold(&self) -> Style {
+        if self.ansi {
+            self.style.bold()
+        } else {
+            Style::new()
+        }
+    }
 }
 
 impl<'a> field::Visit for PrettyVisitor<'a> {
@@ -287,11 +295,7 @@ impl<'a> field::Visit for PrettyVisitor<'a> {
 
     fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
         if let Some(source) = value.source() {
-            let bold = if self.ansi {
-                self.style.bold()
-            } else {
-                Style::new()
-            };
+            let bold = self.bold();
             self.record_debug(
                 field,
                 &format_args!(
@@ -312,11 +316,7 @@ impl<'a> field::Visit for PrettyVisitor<'a> {
         if self.result.is_err() {
             return;
         }
-        let bold = if self.ansi {
-            self.style.bold()
-        } else {
-            Style::new()
-        };
+        let bold = self.bold();
         match field.name() {
             "message" => self.write_padded(&format_args!("{}{:?}", self.style.prefix(), value,)),
             // Skip fields that are actually log metadata that have already been handled

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -234,6 +234,49 @@ impl<'writer> FormatFields<'writer> for Pretty {
     }
 }
 
+// === impl PrettyFields ===
+
+/// An excessively pretty, human-readable [`MakeVisitor`] implementation.
+///
+/// [`MakeVisitor`]: crate::field::MakeVisitor
+#[derive(Debug)]
+pub struct PrettyFields {
+    ansi: bool,
+    // reserve the ability to add fields to this without causing a breaking
+    // change in the future.
+    _private: (),
+}
+
+impl Default for PrettyFields {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PrettyFields {
+    /// Returns a new default [`PrettyFields`] implementation.
+    pub fn new() -> Self {
+        Self {
+            ansi: true,
+            _private: (),
+        }
+    }
+
+    /// Enable ANSI encoding for formatted fields.
+    pub fn with_ansi(self, ansi: bool) -> Self {
+        Self { ansi, ..self }
+    }
+}
+
+impl<'a> MakeVisitor<&'a mut dyn Write> for PrettyFields {
+    type Visitor = PrettyVisitor<'a>;
+
+    #[inline]
+    fn make_visitor(&self, target: &'a mut dyn Write) -> Self::Visitor {
+        PrettyVisitor::new(target, true).with_ansi(self.ansi)
+    }
+}
+
 // === impl PrettyVisitor ===
 
 impl<'a> PrettyVisitor<'a> {

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -37,6 +37,14 @@ pub struct PrettyVisitor<'a> {
     result: fmt::Result,
 }
 
+/// An excessively pretty, human-readable [`MakeVisitor`] implementation.
+///
+/// [`MakeVisitor`]: crate::field::MakeVisitor
+#[derive(Debug)]
+pub struct PrettyFields {
+    ansi: bool,
+}
+
 // === impl Pretty ===
 
 impl Default for Pretty {
@@ -235,17 +243,6 @@ impl<'writer> FormatFields<'writer> for Pretty {
 }
 
 // === impl PrettyFields ===
-
-/// An excessively pretty, human-readable [`MakeVisitor`] implementation.
-///
-/// [`MakeVisitor`]: crate::field::MakeVisitor
-#[derive(Debug)]
-pub struct PrettyFields {
-    ansi: bool,
-    // reserve the ability to add fields to this without causing a breaking
-    // change in the future.
-    _private: (),
-}
 
 impl Default for PrettyFields {
     fn default() -> Self {

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -255,7 +255,6 @@ impl PrettyFields {
     pub fn new() -> Self {
         Self {
             ansi: true,
-            _private: (),
         }
     }
 

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -253,9 +253,7 @@ impl Default for PrettyFields {
 impl PrettyFields {
     /// Returns a new default [`PrettyFields`] implementation.
     pub fn new() -> Self {
-        Self {
-            ansi: true,
-        }
+        Self { ansi: true }
     }
 
     /// Enable ANSI encoding for formatted fields.

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -32,6 +32,7 @@ pub struct Pretty {
 pub struct PrettyVisitor<'a> {
     writer: &'a mut dyn Write,
     is_empty: bool,
+    ansi: bool,
     style: Style,
     result: fmt::Result,
 }
@@ -98,30 +99,40 @@ where
         #[cfg(not(feature = "tracing-log"))]
         let meta = event.metadata();
         write!(writer, "  ")?;
-        time::write(&self.timer, writer, true)?;
+        time::write(&self.timer, writer, self.ansi)?;
 
-        let style = if self.display_level {
+        let style = if self.display_level && self.ansi {
             Pretty::style_for(meta.level())
         } else {
             Style::new()
         };
 
+        if self.display_level {
+            self.format_level(*meta.level(), writer)?;
+        }
+
         if self.display_target {
-            let bold = style.bold();
+            let target_style = if self.ansi { style.bold() } else { style };
             write!(
                 writer,
                 "{}{}{}: ",
-                bold.prefix(),
+                target_style.prefix(),
                 meta.target(),
-                bold.infix(style)
+                target_style.infix(style)
             )?;
         }
-        let mut v = PrettyVisitor::new(writer, true).with_style(style);
+        let mut v = PrettyVisitor::new(writer, true)
+            .with_style(style)
+            .with_ansi(self.ansi);
         event.record(&mut v);
         v.finish()?;
         writer.write_char('\n')?;
 
-        let dimmed = Style::new().dimmed().italic();
+        let dimmed = if self.ansi {
+            Style::new().dimmed().italic()
+        } else {
+            Style::new()
+        };
         let thread = self.display_thread_name || self.display_thread_id;
         if let (true, Some(file), Some(line)) =
             (self.format.display_location, meta.file(), meta.line())
@@ -156,7 +167,11 @@ where
             writer.write_char('\n')?;
         }
 
-        let bold = Style::new().bold();
+        let bold = if self.ansi {
+            Style::new().bold()
+        } else {
+            Style::new()
+        };
         let span = event
             .parent()
             .and_then(|id| ctx.span(&id))
@@ -232,6 +247,7 @@ impl<'a> PrettyVisitor<'a> {
         Self {
             writer,
             is_empty,
+            ansi: true,
             style: Style::default(),
             result: Ok(()),
         }
@@ -239,6 +255,10 @@ impl<'a> PrettyVisitor<'a> {
 
     pub(crate) fn with_style(self, style: Style) -> Self {
         Self { style, ..self }
+    }
+
+    pub(crate) fn with_ansi(self, ansi: bool) -> Self {
+        Self { ansi, ..self }
     }
 
     fn write_padded(&mut self, value: &impl fmt::Debug) {
@@ -267,7 +287,11 @@ impl<'a> field::Visit for PrettyVisitor<'a> {
 
     fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
         if let Some(source) = value.source() {
-            let bold = self.style.bold();
+            let bold = if self.ansi {
+                self.style.bold()
+            } else {
+                Style::new()
+            };
             self.record_debug(
                 field,
                 &format_args!(
@@ -288,7 +312,11 @@ impl<'a> field::Visit for PrettyVisitor<'a> {
         if self.result.is_err() {
             return;
         }
-        let bold = self.style.bold();
+        let bold = if self.ansi {
+            self.style.bold()
+        } else {
+            Style::new()
+        };
         match field.name() {
             "message" => self.write_padded(&format_args!("{}{:?}", self.style.prefix(), value,)),
             // Skip fields that are actually log metadata that have already been handled
@@ -332,6 +360,7 @@ impl<'a> fmt::Debug for PrettyVisitor<'a> {
             .field("is_empty", &self.is_empty)
             .field("result", &self.result)
             .field("style", &self.style)
+            .field("ansi", &self.ansi)
             .finish()
     }
 }


### PR DESCRIPTION
## Background

Currently, when the `Pretty` event formatter is being used, it does not change
its output when the `with_ansi` flag is set to false by the `CollectorBuilder`.

## Overview

While this formatter is generally used in situations such as local development,
where ANSI escape codes are more often acceptable, there are some situations in
which this can lead to mangled output.

This commit makes some minor changes to account for this `ansi` flag when
formatting events using `Pretty`.

Becuase ANSI codes were previously used to imply the event level using colors,
this commit additionally modifies `Pretty` so that it respects `display_level`
when formatting an event.

Now, installing a subscriber like so...

```rust
    tracing_subscriber::fmt()
        .pretty()
        .with_thread_names(true)
        .with_ansi(false)
        .with_level(true)
        .with_max_level(tracing::Level::TRACE)
        .init();
```

...will lead to logs that look like this:

![pretty-no-ansi](https://user-images.githubusercontent.com/57912822/108085612-8287f500-7043-11eb-9afa-436f34431d83.png)

## Changes

* Changes to `<Format<Pretty, T> as FormatEvent<C, N>>::format_event`

* Implement `LevelNames` for `Pretty`, copying `Full`'s
  implementation.

* Add a `PrettyVisitor::ansi` boolean flag, used in its `Visit`
  implementation.

    * Add a new `PrettyVisitor::with_ansi` builder pattern method to
      facilitate this.

## Out of Scope

One detail worth nothing is that this does not solve the problem of *fields*
being formatted without ANSI codes. Configuring a subscriber using this snippet
would still lead to bolded fields in parent spans.

```rust
tracing_subscriber::fmt()
    .pretty()
    .with_ansi(false)
    .with_level(true)
    .with_max_level(tracing::Level::TRACE)
    .init();
```

This can be worked around by using a different field formatter, via
`.fmt_fields(tracing_subscriber::fmt::format::DefaultFields::new())` in the
short-term.

In the long-term, #658 is worth investigating further.
