### PR TITLE
core: impl `Value` for `&mut T` where `T: Value`

### DIFF
--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -428,6 +428,19 @@ where
     }
 }
 
+impl<'a, T: ?Sized> crate::sealed::Sealed for &'a mut T where T: Value + crate::sealed::Sealed + 'a {}
+
+impl<'a, T: ?Sized> Value for &'a mut T
+where
+    T: Value + 'a,
+{
+    fn record(&self, key: &Field, visitor: &mut dyn Visit) {
+        // Don't use `(*self).record(key, visitor)`, otherwise would
+        // cause stack overflow due to `unconditional_recursion`.
+        T::record(self, key, visitor)
+    }
+}
+
 impl<'a> crate::sealed::Sealed for fmt::Arguments<'a> {}
 
 impl<'a> Value for fmt::Arguments<'a> {


### PR DESCRIPTION
Impl `Value` for `&mut T` where `T: Value`. 

#1378 improve the `tracing::instrument` macro's recording behavior: 
all primitive types implementing the `Value` trait will be recorded as fields of that type instead of `fmt::Debug`. This PR is a prerequisite for those `&mut` function arguments to achieve that.