### PR TITLE
chore: fix clippy's awful new "inconsistent struct constructor" lint

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -807,7 +807,7 @@ impl Parse for Field {
         } else {
             None
         };
-        Ok(Self { name, kind, value })
+        Ok(Self { name, value, kind })
     }
 }
 

--- a/tracing-core/src/event.rs
+++ b/tracing-core/src/event.rs
@@ -41,8 +41,8 @@ impl<'a> Event<'a> {
     #[inline]
     pub fn new(metadata: &'static Metadata<'static>, fields: &'a field::ValueSet<'a>) -> Self {
         Event {
-            metadata,
             fields,
+            metadata,
             parent: Parent::Current,
         }
     }
@@ -60,8 +60,8 @@ impl<'a> Event<'a> {
             None => Parent::Root,
         };
         Event {
-            metadata,
             fields,
+            metadata,
             parent,
         }
     }

--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -1119,11 +1119,7 @@ impl<'a, C> Context<'a, C> {
 impl<'a, C> Clone for Context<'a, C> {
     #[inline]
     fn clone(&self) -> Self {
-        let subscriber = if let Some(ref subscriber) = self.subscriber {
-            Some(*subscriber)
-        } else {
-            None
-        };
+        let subscriber = self.subscriber.as_ref().copied();
         Context { subscriber }
     }
 }
@@ -1258,7 +1254,7 @@ pub(crate) mod tests {
             .and_then(NopSubscriber)
             .with_collector(StringCollector("collector".into()));
         let collector =
-            Collect::downcast_ref::<StringCollector>(&s).expect("collector should downcast");
+            <dyn Collect>::downcast_ref::<StringCollector>(&s).expect("collector should downcast");
         assert_eq!(&collector.0, "collector");
     }
 

--- a/tracing-tower/src/service_span.rs
+++ b/tracing-tower/src/service_span.rs
@@ -57,7 +57,7 @@ mod layer {
 
         fn layer(&self, inner: S) -> Self::Service {
             let span = self.get_span.span_for(&inner);
-            Service { span, inner }
+            Service { inner, span }
         }
     }
 
@@ -221,7 +221,7 @@ pub mod make {
 
 impl<S> Service<S> {
     pub fn new(inner: S, span: tracing::Span) -> Self {
-        Self { span, inner }
+        Self { inner, span }
     }
 }
 


### PR DESCRIPTION
This branch fixes some annoying new clippy lints no one cares about.