### PR TITLE
tracing: add basic compare benchmark with `log` facade

### DIFF
--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -79,6 +79,10 @@ harness = false
 name = "global_subscriber"
 harness = false
 
+[[bench]]
+name = "compare"
+harness = false
+
 [badges]
 maintenance = { status = "actively-developed" }
 

--- a/tracing/benches/compare.rs
+++ b/tracing/benches/compare.rs
@@ -1,0 +1,21 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("facade");
+    group.bench_function("log", |b| {
+        b.iter(|| {
+            log::info!("Rust empowering everyone to build reliable and efficient software.");
+        });
+    });
+
+    group.bench_function("tracing", |b| {
+        b.iter(|| {
+            tracing::info!("Rust empowering everyone to build reliable and efficient software.");
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
This PR adds a simple benchmark with the `log` facade. The result proved that `tracing` performance is generally very similar to the `log` crate's. 

![image](https://user-images.githubusercontent.com/3369694/115028748-cee29a80-9ef7-11eb-92d9-bc6b72b89c16.png)
