### PR TITLE
misc. backports

### DIFF
--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -1,4 +1,5 @@
 //! Spans represent periods of time in the execution of a program.
+use crate::field::FieldSet;
 use crate::parent::Parent;
 use crate::stdlib::num::NonZeroU64;
 use crate::{field, Metadata};
@@ -195,6 +196,21 @@ impl<'a> Attributes<'a> {
     /// Returns true if this set of `Attributes` contains _no_ values.
     pub fn is_empty(&self) -> bool {
         self.values.is_empty()
+    }
+
+    /// Returns the set of all [fields] defined by this span's [`Metadata`].
+    ///
+    /// Note that the [`FieldSet`] returned by this method includes *all* the
+    /// fields declared by this span, not just those with values that are recorded
+    /// as part of this set of `Attributes`. Other fields with values not present in
+    /// this `Attributes`' value set may [record] values later.
+    ///
+    /// [fields]: crate::field
+    /// [record]: Attributes::record()
+    /// [`Metadata`]: crate::metadata::Metadata
+    /// [`FieldSet`]: crate::field::FieldSet
+    pub fn fields(&self) -> &FieldSet {
+        self.values.field_set()
     }
 }
 

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -31,3 +31,11 @@ tracing-log = { path = "../tracing-log", version = "0.1", default-features = fal
 [dev-dependencies]
 async-trait = "0.1"
 opentelemetry-jaeger = "0.12"
+criterion = { version = "0.3", default_features = false }
+
+[lib]
+bench = false
+
+[[bench]]
+name = "trace"
+harness = false

--- a/tracing-opentelemetry/benches/trace.rs
+++ b/tracing-opentelemetry/benches/trace.rs
@@ -1,0 +1,129 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use opentelemetry::{
+    sdk::trace::{Tracer, TracerProvider},
+    trace::{SpanBuilder, Tracer as _, TracerProvider as _},
+    Context,
+};
+use std::time::SystemTime;
+use tracing::trace_span;
+use tracing_subscriber::prelude::*;
+
+fn many_children(c: &mut Criterion) {
+    let mut group = c.benchmark_group("otel_many_children");
+
+    group.bench_function("spec_baseline", |b| {
+        let provider = TracerProvider::default();
+        let tracer = provider.get_tracer("bench", None);
+        b.iter(|| {
+            fn dummy(tracer: &Tracer, cx: &Context) {
+                for _ in 0..99 {
+                    tracer.start_with_context("child", cx.clone());
+                }
+            }
+
+            tracer.in_span("parent", |cx| dummy(&tracer, &cx));
+        });
+    });
+
+    {
+        let _subscriber = tracing_subscriber::registry()
+            .with(RegistryAccessLayer)
+            .set_default();
+        group.bench_function("no_data_baseline", |b| b.iter(tracing_harness));
+    }
+
+    {
+        let _subscriber = tracing_subscriber::registry()
+            .with(OtelDataLayer)
+            .set_default();
+        group.bench_function("data_only_baseline", |b| b.iter(tracing_harness));
+    }
+
+    {
+        let provider = TracerProvider::default();
+        let tracer = provider.get_tracer("bench", None);
+        let otel_layer = tracing_opentelemetry::layer()
+            .with_tracer(tracer)
+            .with_tracked_inactivity(false);
+        let _subscriber = tracing_subscriber::registry()
+            .with(otel_layer)
+            .set_default();
+
+        group.bench_function("full", |b| b.iter(tracing_harness));
+    }
+}
+
+struct NoDataSpan;
+struct RegistryAccessLayer;
+
+impl<S> tracing_subscriber::Layer<S> for RegistryAccessLayer
+where
+    S: tracing_core::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+{
+    fn new_span(
+        &self,
+        _attrs: &tracing_core::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+        extensions.insert(NoDataSpan);
+    }
+
+    fn on_close(&self, id: tracing::span::Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let span = ctx.span(&id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+
+        if let Some(no_data) = extensions.remove::<NoDataSpan>() {
+            drop(no_data)
+        }
+    }
+}
+
+struct OtelDataLayer;
+
+impl<S> tracing_subscriber::Layer<S> for OtelDataLayer
+where
+    S: tracing_core::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+{
+    fn new_span(
+        &self,
+        attrs: &tracing_core::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+        extensions.insert(
+            SpanBuilder::from_name(attrs.metadata().name().to_string())
+                .with_start_time(SystemTime::now()),
+        );
+    }
+
+    fn on_close(&self, id: tracing::span::Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let span = ctx.span(&id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+
+        if let Some(builder) = extensions.remove::<SpanBuilder>() {
+            builder.with_end_time(SystemTime::now());
+        }
+    }
+}
+
+fn tracing_harness() {
+    fn dummy() {
+        for _ in 0..99 {
+            let child = trace_span!("child");
+            let _enter = child.enter();
+        }
+    }
+
+    let parent = trace_span!("parent");
+    let _enter = parent.enter();
+
+    dummy();
+}
+
+criterion_group!(benches, many_children);
+criterion_main!(benches);

--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -691,10 +691,9 @@ mod tests {
     #[test]
     fn span_status_code() {
         let tracer = TestTracer(Arc::new(Mutex::new(None)));
-        let subscriber =
-            tracing_subscriber::registry().with(subscriber().with_tracer(tracer.clone()));
+        let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
 
-        tracing::collect::with_default(subscriber, || {
+        tracing::subscriber::with_default(subscriber, || {
             tracing::debug_span!("request", otel.status_code = ?otel::StatusCode::Ok);
         });
         let recorded_status_code = tracer.0.lock().unwrap().as_ref().unwrap().status_code;
@@ -704,12 +703,11 @@ mod tests {
     #[test]
     fn span_status_message() {
         let tracer = TestTracer(Arc::new(Mutex::new(None)));
-        let subscriber =
-            tracing_subscriber::registry().with(subscriber().with_tracer(tracer.clone()));
+        let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
 
         let message = "message";
 
-        tracing::collect::with_default(subscriber, || {
+        tracing::subscriber::with_default(subscriber, || {
             tracing::debug_span!("request", otel.status_message = message);
         });
 

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -23,8 +23,11 @@
 //! Setting this field is useful if you want to display non-static information
 //! in your span name.
 //! * `otel.kind`: Set the span kind to one of the supported OpenTelemetry [span kinds].
+//! * `otel.status_code`: Set the span status code to one of the supported OpenTelemetry [span status codes].
+//! * `otel.status_message`: Set the span status message.
 //!
 //! [span kinds]: https://docs.rs/opentelemetry/latest/opentelemetry/trace/enum.SpanKind.html
+//! [span status codes]: https://docs.rs/opentelemetry/latest/opentelemetry/trace/enum.StatusCode.html
 //!
 //! ### Semantic Conventions
 //!

--- a/tracing-opentelemetry/src/tracer.rs
+++ b/tracing-opentelemetry/src/tracer.rs
@@ -224,7 +224,7 @@ impl otel::Span for CompatSpan {
 
     fn set_status(&self, _code: otel::StatusCode, _message: String) {
         #[cfg(debug_assertions)]
-        panic!("OpenTelemetry and tracing APIs cannot be mixed, use `tracing::span!` macro or `span.record()` instead.");
+        panic!("OpenTelemetry and tracing APIs cannot be mixed, use `tracing::span!` macro or `span.record()` with `otel.status_code` and `otel.status_message` instead.");
     }
 
     fn update_name(&self, _new_name: String) {

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -1070,7 +1070,7 @@ mod test {
         });
         let actual = sanitize_timings(String::from_utf8(BUF.try_lock().unwrap().to_vec()).unwrap());
         assert_eq!(
-            " span1{x=42}: tracing_subscriber::fmt::fmt_layer::test: close\n",
+            "span1{x=42}: tracing_subscriber::fmt::fmt_layer::test: close\n",
             actual.as_str()
         );
     }

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -108,7 +108,8 @@ where
         #[cfg(not(feature = "tracing-log"))]
         let meta = event.metadata();
         write!(writer, "  ")?;
-        time::write(&self.timer, writer, self.ansi)?;
+
+        self.format_timestamp(writer)?;
 
         let style = if self.display_level && self.ansi {
             Pretty::style_for(meta.level())

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -1176,6 +1176,7 @@ mod test {
         }
     }
 
+    #[derive(Clone)]
     pub(crate) struct MockMakeWriter<'a> {
         buf: &'a Mutex<Vec<u8>>,
     }
@@ -1183,6 +1184,10 @@ mod test {
     impl<'a> MockMakeWriter<'a> {
         pub(crate) fn new(buf: &'a Mutex<Vec<u8>>) -> Self {
             Self { buf }
+        }
+
+        pub(crate) fn buf(&self) -> MutexGuard<'a, Vec<u8>> {
+            self.buf.lock().unwrap()
         }
     }
 

--- a/tracing-subscriber/src/fmt/time/mod.rs
+++ b/tracing-subscriber/src/fmt/time/mod.rs
@@ -1,6 +1,4 @@
 //! Formatters for event timestamps.
-#[cfg(feature = "ansi")]
-use ansi_term::Style;
 use std::fmt;
 use std::time::Instant;
 
@@ -245,32 +243,4 @@ impl FormatTime for ChronoLocal {
             ChronoFmtType::Custom(ref format_str) => write!(w, "{}", time.format(format_str)),
         }
     }
-}
-
-#[inline(always)]
-#[cfg(feature = "ansi")]
-pub(crate) fn write<T>(timer: T, writer: &mut dyn fmt::Write, with_ansi: bool) -> fmt::Result
-where
-    T: FormatTime,
-{
-    if with_ansi {
-        let style = Style::new().dimmed();
-        write!(writer, "{}", style.prefix())?;
-        timer.format_time(writer)?;
-        write!(writer, "{}", style.suffix())?;
-    } else {
-        timer.format_time(writer)?;
-    }
-    writer.write_char(' ')?;
-    Ok(())
-}
-
-#[inline(always)]
-#[cfg(not(feature = "ansi"))]
-pub(crate) fn write<T>(timer: T, writer: &mut dyn fmt::Write) -> fmt::Result
-where
-    T: FormatTime,
-{
-    timer.format_time(writer)?;
-    write!(writer, " ")
 }

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -108,7 +108,7 @@ In addition, you can locally override the default subscriber. For example:
 
 ```rust
 use tracing::{info, Level};
-use tracing_subscruber::FmtSubscriber;
+use tracing_subscriber::FmtSubscriber;
 
 fn main() {
     let subscriber = tracing_subscriber::FmtSubscriber::builder()

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -684,14 +684,6 @@ macro_rules! event {
             { message = format_args!($($arg)+), $($fields)* }
         )
     );
-    (parent: $parent:expr, $lvl:expr, { $($fields:tt)* }, $($arg:tt)+ ) => (
-        $crate::event!(
-            target: module_path!(),
-            $lvl,
-            parent: $parent,
-            { message = format_args!($($arg)+), $($fields)* }
-        )
-    );
     (parent: $parent:expr, $lvl:expr, $($k:ident).+ = $($field:tt)*) => (
         $crate::event!(
             target: module_path!(),


### PR DESCRIPTION
This cherry-picks a number of recent commits from `master` to v0.1.x:
* 14eee0a1 core: expose an accessor for the `FieldSet` on `Attributes` (#1331)
* 3b52afc5 subscriber: remove space when timestamps are disabled  (#1355)
* 466221c0 subscriber: add span status fields (#1351)
* d43f0e75 tracing: remove duplicated event macro pattern (#1352)
* 9db56141 subscriber: fix span data for new, exit, and close events (#1334)
* 2ae9f99c docs: fix typo in tracing/README.md (#1305)
* 1038d6db opentelemetry: add preliminary benchmarks (#1303)