### PR TITLE
chore: remove legacy `TraceLogger` in docs

### DIFF
--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -59,7 +59,7 @@
 //!
 //! Note that logger implementations that convert log records to trace events
 //! should not be used with `Collector`s that convert trace events _back_ into
-//! log records (such as the `TraceLogger`), as doing so will result in the
+//! log records, as doing so will result in the
 //! event recursing between the collector and the logger forever (or, in real
 //! life, probably overflowing the call stack).
 //!

--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -38,7 +38,7 @@ use std::{any::TypeId, marker::PhantomData};
 ///
 /// Since `Subscribe` does not implement a complete strategy for collecting
 /// traces, it must be composed with a `Collect` in order to be used. The
-/// `Subscribe` trait is generic over a type parameter (called `S` in the trait
+/// `Subscribe` trait is generic over a type parameter (called `C` in the trait
 /// definition), representing the types of `Collect` they can be composed
 /// with. Thus, a subscriber may be implemented that will only compose with a
 /// particular `Collect` implementation, or additional trait bounds may be


### PR DESCRIPTION
Seems like we forgot to remove this? Since `TraceLogger` has been removed in `tracing-log`'s v0.1.1. Otherwise, this could bring confusion to those new to `tracing-rs`.