### PR TITLE
chore: rectify Context's generic type name to “C”

### DIFF
--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -59,9 +59,9 @@
 //!
 //! Note that logger implementations that convert log records to trace events
 //! should not be used with `Collector`s that convert trace events _back_ into
-//! log records, as doing so will result in the
-//! event recursing between the collector and the logger forever (or, in real
-//! life, probably overflowing the call stack).
+//! log records, as doing so will result in the event recursing between the
+//! collector and the logger forever (or, in real life, probably overflowing
+//! the call stack).
 //!
 //! If the logging of trace events generated from log records produced by the
 //! `log` crate is desired, either the `log` crate should not be used to

--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -542,8 +542,8 @@ pub trait CollectExt: Collect + crate::sealed::Sealed {
 /// [collector]: tracing_core::Collect
 /// [stored data]: super::registry::SpanRef
 #[derive(Debug)]
-pub struct Context<'a, S> {
-    subscriber: Option<&'a S>,
+pub struct Context<'a, C> {
+    subscriber: Option<&'a C>,
 }
 
 /// A [collector] composed of a collector wrapped by one or more


### PR DESCRIPTION
1. I believe we forgot to rename Context's generic type to `C`. 
2. Some docs look kind of messed up according to PR #1245.

So, this PR simply resolves those trivial issues.