### PR TITLE
tracing: reverse one more conversion

### DIFF
--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -1312,9 +1312,9 @@ impl<'a> From<&'a Span> for Option<Id> {
     }
 }
 
-impl Into<Option<Id>> for Span {
-    fn into(self) -> Option<Id> {
-        self.inner.as_ref().map(Inner::id)
+impl From<Span> for Option<Id> {
+    fn from(span: Span) -> Self {
+        span.inner.as_ref().map(Inner::id)
     }
 }
 


### PR DESCRIPTION
This was not fixed in #1335 because the `Into<Id> for Span` conversion
was removed in v0.2.x.

This should make clippy happy on v0.1.x.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
