### PR TITLE
tracing: impl `From<EnteredSpan>` for `Option<Id>`

### DIFF
--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -1309,6 +1309,18 @@ impl<'a> From<&'a Span> for Option<Id> {
     }
 }
 
+impl<'a> From<&'a EnteredSpan> for Option<&'a Id> {
+    fn from(span: &'a EnteredSpan) -> Self {
+        span.inner.as_ref().map(|inner| &inner.id)
+    }
+}
+
+impl<'a> From<&'a EnteredSpan> for Option<Id> {
+    fn from(span: &'a EnteredSpan) -> Self {
+        span.inner.as_ref().map(Inner::id)
+    }
+}
+
 impl Drop for Span {
     fn drop(&mut self) {
         if let Some(Inner {
@@ -1394,6 +1406,11 @@ impl Clone for Inner {
 // ===== impl Entered =====
 
 impl EnteredSpan {
+    /// Returns this span's `Id`, if it is enabled.
+    pub fn id(&self) -> Option<Id> {
+        self.inner.as_ref().map(Inner::id)
+    }
+
     /// Exits this span, returning the underlying [`Span`].
     #[inline]
     pub fn exit(mut self) -> Span {
@@ -1445,6 +1462,7 @@ impl Drop for EnteredSpan {
 struct PhantomNotSend {
     ghost: PhantomData<*mut ()>,
 }
+
 #[allow(non_upper_case_globals)]
 const PhantomNotSend: PhantomNotSend = PhantomNotSend { ghost: PhantomData };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

The following code compiles failed:
```rust
use tracing;

fn main() {
    
    let span = tracing::info_span!("my_span").entered();
    tracing::info!(parent: &span, "test span");
}
```

```log
   Compiling playground v0.0.1 (/playground)
error[E0277]: the trait bound `Option<Id>: From<&EnteredSpan>` is not satisfied
  --> src/main.rs:6:5
   |
6  |     tracing::info!(parent: &span, "test span");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<&EnteredSpan>` is not implemented for `Option<Id>`
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- `impl<'a> From<&'a EnteredSpan> for Option<&'a Id>`.
- `impl<'a> From<&'a EnteredSpan> for Option<Id>`
- Add `id()` method into `EnteredSpan`.
