### PR TITLE
futures: prepare to release 0.2.5

### DIFF
--- a/tracing-futures/CHANGELOG.md
+++ b/tracing-futures/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 0.2.5 (February 16, 2021)
+
+### Changed
+
+- Updated `pin-project` dependency to 1.0 ([#1038])
+
+### Fixed
+
+- Several documentation fixes and improvements ([#832], [#911], [#913], [#941],
+  [#953], [#981])
+
+[#1038]: https://github.com/tokio-rs/tracing/pulls/1038
+[#832]: https://github.com/tokio-rs/tracing/pulls/832
+[#911]: https://github.com/tokio-rs/tracing/pulls/911
+[#913]: https://github.com/tokio-rs/tracing/pulls/913
+[#941]: https://github.com/tokio-rs/tracing/pulls/941
+
 # 0.2.4 (April 21, 2020)
 
 ### Fixed

--- a/tracing-futures/CHANGELOG.md
+++ b/tracing-futures/CHANGELOG.md
@@ -14,7 +14,8 @@
 [#911]: https://github.com/tokio-rs/tracing/pulls/911
 [#913]: https://github.com/tokio-rs/tracing/pulls/913
 [#941]: https://github.com/tokio-rs/tracing/pulls/941
-
+[#953]: https://github.com/tokio-rs/tracing/pulls/953
+[#981]: https://github.com/tokio-rs/tracing/pulls/981
 # 0.2.4 (April 21, 2020)
 
 ### Fixed

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-futures"
-version = "0.2.6"
+version = "0.2.5"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"

--- a/tracing-futures/README.md
+++ b/tracing-futures/README.md
@@ -17,9 +17,9 @@ Utilities for instrumenting futures-based code with [`tracing`].
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-futures.svg
-[crates-url]: https://crates.io/crates/tracing-futures/0.2.3
+[crates-url]: https://crates.io/crates/tracing-futures/0.2.5
 [docs-badge]: https://docs.rs/tracing-futures/badge.svg
-[docs-url]: https://docs.rs/tracing-futures/0.2.3/tracing_futures
+[docs-url]: https://docs.rs/tracing-futures/0.2.5/tracing_futures
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_futures
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -45,8 +45,8 @@ The crate provides the following traits:
 * [`WithSubscriber`] allows a `tracing` [`Subscriber`] to be attached to a
   future, sink, stream, or executor.
 
-[`Instrument`]: https://docs.rs/tracing-futures/0.2.3/tracing_futures/trait.Instrument.html
-[`WithSubscriber`]: https://docs.rs/tracing-futures/0.2.3/tracing_futures/trait.WithSubscriber.html
+[`Instrument`]: https://docs.rs/tracing-futures/0.2.5/tracing_futures/trait.Instrument.html
+[`WithSubscriber`]: https://docs.rs/tracing-futures/0.2.5/tracing_futures/trait.WithSubscriber.html
 [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 [`Subscriber`]: https://docs.rs/tracing/latest/tracing/subscriber/index.html
 [`tracing`]: https://crates.io/tracing

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -47,7 +47,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing-futures = { version = "0.2.3", default-features = false }
+//!   tracing-futures = { version = "0.2.5", default-features = false }
 //!   ```
 //!
 //! The `tokio`, `std-future` and `std` features are enabled by default.
@@ -73,7 +73,7 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
-#![doc(html_root_url = "https://docs.rs/tracing-futures/0.2.4")]
+#![doc(html_root_url = "https://docs.rs/tracing-futures/0.2.5")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.2.5 (February 16, 2021)

### Changed

- Updated `pin-project` dependency to 1.0 ([#1038])

### Fixed

- Several documentation fixes and improvements ([#832], [#911], [#913],
  [#941], [#953], [#981])

[#1038]: https://github.com/tokio-rs/tracing/pulls/1038
[#832]: https://github.com/tokio-rs/tracing/pulls/832
[#911]: https://github.com/tokio-rs/tracing/pulls/911
[#913]: https://github.com/tokio-rs/tracing/pulls/913
[#941]: https://github.com/tokio-rs/tracing/pulls/941
[#953]: https://github.com/tokio-rs/tracing/pulls/953
[#981]: https://github.com/tokio-rs/tracing/pulls/981