### PR TITLE
subscriber: fix extra padding in pretty format

### DIFF
--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -241,12 +241,14 @@ impl<'a> PrettyVisitor<'a> {
         Self { style, ..self }
     }
 
-    fn maybe_pad(&mut self) {
-        if self.is_empty {
+    fn write_padded(&mut self, value: &dyn fmt::Debug) {
+        let padding = if self.is_empty {
             self.is_empty = false;
+            ""
         } else {
-            self.result = write!(self.writer, ", ");
-        }
+            ", "
+        };
+        self.result = write!(self.writer, "{}{:?}", padding, value);
     }
 }
 
@@ -287,28 +289,25 @@ impl<'a> field::Visit for PrettyVisitor<'a> {
             return;
         }
         let bold = self.style.bold();
-        self.maybe_pad();
-        self.result = match field.name() {
-            "message" => write!(self.writer, "{}{:?}", self.style.prefix(), value,),
+        match field.name() {
+            "message" => self.write_padded(&format_args!("{}{:?}", self.style.prefix(), value,)),
             // Skip fields that are actually log metadata that have already been handled
             #[cfg(feature = "tracing-log")]
-            name if name.starts_with("log.") => Ok(()),
-            name if name.starts_with("r#") => write!(
-                self.writer,
+            name if name.starts_with("log.") => self.result = Ok(()),
+            name if name.starts_with("r#") => self.write_padded(&format_args!(
                 "{}{}{}: {:?}",
                 bold.prefix(),
                 &name[2..],
                 bold.infix(self.style),
                 value
-            ),
-            name => write!(
-                self.writer,
+            )),
+            name => self.write_padded(&format_args!(
                 "{}{}{}: {:?}",
                 bold.prefix(),
                 name,
                 bold.infix(self.style),
                 value
-            ),
+            )),
         };
     }
 }

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -241,7 +241,7 @@ impl<'a> PrettyVisitor<'a> {
         Self { style, ..self }
     }
 
-    fn write_padded(&mut self, value: &dyn fmt::Debug) {
+    fn write_padded(&mut self, value: &impl fmt::Debug) {
         let padding = if self.is_empty {
             self.is_empty = false;
             ""


### PR DESCRIPTION
## Motivation

This fixes #1212, where extra padding was written when logging with the
pretty formatter.

## Solution 

With this change we only write padding when we actually decide to write
a value but not when skipping a metadata value such as `log.file` or
`log.line`