### PR TITLE
Simplify common case of immediately entering the span

### DIFF
--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -788,6 +788,7 @@ impl Span {
     /// [`Collect::enter`]: super::collect::Collect::enter()
     /// [`Collect::exit`]: super::collect::Collect::exit()
     /// [`Id`]: super::Id
+    #[inline]
     pub fn enter(&self) -> Entered<'_> {
         self.do_enter();
         Entered {
@@ -797,6 +798,7 @@ impl Span {
     }
 
     /// An owned version of [`Entered`].
+    #[inline]
     pub fn entered(self) -> EnteredSpan {
         self.do_enter();
         EnteredSpan {

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -812,7 +812,7 @@ impl Span {
     ///
     /// ```
     /// # use tracing::info_span;
-    /// let _span = info_span!("something_interesting").entered()
+    /// let _span = info_span!("something_interesting").entered();
     /// ```
     /// rather than:
     /// ```

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -852,13 +852,13 @@ impl Span {
     /// returning the un-entered span:
     ///
     /// ```
-    /// # use tracing::Level;
+    /// # use tracing::{Level, span};
     /// let span = span!(Level::INFO, "doing_something").entered();
     ///
     /// // code here is within the span
     ///
     /// // explicitly exit the span, returning it
-    /// let span = span.exit()
+    /// let span = span.exit();
     ///
     /// // code here is no longer within the span
     ///
@@ -871,6 +871,7 @@ impl Span {
     /// Guards need not be explicitly dropped:
     ///
     /// ```
+    /// # use tracing::trace_span;
     /// fn my_function() -> String {
     ///     // enter a span for the duration of this function.
     ///     let span = trace_span!("my_function").entered();

--- a/tracing/tests/span.rs
+++ b/tracing/tests/span.rs
@@ -299,6 +299,44 @@ fn enter() {
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
+fn entered() {
+    let (collector, handle) = collector::mock()
+        .enter(span::mock().named("foo"))
+        .event(event::mock())
+        .exit(span::mock().named("foo"))
+        .drop_span(span::mock().named("foo"))
+        .done()
+        .run_with_handle();
+    with_default(collector, || {
+        let _span = span!(Level::TRACE, "foo").entered();
+        debug!("dropping guard...");
+    });
+
+    handle.assert_finished();
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn entered_api() {
+    let (collector, handle) = collector::mock()
+        .enter(span::mock().named("foo"))
+        .event(event::mock())
+        .exit(span::mock().named("foo"))
+        .drop_span(span::mock().named("foo"))
+        .done()
+        .run_with_handle();
+    with_default(collector, || {
+        let span = span!(Level::TRACE, "foo").entered();
+        let _derefs_to_span = span.id();
+        debug!("exiting span...");
+        let _: Span = span.exit();
+    });
+
+    handle.assert_finished();
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
 fn moved_field() {
     let (collector, handle) = collector::mock()
         .new_span(


### PR DESCRIPTION
This PR allows the following API:

```
let _guard = tracing::span!("foo").entered();
```

See https://github.com/tokio-rs/tracing/issues/zc for an extended
discussion.


This probably needs better docs, so that the people know that this API exists, but I would prefer to avoid further polishing the docs myself :)

Closes #1246
Closes #192
Closes #79