### PR TITLE
subscriber: explain why we always call `inner.register_callsite()` before if statement

### DIFF
--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -586,6 +586,9 @@ where
             return outer;
         }
 
+        // The intention behind calling `inner.register_callsite()` before the if statement
+        // was to ensure that the inner subscriber is informed that the callsite exists
+        // regardless of the outer subscriber's filtering decision.
         let inner = self.inner.register_callsite(metadata);
         if outer.is_sometimes() {
             // if this interest is "sometimes", return "sometimes" to ensure that
@@ -712,6 +715,9 @@ where
             return outer;
         }
 
+        // The intention behind calling `inner.register_callsite()` before the if statement
+        // was to ensure that the inner subscriber is informed that the callsite exists
+        // regardless of the outer subscriber's filtering decision.
         let inner = self.inner.register_callsite(metadata);
         if outer.is_sometimes() {
             // if this interest is "sometimes", return "sometimes" to ensure that

--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -587,7 +587,7 @@ where
         }
 
         // The intention behind calling `inner.register_callsite()` before the if statement
-        // was to ensure that the inner subscriber is informed that the callsite exists
+        // is to ensure that the inner subscriber is informed that the callsite exists
         // regardless of the outer subscriber's filtering decision.
         let inner = self.inner.register_callsite(metadata);
         if outer.is_sometimes() {
@@ -716,7 +716,7 @@ where
         }
 
         // The intention behind calling `inner.register_callsite()` before the if statement
-        // was to ensure that the inner subscriber is informed that the callsite exists
+        // is to ensure that the inner subscriber is informed that the callsite exists
         // regardless of the outer subscriber's filtering decision.
         let inner = self.inner.register_callsite(metadata);
         if outer.is_sometimes() {


### PR DESCRIPTION
I'm sure we can avoid unnecessary `self.inner.register_callsite()` call in these two `Layered` implementations. 