### PR TITLE
subscriber: prepare to release v0.2.16

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,26 @@
+# 0.2.16 (February 19, 2020)
+
+### Fixed
+
+- **env-filter**: Fixed directives where the level is in mixed case (such as
+  `Info`) failing to parse ([#1126])
+- **fmt**: Fixed `fmt::Subscriber` not providing a max-level hint ([#1251])
+- `tracing-subscriber` no longer enables `tracing` and `tracing-core`'s default
+  features ([#1144])
+  
+### Changed
+
+- **chrono**: Updated `chrono` dependency to 0.4.16 ([#1189])
+- **log**: Updated `tracing-log` dependency to 0.1.2
+
+Thanks to @salewski, @taiki-e, @davidpdrsn and @markdingram for contributing to
+this release!
+
+[#1126]: https://github.com/tokio-rs/tracing/pull/1126
+[#1251]: https://github.com/tokio-rs/tracing/pull/1251
+[#1144]: https://github.com/tokio-rs/tracing/pull/1144
+[#1189]: https://github.com/tokio-rs/tracing/pull/1189
+
 # 0.2.15 (November 2, 2020)
 
 ### Fixed

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -41,7 +41,7 @@ smallvec = { optional = true, version = "1" }
 lazy_static = { optional = true, version = "1" }
 
 # fmt
-tracing-log = { path = "../tracing-log", version = "0.1", optional = true, default-features = false, features = ["log-tracer", "std"] }
+tracing-log = { path = "../tracing-log", version = "0.1.2", optional = true, default-features = false, features = ["log-tracer", "std"] }
 ansi_term = { version = "0.12", optional = true }
 chrono = { version = "0.4.16", optional = true, default-features = false, features = ["clock", "std"] }
 

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.15"
+version = "0.2.16"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -21,7 +21,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.2.15
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.16
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -67,7 +67,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.15")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.16")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.2.16 (February 19, 2020)

### Fixed

- **env-filter**: Fixed directives where the level is in mixed case
  (such as `Info`) failing to parse ([#1126])
- **fmt**: Fixed `fmt::Subscriber` not providing a max-level hint
  ([#1251])
- `tracing-subscriber` no longer enables `tracing` and `tracing-core`'s
  default features ([#1144])

### Changed

- **chrono**: Updated `chrono` dependency to 0.4.16 ([#1189])
- **log**: Updated `tracing-log` dependency to 0.1.2

Thanks to @salewski, @taiki-e, @davidpdrsn and @markdingram for
contributing to this release!

[#1126]: https://github.com/tokio-rs/tracing/pull/1126
[#1251]: https://github.com/tokio-rs/tracing/pull/1251
[#1144]: https://github.com/tokio-rs/tracing/pull/1144
[#1189]: https://github.com/tokio-rs/tracing/pull/1189

Closes #1249