### PR TITLE
docs: fix typo in README.md

### DIFF
--- a/tracing/README.md
+++ b/tracing/README.md
@@ -108,7 +108,7 @@ In addition, you can locally override the default subscriber. For example:
 
 ```rust
 use tracing::{info, Level};
-use tracing_subscruber::FmtSubscriber;
+use tracing_subscriber::FmtSubscriber;
 
 fn main() {
     let subscriber = tracing_subscriber::FmtSubscriber::builder()


### PR DESCRIPTION
This is a simple typo fix, where `tracing_subscriber` was written as `tracing_subscruber`.