### PR TITLE
docs: Fix typo

### DIFF
--- a/tracing/src/dispatcher.rs
+++ b/tracing/src/dispatcher.rs
@@ -122,7 +122,7 @@
 //! currently default `Dispatch`. This is used primarily by `tracing`
 //! instrumentation.
 //!
-//! [`Subscriber`]: struct.Subscriber.html
+//! [`Subscriber`]: trait.Subscriber.html
 //! [`with_default`]: fn.with_default.html
 //! [`set_global_default`]: fn.set_global_default.html
 //! [`get_default`]: fn.get_default.html


### PR DESCRIPTION
There is no struct named `Subscriber`, I think the `Subscriber` here is a trait.