### PR TITLE
Add a public `current_span()` method for `FmtContext`

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -11,7 +11,7 @@ use std::{
 };
 use tracing_core::{
     field,
-    span::{Attributes, Id, Record},
+    span::{Attributes, Current, Id, Record},
     Collect, Event, Metadata,
 };
 
@@ -830,6 +830,11 @@ where
         S: for<'lookup> LookupSpan<'lookup>,
     {
         self.ctx.scope()
+    }
+
+    /// Returns the current span for this formatter.
+    pub fn current_span(&self) -> Current {
+        self.ctx.current_span()
     }
 
     /// Returns the [field formatter] configured by the subscriber invoking


### PR DESCRIPTION
## Motivation
The downstream crate is very restricted to do some format thing related to the current span. Because the `ctx` field of `FmtContext` provided by `FormatEvent::format_event()` is non-public to the third crates and we have no public method to get the current span.

## Solution

Add a new public method called `current_span()` to delegate the method call to inner `ctx`.

## Alternatives

Make two fields of `FmtContext` complete public rather than only public in the crate? Or don't this.
