### PR TITLE
Recording for Floats 

### DIFF
--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -192,6 +192,11 @@ pub trait Visit {
         self.record_debug(field, &value)
     }
 
+    /// Visit an 64-bit floating point value.
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.record_debug(field, &value)
+    }
+
     /// Visit a boolean value.
     fn record_bool(&mut self, field: &Field, value: bool) {
         self.record_debug(field, &value)
@@ -296,44 +301,44 @@ macro_rules! impl_values {
     }
 }
 
-macro_rules! ty_to_nonzero {
-    (u8) => {
-        NonZeroU8
-    };
-    (u16) => {
-        NonZeroU16
-    };
-    (u32) => {
-        NonZeroU32
-    };
-    (u64) => {
-        NonZeroU64
-    };
-    (u128) => {
-        NonZeroU128
-    };
-    (usize) => {
-        NonZeroUsize
-    };
-    (i8) => {
-        NonZeroI8
-    };
-    (i16) => {
-        NonZeroI16
-    };
-    (i32) => {
-        NonZeroI32
-    };
-    (i64) => {
-        NonZeroI64
-    };
-    (i128) => {
-        NonZeroI128
-    };
-    (isize) => {
-        NonZeroIsize
-    };
-}
+// macro_rules! ty_to_nonzero {
+//     (u8) => {
+//         NonZeroU8
+//     };
+//     (u16) => {
+//         NonZeroU16
+//     };
+//     (u32) => {
+//         NonZeroU32
+//     };
+//     (u64) => {
+//         NonZeroU64
+//     };
+//     (u128) => {
+//         NonZeroU128
+//     };
+//     (usize) => {
+//         NonZeroUsize
+//     };
+//     (i8) => {
+//         NonZeroI8
+//     };
+//     (i16) => {
+//         NonZeroI16
+//     };
+//     (i32) => {
+//         NonZeroI32
+//     };
+//     (i64) => {
+//         NonZeroI64
+//     };
+//     (i128) => {
+//         NonZeroI128
+//     };
+//     (isize) => {
+//         NonZeroIsize
+//     };
+// }
 
 macro_rules! impl_one_value {
     (bool, $op:expr, $record:ident) => {
@@ -341,7 +346,7 @@ macro_rules! impl_one_value {
     };
     ($value_ty:tt, $op:expr, $record:ident) => {
         impl_one_value!(normal, $value_ty, $op, $record);
-        impl_one_value!(nonzero, $value_ty, $op, $record);
+        // impl_one_value!(nonzero, $value_ty, $op, $record);
     };
     (normal, $value_ty:tt, $op:expr, $record:ident) => {
         impl $crate::sealed::Sealed for $value_ty {}
@@ -350,22 +355,21 @@ macro_rules! impl_one_value {
                 visitor.$record(key, $op(*self))
             }
         }
-    };
-    (nonzero, $value_ty:tt, $op:expr, $record:ident) => {
-        // This `use num::*;` is reported as unused because it gets emitted
-        // for every single invocation of this macro, so there are multiple `use`s.
-        // All but the first are useless indeed.
-        // We need this import because we can't write a path where one part is
-        // the `ty_to_nonzero!($value_ty)` invocation.
-        #[allow(clippy::useless_attribute, unused)]
-        use num::*;
-        impl $crate::sealed::Sealed for ty_to_nonzero!($value_ty) {}
-        impl $crate::field::Value for ty_to_nonzero!($value_ty) {
-            fn record(&self, key: &$crate::field::Field, visitor: &mut dyn $crate::field::Visit) {
-                visitor.$record(key, $op(self.get()))
-            }
-        }
-    };
+    }; // (nonzero, $value_ty:tt, $op:expr, $record:ident) => {
+       //     // This `use num::*;` is reported as unused because it gets emitted
+       //     // for every single invocation of this macro, so there are multiple `use`s.
+       //     // All but the first are useless indeed.
+       //     // We need this import because we can't write a path where one part is
+       //     // the `ty_to_nonzero!($value_ty)` invocation.
+       //     #[allow(clippy::useless_attribute, unused)]
+       //     use num::*;
+       //     impl $crate::sealed::Sealed for ty_to_nonzero!($value_ty) {}
+       //     impl $crate::field::Value for ty_to_nonzero!($value_ty) {
+       //         fn record(&self, key: &$crate::field::Field, visitor: &mut dyn $crate::field::Visit) {
+       //             visitor.$record(key, $op(self.get()))
+       //         }
+       //     }
+       // };
 }
 
 macro_rules! impl_value {
@@ -388,15 +392,17 @@ impl_values! {
     record_u64(usize, u32, u16, u8 as u64),
     record_i64(i64),
     record_i64(isize, i32, i16, i8 as i64),
+    record_f64(f64),
+    record_f64(f32 as f64),
     record_bool(bool)
 }
 
-impl<T: crate::sealed::Sealed> crate::sealed::Sealed for Wrapping<T> {}
-impl<T: crate::field::Value> crate::field::Value for Wrapping<T> {
-    fn record(&self, key: &crate::field::Field, visitor: &mut dyn crate::field::Visit) {
-        self.0.record(key, visitor)
-    }
-}
+// impl<T: crate::sealed::Sealed> crate::sealed::Sealed for Wrapping<T> {}
+// impl<T: crate::field::Value> crate::field::Value for Wrapping<T> {
+//     fn record(&self, key: &crate::field::Field, visitor: &mut dyn crate::field::Visit) {
+//         self.0.record(key, visitor)
+//     }
+// }
 
 impl crate::sealed::Sealed for str {}
 

--- a/tracing-serde/src/lib.rs
+++ b/tracing-serde/src/lib.rs
@@ -402,6 +402,12 @@ where
         }
     }
 
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        if self.state.is_ok() {
+            self.state = self.serializer.serialize_entry(field.name(), &value)
+        }
+    }
+
     fn record_str(&mut self, field: &Field, value: &str) {
         if self.state.is_ok() {
             self.state = self.serializer.serialize_entry(field.name(), &value)
@@ -443,6 +449,12 @@ where
     }
 
     fn record_i64(&mut self, field: &Field, value: i64) {
+        if self.state.is_ok() {
+            self.state = self.serializer.serialize_field(field.name(), &value)
+        }
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
         if self.state.is_ok() {
             self.state = self.serializer.serialize_field(field.name(), &value)
         }

--- a/tracing-subscriber/src/field/debug.rs
+++ b/tracing-subscriber/src/field/debug.rs
@@ -49,6 +49,11 @@ where
     }
 
     #[inline]
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.0.record_f64(field, value)
+    }
+
+    #[inline]
     fn record_bool(&mut self, field: &Field, value: bool) {
         self.0.record_bool(field, value)
     }

