### PR TITLE
subscriber: change `EnvFilter` to use anchored regexes

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -35,7 +35,7 @@ tracing-core = { path = "../tracing-core", version = "0.2" }
 
 # only required by the filter feature
 tracing = { optional = true, path = "../tracing", version = "0.2", default-features = false, features = ["std"] }
-matchers = { optional = true, version = "0.0.1" }
+matchers = { optional = true, version = "0.1.0" }
 regex = { optional = true, version = "1", default-features = false, features = ["std"] }
 smallvec = { optional = true, version = "1" }
 lazy_static = { optional = true, version = "1" }

--- a/tracing-subscriber/src/filter/env/field.rs
+++ b/tracing-subscriber/src/filter/env/field.rs
@@ -157,7 +157,7 @@ impl fmt::Display for ValueMatch {
 impl FromStr for MatchPattern {
     type Err = matchers::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let matcher = s.parse::<Pattern>()?;
+        let matcher = Pattern::new_anchored(s)?;
         Ok(Self {
             matcher,
             pattern: s.to_owned().into(),


### PR DESCRIPTION
This commit changes `EnvFilter`'s field filters to use regexes which are
anchored at the beginning of the field's `fmt::Display` output, rather
than matching patterns which begin anywhere in the output. Essentially,
the field matching filters previously behaved as though all patterns
began with `.*?`, which is not the desired behavior.

This required an update to `matchers` v0.1.0, which adds an API for
constructing this type of pattern.

Fixes #1234
Closes #1269

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
