### PR TITLE
subscriber: prepare to release 0.2.18

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,4 +1,32 @@
-# 0.2.17 (March 12, 2020)
+# 0.2.18 (April 30, 2021)
+
+### Deprecated
+
+- Deprecated the `CurrentSpan` type, which is inefficient and largely superseded
+  by the `registry` API ([#1321])
+
+### Fixed
+
+- **json**: Invalid JSON emitted for events in spans with no fields ([#1333])
+- **json**: Missing span data for synthesized new span, exit, and close events
+  ([#1334])
+- **fmt**: Extra space before log lines when timestamps are disabled ([#1355])
+
+### Added
+
+- **env-filter**: Support for filters on spans whose names contain any
+  characters other than `{` and `]` ([#1368])
+
+Thanks to @Folyd, and new contributors @akinnane and @aym-v for contributing to
+this release!
+
+[#1321]: https://github.com/tokio-rs/tracing/pull/1321
+[#1333]: https://github.com/tokio-rs/tracing/pull/1333
+[#1334]: https://github.com/tokio-rs/tracing/pull/1334
+[#1355]: https://github.com/tokio-rs/tracing/pull/1355
+[#1368]: https://github.com/tokio-rs/tracing/pull/1368
+
+# 0.2.17 (March 12, 2021)
 
 ### Fixed
 
@@ -24,7 +52,7 @@ Thanks to new contributors @cratelyn, @dignati, and @zicklag, as well as @Folyd,
 [#1290]: https://github.com/tokio-rs/tracing/pull/1290
 [#1277]: https://github.com/tokio-rs/tracing/pull/1277
 
-# 0.2.16 (February 19, 2020)
+# 0.2.16 (February 19, 2021)
 
 ### Fixed
 

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.17"
+version = "0.2.18"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -21,7 +21,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.2.17
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.18
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -67,7 +67,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.17")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.18")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.2.18 (April 30, 2021)

### Deprecated

- Deprecated the `CurrentSpan` type, which is inefficient and largely
  superseded by the `registry` API ([#1321])

### Fixed

- **json**: Invalid JSON emitted for events in spans with no fields
  ([#1333])
- **json**: Missing span data for synthesized new span, exit, and close
  events ([#1334])
- **fmt**: Extra space before log lines when timestamps are disabled
  ([#1355])

### Added

- **env-filter**: Support for filters on spans whose names contain any
  characters other than `{` and `]` ([#1368])

Thanks to @Folyd, and new contributors @akinnane and @aym-v for
contributing to  this release!

[#1321]: https://github.com/tokio-rs/tracing/pull/1321
[#1333]: https://github.com/tokio-rs/tracing/pull/1333
[#1334]: https://github.com/tokio-rs/tracing/pull/1334
[#1355]: https://github.com/tokio-rs/tracing/pull/1355
[#1368]: https://github.com/tokio-rs/tracing/pull/1368