### PR TITLE
backport recent subscriber and attributes changes

### DIFF
--- a/tracing-attributes/tests/async_fn.rs
+++ b/tracing-attributes/tests/async_fn.rs
@@ -4,6 +4,7 @@
 mod support;
 use support::*;
 
+use std::{future::Future, pin::Pin, sync::Arc};
 use tracing::subscriber::with_default;
 use tracing_attributes::instrument;
 
@@ -214,6 +215,18 @@ fn async_fn_with_async_trait_and_fields_expressions_with_generic_parameter() {
     #[derive(Clone, Debug)]
     struct TestImpl;
 
+    // we also test sync functions that return futures, as they should be handled just like
+    // async-trait (>= 0.1.44) functions
+    impl TestImpl {
+        #[instrument(fields(Self=std::any::type_name::<Self>()))]
+        fn sync_fun(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+            let val = self.clone();
+            Box::pin(async move {
+                let _ = val;
+            })
+        }
+    }
+
     #[async_trait]
     impl Test for TestImpl {
         // instrumenting this is currently not possible, see https://github.com/tokio-rs/tracing/issues/864#issuecomment-667508801
@@ -221,7 +234,9 @@ fn async_fn_with_async_trait_and_fields_expressions_with_generic_parameter() {
         async fn call() {}
 
         #[instrument(fields(Self=std::any::type_name::<Self>()))]
-        async fn call_with_self(&self) {}
+        async fn call_with_self(&self) {
+            self.sync_fun().await;
+        }
 
         #[instrument(fields(Self=std::any::type_name::<Self>()))]
         async fn call_with_mut_self(&mut self) {}
@@ -230,6 +245,7 @@ fn async_fn_with_async_trait_and_fields_expressions_with_generic_parameter() {
     //let span = span::mock().named("call");
     let span2 = span::mock().named("call_with_self");
     let span3 = span::mock().named("call_with_mut_self");
+    let span4 = span::mock().named("sync_fun");
     let (subscriber, handle) = subscriber::mock()
         /*.new_span(span.clone()
             .with_field(
@@ -243,6 +259,13 @@ fn async_fn_with_async_trait_and_fields_expressions_with_generic_parameter() {
                 .with_field(field::mock("Self").with_value(&std::any::type_name::<TestImpl>())),
         )
         .enter(span2.clone())
+        .new_span(
+            span4
+                .clone()
+                .with_field(field::mock("Self").with_value(&std::any::type_name::<TestImpl>())),
+        )
+        .enter(span4.clone())
+        .exit(span4)
         .exit(span2.clone())
         .drop_span(span2)
         .new_span(
@@ -261,6 +284,48 @@ fn async_fn_with_async_trait_and_fields_expressions_with_generic_parameter() {
             TestImpl::call().await;
             TestImpl.call_with_self().await;
             TestImpl.call_with_mut_self().await
+        });
+    });
+
+    handle.assert_finished();
+}
+
+#[test]
+fn out_of_scope_fields() {
+    // Reproduces tokio-rs/tracing#1296
+
+    struct Thing {
+        metrics: Arc<()>,
+    }
+
+    impl Thing {
+        #[instrument(skip(self, _req), fields(app_id))]
+        fn call(&mut self, _req: ()) -> Pin<Box<dyn Future<Output = Arc<()>> + Send + Sync>> {
+            // ...
+            let metrics = self.metrics.clone();
+            // ...
+            Box::pin(async move {
+                // ...
+                metrics // cannot find value `metrics` in this scope
+            })
+        }
+    }
+
+    let span = span::mock().named("call");
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(span.clone())
+        .enter(span.clone())
+        .exit(span.clone())
+        .drop_span(span)
+        .done()
+        .run_with_handle();
+
+    with_default(subscriber, || {
+        block_on_future(async {
+            let mut my_thing = Thing {
+                metrics: Arc::new(()),
+            };
+            my_thing.call(()).await;
         });
     });
 

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -279,11 +279,8 @@ where
     /// [time]: #method.without_time
     pub fn with_span_events(self, kind: FmtSpan) -> Self {
         Layer {
-            fmt_event: self.fmt_event,
-            fmt_fields: self.fmt_fields,
             fmt_span: self.fmt_span.with_kind(kind),
-            make_writer: self.make_writer,
-            _inner: self._inner,
+            ..self
         }
     }
 
@@ -293,10 +290,7 @@ where
     pub fn with_ansi(self, ansi: bool) -> Layer<S, N, format::Format<L, T>, W> {
         Layer {
             fmt_event: self.fmt_event.with_ansi(ansi),
-            fmt_fields: self.fmt_fields,
-            fmt_span: self.fmt_span,
-            make_writer: self.make_writer,
-            _inner: self._inner,
+            ..self
         }
     }
 
@@ -304,10 +298,7 @@ where
     pub fn with_target(self, display_target: bool) -> Layer<S, N, format::Format<L, T>, W> {
         Layer {
             fmt_event: self.fmt_event.with_target(display_target),
-            fmt_fields: self.fmt_fields,
-            fmt_span: self.fmt_span,
-            make_writer: self.make_writer,
-            _inner: self._inner,
+            ..self
         }
     }
 
@@ -315,10 +306,7 @@ where
     pub fn with_level(self, display_level: bool) -> Layer<S, N, format::Format<L, T>, W> {
         Layer {
             fmt_event: self.fmt_event.with_level(display_level),
-            fmt_fields: self.fmt_fields,
-            fmt_span: self.fmt_span,
-            make_writer: self.make_writer,
-            _inner: self._inner,
+            ..self
         }
     }
 
@@ -329,10 +317,7 @@ where
     pub fn with_thread_ids(self, display_thread_ids: bool) -> Layer<S, N, format::Format<L, T>, W> {
         Layer {
             fmt_event: self.fmt_event.with_thread_ids(display_thread_ids),
-            fmt_fields: self.fmt_fields,
-            fmt_span: self.fmt_span,
-            make_writer: self.make_writer,
-            _inner: self._inner,
+            ..self
         }
     }
 
@@ -346,10 +331,7 @@ where
     ) -> Layer<S, N, format::Format<L, T>, W> {
         Layer {
             fmt_event: self.fmt_event.with_thread_names(display_thread_names),
-            fmt_fields: self.fmt_fields,
-            fmt_span: self.fmt_span,
-            make_writer: self.make_writer,
-            _inner: self._inner,
+            ..self
         }
     }
 
@@ -422,9 +404,7 @@ impl<S, T, W> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
         Layer {
             fmt_event: self.fmt_event.flatten_event(flatten_event),
             fmt_fields: format::JsonFields::new(),
-            fmt_span: self.fmt_span,
-            make_writer: self.make_writer,
-            _inner: self._inner,
+            ..self
         }
     }
 
@@ -439,9 +419,7 @@ impl<S, T, W> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
         Layer {
             fmt_event: self.fmt_event.with_current_span(display_current_span),
             fmt_fields: format::JsonFields::new(),
-            fmt_span: self.fmt_span,
-            make_writer: self.make_writer,
-            _inner: self._inner,
+            ..self
         }
     }
 
@@ -456,9 +434,7 @@ impl<S, T, W> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
         Layer {
             fmt_event: self.fmt_event.with_span_list(display_span_list),
             fmt_fields: format::JsonFields::new(),
-            fmt_span: self.fmt_span,
-            make_writer: self.make_writer,
-            _inner: self._inner,
+            ..self
         }
     }
 }

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -8,7 +8,7 @@ use format::{FmtSpan, TimingDisplay};
 use std::{any::TypeId, cell::RefCell, fmt, io, marker::PhantomData, ops::Deref, time::Instant};
 use tracing_core::{
     field,
-    span::{Attributes, Id, Record},
+    span::{Attributes, Current, Id, Record},
     Event, Metadata, Subscriber,
 };
 
@@ -854,6 +854,11 @@ where
         S: for<'lookup> LookupSpan<'lookup>,
     {
         self.ctx.scope()
+    }
+
+    /// Returns the current span for this formatter.
+    pub fn current_span(&self) -> Current {
+        self.ctx.current_span()
     }
 
     /// Returns the [field formatter] configured by the subscriber invoking

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1088,40 +1088,89 @@ impl<'a, F> fmt::Debug for FieldFnVisitor<'a, F> {
 ///
 /// See also [`with_span_events`](../struct.SubscriberBuilder.html#method.with_span_events).
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
-pub struct FmtSpan(FmtSpanInner);
+pub struct FmtSpan(u8);
 
 impl FmtSpan {
-    /// spans are ignored (this is the default)
-    pub const NONE: FmtSpan = FmtSpan(FmtSpanInner::None);
-    /// one event per enter/exit of a span
-    pub const ACTIVE: FmtSpan = FmtSpan(FmtSpanInner::Active);
+    /// one event when span is created
+    pub const NEW: FmtSpan = FmtSpan(1 << 0);
+    /// one event per enter of a span
+    pub const ENTER: FmtSpan = FmtSpan(1 << 1);
+    /// one event per exit of a span
+    pub const EXIT: FmtSpan = FmtSpan(1 << 2);
     /// one event when the span is dropped
-    pub const CLOSE: FmtSpan = FmtSpan(FmtSpanInner::Close);
-    /// events at all points (new, enter, exit, drop)
-    pub const FULL: FmtSpan = FmtSpan(FmtSpanInner::Full);
-}
+    pub const CLOSE: FmtSpan = FmtSpan(1 << 3);
 
-impl Debug for FmtSpan {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.0 {
-            FmtSpanInner::None => f.write_str("FmtSpan::NONE"),
-            FmtSpanInner::Active => f.write_str("FmtSpan::ACTIVE"),
-            FmtSpanInner::Close => f.write_str("FmtSpan::CLOSE"),
-            FmtSpanInner::Full => f.write_str("FmtSpan::FULL"),
-        }
+    /// spans are ignored (this is the default)
+    pub const NONE: FmtSpan = FmtSpan(0);
+    /// one event per enter/exit of a span
+    pub const ACTIVE: FmtSpan = FmtSpan(FmtSpan::ENTER.0 | FmtSpan::EXIT.0);
+    /// events at all points (new, enter, exit, drop)
+    pub const FULL: FmtSpan =
+        FmtSpan(FmtSpan::NEW.0 | FmtSpan::ENTER.0 | FmtSpan::EXIT.0 | FmtSpan::CLOSE.0);
+
+    /// Check whether or not a certain flag is set for this [`FmtSpan`]
+    fn contains(&self, other: FmtSpan) -> bool {
+        self.clone() & other.clone() == other
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-enum FmtSpanInner {
-    /// spans are ignored (this is the default)
-    None,
-    /// one event per enter/exit of a span
-    Active,
-    /// one event when the span is dropped
-    Close,
-    /// events at all points (new, enter, exit, drop)
-    Full,
+macro_rules! impl_fmt_span_bit_op {
+    ($trait:ident, $func:ident, $op:tt) => {
+        impl std::ops::$trait for FmtSpan {
+            type Output = FmtSpan;
+
+            fn $func(self, rhs: Self) -> Self::Output {
+                FmtSpan(self.0 $op rhs.0)
+            }
+        }
+    };
+}
+
+macro_rules! impl_fmt_span_bit_assign_op {
+    ($trait:ident, $func:ident, $op:tt) => {
+        impl std::ops::$trait for FmtSpan {
+            fn $func(&mut self, rhs: Self) {
+                *self = FmtSpan(self.0 $op rhs.0)
+            }
+        }
+    };
+}
+
+impl_fmt_span_bit_op!(BitAnd, bitand, &);
+impl_fmt_span_bit_op!(BitOr, bitor, |);
+impl_fmt_span_bit_op!(BitXor, bitxor, ^);
+
+impl_fmt_span_bit_assign_op!(BitAndAssign, bitand_assign, &);
+impl_fmt_span_bit_assign_op!(BitOrAssign, bitor_assign, |);
+impl_fmt_span_bit_assign_op!(BitXorAssign, bitxor_assign, ^);
+
+impl Debug for FmtSpan {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut wrote_flag = false;
+        let mut write_flags = |flag, flag_str| -> fmt::Result {
+            if self.contains(flag) {
+                if wrote_flag {
+                    f.write_str(" | ")?;
+                }
+
+                f.write_str(flag_str)?;
+                wrote_flag = true;
+            }
+
+            Ok(())
+        };
+
+        if FmtSpan::NONE | self.clone() == FmtSpan::NONE {
+            f.write_str("FmtSpan::NONE")?;
+        } else {
+            write_flags(FmtSpan::NEW, "FmtSpan::NEW")?;
+            write_flags(FmtSpan::ENTER, "FmtSpan::ENTER")?;
+            write_flags(FmtSpan::EXIT, "FmtSpan::EXIT")?;
+            write_flags(FmtSpan::CLOSE, "FmtSpan::CLOSE")?;
+        }
+
+        Ok(())
+    }
 }
 
 pub(super) struct FmtSpanConfig {
@@ -1143,13 +1192,16 @@ impl FmtSpanConfig {
         }
     }
     pub(super) fn trace_new(&self) -> bool {
-        matches!(self.kind, FmtSpan::FULL)
+        self.kind.contains(FmtSpan::NEW)
     }
-    pub(super) fn trace_active(&self) -> bool {
-        matches!(self.kind, FmtSpan::ACTIVE | FmtSpan::FULL)
+    pub(super) fn trace_enter(&self) -> bool {
+        self.kind.contains(FmtSpan::ENTER)
+    }
+    pub(super) fn trace_exit(&self) -> bool {
+        self.kind.contains(FmtSpan::EXIT)
     }
     pub(super) fn trace_close(&self) -> bool {
-        matches!(self.kind, FmtSpan::CLOSE | FmtSpan::FULL)
+        self.kind.contains(FmtSpan::CLOSE)
     }
 }
 
@@ -1193,7 +1245,7 @@ pub(super) mod test {
     use lazy_static::lazy_static;
     use tracing::{self, subscriber::with_default};
 
-    use super::TimingDisplay;
+    use super::{FmtSpan, TimingDisplay};
     use std::{fmt, sync::Mutex};
 
     pub(crate) struct MockTime;
@@ -1379,5 +1431,32 @@ pub(super) mod test {
         assert_eq!(fmt(12345678901), "12.3s");
         assert_eq!(fmt(123456789012), "123s");
         assert_eq!(fmt(1234567890123), "1235s");
+    }
+
+    #[test]
+    fn fmt_span_combinations() {
+        let f = FmtSpan::NONE;
+        assert_eq!(f.contains(FmtSpan::NEW), false);
+        assert_eq!(f.contains(FmtSpan::ENTER), false);
+        assert_eq!(f.contains(FmtSpan::EXIT), false);
+        assert_eq!(f.contains(FmtSpan::CLOSE), false);
+
+        let f = FmtSpan::ACTIVE;
+        assert_eq!(f.contains(FmtSpan::NEW), false);
+        assert_eq!(f.contains(FmtSpan::ENTER), true);
+        assert_eq!(f.contains(FmtSpan::EXIT), true);
+        assert_eq!(f.contains(FmtSpan::CLOSE), false);
+
+        let f = FmtSpan::FULL;
+        assert_eq!(f.contains(FmtSpan::NEW), true);
+        assert_eq!(f.contains(FmtSpan::ENTER), true);
+        assert_eq!(f.contains(FmtSpan::EXIT), true);
+        assert_eq!(f.contains(FmtSpan::CLOSE), true);
+
+        let f = FmtSpan::NEW | FmtSpan::CLOSE;
+        assert_eq!(f.contains(FmtSpan::NEW), true);
+        assert_eq!(f.contains(FmtSpan::ENTER), false);
+        assert_eq!(f.contains(FmtSpan::EXIT), false);
+        assert_eq!(f.contains(FmtSpan::CLOSE), true);
     }
 }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -293,6 +293,23 @@ impl<F, T> Format<F, T> {
     /// See [`Pretty`].
     ///
     /// Note that this requires the "ansi" feature to be enabled.
+    ///
+    /// # Options
+    ///
+    /// [`Format::with_ansi`] can be used to disable ANSI terminal escape codes (which enable
+    /// formatting such as colors, bold, italic, etc) in event formatting. However, a field
+    /// formatter must be manually provided to avoid ANSI in the formatting of parent spans, like
+    /// so:
+    ///
+    /// ```
+    /// # use tracing_subscriber::fmt::format;
+    /// tracing_subscriber::fmt()
+    ///    .pretty()
+    ///    .with_ansi(false)
+    ///    .fmt_fields(format::PrettyFields::new().with_ansi(false))
+    ///    // ... other settings ...
+    ///    .init();
+    /// ```
     #[cfg(feature = "ansi")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
     pub fn pretty(self) -> Format<Pretty, T> {

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1168,7 +1168,6 @@ impl Default for FmtSpanConfig {
     }
 }
 
-#[repr(transparent)]
 pub(super) struct TimingDisplay(pub(super) u64);
 impl Display for TimingDisplay {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -242,12 +242,14 @@ impl<'a> PrettyVisitor<'a> {
         Self { style, ..self }
     }
 
-    fn maybe_pad(&mut self) {
-        if self.is_empty {
+    fn write_padded(&mut self, value: &impl fmt::Debug) {
+        let padding = if self.is_empty {
             self.is_empty = false;
+            ""
         } else {
-            self.result = write!(self.writer, ", ");
-        }
+            ", "
+        };
+        self.result = write!(self.writer, "{}{:?}", padding, value);
     }
 }
 
@@ -288,28 +290,25 @@ impl<'a> field::Visit for PrettyVisitor<'a> {
             return;
         }
         let bold = self.style.bold();
-        self.maybe_pad();
-        self.result = match field.name() {
-            "message" => write!(self.writer, "{}{:?}", self.style.prefix(), value,),
+        match field.name() {
+            "message" => self.write_padded(&format_args!("{}{:?}", self.style.prefix(), value,)),
             // Skip fields that are actually log metadata that have already been handled
             #[cfg(feature = "tracing-log")]
-            name if name.starts_with("log.") => Ok(()),
-            name if name.starts_with("r#") => write!(
-                self.writer,
+            name if name.starts_with("log.") => self.result = Ok(()),
+            name if name.starts_with("r#") => self.write_padded(&format_args!(
                 "{}{}{}: {:?}",
                 bold.prefix(),
                 &name[2..],
                 bold.infix(self.style),
                 value
-            ),
-            name => write!(
-                self.writer,
+            )),
+            name => self.write_padded(&format_args!(
                 "{}{}{}: {:?}",
                 bold.prefix(),
                 name,
                 bold.infix(self.style),
                 value
-            ),
+            )),
         };
     }
 }

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -643,8 +643,8 @@ where
     /// [time]: #method.without_time
     pub fn with_span_events(self, kind: format::FmtSpan) -> Self {
         SubscriberBuilder {
-            filter: self.filter,
             inner: self.inner.with_span_events(kind),
+            ..self
         }
     }
 
@@ -653,8 +653,8 @@ where
     #[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
     pub fn with_ansi(self, ansi: bool) -> SubscriberBuilder<N, format::Format<L, T>, F, W> {
         SubscriberBuilder {
-            filter: self.filter,
             inner: self.inner.with_ansi(ansi),
+            ..self
         }
     }
 
@@ -664,8 +664,8 @@ where
         display_target: bool,
     ) -> SubscriberBuilder<N, format::Format<L, T>, F, W> {
         SubscriberBuilder {
-            filter: self.filter,
             inner: self.inner.with_target(display_target),
+            ..self
         }
     }
 
@@ -675,8 +675,8 @@ where
         display_level: bool,
     ) -> SubscriberBuilder<N, format::Format<L, T>, F, W> {
         SubscriberBuilder {
-            filter: self.filter,
             inner: self.inner.with_level(display_level),
+            ..self
         }
     }
 
@@ -689,8 +689,8 @@ where
         display_thread_names: bool,
     ) -> SubscriberBuilder<N, format::Format<L, T>, F, W> {
         SubscriberBuilder {
-            filter: self.filter,
             inner: self.inner.with_thread_names(display_thread_names),
+            ..self
         }
     }
 
@@ -703,8 +703,8 @@ where
         display_thread_ids: bool,
     ) -> SubscriberBuilder<N, format::Format<L, T>, F, W> {
         SubscriberBuilder {
-            filter: self.filter,
             inner: self.inner.with_thread_ids(display_thread_ids),
+            ..self
         }
     }
 

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -623,17 +623,32 @@ where
     /// - `FmtSpan::NONE`: No events will be synthesized when spans are
     ///    created, entered, exited, or closed. Data from spans will still be
     ///    included as the context for formatted events. This is the default.
-    /// - `FmtSpan::ACTIVE`: Events will be synthesized when spans are entered
-    ///    or exited.
+    /// - `FmtSpan::NEW`: An event will be synthesized when spans are created.
+    /// - `FmtSpan::ENTER`: An event will be synthesized when spans are entered.
+    /// - `FmtSpan::EXIT`: An event will be synthesized when spans are exited.
     /// - `FmtSpan::CLOSE`: An event will be synthesized when a span closes. If
     ///    [timestamps are enabled][time] for this formatter, the generated
     ///    event will contain fields with the span's _busy time_ (the total
     ///    time for which it was entered) and _idle time_ (the total time that
     ///    the span existed but was not entered).
+    /// - `FmtSpan::ACTIVE`: An event will be synthesized when spans are entered
+    ///    or exited.
     /// - `FmtSpan::FULL`: Events will be synthesized whenever a span is
     ///    created, entered, exited, or closed. If timestamps are enabled, the
     ///    close event will contain the span's busy and idle time, as
     ///    described above.
+    ///
+    /// The options can be enabled in any combination. For instance, the following
+    /// will synthesize events whenever spans are created and closed:
+    ///
+    /// ```rust
+    /// use tracing_subscriber::fmt::format::FmtSpan;
+    /// use tracing_subscriber::fmt;
+    ///
+    /// let subscriber = fmt()
+    ///     .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+    ///     .finish();
+    /// ```
     ///
     /// Note that the generated events will only be part of the log output by
     /// this formatter; they will not be recorded by other `Subscriber`s or by


### PR DESCRIPTION
This backports PRs #1289, #1282, #1290, #1297, #1275, #1277, and #1240 from the `master` branch to v0.1.x. This will let us publish new releases of `tracing-attributes` (with a fix for #1296) and `tracing-subscriber` (with several fixes & API additions).

I'll go ahead and rebase-merge this when CI passes