### PR TITLE
downcast_raw returns NonNull

### DIFF
--- a/tracing-core/src/collect.rs
+++ b/tracing-core/src/collect.rs
@@ -418,7 +418,7 @@ pub trait Collect: 'static {
     // === Downcasting methods ================================================
 
     /// If `self` is the same type as the provided `TypeId`, returns an untyped
-    /// NonNull pointer to that type. Otherwise, returns `None`.
+    /// [`NonNull`] pointer to that type. Otherwise, returns `None`.
     ///
     /// If you wish to downcast a `Collector`, it is strongly advised to use
     /// the safe API provided by [`downcast_ref`] instead.
@@ -442,9 +442,10 @@ pub trait Collect: 'static {
     /// undefined behaviour, so implementing `downcast_raw` is unsafe.
     ///
     /// [`downcast_ref`]: #method.downcast_ref
+    /// [`NonNull`]: core::ptr::NonNull
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
         if id == TypeId::of::<Self>() {
-            Some(NonNull::new_unchecked(self as *const Self as *mut ()))
+            Some(NonNull::from(self).cast())
         } else {
             None
         }
@@ -462,7 +463,7 @@ impl dyn Collect {
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
         unsafe {
             let raw = self.downcast_raw(TypeId::of::<T>())?;
-            Some(&*(raw.as_ptr() as *const _))
+            Some(&*(raw.cast::<T>().as_ptr()))
         }
     }
 }

--- a/tracing-core/src/collect.rs
+++ b/tracing-core/src/collect.rs
@@ -463,7 +463,7 @@ impl dyn Collect {
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
         unsafe {
             let raw = self.downcast_raw(TypeId::of::<T>())?;
-            Some(&*(raw.cast::<T>().as_ptr()))
+            Some(&*(raw.cast().as_ptr()))
         }
     }
 }

--- a/tracing-core/src/collect.rs
+++ b/tracing-core/src/collect.rs
@@ -2,6 +2,7 @@
 use crate::{span, Event, LevelFilter, Metadata};
 
 use core::any::{Any, TypeId};
+use core::ptr::NonNull;
 
 /// Trait representing the functions required to collect trace data.
 ///
@@ -417,7 +418,7 @@ pub trait Collect: 'static {
     // === Downcasting methods ================================================
 
     /// If `self` is the same type as the provided `TypeId`, returns an untyped
-    /// `*const` pointer to that type. Otherwise, returns `None`.
+    /// NonNull pointer to that type. Otherwise, returns `None`.
     ///
     /// If you wish to downcast a `Collector`, it is strongly advised to use
     /// the safe API provided by [`downcast_ref`] instead.
@@ -436,14 +437,14 @@ pub trait Collect: 'static {
     /// # Safety
     ///
     /// The [`downcast_ref`] method expects that the pointer returned by
-    /// `downcast_raw` is non-null and points to a valid instance of the type
+    /// `downcast_raw` points to a valid instance of the type
     /// with the provided `TypeId`. Failure to ensure this will result in
     /// undefined behaviour, so implementing `downcast_raw` is unsafe.
     ///
     /// [`downcast_ref`]: #method.downcast_ref
-    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+    unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
         if id == TypeId::of::<Self>() {
-            Some(self as *const Self as *const ())
+            Some(NonNull::new_unchecked(self as *const Self as *mut ()))
         } else {
             None
         }
@@ -461,11 +462,7 @@ impl dyn Collect {
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
         unsafe {
             let raw = self.downcast_raw(TypeId::of::<T>())?;
-            if raw.is_null() {
-                None
-            } else {
-                Some(&*(raw as *const _))
-            }
+            Some(&*(raw.as_ptr() as *const _))
         }
     }
 }

--- a/tracing-error/src/layer.rs
+++ b/tracing-error/src/layer.rs
@@ -1,6 +1,9 @@
-use std::any::{type_name, TypeId};
 use std::fmt;
 use std::marker::PhantomData;
+use std::{
+    any::{type_name, TypeId},
+    ptr::NonNull,
+};
 use tracing::{span, Collect, Dispatch, Metadata};
 use tracing_subscriber::fmt::format::{DefaultFields, FormatFields};
 use tracing_subscriber::{
@@ -57,12 +60,14 @@ where
         }
     }
 
-    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+    unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
         match id {
-            id if id == TypeId::of::<Self>() => Some(self as *const _ as *const ()),
-            id if id == TypeId::of::<WithContext>() => {
-                Some(&self.get_context as *const _ as *const ())
+            id if id == TypeId::of::<Self>() => {
+                Some(NonNull::new_unchecked(self as *const _ as *mut ()))
             }
+            id if id == TypeId::of::<WithContext>() => Some(NonNull::new_unchecked(
+                &self.get_context as *const _ as *mut (),
+            )),
             _ => None,
         }
     }

