### PR TITLE
subscriber: fix `on_event` serialization when no fields set on span

### DIFF
--- a/tracing-serde/src/fields.rs
+++ b/tracing-serde/src/fields.rs
@@ -21,7 +21,7 @@ impl<'a> Serialize for SerializeFieldMap<'a, Event<'_>> {
     where
         S: Serializer,
     {
-        let len = self.0.metadata().fields().len();
+        let len = self.0.fields().count();
         let serializer = serializer.serialize_map(Some(len))?;
         let mut visitor = SerdeMapVisitor::new(serializer);
         self.0.record(&mut visitor);

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -496,7 +496,7 @@ impl<'a> fmt::Debug for WriteAdaptor<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::fmt::{test::MockMakeWriter, time::FormatTime, CollectorBuilder};
+    use crate::fmt::{format::FmtSpan, test::MockMakeWriter, time::FormatTime, CollectorBuilder};
     use tracing::{self, collect::with_default};
 
     use std::fmt;
@@ -650,6 +650,23 @@ mod test {
                 parse_buf()["fields"]["message"],
                 "an event inside the root span"
             );
+        });
+    }
+
+    #[test]
+    fn json_span_event() {
+        // Check span events serialize correctly.
+        // Discussion: https://github.com/tokio-rs/tracing/issues/829#issuecomment-661984255
+        //
+        let expected = r#"{"timestamp":"fake time","level":"INFO","fields":{"message":"enter"},"target":"tracing_subscriber::fmt::format::json::test"}"#;
+        let collector = collector()
+            .flatten_event(false)
+            .with_current_span(false)
+            .with_span_list(false)
+            .with_span_events(FmtSpan::ENTER);
+
+        test_json(expected, collector, || {
+            tracing::info_span!("valid_json").in_scope(|| {});
         });
     }
 


### PR DESCRIPTION
## Motivation
Serializing a spans `on_ACTION` events, when no `fields` are set on the span, results in invalid JSON. This is because `serializier_map` was getting a size hint for `self.0.metadata().fields().len()` then serializing `self.0.fields.field_set()` instead. This resulted in the `fields` key being set to an empty object, then Serde serializes the k/v pairs from `field_set()`. This was causing an erroneous closing brace `}` to be added after the serialized fields.

This is discussed here: https://github.com/tokio-rs/tracing/issues/829#issuecomment-661984255

``` toml
[dependencies]
tracing = "=0.1.25"
tracing-serde = "=0.1.2"
tracing-subscriber = "=0.2.17"
```

``` rust
use tracing_subscriber::fmt::format::FmtSpan;

fn main() {
    tracing_subscriber::fmt()
        .json()
        .with_span_events(FmtSpan::FULL)
        .init();

    tracing::info_span!("broken_json").in_scope(|| {
    });

    tracing::info_span!("valid_json", "").in_scope(|| {
    });
}
```

``` json
{"timestamp":"Mar 28 19:08:44.323","level":"INFO","fields":{},"message":"new"},"target":"json_events"}
{"timestamp":"Mar 28 19:08:44.323","level":"INFO","fields":{},"message":"enter"},"target":"json_events","span":{"name":"broken_json"},"spans":[{"name":"broken_json"}]}
{"timestamp":"Mar 28 19:08:44.323","level":"INFO","fields":{},"message":"exit"},"target":"json_events"}
{"timestamp":"Mar 28 19:08:44.323","level":"INFO","fields":{},"message":"close","time.busy":"61.7µs","time.idle":"113µs"},"target":"json_events"}
{"timestamp":"Mar 28 19:08:44.323","level":"INFO","fields":{"message":"new"},"target":"json_events"}
{"timestamp":"Mar 28 19:08:44.323","level":"INFO","fields":{"message":"enter"},"target":"json_events","span":{"message":"","name":"valid_json"},"spans":[{"message":"","name":"valid_json"}]}
{"timestamp":"Mar 28 19:08:44.323","level":"INFO","fields":{"message":"exit"},"target":"json_events"}
{"timestamp":"Mar 28 19:08:44.323","level":"INFO","fields":{"message":"close","time.busy":"70.6µs","time.idle":"70.7µs"},"target":"json_events"}
```

## Solution 
This change aligns the size hint with the size of actual serialized data. 