### PR TITLE
subscriber: adding a new builder option (`with_span_context`) to the formatters to allow disabling spans

### DIFF
--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1068,6 +1068,13 @@ impl<'a, F> fmt::Debug for FieldFnVisitor<'a, F> {
 
 /// Configures what points in the span lifecycle are logged as events.
 ///
+/// # Notice:
+///
+/// The intention behind `FmtSpan` is to control when we emit synthesized
+/// events for the span lifecycle, not to control whether or not any data
+/// from spans is included. If you need to disable the whole span context when formatting,
+/// considering use [`CollectorBuilder::with_span_context`](super::CollectorBuilder::with_span_context()).
+///
 /// See also [`with_span_events`](super::CollectorBuilder::with_span_events()).
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct FmtSpan(u8);
@@ -1158,6 +1165,7 @@ impl Debug for FmtSpan {
 pub(super) struct FmtSpanConfig {
     pub(super) kind: FmtSpan,
     pub(super) fmt_timing: bool,
+    pub(super) with_span_context: bool,
 }
 
 impl FmtSpanConfig {
@@ -1165,12 +1173,16 @@ impl FmtSpanConfig {
         Self {
             kind: self.kind,
             fmt_timing: false,
+            with_span_context: true,
         }
     }
     pub(super) fn with_kind(self, kind: FmtSpan) -> Self {
+        Self { kind, ..self }
+    }
+    pub(super) fn with_span_context(self, with_span_context: bool) -> Self {
         Self {
-            kind,
-            fmt_timing: self.fmt_timing,
+            with_span_context,
+            ..self
         }
     }
     pub(super) fn trace_new(&self) -> bool {
@@ -1198,6 +1210,7 @@ impl Default for FmtSpanConfig {
         Self {
             kind: FmtSpan::NONE,
             fmt_timing: true,
+            with_span_context: true,
         }
     }
 }

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -682,6 +682,14 @@ where
         }
     }
 
+    /// Configures whether or not to include the span context.
+    pub fn with_span_context(self, with_span_context: bool) -> Self {
+        CollectorBuilder {
+            inner: self.inner.with_span_context(with_span_context),
+            ..self
+        }
+    }
+
     /// Enable ANSI terminal colors for formatted output.
     #[cfg(feature = "ansi")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]


### PR DESCRIPTION

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Disabling the logging of spans by `fmt` while still recording them with a distributed 
tracing system like OpenTelemetry, is one that isn't nicely solved by the filtering 
system currently. 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add a new builder option to the formatters to allow disabling spans in `fmt` 
while still allowing other layers like OpenTelemetry to record them.

- Add `with_span_context()` new builder option.
- Add extra docs to clarify the design intention  of `FmtSpan`.

Related PR: #1313