--- a/tracing-error/src/layer.rs
+++ b/tracing-error/src/layer.rs
@@ -62,12 +62,10 @@ where
 
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
         match id {
-            id if id == TypeId::of::<Self>() => {
-                Some(NonNull::new_unchecked(self as *const _ as *mut ()))
+            id if id == TypeId::of::<Self>() => Some(NonNull::from(self).cast()),
+            id if id == TypeId::of::<WithContext>() => {
+                Some(NonNull::from(&self.get_context).cast())
             }
-            id if id == TypeId::of::<WithContext>() => Some(NonNull::new_unchecked(
-                &self.get_context as *const _ as *mut (),
-            )),
             _ => None,
         }
     }

--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -558,12 +558,10 @@ where
     // for the lifetime of `&self`.
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
         match id {
-            id if id == TypeId::of::<Self>() => {
-                Some(NonNull::new_unchecked(self as *const _ as *mut ()))
+            id if id == TypeId::of::<Self>() => Some(NonNull::from(self).cast()),
+            id if id == TypeId::of::<WithContext>() => {
+                Some(NonNull::from(&self.get_context).cast())
             }
-            id if id == TypeId::of::<WithContext>() => Some(NonNull::new_unchecked(
-                &self.get_context as *const _ as *mut (),
-            )),
             _ => None,
         }
     }

--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -1,9 +1,9 @@
 use crate::PreSampledTracer;
 use opentelemetry::{trace as otel, trace::TraceContextExt, Context as OtelContext, Key, KeyValue};
-use std::any::TypeId;
 use std::fmt;
 use std::marker;
 use std::time::{Instant, SystemTime};
+use std::{any::TypeId, ptr::NonNull};
 use tracing_core::span::{self, Attributes, Id, Record};
 use tracing_core::{field, Collect, Event};
 #[cfg(feature = "tracing-log")]
@@ -556,12 +556,14 @@ where
 
     // SAFETY: this is safe because the `WithContext` function pointer is valid
     // for the lifetime of `&self`.
-    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+    unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
         match id {
-            id if id == TypeId::of::<Self>() => Some(self as *const _ as *const ()),
-            id if id == TypeId::of::<WithContext>() => {
-                Some(&self.get_context as *const _ as *const ())
+            id if id == TypeId::of::<Self>() => {
+                Some(NonNull::new_unchecked(self as *const _ as *mut ()))
             }
+            id if id == TypeId::of::<WithContext>() => Some(NonNull::new_unchecked(
+                &self.get_context as *const _ as *mut (),
+            )),
             _ => None,
         }
     }

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -5,7 +5,10 @@ use crate::{
     subscribe::{self, Context, Scope},
 };
 use format::{FmtSpan, TimingDisplay};
-use std::{any::TypeId, cell::RefCell, fmt, io, marker::PhantomData, ops::Deref, time::Instant};
+use std::{
+    any::TypeId, cell::RefCell, fmt, io, marker::PhantomData, ops::Deref, ptr::NonNull,
+    time::Instant,
+};
 use tracing_core::{
     field,
     span::{Attributes, Id, Record},
@@ -706,16 +709,24 @@ where
         });
     }
 
-    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+    unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
         // This `downcast_raw` impl allows downcasting a `fmt` layer to any of
         // its components (event formatter, field formatter, and `MakeWriter`)
         // as well as to the layer's type itself. The potential use-cases for
         // this *may* be somewhat niche, though...
         match () {
-            _ if id == TypeId::of::<Self>() => Some(self as *const Self as *const ()),
-            _ if id == TypeId::of::<E>() => Some(&self.fmt_event as *const E as *const ()),
-            _ if id == TypeId::of::<N>() => Some(&self.fmt_fields as *const N as *const ()),
-            _ if id == TypeId::of::<W>() => Some(&self.make_writer as *const W as *const ()),
+            _ if id == TypeId::of::<Self>() => {
+                Some(NonNull::new_unchecked(self as *const Self as *mut ()))
+            }
+            _ if id == TypeId::of::<E>() => Some(NonNull::new_unchecked(
+                &self.fmt_event as *const E as *mut (),
+            )),
+            _ if id == TypeId::of::<N>() => Some(NonNull::new_unchecked(
+                &self.fmt_fields as *const N as *mut (),
+            )),
+            _ if id == TypeId::of::<W>() => Some(NonNull::new_unchecked(
+                &self.make_writer as *const W as *mut (),
+            )),
             _ => None,
         }
     }

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -715,18 +715,10 @@ where
         // as well as to the layer's type itself. The potential use-cases for
         // this *may* be somewhat niche, though...
         match () {
-            _ if id == TypeId::of::<Self>() => {
-                Some(NonNull::new_unchecked(self as *const Self as *mut ()))
-            }
-            _ if id == TypeId::of::<E>() => Some(NonNull::new_unchecked(
-                &self.fmt_event as *const E as *mut (),
-            )),
-            _ if id == TypeId::of::<N>() => Some(NonNull::new_unchecked(
-                &self.fmt_fields as *const N as *mut (),
-            )),
-            _ if id == TypeId::of::<W>() => Some(NonNull::new_unchecked(
-                &self.make_writer as *const W as *mut (),
-            )),
+            _ if id == TypeId::of::<Self>() => Some(NonNull::from(self).cast()),
+            _ if id == TypeId::of::<E>() => Some(NonNull::from(&self.fmt_event).cast()),
+            _ if id == TypeId::of::<N>() => Some(NonNull::from(&self.fmt_fields).cast()),
+            _ if id == TypeId::of::<W>() => Some(NonNull::from(&self.make_writer).cast()),
             _ => None,
         }
     }

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -514,7 +514,7 @@ where
 
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
         if id == TypeId::of::<Self>() {
-            Some(NonNull::new_unchecked(self as *const Self as *mut ()))
+            Some(NonNull::from(self).cast())
         } else {
             self.inner.downcast_raw(id)
         }

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -283,7 +283,7 @@
 //! [`Collect`]:
 //!     https://docs.rs/tracing/latest/tracing/trait.Collect.html
 //! [`tracing`]: https://crates.io/crates/tracing
