### PR TITLE
Add opentelemetry source code attributes to spans

### DIFF
--- a/tracing-opentelemetry/src/subscriber.rs
+++ b/tracing-opentelemetry/src/subscriber.rs
@@ -421,6 +421,22 @@ where
             builder.trace_id = Some(self.tracer.new_trace_id());
         }
 
+        let builder_attrs = builder.attributes.get_or_insert(Vec::new());
+
+        let meta = attrs.metadata();
+
+        if let Some(filename) = meta.file() {
+            builder_attrs.push(KeyValue::new("code.filepath", filename));
+        }
+
+        if let Some(module) = meta.module_path() {
+            builder_attrs.push(KeyValue::new("code.namespace", module));
+        }
+
+        if let Some(line) = meta.line() {
+            builder_attrs.push(KeyValue::new("code.lineno", line as i64));
+        }
+
         attrs.record(&mut SpanAttributeVisitor(&mut builder));
         extensions.insert(builder);
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

There is some more context in #1397 but the main idea is that we should be able to trace a Span back to the location in the code where it was created. Currently many crates have spans with very generic names (`h2` has `send_data` and `reserve_capacity`) and this makes it very difficult to figure out where spans are coming from. This change will make it much easier to find the location in the code where spans are created.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

We can capture the location information using the existing location data on the `tracing::Span`.

The opentelemetry specification calls for a number of attributes to correlate
traces to their location in the code. They are documented here [1]. This commit
adds support for the following fields based on the tracing span metadata (all
relative to span creation):

- `code.namespace`: Crate & module path (`my_crate::my_mod`)
- `code.filepath`: Relative path to the source code file (`src/my_mod.rs`)
- `code.lineno`: Line number in the file indicated by `code.filepath` (`72`)

As written this will annotate all spans with these attributes. If we want to be
a bit more conservative, I could add an instance variable to the Subscriber that
allows users to opt-in or opt-out of this functionality.

[1]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#source-code-attributes


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

# Note

I saw that there is a requirement to add tests for new functionality, but I do not see any tests around the attributes that this crate adds to opentelemetry Spans and Events. I have not added any tests because I'm not sure how to write those or where they would go.