### PR TITLE
subscriber: set the max `log` `LevelFilter` in `init`

### DIFF
--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -346,6 +346,7 @@ impl crate::sealed::Sealed for log::Level {}
 
 impl AsTrace for log::Level {
     type Trace = tracing_core::Level;
+    #[inline]
     fn as_trace(&self) -> tracing_core::Level {
         match self {
             log::Level::Error => tracing_core::Level::ERROR,

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -358,6 +358,39 @@ impl AsTrace for log::Level {
     }
 }
 
+impl crate::sealed::Sealed for log::LevelFilter {}
+
+impl AsTrace for log::LevelFilter {
+    type Trace = tracing_core::LevelFilter;
+    #[inline]
+    fn as_trace(&self) -> tracing_core::LevelFilter {
+        match self {
+            log::LevelFilter::Off => tracing_core::LevelFilter::OFF,
+            log::LevelFilter::Error => tracing_core::LevelFilter::ERROR,
+            log::LevelFilter::Warn => tracing_core::LevelFilter::WARN,
+            log::LevelFilter::Info => tracing_core::LevelFilter::INFO,
+            log::LevelFilter::Debug => tracing_core::LevelFilter::DEBUG,
+            log::LevelFilter::Trace => tracing_core::LevelFilter::TRACE,
+        }
+    }
+}
+
+impl crate::sealed::Sealed for tracing_core::LevelFilter {}
+
+impl AsLog for tracing_core::LevelFilter {
+    type Log = log::LevelFilter;
+    #[inline]
+    fn as_log(&self) -> Self::Log {
+        match *self {
+            tracing_core::LevelFilter::OFF => log::LevelFilter::Off,
+            tracing_core::LevelFilter::ERROR => log::LevelFilter::Error,
+            tracing_core::LevelFilter::WARN => log::LevelFilter::Warn,
+            tracing_core::LevelFilter::INFO => log::LevelFilter::Info,
+            tracing_core::LevelFilter::DEBUG => log::LevelFilter::Debug,
+            tracing_core::LevelFilter::TRACE => log::LevelFilter::Trace,
+        }
+    }
+}
 /// Extends log `Event`s to provide complete `Metadata`.
 ///
 /// In `tracing-log`, an `Event` produced by a log (through [`AsTrace`]) has an hard coded

--- a/tracing-log/src/log_tracer.rs
+++ b/tracing-log/src/log_tracer.rs
@@ -158,7 +158,17 @@ impl Default for LogTracer {
 
 impl log::Log for LogTracer {
     fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        // First, check the log record against the current max level enabled by
+        // the current `tracing` subscriber.
+        if metadata.level().as_trace() > tracing_core::LevelFilter::current() {
+            // If the log record's level is above that, disable it.
+            return false;
+        }
+
+        // Okay, it wasn't disabled by the max level — do we have any specific
+        // modules to ignore?
         if self.ignore_crates.is_empty() {
+            // If we don't, just enable it.
             return true;
         }
 

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -566,12 +566,9 @@ where
     /// because a global collector was already installed by another
     /// call to `try_init`.
     pub fn try_init(self) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-        #[cfg(feature = "tracing-log")]
-        tracing_log::LogTracer::init().map_err(Box::new)?;
+        use crate::util::SubscriberInitExt;
+        self.finish().try_init()?;
 
-        tracing_core::dispatch::set_global_default(tracing_core::dispatch::Dispatch::new(
-            self.finish(),
-        ))?;
         Ok(())
     }
 


### PR DESCRIPTION
Depends on #1247.

Since `tracing-subscriber`'s `init` and `try_init` functions set the
global default collector, we can use the collector's max-level hint as
the max level for the log crate, as well. This should significantly
improve performance for skipping `log` records that fall below the
collector's max level, as they will not have to call the
`LogTracer::enabled` method.

This will prevent issues like bytecodealliance/wasmtime#2662
from occurring in the future. See also #1249.

In order to implement this, I also changed the `FmtCollector`'s
`try_init` to just use `util::SubscriberInitExt`'s `try_init` function,
so that the same code isn't duplicated in multiple places. I also
added `AsLog` and `AsTrace` conversions for `LevelFilter`s in
the `tracing-log` crate.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>