-use std::{any::TypeId, error::Error, io};
+use std::{any::TypeId, error::Error, io, ptr::NonNull};
 use tracing_core::{collect::Interest, span, Event, Metadata};
 
 mod fmt_subscriber;
@@ -512,9 +512,9 @@ where
         self.inner.max_level_hint()
     }
 
-    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+    unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
         if id == TypeId::of::<Self>() {
-            Some(self as *const Self as *const ())
+            Some(NonNull::new_unchecked(self as *const Self as *mut ()))
         } else {
             self.inner.downcast_raw(id)
         }

--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -9,7 +9,7 @@ use tracing_core::{
 
 #[cfg(feature = "registry")]
 use crate::registry::{self, LookupSpan, Registry, SpanRef};
-use std::{any::TypeId, marker::PhantomData};
+use std::{any::TypeId, marker::PhantomData, ptr::NonNull};
 
 /// A composable handler for `tracing` events.
 ///
@@ -496,9 +496,9 @@ where
     }
 
     #[doc(hidden)]
-    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+    unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
         if id == TypeId::of::<Self>() {
-            Some(self as *const _ as *const ())
+            Some(NonNull::new_unchecked(self as *const Self as *mut ()))
         } else {
             None
         }
@@ -694,9 +694,9 @@ where
     }
 
     #[doc(hidden)]
-    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+    unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
         if id == TypeId::of::<Self>() {
-            return Some(self as *const _ as *const ());
+            return Some(NonNull::new_unchecked(self as *const Self as *mut ()));
         }
         self.subscriber
             .downcast_raw(id)
@@ -788,9 +788,9 @@ where
     }
 
     #[doc(hidden)]
-    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+    unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
         if id == TypeId::of::<Self>() {
-            return Some(self as *const _ as *const ());
+            return Some(NonNull::new_unchecked(self as *const Self as *mut ()));
         }
         self.subscriber
             .downcast_raw(id)
@@ -885,9 +885,9 @@ where
 
     #[doc(hidden)]
     #[inline]
-    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+    unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
         if id == TypeId::of::<Self>() {
-            Some(self as *const _ as *const ())
+            Some(NonNull::new_unchecked(self as *const Self as *mut ()))
         } else {
             self.as_ref().and_then(|inner| inner.downcast_raw(id))
         }

--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -498,7 +498,7 @@ where
     #[doc(hidden)]
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
         if id == TypeId::of::<Self>() {
-            Some(NonNull::new_unchecked(self as *const Self as *mut ()))
+            Some(NonNull::from(self).cast())
         } else {
             None
         }
@@ -696,7 +696,7 @@ where
     #[doc(hidden)]
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
         if id == TypeId::of::<Self>() {
-            return Some(NonNull::new_unchecked(self as *const Self as *mut ()));
+            return Some(NonNull::from(self).cast());
         }
         self.subscriber
             .downcast_raw(id)
@@ -790,7 +790,7 @@ where
     #[doc(hidden)]
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
         if id == TypeId::of::<Self>() {
-            return Some(NonNull::new_unchecked(self as *const Self as *mut ()));
+            return Some(NonNull::from(self).cast());
         }
         self.subscriber
             .downcast_raw(id)
@@ -887,7 +887,7 @@ where
     #[inline]
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
         if id == TypeId::of::<Self>() {
-            Some(NonNull::new_unchecked(self as *const Self as *mut ()))
+            Some(NonNull::from(self).cast())
         } else {
             self.as_ref().and_then(|inner| inner.downcast_raw(id))
         }


### PR DESCRIPTION
## Motivation
Resolves #1073, quoting from there:
> If we changed this to Option<NonNull<()>> we could benefit from niche optimization, saving us the option discriminant and making this return a single word pointer. That may in turn let us benefit from additional optimizations. This could make downcasting slightly faster.

## Solution

I've made the change to the function signature and let rustc guide me through the process of fixing all callers. This was mostly straightforward but it is `unsafe` code so I'm not sure the changes here are correct.