### PR TITLE
a bunch more backports

### DIFF
--- a/examples/examples/panic_hook.rs
+++ b/examples/examples/panic_hook.rs
@@ -1,0 +1,51 @@
+//! This example demonstrates how `tracing` events can be recorded from within a
+//! panic hook, capturing the span context in which the program panicked.
+
+fn main() {
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::TRACE)
+        .finish();
+
+    // NOTE: Using `tracing` in a panic hook requires the use of the *global*
+    // trace dispatcher (`tracing::subscriber::set_global_default`), rather than
+    // the per-thread scoped dispatcher
+    // (`tracing::subscriber::with_default`/`set_default`). With the scoped trace
+    // dispatcher, the subscriber's thread-local context may already have been
+    // torn down by unwinding by the time the panic handler is reached.
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+
+    // Set a panic hook that records the panic as a `tracing` event at the
+    // `ERROR` verbosity level.
+    //
+    // If we are currently in a span when the panic occurred, the logged event
+    // will include the current span, allowing the context in which the panic
+    // occurred to be recorded.
+    std::panic::set_hook(Box::new(|panic| {
+        // If the panic has a source location, record it as structured fields.
+        if let Some(location) = panic.location() {
+            // On nightly Rust, where the `PanicInfo` type also exposes a
+            // `message()` method returning just the message, we could record
+            // just the message instead of the entire `fmt::Display`
+            // implementation, avoiding the duplciated location
+            tracing::error!(
+                message = %panic,
+                panic.file = location.file(),
+                panic.line = location.line(),
+                panic.column = location.column(),
+            );
+        } else {
+            tracing::error!(message = %panic);
+        }
+    }));
+
+    for i in 0..10 {
+        check_number(i);
+    }
+}
+
+#[tracing::instrument]
+fn check_number(x: i32) {
+    if x % 2 == 0 {
+        panic!("I don't work with even numbers!");
+    }
+}

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -641,14 +641,14 @@ impl Dispatch {
     /// `T`.
     #[inline]
     pub fn is<T: Any>(&self) -> bool {
-        Subscriber::is::<T>(&*self.subscriber)
+        <dyn Subscriber>::is::<T>(&*self.subscriber)
     }
 
     /// Returns some reference to the `Subscriber` this `Dispatch` forwards to
     /// if it is of type `T`, or `None` if it isn't.
     #[inline]
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
-        Subscriber::downcast_ref(&*self.subscriber)
+        <dyn Subscriber>::downcast_ref(&*self.subscriber)
     }
 }
 

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -1,7 +1,10 @@
 //! Subscribers collect and record trace data.
 use crate::{span, Event, LevelFilter, Metadata};
 
-use crate::stdlib::any::{Any, TypeId};
+use crate::stdlib::{
+    any::{Any, TypeId},
+    boxed::Box,
+};
 
 /// Trait representing the functions required to collect trace data.
 ///
@@ -557,5 +560,82 @@ impl Interest {
         } else {
             Interest::sometimes()
         }
