### PR TITLE
tracing: remove duplicated `event!()` macro pattern

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -685,14 +685,6 @@ macro_rules! event {
             { message = format_args!($($arg)+), $($fields)* }
         )
     );
-    (parent: $parent:expr, $lvl:expr, { $($fields:tt)* }, $($arg:tt)+ ) => (
-        $crate::event!(
-            target: module_path!(),
-            $lvl,
-            parent: $parent,
-            { message = format_args!($($arg)+), $($fields)* }
-        )
-    );
     (parent: $parent:expr, $lvl:expr, $($k:ident).+ = $($field:tt)*) => (
         $crate::event!(
             target: module_path!(),


### PR DESCRIPTION
The following two patterns for the `event!()` are identical to each other, and the second one swapped the order of `$lvl` and `parent: $parent` which I don't think is correct.
```rust
    (parent: $parent:expr, $lvl:expr, { $($fields:tt)* }, $($arg:tt)+ ) => (
        $crate::event!(
            target: module_path!(),
            parent: $parent,
            $lvl,
            { message = format_args!($($arg)+), $($fields)* }
        )
    );
    (parent: $parent:expr, $lvl:expr, { $($fields:tt)* }, $($arg:tt)+ ) => (
        $crate::event!(
            target: module_path!(),
            $lvl,
            parent: $parent,
            { message = format_args!($($arg)+), $($fields)* }
        )
    );
```

I found the duplicated via [macro_railraod](https://github.com/lukaslueg/macro_railroad). Here is the diagram:

![image](https://user-images.githubusercontent.com/3369694/114296705-47ec8700-9adf-11eb-971f-f485329d0339.png)
