### PR TITLE
subscriber: fix FmtCollector not forwarding max level 

### DIFF
--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -507,6 +507,11 @@ where
         self.inner.try_close(id)
     }
 
+    #[inline]
+    fn max_level_hint(&self) -> Option<tracing_core::LevelFilter> {
+        self.inner.max_level_hint()
+    }
+
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
         if id == TypeId::of::<Self>() {
             Some(self as *const Self as *const ())

--- a/tracing-subscriber/tests/fmt_max_level_hint.rs
+++ b/tracing-subscriber/tests/fmt_max_level_hint.rs
@@ -1,0 +1,10 @@
+
+use tracing_subscriber::filter::LevelFilter;
+
+#[test]
+fn fmt_sets_max_level_hint() {
+    tracing_subscriber::fmt()
+       .with_max_level(LevelFilter::DEBUG)
+       .init();
+    assert_eq!(LevelFilter::current(), LevelFilter::DEBUG);
+}

--- a/tracing-subscriber/tests/fmt_max_level_hint.rs
+++ b/tracing-subscriber/tests/fmt_max_level_hint.rs
@@ -1,10 +1,9 @@
-
 use tracing_subscriber::filter::LevelFilter;
 
 #[test]
 fn fmt_sets_max_level_hint() {
     tracing_subscriber::fmt()
-       .with_max_level(LevelFilter::DEBUG)
-       .init();
+        .with_max_level(LevelFilter::DEBUG)
+        .init();
     assert_eq!(LevelFilter::current(), LevelFilter::DEBUG);
 }

--- a/tracing-subscriber/tests/registry_max_level_hint.rs
+++ b/tracing-subscriber/tests/registry_max_level_hint.rs
@@ -1,14 +1,10 @@
-
-use tracing_subscriber::{
-    filter::LevelFilter,
-    prelude::*,
-};
+use tracing_subscriber::{filter::LevelFilter, prelude::*};
 
 #[test]
 fn registry_sets_max_level_hint() {
     tracing_subscriber::registry()
-       .with(tracing_subscriber::fmt::subscriber())
-       .with(LevelFilter::DEBUG)
-       .init();
+        .with(tracing_subscriber::fmt::subscriber())
+        .with(LevelFilter::DEBUG)
+        .init();
     assert_eq!(LevelFilter::current(), LevelFilter::DEBUG);
 }

--- a/tracing-subscriber/tests/registry_max_level_hint.rs
+++ b/tracing-subscriber/tests/registry_max_level_hint.rs
@@ -1,0 +1,14 @@
+
+use tracing_subscriber::{
+    filter::LevelFilter,
+    prelude::*,
+};
+
+#[test]
+fn registry_sets_max_level_hint() {
+    tracing_subscriber::registry()
+       .with(tracing_subscriber::fmt::subscriber())
+       .with(LevelFilter::DEBUG)
+       .init();
+    assert_eq!(LevelFilter::current(), LevelFilter::DEBUG);
+}


### PR DESCRIPTION
The `FmtCollector` type is missing a `Collect::max_level_hint`
method that forwards the inner stack's max level hint.

This fixes that, and adds tests.