### PR TITLE
subscriber: remove space when timestamps are disabled 

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -1006,7 +1006,7 @@ mod test {
         });
         let actual = sanitize_timings(make_writer.get_string());
         assert_eq!(
-            " span1{x=42}: tracing_subscriber::fmt::fmt_subscriber::test: close\n",
+            "span1{x=42}: tracing_subscriber::fmt::fmt_subscriber::test: close\n",
             actual.as_str()
         );
     }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -473,12 +473,14 @@ impl<F, T> Format<F, T> {
         // If ANSI color codes are enabled, format the timestamp with ANSI
         // colors.
         #[cfg(feature = "ansi")]
-        if self.ansi {
-            let style = Style::new().dimmed();
-            write!(writer, "{}", style.prefix())?;
-            self.timer.format_time(writer)?;
-            write!(writer, "{} ", style.suffix())?;
-            return Ok(());
+        {
+            if self.ansi {
+                let style = Style::new().dimmed();
+                write!(writer, "{}", style.prefix())?;
+                self.timer.format_time(writer)?;
+                write!(writer, "{} ", style.suffix())?;
+                return Ok(());
+            }
         }
 
         // Otherwise, just format the timestamp without ANSI formatting.

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1239,6 +1239,22 @@ pub(super) mod test {
         }
     }
 
+    #[test]
+    fn disable_everything() {
+        // This test reproduces https://github.com/tokio-rs/tracing/issues/1354
+        let make_writer = MockMakeWriter::default();
+        let subscriber = crate::fmt::Collector::builder()
+            .with_writer(make_writer.clone())
+            .without_time()
+            .with_level(false)
+            .with_target(false)
+            .with_thread_ids(false)
+            .with_thread_names(false);
+        #[cfg(feature = "ansi")]
+        let subscriber = subscriber.with_ansi(false);
+        run_test(subscriber, make_writer, "hello\n")
+    }
+
     #[cfg(feature = "ansi")]
     #[test]
     fn with_ansi_true() {

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -107,7 +107,8 @@ where
         #[cfg(not(feature = "tracing-log"))]
         let meta = event.metadata();
         write!(writer, "  ")?;
-        time::write(&self.timer, writer, self.ansi)?;
+
+        self.format_timestamp(writer)?;
 
         let style = if self.display_level && self.ansi {
             Pretty::style_for(meta.level())

--- a/tracing-subscriber/src/fmt/time/mod.rs
+++ b/tracing-subscriber/src/fmt/time/mod.rs
@@ -1,6 +1,4 @@
 //! Formatters for event timestamps.
-#[cfg(feature = "ansi")]
-use ansi_term::Style;
 use std::fmt;
 use std::time::Instant;
 
@@ -243,32 +241,4 @@ impl FormatTime for ChronoLocal {
             ChronoFmtType::Custom(ref format_str) => write!(w, "{}", time.format(format_str)),
         }
     }
-}
-
-#[inline(always)]
-#[cfg(feature = "ansi")]
-pub(crate) fn write<T>(timer: T, writer: &mut dyn fmt::Write, with_ansi: bool) -> fmt::Result
-where
-    T: FormatTime,
-{
-    if with_ansi {
-        let style = Style::new().dimmed();
-        write!(writer, "{}", style.prefix())?;
-        timer.format_time(writer)?;
-        write!(writer, "{}", style.suffix())?;
-    } else {
-        timer.format_time(writer)?;
-    }
-    writer.write_char(' ')?;
-    Ok(())
-}
-
-#[inline(always)]
-#[cfg(not(feature = "ansi"))]
-pub(crate) fn write<T>(timer: T, writer: &mut dyn fmt::Write) -> fmt::Result
-where
-    T: FormatTime,
-{
-    timer.format_time(writer)?;
-    write!(writer, " ")
 }


### PR DESCRIPTION
## Motivation

Currently, the default `Compact` and `Full` formatters in
`tracing-subscriber` will prefix log lines with a single space when
timestamps are disabled. The space is emitted in order to pad the
timestamp from the rest of the log line, but it shouldn't be emitted
when timestamps are turned off. This should be fixed.

## Solution

This branch fixes the issue by skipping `time::write` entirely when
timestamps are disabled. This is done by tracking an additional boolean
flag for disabling timestamps.

Incidentally, this now means that span lifecycle timing can be enabled
even if event timestamps are disabled, like this:
```rust
use tracing_subscriber::fmt;
let subscriber = fmt::subscriber()
    .without_time()
    .with_timer(SystemTime::now)
    .with_span_events(fmt::FmtSpan::FULL);
```
or similar.

I also added a new test reproducing the issue, and did a little
refactoring to try and clean up the timestamp formatting code a bit.

Closes #1354