### PR TITLE
attributes: prepare to release v0.1.14

### DIFF
--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,4 +1,15 @@
 
+# 0.1.14 (March 10, 2021)
+
+### Fixed
+
+- Compatibility between `#[instrument]` and `async-trait` v0.1.43 and newer
+  ([#1228])
+
+Thanks to @nightmared for lots of hard work on this fix!
+
+[#1228]: https://github.com/tokio-rs/tracing/pull/1228
+
 # 0.1.13 (February 17, 2021)
 
 ### Fixed

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-attributes"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.13"
+version = "0.1.14"
 authors = [
     "Tokio Contributors <team@tokio.rs>",
     "Eliza Weisman <eliza@buoyant.io>",

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -18,7 +18,7 @@ Macro attributes for application-level tracing.
 [crates-badge]: https://img.shields.io/crates/v/tracing-attributes.svg
 [crates-url]: https://crates.io/crates/tracing-attributes
 [docs-badge]: https://docs.rs/tracing-attributes/badge.svg
-[docs-url]: https://docs.rs/tracing-attributes/0.1.13
+[docs-url]: https://docs.rs/tracing-attributes/0.1.14
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_attributes
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -47,7 +47,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing-attributes = "0.1.13"
+tracing-attributes = "0.1.14"
 ```
 
 

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tracing-attributes = "0.1.13"
+//! tracing-attributes = "0.1.14"
 //! ```
 //!
 //! The [`#[instrument]`][instrument] attribute can now be added to a function
@@ -52,7 +52,7 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
-#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.13")]
+#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.14")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -29,7 +29,7 @@ edition = "2018"
 [dependencies]
 tracing-core = { path = "../tracing-core", version = "0.1.17", default-features = false }
 log = { version = "0.4", optional = true }
-tracing-attributes = { path = "../tracing-attributes", version = "0.1.13", optional = true }
+tracing-attributes = { path = "../tracing-attributes", version = "0.1.14", optional = true }
 cfg-if = "1.0.0"
 pin-project-lite = "0.2"
 


### PR DESCRIPTION
### Fixed

- Compatibility between `#[instrument]` and `async-trait` v0.1.43 and
  newer ([#1228])

Thanks to @nightmared for lots of hard work on this fix!

[#1228]: https://github.com/tokio-rs/tracing/pull/1228
