### PR TITLE
log: compare `log` record `Level`s against the max level

### DIFF
--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -346,6 +346,7 @@ impl crate::sealed::Sealed for log::Level {}
 
 impl AsTrace for log::Level {
     type Trace = tracing_core::Level;
+    #[inline]
     fn as_trace(&self) -> tracing_core::Level {
         match self {
             log::Level::Error => tracing_core::Level::ERROR,

--- a/tracing-log/src/log_tracer.rs
+++ b/tracing-log/src/log_tracer.rs
@@ -158,7 +158,17 @@ impl Default for LogTracer {
 
 impl log::Log for LogTracer {
     fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        // First, check the log record against the current max level enabled by
+        // the current `tracing` subscriber.
+        if metadata.level().as_trace() > tracing_core::LevelFilter::current() {
+            // If the log record's level is above that, disable it.
+            return false;
+        }
+
+        // Okay, it wasn't disabled by the max level — do we have any specific
+        // modules to ignore?
         if self.ignore_crates.is_empty() {
+            // If we don't, just enable it.
             return true;
         }
 


### PR DESCRIPTION
This branch adds a check against the current value of the max global
`LevelFilter` hint in `tracing_log`'s `LogTracer::enabled` method. This
should prevent `log::${LEVEL}_enabled!` from always returning `true`
when `tracing` is in use, fixing a performance issue when consuming
`log` records from tracing (see bytecodealliance/wasmtime#2662).

This does, however, mean `LogTracer::enabled` will always be called if
the max `log` level is not set. We can't determine whether we can set
`log`'s max level in `tracing_log`, since we don't know if subscribers
will change (resulting in the current max `tracing` level filter
changing), or if the current subscriber is set as the global default.
Higher-level code in `tracing_subscriber` can do this, though, in
`init()`, because it _does_ know that it's setting a global default.
I'll add that in a follow-up PR.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>