### PR TITLE
chore: unify generic name of `Collect`

### DIFF
--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -491,9 +491,9 @@ impl Dispatch {
     /// [`Collect`]: super::collect::Collect
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "std", feature = "alloc"))))]
-    pub fn new<S>(collector: S) -> Self
+    pub fn new<C>(collector: C) -> Self
     where
-        S: Collect + Send + Sync + 'static,
+        C: Collect + Send + Sync + 'static,
     {
         let me = Dispatch {
             collector: Kind::Scoped(Arc::new(collector)),
@@ -819,12 +819,12 @@ impl fmt::Debug for Dispatch {
 }
 
 #[cfg(feature = "std")]
-impl<S> From<S> for Dispatch
+impl<C> From<C> for Dispatch
 where
-    S: Collect + Send + Sync + 'static,
+    C: Collect + Send + Sync + 'static,
 {
     #[inline]
-    fn from(collector: S) -> Self {
+    fn from(collector: C) -> Self {
         Dispatch::new(collector)
     }
 }

--- a/tracing-error/src/subscriber.rs
+++ b/tracing-error/src/subscriber.rs
@@ -22,11 +22,11 @@ use tracing_subscriber::{
 /// [`SpanTrace`]: super::SpanTrace
 /// [field formatter]: tracing_subscriber::fmt::FormatFields
 /// [default format]: tracing_subscriber::fmt::format::DefaultFields
-pub struct ErrorSubscriber<S, F = DefaultFields> {
+pub struct ErrorSubscriber<C, F = DefaultFields> {
     format: F,
 
     get_context: WithContext,
-    _subscriber: PhantomData<fn(S)>,
+    _collector: PhantomData<fn(C)>,
 }
 
 // this function "remembers" the types of the subscriber and the formatter,
@@ -36,9 +36,9 @@ pub(crate) struct WithContext(
     fn(&Dispatch, &span::Id, f: &mut dyn FnMut(&'static Metadata<'static>, &str) -> bool),
 );
 
-impl<S, F> Subscribe<S> for ErrorSubscriber<S, F>
+impl<C, F> Subscribe<C> for ErrorSubscriber<C, F>
 where
-    S: Collect + for<'span> LookupSpan<'span>,
+    C: Collect + for<'span> LookupSpan<'span>,
     F: for<'writer> FormatFields<'writer> + 'static,
 {
     /// Notifies this subscriber that a new span was constructed with the given
@@ -47,7 +47,7 @@ where
         &self,
         attrs: &span::Attributes<'_>,
         id: &span::Id,
-        ctx: subscribe::Context<'_, S>,
+        ctx: subscribe::Context<'_, C>,
     ) {
         let span = ctx.span(id).expect("span must already exist!");
         if span.extensions().get::<FormattedFields<F>>().is_some() {
@@ -71,10 +71,10 @@ where
     }
 }
 
-impl<S, F> ErrorSubscriber<S, F>
+impl<C, F> ErrorSubscriber<C, F>
 where
     F: for<'writer> FormatFields<'writer> + 'static,
-    S: Collect + for<'span> LookupSpan<'span>,
+    C: Collect + for<'span> LookupSpan<'span>,
 {
     /// Returns a new `ErrorSubscriber` with the provided [field formatter].
     ///
@@ -83,7 +83,7 @@ where
         Self {
             format,
             get_context: WithContext(Self::get_context),
-            _subscriber: PhantomData,
+            _collector: PhantomData,
         }
     }
 
@@ -92,10 +92,10 @@ where
         id: &span::Id,
         f: &mut dyn FnMut(&'static Metadata<'static>, &str) -> bool,
     ) {
-        let subscriber = dispatch
-            .downcast_ref::<S>()
-            .expect("subscriber should downcast to expected type; this is a bug!");
-        let span = subscriber
+        let collector = dispatch
+            .downcast_ref::<C>()
+            .expect("collector should downcast to expected type; this is a bug!");
+        let span = collector
             .span(id)
             .expect("registry should have a span for the current ID");
         let parents = span.parents();
@@ -123,20 +123,20 @@ impl WithContext {
     }
 }
 
-impl<S> Default for ErrorSubscriber<S>
+impl<C> Default for ErrorSubscriber<C>
 where
-    S: Collect + for<'span> LookupSpan<'span>,
+    C: Collect + for<'span> LookupSpan<'span>,
 {
     fn default() -> Self {
         Self::new(DefaultFields::default())
     }
 }
 
-impl<S, F: fmt::Debug> fmt::Debug for ErrorSubscriber<S, F> {
+impl<C, F: fmt::Debug> fmt::Debug for ErrorSubscriber<C, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ErrorSubscriber")
             .field("format", &self.format)
-            .field("subscriber", &format_args!("{}", type_name::<S>()))
+            .field("collector", &format_args!("{}", type_name::<C>()))
             .finish()
     }
 }

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -207,9 +207,9 @@ pub trait WithCollector: Sized {
     ///
     /// [collector]: tracing::collect::Collect
     /// [default]: tracing::dispatch#setting-the-default-collector
-    fn with_collector<S>(self, collector: S) -> WithDispatch<Self>
+    fn with_collector<C>(self, collector: C) -> WithDispatch<Self>
     where
-        S: Into<Dispatch>,
+        C: Into<Dispatch>,
     {
         WithDispatch {
             inner: self,

--- a/tracing-opentelemetry/benches/trace.rs
+++ b/tracing-opentelemetry/benches/trace.rs
@@ -56,22 +56,22 @@ fn many_children(c: &mut Criterion) {
 struct NoDataSpan;
 struct RegistryAccessCollector;
 
-impl<S> tracing_subscriber::Subscribe<S> for RegistryAccessCollector
+impl<C> tracing_subscriber::Subscribe<C> for RegistryAccessCollector
 where
-    S: tracing_core::Collect + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+    C: tracing_core::Collect + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
 {
     fn new_span(
         &self,
         _attrs: &tracing_core::span::Attributes<'_>,
         id: &tracing::span::Id,
-        ctx: tracing_subscriber::subscribe::Context<'_, S>,
+        ctx: tracing_subscriber::subscribe::Context<'_, C>,
     ) {
         let span = ctx.span(id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
         extensions.insert(NoDataSpan);
     }
 
-    fn on_close(&self, id: tracing::span::Id, ctx: tracing_subscriber::subscribe::Context<'_, S>) {
+    fn on_close(&self, id: tracing::span::Id, ctx: tracing_subscriber::subscribe::Context<'_, C>) {
         let span = ctx.span(&id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
 
@@ -83,15 +83,15 @@ where
 
 struct OtelDataCollector;
 
-impl<S> tracing_subscriber::Subscribe<S> for OtelDataCollector
+impl<C> tracing_subscriber::Subscribe<C> for OtelDataCollector
 where
-    S: tracing_core::Collect + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+    C: tracing_core::Collect + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
 {
     fn new_span(
         &self,
         attrs: &tracing_core::span::Attributes<'_>,
         id: &tracing::span::Id,
-        ctx: tracing_subscriber::subscribe::Context<'_, S>,
+        ctx: tracing_subscriber::subscribe::Context<'_, C>,
     ) {
         let span = ctx.span(id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
@@ -101,7 +101,7 @@ where
         );
     }
 
-    fn on_close(&self, id: tracing::span::Id, ctx: tracing_subscriber::subscribe::Context<'_, S>) {
+    fn on_close(&self, id: tracing::span::Id, ctx: tracing_subscriber::subscribe::Context<'_, C>) {
         let span = ctx.span(&id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
 

--- a/tracing-subscriber/src/filter/level.rs
+++ b/tracing-subscriber/src/filter/level.rs
@@ -8,7 +8,7 @@ pub use tracing_core::metadata::{LevelFilter, ParseLevelFilterError as ParseErro
 
 // === impl LevelFilter ===
 
-impl<S: Collect> crate::Subscribe<S> for LevelFilter {
+impl<C: Collect> crate::Subscribe<C> for LevelFilter {
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         if self >= metadata.level() {
             Interest::always()
@@ -17,7 +17,7 @@ impl<S: Collect> crate::Subscribe<S> for LevelFilter {
         }
     }
 
-    fn enabled(&self, metadata: &Metadata<'_>, _: crate::subscribe::Context<'_, S>) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>, _: crate::subscribe::Context<'_, C>) -> bool {
         self >= metadata.level()
     }
 

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -61,15 +61,15 @@ use tracing_core::{
 ///
 /// [`Subscriber`]: subscribe::Subscribe
 #[derive(Debug)]
-pub struct Subscriber<S, N = format::DefaultFields, E = format::Format, W = fn() -> io::Stdout> {
+pub struct Subscriber<C, N = format::DefaultFields, E = format::Format, W = fn() -> io::Stdout> {
     make_writer: W,
     fmt_fields: N,
     fmt_event: E,
     fmt_span: format::FmtSpanConfig,
-    _inner: PhantomData<S>,
+    _inner: PhantomData<C>,
 }
 
-impl<S> Subscriber<S> {
+impl<C> Subscriber<C> {
     /// Returns a new [`Subscriber`] with the default configuration.
     pub fn new() -> Self {
         Self::default()
@@ -77,9 +77,9 @@ impl<S> Subscriber<S> {
 }
 
 // This needs to be a separate impl block because they place different bounds on the type parameters.
-impl<S, N, E, W> Subscriber<S, N, E, W>
+impl<C, N, E, W> Subscriber<C, N, E, W>
 where
-    S: Collect + for<'a> LookupSpan<'a>,
+    C: Collect + for<'a> LookupSpan<'a>,
     N: for<'writer> FormatFields<'writer> + 'static,
     W: for<'writer> MakeWriter<'writer> + 'static,
 {
@@ -104,9 +104,9 @@ where
     /// ```
     /// [`FormatEvent`]: format::FormatEvent
     /// [`Event`]: tracing::Event
-    pub fn event_format<E2>(self, e: E2) -> Subscriber<S, N, E2, W>
+    pub fn event_format<E2>(self, e: E2) -> Subscriber<C, N, E2, W>
     where
-        E2: FormatEvent<S, N> + 'static,
+        E2: FormatEvent<C, N> + 'static,
     {
         Subscriber {
             fmt_fields: self.fmt_fields,
@@ -119,7 +119,7 @@ where
 }
 
 // This needs to be a separate impl block because they place different bounds on the type parameters.
-impl<S, N, E, W> Subscriber<S, N, E, W> {
+impl<C, N, E, W> Subscriber<C, N, E, W> {
     /// Sets the [`MakeWriter`] that the [`Subscriber`] being built will use to write events.
     ///
     /// # Examples
@@ -139,7 +139,7 @@ impl<S, N, E, W> Subscriber<S, N, E, W> {
     ///
     /// [`MakeWriter`]: super::writer::MakeWriter
     /// [`Subscriber`]: super::Subscriber
-    pub fn with_writer<W2>(self, make_writer: W2) -> Subscriber<S, N, E, W2>
+    pub fn with_writer<W2>(self, make_writer: W2) -> Subscriber<C, N, E, W2>
     where
         W2: for<'writer> MakeWriter<'writer> + 'static,
     {
@@ -174,7 +174,7 @@ impl<S, N, E, W> Subscriber<S, N, E, W> {
     /// [capturing]:
     /// https://doc.rust-lang.org/book/ch11-02-running-tests.html#showing-function-output
     /// [`TestWriter`]: super::writer::TestWriter
-    pub fn with_test_writer(self) -> Subscriber<S, N, E, TestWriter> {
+    pub fn with_test_writer(self) -> Subscriber<C, N, E, TestWriter> {
         Subscriber {
             fmt_fields: self.fmt_fields,
             fmt_event: self.fmt_event,
@@ -185,7 +185,7 @@ impl<S, N, E, W> Subscriber<S, N, E, W> {
     }
 }
 
-impl<S, N, L, T, W> Subscriber<S, N, format::Format<L, T>, W>
+impl<C, N, L, T, W> Subscriber<C, N, format::Format<L, T>, W>
 where
     N: for<'writer> FormatFields<'writer> + 'static,
 {
@@ -200,7 +200,7 @@ where
     /// [`timer`]: super::time::FormatTime
     /// [`ChronoUtc`]: super::time::ChronoUtc
     /// [`ChronoLocal`]: super::time::ChronoLocal
-    pub fn with_timer<T2>(self, timer: T2) -> Subscriber<S, N, format::Format<L, T2>, W> {
+    pub fn with_timer<T2>(self, timer: T2) -> Subscriber<C, N, format::Format<L, T2>, W> {
         Subscriber {
             fmt_event: self.fmt_event.with_timer(timer),
             fmt_fields: self.fmt_fields,
@@ -211,7 +211,7 @@ where
     }
 
     /// Do not emit timestamps with spans and event.
-    pub fn without_time(self) -> Subscriber<S, N, format::Format<L, ()>, W> {
+    pub fn without_time(self) -> Subscriber<C, N, format::Format<L, ()>, W> {
         Subscriber {
             fmt_event: self.fmt_event.without_time(),
             fmt_fields: self.fmt_fields,
@@ -272,7 +272,7 @@ where
     /// Enable ANSI terminal colors for formatted output.
     #[cfg(feature = "ansi")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
-    pub fn with_ansi(self, ansi: bool) -> Subscriber<S, N, format::Format<L, T>, W> {
+    pub fn with_ansi(self, ansi: bool) -> Subscriber<C, N, format::Format<L, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.with_ansi(ansi),
             ..self
@@ -280,7 +280,7 @@ where
     }
 
     /// Sets whether or not an event's target is displayed.
-    pub fn with_target(self, display_target: bool) -> Subscriber<S, N, format::Format<L, T>, W> {
+    pub fn with_target(self, display_target: bool) -> Subscriber<C, N, format::Format<L, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.with_target(display_target),
             ..self
@@ -288,7 +288,7 @@ where
     }
 
     /// Sets whether or not an event's level is displayed.
-    pub fn with_level(self, display_level: bool) -> Subscriber<S, N, format::Format<L, T>, W> {
+    pub fn with_level(self, display_level: bool) -> Subscriber<C, N, format::Format<L, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.with_level(display_level),
             ..self
@@ -302,7 +302,7 @@ where
     pub fn with_thread_ids(
         self,
         display_thread_ids: bool,
-    ) -> Subscriber<S, N, format::Format<L, T>, W> {
+    ) -> Subscriber<C, N, format::Format<L, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.with_thread_ids(display_thread_ids),
             ..self
@@ -316,7 +316,7 @@ where
     pub fn with_thread_names(
         self,
         display_thread_names: bool,
-    ) -> Subscriber<S, N, format::Format<L, T>, W> {
+    ) -> Subscriber<C, N, format::Format<L, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.with_thread_names(display_thread_names),
             ..self
@@ -324,7 +324,7 @@ where
     }
 
     /// Sets the subscriber being built to use a [less verbose formatter](format::Compact).
-    pub fn compact(self) -> Subscriber<S, N, format::Format<format::Compact, T>, W>
+    pub fn compact(self) -> Subscriber<C, N, format::Format<format::Compact, T>, W>
     where
         N: for<'writer> FormatFields<'writer> + 'static,
     {
@@ -340,7 +340,7 @@ where
     /// Sets the subscriber being built to use an [excessively pretty, human-readable formatter](crate::fmt::format::Pretty).
     #[cfg(feature = "ansi")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
-    pub fn pretty(self) -> Subscriber<S, format::Pretty, format::Format<format::Pretty, T>, W> {
+    pub fn pretty(self) -> Subscriber<C, format::Pretty, format::Format<format::Pretty, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.pretty(),
             fmt_fields: format::Pretty::default(),
@@ -367,7 +367,7 @@ where
     ///
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
-    pub fn json(self) -> Subscriber<S, format::JsonFields, format::Format<format::Json, T>, W> {
+    pub fn json(self) -> Subscriber<C, format::JsonFields, format::Format<format::Json, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.json(),
             fmt_fields: format::JsonFields::new(),
@@ -380,14 +380,14 @@ where
 
 #[cfg(feature = "json")]
 #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
-impl<S, T, W> Subscriber<S, format::JsonFields, format::Format<format::Json, T>, W> {
+impl<C, T, W> Subscriber<C, format::JsonFields, format::Format<format::Json, T>, W> {
     /// Sets the JSON subscriber being built to flatten event metadata.
     ///
     /// See [`format::Json`]
     pub fn flatten_event(
         self,
         flatten_event: bool,
-    ) -> Subscriber<S, format::JsonFields, format::Format<format::Json, T>, W> {
+    ) -> Subscriber<C, format::JsonFields, format::Format<format::Json, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.flatten_event(flatten_event),
             fmt_fields: format::JsonFields::new(),
@@ -402,7 +402,7 @@ impl<S, T, W> Subscriber<S, format::JsonFields, format::Format<format::Json, T>,
     pub fn with_current_span(
         self,
         display_current_span: bool,
-    ) -> Subscriber<S, format::JsonFields, format::Format<format::Json, T>, W> {
+    ) -> Subscriber<C, format::JsonFields, format::Format<format::Json, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.with_current_span(display_current_span),
             fmt_fields: format::JsonFields::new(),
@@ -417,7 +417,7 @@ impl<S, T, W> Subscriber<S, format::JsonFields, format::Format<format::Json, T>,
     pub fn with_span_list(
         self,
         display_span_list: bool,
-    ) -> Subscriber<S, format::JsonFields, format::Format<format::Json, T>, W> {
+    ) -> Subscriber<C, format::JsonFields, format::Format<format::Json, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.with_span_list(display_span_list),
             fmt_fields: format::JsonFields::new(),
@@ -426,10 +426,10 @@ impl<S, T, W> Subscriber<S, format::JsonFields, format::Format<format::Json, T>,
     }
 }
 
-impl<S, N, E, W> Subscriber<S, N, E, W> {
+impl<C, N, E, W> Subscriber<C, N, E, W> {
     /// Sets the field formatter that the subscriber being built will use to record
     /// fields.
-    pub fn fmt_fields<N2>(self, fmt_fields: N2) -> Subscriber<S, N2, E, W>
+    pub fn fmt_fields<N2>(self, fmt_fields: N2) -> Subscriber<C, N2, E, W>
     where
         N2: for<'writer> FormatFields<'writer> + 'static,
     {
@@ -443,7 +443,7 @@ impl<S, N, E, W> Subscriber<S, N, E, W> {
     }
 }
 
-impl<S> Default for Subscriber<S> {
+impl<C> Default for Subscriber<C> {
     fn default() -> Self {
         Subscriber {
             fmt_fields: format::DefaultFields::default(),
@@ -455,15 +455,15 @@ impl<S> Default for Subscriber<S> {
     }
 }
 
-impl<S, N, E, W> Subscriber<S, N, E, W>
+impl<C, N, E, W> Subscriber<C, N, E, W>
 where
-    S: Collect + for<'a> LookupSpan<'a>,
+    C: Collect + for<'a> LookupSpan<'a>,
     N: for<'writer> FormatFields<'writer> + 'static,
-    E: FormatEvent<S, N> + 'static,
+    E: FormatEvent<C, N> + 'static,
     W: for<'writer> MakeWriter<'writer> + 'static,
 {
     #[inline]
-    fn make_ctx<'a>(&'a self, ctx: Context<'a, S>) -> FmtContext<'a, S, N> {
+    fn make_ctx<'a>(&'a self, ctx: Context<'a, C>) -> FmtContext<'a, C, N> {
         FmtContext {
             ctx,
             fmt_fields: &self.fmt_fields,
@@ -536,14 +536,14 @@ macro_rules! with_event_from_span {
     };
 }
 
-impl<S, N, E, W> subscribe::Subscribe<S> for Subscriber<S, N, E, W>
+impl<C, N, E, W> subscribe::Subscribe<C> for Subscriber<C, N, E, W>
 where
-    S: Collect + for<'a> LookupSpan<'a>,
+    C: Collect + for<'a> LookupSpan<'a>,
     N: for<'writer> FormatFields<'writer> + 'static,
-    E: FormatEvent<S, N> + 'static,
+    E: FormatEvent<C, N> + 'static,
     W: for<'writer> MakeWriter<'writer> + 'static,
 {
-    fn new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+    fn new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, C>) {
         let span = ctx.span(id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
 
@@ -574,7 +574,7 @@ where
         }
     }
 
-    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, C>) {
         let span = ctx.span(id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
         if let Some(FormattedFields { ref mut fields, .. }) =
@@ -593,7 +593,7 @@ where
         }
     }
 
-    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
+    fn on_enter(&self, id: &Id, ctx: Context<'_, C>) {
         if self.fmt_span.trace_enter() || self.fmt_span.trace_close() && self.fmt_span.fmt_timing {
             let span = ctx.span(id).expect("Span not found, this is a bug");
             let mut extensions = span.extensions_mut();
@@ -613,7 +613,7 @@ where
         }
     }
 
-    fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
+    fn on_exit(&self, id: &Id, ctx: Context<'_, C>) {
         if self.fmt_span.trace_exit() || self.fmt_span.trace_close() && self.fmt_span.fmt_timing {
             let span = ctx.span(id).expect("Span not found, this is a bug");
             let mut extensions = span.extensions_mut();
@@ -633,7 +633,7 @@ where
         }
     }
 
-    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+    fn on_close(&self, id: Id, ctx: Context<'_, C>) {
         if self.fmt_span.trace_close() {
             let span = ctx.span(&id).expect("Span not found, this is a bug");
             let extensions = span.extensions();
@@ -670,7 +670,7 @@ where
         }
     }
 
-    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, C>) {
         thread_local! {
             static BUF: RefCell<String> = RefCell::new(String::new());
         }
@@ -716,20 +716,20 @@ where
 }
 
 /// Provides the current span context to a formatter.
-pub struct FmtContext<'a, S, N> {
-    pub(crate) ctx: Context<'a, S>,
+pub struct FmtContext<'a, C, N> {
+    pub(crate) ctx: Context<'a, C>,
     pub(crate) fmt_fields: &'a N,
 }
 
-impl<'a, S, N> fmt::Debug for FmtContext<'a, S, N> {
+impl<'a, C, N> fmt::Debug for FmtContext<'a, C, N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FmtContext").finish()
     }
 }
 
-impl<'cx, 'writer, S, N> FormatFields<'writer> for FmtContext<'cx, S, N>
+impl<'cx, 'writer, C, N> FormatFields<'writer> for FmtContext<'cx, C, N>
 where
-    S: Collect + for<'lookup> LookupSpan<'lookup>,
+    C: Collect + for<'lookup> LookupSpan<'lookup>,
     N: FormatFields<'writer> + 'static,
 {
     fn format_fields<R: RecordFields>(
@@ -741,9 +741,9 @@ where
     }
 }
 
-impl<'a, S, N> FmtContext<'a, S, N>
+impl<'a, C, N> FmtContext<'a, C, N>
 where
-    S: Collect + for<'lookup> LookupSpan<'lookup>,
+    C: Collect + for<'lookup> LookupSpan<'lookup>,
     N: for<'writer> FormatFields<'writer> + 'static,
 {
     /// Visits every span in the current context with a closure.
@@ -753,7 +753,7 @@ where
     /// and so on until a root span is reached.
     pub fn visit_spans<E, F>(&self, mut f: F) -> Result<(), E>
     where
-        F: FnMut(&SpanRef<'_, S>) -> Result<(), E>,
+        F: FnMut(&SpanRef<'_, C>) -> Result<(), E>,
     {
         // visit all the current spans
         for span in self.ctx.scope() {
@@ -769,7 +769,7 @@ where
     #[inline]
     pub fn metadata(&self, id: &Id) -> Option<&'static Metadata<'static>>
     where
-        S: for<'lookup> LookupSpan<'lookup>,
+        C: for<'lookup> LookupSpan<'lookup>,
     {
         self.ctx.metadata(id)
     }
@@ -781,9 +781,9 @@ where
     ///
     /// [stored data]: SpanRef
     #[inline]
-    pub fn span(&self, id: &Id) -> Option<SpanRef<'_, S>>
+    pub fn span(&self, id: &Id) -> Option<SpanRef<'_, C>>
     where
-        S: for<'lookup> LookupSpan<'lookup>,
+        C: for<'lookup> LookupSpan<'lookup>,
     {
         self.ctx.span(id)
     }
@@ -792,7 +792,7 @@ where
     #[inline]
     pub fn exists(&self, id: &Id) -> bool
     where
-        S: for<'lookup> LookupSpan<'lookup>,
+        C: for<'lookup> LookupSpan<'lookup>,
     {
         self.ctx.exists(id)
     }
@@ -804,9 +804,9 @@ where
     ///
     /// [stored data]: SpanRef
     #[inline]
-    pub fn lookup_current(&self) -> Option<SpanRef<'_, S>>
+    pub fn lookup_current(&self) -> Option<SpanRef<'_, C>>
     where
-        S: for<'lookup> LookupSpan<'lookup>,
+        C: for<'lookup> LookupSpan<'lookup>,
     {
         self.ctx.lookup_current()
     }
@@ -816,9 +816,9 @@ where
     /// the current span.
     ///
     /// [stored data]: SpanRef
-    pub fn scope(&self) -> Scope<'_, S>
+    pub fn scope(&self) -> Scope<'_, C>
     where
-        S: for<'lookup> LookupSpan<'lookup>,
+        C: for<'lookup> LookupSpan<'lookup>,
     {
         self.ctx.scope()
     }

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -172,20 +172,20 @@ where
     }
 }
 
-impl<S, N, T> FormatEvent<S, N> for Format<Json, T>
+impl<C, N, T> FormatEvent<C, N> for Format<Json, T>
 where
-    S: Collect + for<'lookup> LookupSpan<'lookup>,
+    C: Collect + for<'lookup> LookupSpan<'lookup>,
     N: for<'writer> FormatFields<'writer> + 'static,
     T: FormatTime,
 {
     fn format_event(
         &self,
-        ctx: &FmtContext<'_, S, N>,
+        ctx: &FmtContext<'_, C, N>,
         writer: &mut dyn fmt::Write,
         event: &Event<'_>,
     ) -> fmt::Result
     where
-        S: Collect + for<'a> LookupSpan<'a>,
+        C: Collect + for<'a> LookupSpan<'a>,
     {
         let mut timestamp = String::new();
         self.timer.format_time(&mut timestamp)?;

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -56,9 +56,9 @@ use fmt::{Debug, Display};
 ///
 /// struct MyFormatter;
 ///
-/// impl<S, N> FormatEvent<S, N> for MyFormatter
+/// impl<C, N> FormatEvent<C, N> for MyFormatter
 /// where
-///     S: Collect + for<'a> LookupSpan<'a>,
+///     C: Collect + for<'a> LookupSpan<'a>,
 ///     N: for<'a> FormatFields<'a> + 'static,
 /// {
 ///     fn format_event(
@@ -116,29 +116,29 @@ use fmt::{Debug, Display};
 ///
 /// [`fmt::Collector`]: super::Collector
 /// [`fmt::Subscriber`]: super::Subscriber
-pub trait FormatEvent<S, N>
+pub trait FormatEvent<C, N>
 where
-    S: Collect + for<'a> LookupSpan<'a>,
+    C: Collect + for<'a> LookupSpan<'a>,
     N: for<'a> FormatFields<'a> + 'static,
 {
     /// Write a log message for `Event` in `Context` to the given `Write`.
     fn format_event(
         &self,
-        ctx: &FmtContext<'_, S, N>,
+        ctx: &FmtContext<'_, C, N>,
         writer: &mut dyn fmt::Write,
         event: &Event<'_>,
     ) -> fmt::Result;
 }
 
-impl<S, N> FormatEvent<S, N>
-    for fn(ctx: &FmtContext<'_, S, N>, &mut dyn fmt::Write, &Event<'_>) -> fmt::Result
+impl<C, N> FormatEvent<C, N>
+    for fn(ctx: &FmtContext<'_, C, N>, &mut dyn fmt::Write, &Event<'_>) -> fmt::Result
 where
-    S: Collect + for<'a> LookupSpan<'a>,
+    C: Collect + for<'a> LookupSpan<'a>,
     N: for<'a> FormatFields<'a> + 'static,
 {
     fn format_event(
         &self,
-        ctx: &FmtContext<'_, S, N>,
+        ctx: &FmtContext<'_, C, N>,
         writer: &mut dyn fmt::Write,
         event: &Event<'_>,
     ) -> fmt::Result {
@@ -531,15 +531,15 @@ impl<T> Format<Json, T> {
     }
 }
 
-impl<S, N, T> FormatEvent<S, N> for Format<Full, T>
+impl<C, N, T> FormatEvent<C, N> for Format<Full, T>
 where
-    S: Collect + for<'a> LookupSpan<'a>,
+    C: Collect + for<'a> LookupSpan<'a>,
     N: for<'a> FormatFields<'a> + 'static,
     T: FormatTime,
 {
     fn format_event(
         &self,
-        ctx: &FmtContext<'_, S, N>,
+        ctx: &FmtContext<'_, C, N>,
         writer: &mut dyn fmt::Write,
         event: &Event<'_>,
     ) -> fmt::Result {
@@ -591,15 +591,15 @@ where
     }
 }
 
-impl<S, N, T> FormatEvent<S, N> for Format<Compact, T>
+impl<C, N, T> FormatEvent<C, N> for Format<Compact, T>
 where
-    S: Collect + for<'a> LookupSpan<'a>,
+    C: Collect + for<'a> LookupSpan<'a>,
     N: for<'a> FormatFields<'a> + 'static,
     T: FormatTime,
 {
     fn format_event(
         &self,
-        ctx: &FmtContext<'_, S, N>,
+        ctx: &FmtContext<'_, C, N>,
         writer: &mut dyn fmt::Write,
         event: &Event<'_>,
     ) -> fmt::Result {
@@ -820,25 +820,25 @@ impl<'a> fmt::Debug for DefaultVisitor<'a> {
     }
 }
 
-struct FullCtx<'a, S, N>
+struct FullCtx<'a, C, N>
 where
-    S: Collect + for<'lookup> LookupSpan<'lookup>,
+    C: Collect + for<'lookup> LookupSpan<'lookup>,
     N: for<'writer> FormatFields<'writer> + 'static,
 {
-    ctx: &'a FmtContext<'a, S, N>,
+    ctx: &'a FmtContext<'a, C, N>,
     span: Option<&'a span::Id>,
     #[cfg(feature = "ansi")]
     ansi: bool,
 }
 
-impl<'a, S, N: 'a> FullCtx<'a, S, N>
+impl<'a, C, N: 'a> FullCtx<'a, C, N>
 where
-    S: Collect + for<'lookup> LookupSpan<'lookup>,
+    C: Collect + for<'lookup> LookupSpan<'lookup>,
     N: for<'writer> FormatFields<'writer> + 'static,
 {
     #[cfg(feature = "ansi")]
     pub(crate) fn new(
-        ctx: &'a FmtContext<'a, S, N>,
+        ctx: &'a FmtContext<'a, C, N>,
         span: Option<&'a span::Id>,
         ansi: bool,
     ) -> Self {
@@ -846,7 +846,7 @@ where
     }
 
     #[cfg(not(feature = "ansi"))]
-    pub(crate) fn new(ctx: &'a FmtContext<'a, S, N>, span: Option<&'a span::Id>) -> Self {
+    pub(crate) fn new(ctx: &'a FmtContext<'a, C, N>, span: Option<&'a span::Id>) -> Self {
         Self { ctx, span }
     }
 
@@ -862,9 +862,9 @@ where
     }
 }
 
-impl<'a, S, N> fmt::Display for FullCtx<'a, S, N>
+impl<'a, C, N> fmt::Display for FullCtx<'a, C, N>
 where
-    S: Collect + for<'lookup> LookupSpan<'lookup>,
+    C: Collect + for<'lookup> LookupSpan<'lookup>,
     N: for<'writer> FormatFields<'writer> + 'static,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -63,7 +63,7 @@ use fmt::{Debug, Display};
 /// {
 ///     fn format_event(
 ///         &self,
-///         ctx: &FmtContext<'_, S, N>,
+///         ctx: &FmtContext<'_, C, N>,
 ///         writer: &mut dyn fmt::Write,
 ///         event: &Event<'_>,
 ///     ) -> fmt::Result {

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -411,7 +411,7 @@ pub fn fmt() -> CollectorBuilder {
 ///
 /// [formatting subscriber]: Subscriber
 /// [composed]: super::subscribe
-pub fn subscriber<S>() -> Subscriber<S> {
+pub fn subscriber<C>() -> Subscriber<C> {
     Subscriber::default()
 }
 

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -17,8 +17,8 @@
 //! # use tracing_core::Collect;
 //! # pub struct FooSubscriber {}
 //! # pub struct BarSubscriber {}
-//! # impl<S: Collect> Subscribe<S> for FooSubscriber {}
-//! # impl<S: Collect> Subscribe<S> for BarSubscriber {}
+//! # impl<C: Collect> Subscribe<C> for FooSubscriber {}
+//! # impl<C: Collect> Subscribe<C> for BarSubscriber {}
 //! # impl FooSubscriber {
 //! # fn new() -> Self { Self {} }
 //! # }
@@ -43,9 +43,9 @@
 //!     // ...
 //! }
 //!
-//! impl<S> Subscribe<S> for MySubscriber
+//! impl<C> Subscribe<C> for MySubscriber
 //! where
-//!     S: Collect + for<'a> registry::LookupSpan<'a>,
+//!     C: Collect + for<'a> registry::LookupSpan<'a>,
 //! {
 //!     // ...
 //! }

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -490,11 +490,11 @@ mod tests {
 
     struct SetRemoved(Arc<()>);
 
-    impl<S> Subscribe<S> for CloseSubscriber
+    impl<C> Subscribe<C> for CloseSubscriber
     where
-        S: Collect + for<'a> LookupSpan<'a>,
+        C: Collect + for<'a> LookupSpan<'a>,
     {
-        fn new_span(&self, _: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        fn new_span(&self, _: &Attributes<'_>, id: &Id, ctx: Context<'_, C>) {
             let span = ctx.span(id).expect("Missing span; this is a bug");
             let mut lock = self.inner.lock().unwrap();
             let is_removed = Arc::new(());
@@ -508,7 +508,7 @@ mod tests {
             extensions.insert(SetRemoved(is_removed));
         }
 
-        fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        fn on_close(&self, id: Id, ctx: Context<'_, C>) {
             let span = if let Some(span) = ctx.span(&id) {
                 span
             } else {

--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -59,7 +59,7 @@ use std::{any::TypeId, marker::PhantomData, ptr::NonNull};
 ///     // ...
 /// }
 ///
-/// impl<S: Collect> Subscribe<S> for MySubscriber {
+/// impl<C: Collect> Subscribe<C> for MySubscriber {
 ///     // ...
 /// }
 ///
@@ -100,7 +100,7 @@ use std::{any::TypeId, marker::PhantomData, ptr::NonNull};
 ///     // ...
 /// }
 ///
-/// impl<S: Collect> Subscribe<S> for MyOtherSubscriber {
+/// impl<C: Collect> Subscribe<C> for MyOtherSubscriber {
 ///     // ...
 /// }
 ///
@@ -108,11 +108,11 @@ use std::{any::TypeId, marker::PhantomData, ptr::NonNull};
 ///     // ...
 /// }
 ///
-/// impl<S: Collect> Subscribe<S> for MyThirdSubscriber {
+/// impl<C: Collect> Subscribe<C> for MyThirdSubscriber {
 ///     // ...
 /// }
 /// # pub struct MySubscriber {}
-/// # impl<S: Collect> Subscribe<S> for MySubscriber {}
+/// # impl<C: Collect> Subscribe<C> for MySubscriber {}
 /// # pub struct MyCollector { }
 /// # use tracing_core::{span::{Id, Attributes, Record}, Metadata, Event};
 /// # impl Collect for MyCollector {
@@ -348,11 +348,11 @@ where
     ///     // ...
     /// }
     ///
-    /// impl<S: Collect> Subscribe<S> for FooSubscriber {
+    /// impl<C: Collect> Subscribe<C> for FooSubscriber {
     ///     // ...
     /// }
     ///
-    /// impl<S: Collect> Subscribe<S> for BarSubscriber {
+    /// impl<C: Collect> Subscribe<C> for BarSubscriber {
     ///     // ...
     /// }
     ///
@@ -388,8 +388,8 @@ where
     /// # pub struct FooSubscriber {}
     /// # pub struct BarSubscriber {}
     /// # pub struct MyCollector {}
-    /// # impl<S: Collect> Subscribe<S> for FooSubscriber {}
-    /// # impl<S: Collect> Subscribe<S> for BarSubscriber {}
+    /// # impl<C: Collect> Subscribe<C> for FooSubscriber {}
+    /// # impl<C: Collect> Subscribe<C> for BarSubscriber {}
     /// # impl FooSubscriber {
     /// # fn new() -> Self { Self {} }
     /// # }

--- a/tracing/src/collect.rs
+++ b/tracing/src/collect.rs
@@ -36,9 +36,9 @@ where
 /// [span]: super::span
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "std", feature = "alloc"))))]
-pub fn set_global_default<S>(collector: S) -> Result<(), SetGlobalDefaultError>
+pub fn set_global_default<C>(collector: C) -> Result<(), SetGlobalDefaultError>
 where
-    S: Collect + Send + Sync + 'static,
+    C: Collect + Send + Sync + 'static,
 {
     crate::dispatch::set_global_default(crate::Dispatch::new(collector))
 }
@@ -56,9 +56,9 @@ where
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[must_use = "Dropping the guard unregisters the collector."]
-pub fn set_default<S>(collector: S) -> DefaultGuard
+pub fn set_default<C>(collector: C) -> DefaultGuard
 where
-    S: Collect + Send + Sync + 'static,
+    C: Collect + Send + Sync + 'static,
 {
     crate::dispatch::set_default(&crate::Dispatch::new(collector))
 }

--- a/tracing/src/instrument.rs
+++ b/tracing/src/instrument.rs
@@ -87,9 +87,9 @@ pub trait WithCollector: Sized {
     ///
     /// [`Collect`]: super::Collect
     /// [default]: crate::dispatch#setting-the-default-collector
-    fn with_collector<S>(self, collector: S) -> WithDispatch<Self>
+    fn with_collector<C>(self, collector: C) -> WithDispatch<Self>
     where
-        S: Into<Dispatch>,
+        C: Into<Dispatch>,
     {
         WithDispatch {
             inner: self,


### PR DESCRIPTION
The name `S` in `S: Collect` trait bound is outdated since we renamed `Subscribe` to `Collect`. We'd better unify the generic name of `S: Collect` to `C: Collect`.