### PR TITLE
subscriber: remove trailing space from ChronoLocal time formatter

### DIFF
--- a/tracing-subscriber/src/fmt/time/mod.rs
+++ b/tracing-subscriber/src/fmt/time/mod.rs
@@ -241,8 +241,8 @@ impl FormatTime for ChronoLocal {
     fn format_time(&self, w: &mut dyn fmt::Write) -> fmt::Result {
         let time = chrono::Local::now();
         match self.format {
-            ChronoFmtType::Rfc3339 => write!(w, "{} ", time.to_rfc3339()),
-            ChronoFmtType::Custom(ref format_str) => write!(w, "{} ", time.format(format_str)),
+            ChronoFmtType::Rfc3339 => write!(w, "{}", time.to_rfc3339()),
+            ChronoFmtType::Custom(ref format_str) => write!(w, "{}", time.format(format_str)),
         }
     }
 }


### PR DESCRIPTION
This backports #1103 to `v0.1.x`

I reckon this is a bug, and @samschlegel fixed this for ChronoUtc,
but not for ChronoLocal.

Closes #1271 