### PR TITLE
Remove unnecessary transparent attribute

### DIFF
--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1121,7 +1121,6 @@ impl Default for FmtSpanConfig {
     }
 }
 
-#[repr(transparent)]
 pub(super) struct TimingDisplay(pub(super) u64);
 impl Display for TimingDisplay {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
As far as I can tell, we are not relying on transparency anywhere, so
using this rather refined feature here is confusing.