### PR TITLE
subscriber: Stop using prelude imports in doctests

### DIFF
--- a/examples/examples/toggle-subscribers.rs
+++ b/examples/examples/toggle-subscribers.rs
@@ -11,7 +11,7 @@
 ///
 use clap::{App, Arg};
 use tracing::info;
-use tracing_subscriber::{prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt};
+use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt};
 
 #[path = "fmt/yak_shave.rs"]
 mod yak_shave;

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -23,7 +23,7 @@ use tracing_core::{
 ///
 /// ```rust
 /// use tracing_subscriber::{fmt, Registry};
-/// use tracing_subscriber::prelude::*;
+/// use tracing_subscriber::subscribe::CollectExt;
 ///
 /// let collector = Registry::default()
 ///     .with(fmt::Subscriber::default());
@@ -35,7 +35,7 @@ use tracing_core::{
 ///
 /// ```rust
 /// use tracing_subscriber::{fmt, Registry};
-/// use tracing_subscriber::prelude::*;
+/// use tracing_subscriber::subscribe::CollectExt;
 ///
 /// let fmt_subscriber = fmt::subscriber()
 ///    .with_target(false) // don't include event targets when logging
@@ -49,7 +49,7 @@ use tracing_core::{
 ///
 /// ```rust
 /// use tracing_subscriber::fmt::{self, format, time};
-/// use tracing_subscriber::prelude::*;
+/// use tracing_subscriber::Subscribe;
 ///
 /// let fmt = format().with_timer(time::Uptime::default());
 /// let fmt_subscriber = fmt::subscriber()

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -261,7 +261,8 @@
 //!
 //! ```rust
 //! use tracing_subscriber::{fmt, EnvFilter};
-//! use tracing_subscriber::prelude::*;
+//! use tracing_subscriber::subscribe::CollectExt;
+//! use tracing_subscriber::util::SubscriberInitExt;
 //!
 //! let fmt_subscriber = fmt::subscriber()
 //!     .with_target(false);
@@ -846,12 +847,12 @@ impl<N, E, F, W> CollectorBuilder<N, E, F, W> {
     /// For example:
     /// ```rust
     /// use tracing_subscriber::fmt::format;
-    /// use tracing_subscriber::prelude::*;
+    /// use tracing_subscriber::field::MakeExt;
     ///
     /// let formatter =
     ///     // Construct a custom formatter for `Debug` fields
     ///     format::debug_fn(|writer, field, value| write!(writer, "{}: {:?}", field, value))
-    ///         // Use the `tracing_subscriber::MakeFmtExt` trait to wrap the
+    ///         // Use the `tracing_subscriber::MakeExt` trait to wrap the
     ///         // formatter so that a delimiter is added between fields.
     ///         .delimited(", ");
     ///
@@ -982,7 +983,7 @@ impl<N, E, F, W> CollectorBuilder<N, E, F, W> {
     ///
     /// ```
     /// use tracing::Level;
-    /// use tracing_subscriber::prelude::*;
+    /// use tracing_subscriber::util::SubscriberInitExt;
     ///
     /// let builder = tracing_subscriber::fmt()
     ///      // Set a max level filter on the collector

--- a/tracing-subscriber/src/prelude.rs
+++ b/tracing-subscriber/src/prelude.rs
@@ -3,12 +3,6 @@
 //! This brings into scope a number of extension traits that define methods on
 //! types defined here and in other crates.
 
-pub use crate::field::{
-    MakeExt as __tracing_subscriber_field_MakeExt,
-    RecordFields as __tracing_subscriber_field_RecordFields,
-};
-pub use crate::subscribe::{
-    CollectExt as __tracing_subscriber_SubscriberExt, Subscribe as __tracing_subscriber_Layer,
-};
-
+pub use crate::field::{MakeExt as _, RecordFields as _};
+pub use crate::subscribe::{CollectExt as _, Subscribe as _};
 pub use crate::util::SubscriberInitExt as _;

--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -52,7 +52,7 @@ use std::{any::TypeId, marker::PhantomData, ptr::NonNull};
 /// For example:
 /// ```rust
 /// use tracing_subscriber::Subscribe;
-/// use tracing_subscriber::prelude::*;
+/// use tracing_subscriber::subscribe::CollectExt;
 /// use tracing::Collect;
 ///
 /// pub struct MySubscriber {
@@ -94,7 +94,7 @@ use std::{any::TypeId, marker::PhantomData, ptr::NonNull};
 /// Multiple `Subscriber`s may be composed in the same manner:
 /// ```rust
 /// # use tracing_subscriber::Subscribe;
-/// # use tracing_subscriber::prelude::*;
+/// # use tracing_subscriber::subscribe::CollectExt;
 /// # use tracing::Collect;
 /// pub struct MyOtherSubscriber {
 ///     // ...


### PR DESCRIPTION
## Motivation

I dislike using `*` imports in my code, so I'm not using prelude modules provided by libraries. With the way the examples in the `tracing-subscriber` docs are currently set up, there is no hint on where some methods are coming from. Just removing the prelude import unfortunately doesn't lead to a solution. The compiler prefers the prelude re-export:

```
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
3   | use crate::tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
    |
```

## Solution

Use the traits directly in the documentation examples.