### PR TITLE
tracing: prepare to release v0.1.25

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.1.25 (February 23, 2021)
+
+### Added
+
+- `Span::entered` method for entering a span and moving it into a guard by value
+  rather than borrowing it ([#1252])
+
+Thanks to @matklad for contributing to this release!
+
+[#1252]: https://github.com/tokio-rs/tracing/pull/1252
+
 # 0.1.24 (February 17, 2021)
 
 ### Fixed

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.24"
+version = "0.1.25"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -16,9 +16,9 @@ Application-level tracing for Rust.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.24
+[crates-url]: https://crates.io/crates/tracing/0.1.25
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.24
+[docs-url]: https://docs.rs/tracing/0.1.25
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -251,7 +251,7 @@ my_future
 is as long as the future's.
 
 The second, and preferred, option is through the
-[`#[instrument]`](https://docs.rs/tracing/0.1.24/tracing/attr.instrument.html)
+[`#[instrument]`](https://docs.rs/tracing/0.1.25/tracing/attr.instrument.html)
 attribute:
 
 ```rust
@@ -298,7 +298,7 @@ span.in_scope(|| {
 // Dropping the span will close it, indicating that it has ended.
 ```
 
-The [`#[instrument]`](https://docs.rs/tracing/0.1.24/tracing/attr.instrument.html) attribute macro
+The [`#[instrument]`](https://docs.rs/tracing/0.1.25/tracing/attr.instrument.html) attribute macro
 can reduce some of this boilerplate:
 
 ```rust

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -174,8 +174,7 @@ pub fn shave_all(yaks: usize) -> usize {
     //
     // local variables (`yaks`) can be used as field values
     // without an assignment, similar to struct initializers.
-    let span = span!(Level::TRACE, "shaving_yaks", yaks);
-    let _enter = span.enter();
+    let _span_ = span!(Level::TRACE, "shaving_yaks", yaks).entered();
 
     info!("shaving yaks");
 
@@ -212,11 +211,17 @@ If you are instrumenting code that make use of
 [`std::future::Future`](https://doc.rust-lang.org/stable/std/future/trait.Future.html)
 or async/await, be sure to use the
 [`tracing-futures`](https://docs.rs/tracing-futures) crate. This is needed
-because the following example _will not_ work:
+because the following examples _will not_ work:
 
 ```rust
 async {
     let _s = span.enter();
+    // ...
+}
+```
+```rust
+async {
+    let _s = tracing::span!(...).entered();
     // ...
 }
 ```

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -495,8 +495,7 @@
 //!     //
 //!     // local variables (`yaks`) can be used as field values
 //!     // without an assignment, similar to struct initializers.
-//!     let span = span!(Level::TRACE, "shaving_yaks", yaks);
-//!     let _enter = span.enter();
+//!     let _span = span!(Level::TRACE, "shaving_yaks", yaks).entered();
 //!
 //!     info!("shaving yaks");
 //!

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -783,7 +783,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing = { version = "0.1.24", default-features = false }
+//!   tracing = { version = "0.1.25", default-features = false }
 //!   ```
 //!
 //! <div class="information">
@@ -839,7 +839,7 @@
 //! [flags]: #crate-feature-flags
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.24")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.25")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -57,13 +57,12 @@
 //!
 //! A thread of execution is said to _enter_ a span when it begins executing,
 //! and _exit_ the span when it switches to another context. Spans may be
-//! entered through the [`enter`] and [`in_scope`] methods.
+//! entered through the [`enter`], [`entered`], and [`in_scope`] methods.
 //!
-//! The `enter` method enters a span, returning a [guard] that exits the span
+//! The [`enter`] method enters a span, returning a [guard] that exits the span
 //! when dropped
 //! ```
-//! # #[macro_use] extern crate tracing;
-//! # use tracing::Level;
+//! # use tracing::{span, Level};
 //! let my_var: u64 = 5;
 //! let my_span = span!(Level::TRACE, "my_span", my_var);
 //!
@@ -86,11 +85,28 @@
 //!     for details.
 //! </pre></div>
 //!
-//! `in_scope` takes a closure or function pointer and executes it inside the
-//! span.
+//! The [`entered`] method is analogous to [`enter`], but moves the span into
+//! the returned guard, rather than borrowing it. This allows creating and
+//! entering a span in a single expression:
+//!
 //! ```
-//! # #[macro_use] extern crate tracing;
-//! # use tracing::Level;
+//! # use tracing::{span, Level};
+//! // Create a span and enter it, returning a guard:
+//! let span = span!(Level::INFO, "my_span").entered();
+//!
+//! // We are now inside the span! Like `enter()`, the guard returned by
+//! // `entered()` will exit the span when it is dropped...
+//!
+//! // ...but, it can also be exited explicitly, returning the `Span`
+//! // struct:
+//! let span = span.exit();
+//! ```
+//!
+//! Finally, [`in_scope`] takes a closure or function pointer and executes it
+//! inside the span:
+//!
+//! ```
+//! # use tracing::{span, Level};
 //! let my_var: u64 = 5;
 //! let my_span = span!(Level::TRACE, "my_span", my_var = &my_var);
 //!
@@ -309,6 +325,7 @@
 //! [`Subscriber`]: ../subscriber/trait.Subscriber.html
 //! [`Attributes`]: struct.Attributes.html
 //! [`enter`]: struct.Span.html#method.enter
+//! [`entered`]: struct.Span.html#method.entered
 //! [`in_scope`]: struct.Span.html#method.in_scope
 //! [`follows_from`]: struct.Span.html#method.follows_from
 //! [guard]: struct.Entered.html


### PR DESCRIPTION
# 0.1.25 (February 23, 2021)

### Added

- `Span::entered` method for entering a span and moving it into a guard by value
  rather than borrowing it ([#1252])

Thanks to @matklad for contributing to this release!

[#1252]: https://github.com/tokio-rs/tracing/pull/1252