### PR TITLE
subscriber: ignore the whole span's fields if we are FmtSpan::NONE level

### DIFF
--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1173,6 +1173,9 @@ impl FmtSpanConfig {
             fmt_timing: self.fmt_timing,
         }
     }
+    pub(super) fn trace_none(&self) -> bool {
+        self.kind.contains(FmtSpan::NONE)
+    }
     pub(super) fn trace_new(&self) -> bool {
         self.kind.contains(FmtSpan::NEW)
     }


### PR DESCRIPTION
The `FmtSpan::NONE` isn't a complete ignorance for the span's related lifecycles, such as the `new_span()` and `on_record()`. This PR aims to fix this. 