### PR TITLE
subscriber: prepare to release 0.2.17

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,29 @@
+# 0.2.17 (March 12, 2020)
+
+### Fixed
+
+- **fmt**: `Pretty` formatter now honors `with_ansi(false)` to disable ANSI
+  terminal formatting ([#1240])
+- **fmt**: Fixed extra padding when using `Pretty` formatter ([#1275])
+- **chrono**: Removed extra trailing space with `ChronoLocal` time formatter
+  ([#1103])
+
+### Added
+
+- **fmt**: Added `FmtContext::current_span()` method, returning the current span
+  ([#1290])
+- **fmt**: `FmtSpan` variants may now be combined using the `|` operator for
+  more granular control over what span events are generated ([#1277])
+
+Thanks to new contributors @cratelyn, @dignati, and @zicklag, as well as @Folyd,
+@matklad, and @najamelan, for contributing to this release!
+
+[#1240]: https://github.com/tokio-rs/tracing/pull/1240
+[#1275]: https://github.com/tokio-rs/tracing/pull/1275
+[#1103]: https://github.com/tokio-rs/tracing/pull/1103
+[#1290]: https://github.com/tokio-rs/tracing/pull/1290
+[#1277]: https://github.com/tokio-rs/tracing/pull/1277
+
 # 0.2.16 (February 19, 2020)
 
 ### Fixed

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.16"
+version = "0.2.17"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -21,7 +21,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.2.16
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.17
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -67,7 +67,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.16")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.17")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.2.17 (March 12, 2020)

### Fixed

- **fmt**: `Pretty` formatter now honors `with_ansi(false)` to disable
  ANSI terminal formatting ([#1240])
- **fmt**: Fixed extra padding when using `Pretty` formatter ([#1275])
- **chrono**: Removed extra trailing space with `ChronoLocal` time
  formatter ([#1103])

### Added

- **fmt**: Added `FmtContext::current_span()` method, returning the
  current span
  ([#1290])
- **fmt**: `FmtSpan` variants may now be combined using the `|` operator
  for more granular control over what span events are generated
  ([#1277])

Thanks to new contributors @cratelyn, @dignati, and @zicklag, as well as
@Folyd, @matklad, and @najamelan, for contributing to this release!