+    }
+}
+
+impl Subscriber for Box<dyn Subscriber + Send + Sync + 'static> {
+    #[inline]
+    fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
+        self.as_ref().register_callsite(metadata)
+    }
+
+    #[inline]
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        self.as_ref().enabled(metadata)
+    }
+
+    #[inline]
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        self.as_ref().max_level_hint()
+    }
+
+    #[inline]
+    fn new_span(&self, span: &span::Attributes<'_>) -> span::Id {
+        self.as_ref().new_span(span)
+    }
+
+    #[inline]
+    fn record(&self, span: &span::Id, values: &span::Record<'_>) {
+        self.as_ref().record(span, values)
+    }
+
+    #[inline]
+    fn record_follows_from(&self, span: &span::Id, follows: &span::Id) {
+        self.as_ref().record_follows_from(span, follows)
+    }
+
+    #[inline]
+    fn event(&self, event: &Event<'_>) {
+        self.as_ref().event(event)
+    }
+
+    #[inline]
+    fn enter(&self, span: &span::Id) {
+        self.as_ref().enter(span)
+    }
+
+    #[inline]
+    fn exit(&self, span: &span::Id) {
+        self.as_ref().exit(span)
+    }
+
+    #[inline]
+    fn clone_span(&self, id: &span::Id) -> span::Id {
+        self.as_ref().clone_span(id)
+    }
+
+    #[inline]
+    fn try_close(&self, id: span::Id) -> bool {
+        self.as_ref().try_close(id)
+    }
+
+    #[inline]
+    #[allow(deprecated)]
+    fn drop_span(&self, id: span::Id) {
+        self.as_ref().try_close(id);
+    }
+
+    #[inline]
+    fn current_span(&self) -> span::Current {
+        self.as_ref().current_span()
+    }
+
+    #[inline]
+    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+        if id == TypeId::of::<Self>() {
+            return Some(self as *const Self as *const _);
+        }
+
+        self.as_ref().downcast_raw(id)
     }
 }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -361,15 +361,15 @@ impl<F, T> Format<F, T> {
 
     /// Use the given [`timer`] for log message timestamps.
     ///
-    /// See [`time`] for the provided timer implementations.
+    /// See [`time` module] for the provided timer implementations.
     ///
     /// Note that using the `chrono` feature flag enables the
     /// additional time formatters [`ChronoUtc`] and [`ChronoLocal`].
     ///
-    /// [`time`]: ./time/index.html
-    /// [`timer`]: ./time/trait.FormatTime.html
-    /// [`ChronoUtc`]: ./time/struct.ChronoUtc.html
-    /// [`ChronoLocal`]: ./time/struct.ChronoLocal.html
+    /// [`timer`]: super::time::FormatTime
+    /// [`time` module]: mod@super::time
+    /// [`ChronoUtc`]: super::time::ChronoUtc
+    /// [`ChronoLocal`]: super::time::ChronoLocal
     pub fn with_timer<T2>(self, timer: T2) -> Format<F, T2> {
         Format {
             format: self.format,

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -173,6 +173,25 @@
 //! # fn main() {}
 //! ```
 //!
+//! For functions which don't have built-in tracing support and can't have
+//! the `#[instrument]` attribute applied (such as from an external crate,
+//! the [`Span` struct][`Span`] has a [`in_scope()` method][`in_scope`]
+//! which can be used to easily wrap synchonous code in a span.
+//!
+//! For example:
+//! ```rust
+//! use tracing::info_span;
+//!
+//! # fn doc() -> Result<(), ()> {
+//! # mod serde_json {
+//! #    pub(crate) fn from_slice(buf: &[u8]) -> Result<(), ()> { Ok(()) }
+//! # }
+//! # let buf: [u8; 0] = [];
+//! let json = info_span!("json.parse").in_scope(|| serde_json::from_slice(&buf))?;
+//! # let _ = json; // suppress unused variable warning
+//! # Ok(())
+//! # }
+//! ```
 //!
 //! You can find more examples showing how to use this crate [here][examples].
 //!

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -1318,6 +1318,18 @@ impl From<Span> for Option<Id> {
     }
 }
 
+impl<'a> From<&'a EnteredSpan> for Option<&'a Id> {
+    fn from(span: &'a EnteredSpan) -> Self {
+        span.inner.as_ref().map(|inner| &inner.id)
+    }
+}
+
+impl<'a> From<&'a EnteredSpan> for Option<Id> {
+    fn from(span: &'a EnteredSpan) -> Self {
+        span.inner.as_ref().map(Inner::id)
+    }
+}
+
 impl Drop for Span {
     fn drop(&mut self) {
         if let Some(Inner {
@@ -1403,6 +1415,11 @@ impl Clone for Inner {
 // ===== impl Entered =====
 
 impl EnteredSpan {
+    /// Returns this span's `Id`, if it is enabled.
+    pub fn id(&self) -> Option<Id> {
+        self.inner.as_ref().map(Inner::id)
+    }
+
     /// Exits this span, returning the underlying [`Span`].
     #[inline]
     pub fn exit(mut self) -> Span {
@@ -1454,6 +1471,7 @@ impl Drop for EnteredSpan {
 struct PhantomNotSend {
     ghost: PhantomData<*mut ()>,
 }
+
 #[allow(non_upper_case_globals)]
 const PhantomNotSend: PhantomNotSend = PhantomNotSend { ghost: PhantomData };
 


### PR DESCRIPTION
This backports the following commits to `v0.1.x`:

* d4493a81 (HEAD -> eliza/backport-1368) docs: document span.in_scope() at top-level (#1344)
* 49461236 tracing: impl `From<EnteredSpan>` for `Option<Id>` (#1325)
* 5f68c71a core: add support for `Arc<dyn Subscriber + ...>`
* a94767a7 tracing: add an example of `tracing` in a panic hook (#1375)
* 1316eaf4 core: add `Subscriber` impl for `Box<dyn Subscriber + ...>` (#1358)
* e2eb1893 subscriber: support special chars in span names (#1368)
* 3c581270 chore: fix cargo docs warnings (#1362)

I'm gonna merge this when CI passes & then hopefully do some releases.