--- a/tracing-subscriber/src/field/delimited.rs
+++ b/tracing-subscriber/src/field/delimited.rs
@@ -95,6 +95,11 @@ where
         self.inner.record_u64(field, value);
     }
 
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.delimit();
+        self.inner.record_f64(field, value);
+    }
+
     fn record_bool(&mut self, field: &Field, value: bool) {
         self.delimit();
         self.inner.record_bool(field, value);

--- a/tracing-subscriber/src/field/display.rs
+++ b/tracing-subscriber/src/field/display.rs
@@ -51,6 +51,11 @@ where
     }
 
     #[inline]
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.0.record_f64(field, value)
+    }
+
+    #[inline]
     fn record_bool(&mut self, field: &Field, value: bool) {
         self.0.record_bool(field, value)
     }

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -430,6 +430,12 @@ impl<'a> field::Visit for JsonVisitor<'a> {
             .insert(&field.name(), serde_json::Value::from(value));
     }
 
+    /// Visit an unsigned 64-bit integer value.
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.values
+            .insert(&field.name(), serde_json::Value::from(value));
+    }
+
     /// Visit a boolean value.
     fn record_bool(&mut self, field: &Field, value: bool) {
         self.values


### PR DESCRIPTION
## Motivation

Currently floats cannot be logged/recorded other than in Debug or Display format which ends up stringifying them on output.

Simple Example:
```Rust
#[macro_use]
extern crate tracing;

use std::error::Error;

fn main() -> Result<(), Box<dyn Error>> {
    let builder = tracing_subscriber::fmt().json();
    builder.init();

    let integer: i64 = 25;
    let float: f64 = 25.567;

    event!(tracing::Level::INFO, integer = integer, "Test Integer");
    event!(tracing::Level::INFO, float = %float, "Test Display Float");
    event!(tracing::Level::INFO, float = ?float, "Test Debug Float");

    Ok(())
}

```

results in: 

```JSON
{"timestamp":"Apr 25 14:15:35.469","level":"INFO","fields":{"message":"Test Integer","integer":25},"target":"tracing_test"}
{"timestamp":"Apr 25 14:15:35.469","level":"INFO","fields":{"message":"Test Display Float","float":"25.567"},"target":"tracing_test"}
{"timestamp":"Apr 25 14:15:35.469","level":"INFO","fields":{"message":"Test Debug Float","float":"25.567"},"target":"tracing_test"}
```

And won't compile if passed the float directly:

```
error[E0277]: the trait bound `f64: Value` is not satisfied
  --> src/main.rs:15:5
   |
15 |     event!(tracing::Level::INFO, float = float, "Test Float");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Value` is not implemented for `f64`
   |
   = note: required for the cast to the object type `dyn Value`
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to previous error
```

Log ingesting/processing tools (eg Datadog/ELK etc) cannot parse these float strings without custom rules for each field to try and coerce the outputted string into the appropriate type, which is required in order to generate metrics etc. 

This resolves issue mentioned in the Tokio Discord a few times and #726 

## Solution

In order to implement I have added the relevant record_64 functions.

However, in order to get it working I had to comment out the `impl_one_value!(nonzero, ...)` macro. 

I don't currently understand the benefits of the implementation (why it is needed), or how to avoid it causing conflict with the float implementation. 

Before I write/fix the tests for the implementation/remove current NonZero failing test, if a reviewer could explain why it is needed and offer pointers as to how to work around it, or green light its removal it would be much appreciated 🙏 
