### PR TITLE
core: add `as_str()` for `Level`

### DIFF
--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -283,6 +283,19 @@ impl Level {
     ///
     /// Designates very low priority, often extremely verbose, information.
     pub const TRACE: Level = Level(LevelInner::Trace);
+
+    /// Get the string representation of the `Level`.
+    ///
+    /// This returns the same string as the `fmt::Display` implementation.
+    pub fn as_str(&self) -> &str {
+        match *self {
+            Level::TRACE => "TRACE",
+            Level::DEBUG => "DEBUG",
+            Level::INFO => "INFO",
+            Level::WARN => "WARN",
+            Level::ERROR => "ERROR",
+        }
+    }
 }
 
 impl fmt::Display for Level {

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -284,10 +284,10 @@ impl Level {
     /// Designates very low priority, often extremely verbose, information.
     pub const TRACE: Level = Level(LevelInner::Trace);
 
-    /// Get the string representation of the `Level`.
+    /// Returns the string representation of the `Level`.
     ///
     /// This returns the same string as the `fmt::Display` implementation.
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &'static str {
         match *self {
             Level::TRACE => "TRACE",
             Level::DEBUG => "DEBUG",


### PR DESCRIPTION


## Motivation

Get the string representation of the `Level` is quite a common usecase.
Without this method, I normally need to implement it by myself, which is fairly noisy.

```rust
#[inline]
fn level_to_str(level: &tracing::Level) -> &'static str {
    match *level {
        tracing::Level::TRACE => "TRACE",
        tracing::Level::DEBUG => "DEBUG",
        tracing::Level::INFO => "INFO",
        tracing::Level::WARN => "WARN",
        tracing::Level::ERROR => "ERROR"
    }
}
```

## Solution

Add an `as_str()` method for `Level`. Similar to [log::Level::as_str()](https://docs.rs/log/0.4.14/log/enum.Level.html#method.as_str).
