### PR TITLE
opentelemetry: update to otel 0.14.x

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -51,5 +51,5 @@ inferno = "0.10.0"
 tempdir = "0.3.7"
 
 # opentelemetry example
-opentelemetry = { version = "0.13", default-features = false, features = ["trace"] }
-opentelemetry-jaeger = "0.12"
+opentelemetry = { version = "0.14", default-features = false, features = ["trace"] }
+opentelemetry-jaeger = "0.13"

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2018"
 default = ["tracing-log"]
 
 [dependencies]
-opentelemetry = { version = "0.13", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.14", default-features = false, features = ["trace"] }
 tracing = { path = "../tracing", version = "0.2", default-features = false, features = ["std"] }
 tracing-core = { path = "../tracing-core", version = "0.2" }
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry"] }
@@ -31,7 +31,7 @@ tracing-log = { path = "../tracing-log", version = "0.2", default-features = fal
 [dev-dependencies]
 async-trait = "0.1"
 criterion = { version = "0.3", default_features = false }
-opentelemetry-jaeger = "0.12"
+opentelemetry-jaeger = "0.13"
 
 [lib]
 bench = false

--- a/tracing-opentelemetry/src/span_ext.rs
+++ b/tracing-opentelemetry/src/span_ext.rs
@@ -78,7 +78,9 @@ impl OpenTelemetrySpanExt for tracing::Span {
         self.with_collector(move |(id, collector)| {
             if let Some(get_context) = collector.downcast_ref::<WithContext>() {
                 get_context.with_context(collector, id, move |builder, _tracer| {
-                    builder.parent_context = cx.take();
+                    if let Some(cx) = cx.take() {
+                        builder.parent_context = cx;
+                    }
                 });
             }
         });

--- a/tracing-opentelemetry/src/tracer.rs
+++ b/tracing-opentelemetry/src/tracer.rs
@@ -5,9 +5,8 @@ use opentelemetry::{
         SpanBuilder, SpanContext, SpanId, SpanKind, TraceContextExt, TraceId, TraceState,
         TRACE_FLAG_SAMPLED,
     },
-    Context as OtelContext, KeyValue,
+    Context as OtelContext,
 };
-use std::time::SystemTime;
 
 /// An interface for authors of OpenTelemetry SDKs to build pre-sampled tracers.
 ///
@@ -51,10 +50,7 @@ pub trait PreSampledTracer {
 
 impl PreSampledTracer for otel::NoopTracer {
     fn sampled_context(&self, builder: &mut otel::SpanBuilder) -> OtelContext {
-        builder
-            .parent_context
-            .clone()
-            .unwrap_or_else(OtelContext::new)
+        builder.parent_context.clone()
     }
 
     fn new_trace_id(&self) -> otel::TraceId {
@@ -73,9 +69,7 @@ impl PreSampledTracer for Tracer {
             return OtelContext::new();
         }
         let provider = self.provider().unwrap();
-
-        // Ensure parent context exists and contains data necessary for sampling
-        let parent_cx = build_parent_context(&builder);
+        let parent_cx = &builder.parent_context;
 
         // Gather trace state
         let (no_parent, trace_id, remote_parent, parent_trace_flags) =
@@ -85,7 +79,7 @@ impl PreSampledTracer for Tracer {
         let (flags, trace_state) = if let Some(result) = &builder.sampling_result {
             process_sampling_result(result, parent_trace_flags)
         } else if no_parent || remote_parent {
-            builder.sampling_result = Some(provider.config().default_sampler.should_sample(
+            builder.sampling_result = Some(provider.config().sampler.should_sample(
                 Some(&parent_cx),
                 trace_id,
                 &builder.name,
@@ -109,7 +103,7 @@ impl PreSampledTracer for Tracer {
 
         let span_id = builder.span_id.unwrap_or_else(SpanId::invalid);
         let span_context = SpanContext::new(trace_id, span_id, flags, false, trace_state);
-        parent_cx.with_span(CompatSpan(span_context))
+        parent_cx.with_remote_span_context(span_context)
     }
 
     fn new_trace_id(&self) -> otel::TraceId {
@@ -125,31 +119,14 @@ impl PreSampledTracer for Tracer {
     }
 }
 
-fn build_parent_context(builder: &SpanBuilder) -> OtelContext {
-    builder
-        .parent_context
-        .as_ref()
-        .map(|cx| {
-            // Sampling expects to be able to access the parent span via `span` so wrap remote span
-            // context in a wrapper span if necessary. Remote span contexts will be passed to
-            // subsequent context's, so wrapping is only necessary if there is no active span.
-            match cx.remote_span_context() {
-                Some(remote_sc) if !cx.has_active_span() => {
-                    cx.with_span(CompatSpan(remote_sc.clone()))
-                }
-                _ => cx.clone(),
-            }
-        })
-        .unwrap_or_default()
-}
-
 fn current_trace_state(
     builder: &SpanBuilder,
     parent_cx: &OtelContext,
     provider: &TracerProvider,
 ) -> (bool, TraceId, bool, u8) {
     if parent_cx.has_active_span() {
-        let sc = parent_cx.span().span_context();
+        let span = parent_cx.span();
+        let sc = span.span_context();
         (false, sc.trace_id(), sc.is_remote(), sc.trace_flags())
     } else {
         (
@@ -185,58 +162,6 @@ fn process_sampling_result(
     }
 }
 
-#[derive(Debug)]
-struct CompatSpan(otel::SpanContext);
-impl otel::Span for CompatSpan {
-    fn add_event_with_timestamp(
-        &self,
-        _name: String,
-        _timestamp: std::time::SystemTime,
-        _attributes: Vec<KeyValue>,
-    ) {
-        #[cfg(debug_assertions)]
-        panic!(
-            "OpenTelemetry and tracing APIs cannot be mixed, use `tracing::event!` macro instead."
-        );
-    }
-
-    /// This method is used by OpenTelemetry propagators to inject span context
-    /// information into [`Injector`]s.
-    ///
-    /// [`Injector`]: opentelemetry::propagation::Injector
-    fn span_context(&self) -> &otel::SpanContext {
-        &self.0
-    }
-
-    fn is_recording(&self) -> bool {
-        #[cfg(debug_assertions)]
-        panic!("cannot record via OpenTelemetry API when using extracted span in tracing");
-
-        #[cfg(not(debug_assertions))]
-        false
-    }
-
-    fn set_attribute(&self, _attribute: KeyValue) {
-        #[cfg(debug_assertions)]
-        panic!("OpenTelemetry and tracing APIs cannot be mixed, use `tracing::span!` macro or `span.record()` instead.");
-    }
-
-    fn set_status(&self, _code: otel::StatusCode, _message: String) {
-        #[cfg(debug_assertions)]
-        panic!("OpenTelemetry and tracing APIs cannot be mixed, use `tracing::span!` macro or `span.record()` with `otel.status_code` and `otel.status_message` instead.");
-    }
-
-    fn update_name(&self, _new_name: String) {
-        #[cfg(debug_assertions)]
-        panic!("OpenTelemetry and tracing APIs cannot be mixed, use `span.record()` with `otel.name` instead.");
-    }
-
-    fn end_with_timestamp(&self, _timestamp: SystemTime) {
-        #[cfg(debug_assertions)]
-        panic!("OpenTelemetry and tracing APIs cannot be mixed, span end times are set when the underlying tracing span closes.");
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -251,7 +176,8 @@ mod tests {
         builder.span_id = Some(SpanId::from_u64(1));
         builder.trace_id = None;
         let cx = tracer.sampled_context(&mut builder);
-        let span_context = cx.span().span_context();
+        let span = cx.span();
+        let span_context = span.span_context();
 
         assert!(span_context.is_valid());
     }
@@ -287,7 +213,7 @@ mod tests {
                 .build();
             let tracer = provider.get_tracer("test", None);
             let mut builder = SpanBuilder::from_name("parent".to_string());
-            builder.parent_context = Some(parent_cx);
+            builder.parent_context = parent_cx;
             builder.sampling_result = previous_sampling_result;
             let sampled = tracer.sampled_context(&mut builder);
 

--- a/tracing-opentelemetry/tests/trace_state_propagation.rs
+++ b/tracing-opentelemetry/tests/trace_state_propagation.rs
@@ -17,7 +17,7 @@ use tracing_subscriber::prelude::*;
 
 #[test]
 fn trace_with_active_otel_context() {
-    let (cx, subscriber, exporter, _provider) = build_sampled_context();
+    let (cx, subscriber, exporter, provider) = build_sampled_context();
     let attached = cx.attach();
 
     tracing::collect::with_default(subscriber, || {
@@ -25,6 +25,7 @@ fn trace_with_active_otel_context() {
     });
 
     drop(attached); // end implicit parent
+    drop(provider); // flush all spans
 
     let spans = exporter.0.lock().unwrap();
     assert_eq!(spans.len(), 2);
@@ -33,13 +34,14 @@ fn trace_with_active_otel_context() {
 
 #[test]
 fn trace_with_assigned_otel_context() {
-    let (cx, subscriber, exporter, _provider) = build_sampled_context();
+    let (cx, subscriber, exporter, provider) = build_sampled_context();
 
     tracing::collect::with_default(subscriber, || {
         let child = tracing::debug_span!("child");
         child.set_parent(cx);
     });
 
+    drop(provider); // flush all spans
     let spans = exporter.0.lock().unwrap();
     assert_eq!(spans.len(), 2);
     assert_shared_attrs_eq(&spans[0].span_context, &spans[1].span_context);
@@ -47,7 +49,7 @@ fn trace_with_assigned_otel_context() {
 
 #[test]
 fn trace_root_with_children() {
-    let (_tracer, _provider, exporter, subscriber) = test_tracer();
+    let (_tracer, provider, exporter, subscriber) = test_tracer();
 
     tracing::collect::with_default(subscriber, || {
         // Propagate trace information through tracing parent -> child
@@ -55,6 +57,7 @@ fn trace_root_with_children() {
         root.in_scope(|| tracing::debug_span!("child"));
     });
 
+    drop(provider); // flush all spans
     let spans = exporter.0.lock().unwrap();
     assert_eq!(spans.len(), 2);
     assert_shared_attrs_eq(&spans[0].span_context, &spans[1].span_context);


### PR DESCRIPTION
## Motivation

Support the latest OpenTelemetry specification.

## Solution

Update `opentelemetry` to the latest `0.14.x` release. Despite breaking changes upstream, no additional public API or behavioral changes are necessary in `tracing-opentelemetry`, but simplifications in the propagation of span information have removed the need for the current internal `CompatSpan` and custom parent context construction.

Performance has improved by ~30% on current benchmarks.

Resolves #1395, Resolves #1396