### PR TITLE
Blanket-implement tracing::instrument::WithSubscriber

### DIFF
--- a/tracing/src/instrument.rs
+++ b/tracing/src/instrument.rs
@@ -120,6 +120,8 @@ pub trait WithSubscriber: Sized {
     }
 }
 
+impl<T: Sized> WithSubscriber for T {}
+
 pin_project! {
     /// A future that has been instrumented with a `tracing` subscriber.
     #[derive(Clone, Debug)]


### PR DESCRIPTION
This provides a blanket implementation of `WithSubscriber`, as already implied by the docs, discussed at https://canary.discord.com/channels/500028886025895936/627649734592561152/850435247216001074, and already implemented by `tracing-futures`.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

The current docs are confusing since they describe behaviour that is effectively unusable.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->