### PR TITLE
chore: backport fix clippy's awful new "inconsistent struct constructor" lint

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -983,7 +983,7 @@ impl Parse for Field {
         } else {
             None
         };
-        Ok(Self { name, kind, value })
+        Ok(Self { name, value, kind })
     }
 }
 

--- a/tracing-core/src/event.rs
+++ b/tracing-core/src/event.rs
@@ -41,8 +41,8 @@ impl<'a> Event<'a> {
     #[inline]
     pub fn new(metadata: &'static Metadata<'static>, fields: &'a field::ValueSet<'a>) -> Self {
         Event {
-            metadata,
             fields,
+            metadata,
             parent: Parent::Current,
         }
     }
@@ -60,8 +60,8 @@ impl<'a> Event<'a> {
             None => Parent::Root,
         };
         Event {
-            metadata,
             fields,
+            metadata,
             parent,
         }
     }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -827,7 +827,7 @@ where
         span: Option<&'a span::Id>,
         ansi: bool,
     ) -> Self {
-        Self { ctx, ansi, span }
+        Self { ctx, span, ansi }
     }
 
     #[cfg(not(feature = "ansi"))]

--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -1135,11 +1135,7 @@ impl<'a, S> Context<'a, S> {
 impl<'a, S> Clone for Context<'a, S> {
     #[inline]
     fn clone(&self) -> Self {
-        let subscriber = if let Some(ref subscriber) = self.subscriber {
-            Some(*subscriber)
-        } else {
-            None
-        };
+        let subscriber = self.subscriber.as_ref().copied();
         Context { subscriber }
     }
 }
@@ -1271,8 +1267,8 @@ pub(crate) mod tests {
             .and_then(NopLayer)
             .and_then(NopLayer)
             .with_subscriber(StringSubscriber("subscriber".into()));
-        let subscriber =
-            Subscriber::downcast_ref::<StringSubscriber>(&s).expect("subscriber should downcast");
+        let subscriber = <dyn Subscriber>::downcast_ref::<StringSubscriber>(&s)
+            .expect("subscriber should downcast");
         assert_eq!(&subscriber.0, "subscriber");
     }
 
@@ -1282,11 +1278,14 @@ pub(crate) mod tests {
             .and_then(StringLayer2("layer_2".into()))
             .and_then(StringLayer3("layer_3".into()))
             .with_subscriber(NopSubscriber);
-        let layer = Subscriber::downcast_ref::<StringLayer>(&s).expect("layer 1 should downcast");
+        let layer =
+            <dyn Subscriber>::downcast_ref::<StringLayer>(&s).expect("layer 1 should downcast");
         assert_eq!(&layer.0, "layer_1");
-        let layer = Subscriber::downcast_ref::<StringLayer2>(&s).expect("layer 2 should downcast");
+        let layer =
+            <dyn Subscriber>::downcast_ref::<StringLayer2>(&s).expect("layer 2 should downcast");
         assert_eq!(&layer.0, "layer_2");
-        let layer = Subscriber::downcast_ref::<StringLayer3>(&s).expect("layer 3 should downcast");
+        let layer =
+            <dyn Subscriber>::downcast_ref::<StringLayer3>(&s).expect("layer 3 should downcast");
         assert_eq!(&layer.0, "layer_3");
     }
 }

--- a/tracing-tower/src/service_span.rs
+++ b/tracing-tower/src/service_span.rs
@@ -57,7 +57,7 @@ mod layer {
 
         fn layer(&self, inner: S) -> Self::Service {
             let span = self.get_span.span_for(&inner);
-            Service { span, inner }
+            Service { inner, span }
         }
     }
 
@@ -221,7 +221,7 @@ pub mod make {
 
 impl<S> Service<S> {
     pub fn new(inner: S, span: tracing::Span) -> Self {
-        Self { span, inner }
+        Self { inner, span }
     }
 }
 


### PR DESCRIPTION
Backport #1401 into `v0.1.x`