### PR TITLE
chore: reverse the polarity of conversions, fix clippy

### DIFF
--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -657,7 +657,7 @@ impl FieldSet {
     {
         ValueSet {
             fields: self,
-            values: &values.borrow()[..],
+            values: values.borrow(),
         }
     }
 

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -366,10 +366,10 @@ impl From<Option<Level>> for LevelFilter {
     }
 }
 
-impl Into<Option<Level>> for LevelFilter {
+impl From<LevelFilter> for Option<Level> {
     #[inline]
-    fn into(self) -> Option<Level> {
-        self.into_level()
+    fn from(filter: LevelFilter) -> Self {
+        filter.into_level()
     }
 }
 

--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -96,9 +96,9 @@ impl Id {
     }
 }
 
-impl<'a> Into<Option<Id>> for &'a Id {
-    fn into(self) -> Option<Id> {
-        Some(self.clone())
+impl<'a> From<&'a Id> for Option<Id> {
+    fn from(id: &'a Id) -> Self {
+        Some(id.clone())
     }
 }
 

--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -292,26 +292,29 @@ impl Current {
     }
 }
 
-impl<'a> Into<Option<&'a Id>> for &'a Current {
-    fn into(self) -> Option<&'a Id> {
-        self.id()
+impl<'a> From<&'a Current> for Option<&'a Id> {
+    fn from(cur: &'a Current) -> Self {
+        cur.id()
     }
 }
 
-impl<'a> Into<Option<Id>> for &'a Current {
-    fn into(self) -> Option<Id> {
-        self.id().cloned()
+impl<'a> From<&'a Current> for Option<Id> {
+    fn from(cur: &'a Current) -> Self {
+        cur.id().cloned()
     }
 }
 
-impl Into<Option<Id>> for Current {
-    fn into(self) -> Option<Id> {
-        self.id().cloned()
+impl From<Current> for Option<Id> {
+    fn from(cur: Current) -> Self {
+        match cur.inner {
+            CurrentInner::Current { id, .. } => Some(id),
+            _ => None,
+        }
     }
 }
 
-impl<'a> Into<Option<&'static Metadata<'static>>> for &'a Current {
-    fn into(self) -> Option<&'static Metadata<'static>> {
-        self.metadata()
+impl<'a> From<&'a Current> for Option<&'static Metadata<'static>> {
+    fn from(cur: &'a Current) -> Self {
+        cur.metadata()
     }
 }

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -590,7 +590,7 @@ where
     }
 }
 
-impl<N, E, F, W> Into<tracing_core::Dispatch> for CollectorBuilder<N, E, F, W>
+impl<N, E, F, W> From<CollectorBuilder<N, E, F, W>> for tracing_core::Dispatch
 where
     N: for<'writer> FormatFields<'writer> + 'static,
     E: FormatEvent<Registry, N> + 'static,
@@ -599,8 +599,8 @@ where
     fmt_subscriber::Subscriber<Registry, N, E, W>:
         subscribe::Subscribe<Registry> + Send + Sync + 'static,
 {
-    fn into(self) -> tracing_core::Dispatch {
-        tracing_core::Dispatch::new(self.finish())
+    fn from(builder: CollectorBuilder<N, E, F, W>) -> tracing_core::Dispatch {
+        tracing_core::Dispatch::new(builder.finish())
     }
 }
 

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -1297,15 +1297,15 @@ impl fmt::Debug for Span {
     }
 }
 
-impl<'a> Into<Option<&'a Id>> for &'a Span {
-    fn into(self) -> Option<&'a Id> {
-        self.inner.as_ref().map(|inner| &inner.id)
+impl<'a> From<&'a Span> for Option<&'a Id> {
+    fn from(span: &'a Span) -> Self {
+        span.inner.as_ref().map(|inner| &inner.id)
     }
 }
 
-impl<'a> Into<Option<Id>> for &'a Span {
-    fn into(self) -> Option<Id> {
-        self.inner.as_ref().map(Inner::id)
+impl<'a> From<&'a Span> for Option<Id> {
+    fn from(span: &'a Span) -> Self {
+        span.inner.as_ref().map(Inner::id)
     }
 }
 

--- a/tracing/tests/support/field.rs
+++ b/tracing/tests/support/field.rs
@@ -66,13 +66,13 @@ impl MockField {
     }
 }
 
-impl Into<Expect> for MockField {
-    fn into(self) -> Expect {
+impl From<MockField> for Expect {
+    fn from(field: MockField) -> Self {
         Expect {
             fields: HashMap::new(),
             only: false,
         }
-        .and(self)
+        .and(field)
     }
 }
 

--- a/tracing/tests/support/span.rs
+++ b/tracing/tests/support/span.rs
@@ -113,10 +113,10 @@ impl fmt::Display for MockSpan {
     }
 }
 
-impl Into<NewSpan> for MockSpan {
-    fn into(self) -> NewSpan {
-        NewSpan {
-            span: self,
+impl From<MockSpan> for NewSpan {
+    fn from(span: MockSpan) -> Self {
+        Self {
+            span,
             ..Default::default()
         }
     }


### PR DESCRIPTION
Clippy now warns about implementing `Into` rather than `From`, since
`From` automatically provides `Into` but `Into` does not provide `From`.

This commit fixes the direction of those conversions, placating Clippy.

Additionally, it fixes a redundant use of slice syntax that Clippy also
complained about.