### PR TITLE
Fix link to RAII pattern document

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -196,7 +196,7 @@
 //!
 //! You can find more examples showing how to use this crate [here][examples].
 //!
-//! [RAII]: https://github.com/rust-unofficial/patterns/blob/master/patterns/RAII.md
+//! [RAII]: https://github.com/rust-unofficial/patterns/blob/master/patterns/behavioural/RAII.md
 //! [examples]: https://github.com/tokio-rs/tracing/tree/master/examples
 //!
 //! ### Events


### PR DESCRIPTION
## Motivation

The RAII pattern documentation has been moved.

## Solution

Update the link to the document.