### PR TITLE
subscriber: deprecate `CurrentSpan`

### DIFF
--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -160,6 +160,7 @@ pub use fmt::fmt;
 use std::default::Default;
 /// Tracks the currently executing span on a per-thread basis.
 #[derive(Debug)]
+#[deprecated(since = "0.2.18", note = "Will be removed in v0.3")]
 pub struct CurrentSpan {
     current: thread::Local<Vec<Id>>,
 }

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -165,6 +165,7 @@ pub struct CurrentSpan {
     current: thread::Local<Vec<Id>>,
 }
 
+#[allow(deprecated)]
 impl CurrentSpan {
     /// Returns a new `CurrentSpan`.
     pub fn new() -> Self {
@@ -195,6 +196,7 @@ impl CurrentSpan {
     }
 }
 
+#[allow(deprecated)]
 impl Default for CurrentSpan {
     fn default() -> Self {
         Self::new()


### PR DESCRIPTION
The `tracing-subscriber::CurrentSpan` should be deprectead in `v0.2.x`.

Related PR #1320. 