### PR TITLE
Use display_timestamp and display_level in Json format_event

### DIFF
--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -204,8 +204,13 @@ where
 
             let mut serializer = serializer.serialize_map(None)?;
 
-            serializer.serialize_entry("timestamp", &timestamp)?;
-            serializer.serialize_entry("level", &meta.level().as_serde())?;
+            if self.display_timestamp {
+                serializer.serialize_entry("timestamp", &timestamp)?;
+            }
+
+            if self.display_level {
+                serializer.serialize_entry("level", &meta.level().as_serde())?;
+            }
 
             let format_field_marker: std::marker::PhantomData<N> = std::marker::PhantomData;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

It should be possible to remove `timestamp` and `level` fields when using json formatting.

As of now this has no effect:

```rs
let subscriber = tracing_subscriber::fmt()
    .with_level(false)
    .without_time()
    .json()
    .finish();
```

## Solution

Use the existing `display_timestamp` and `display_level` fields to conditionally serialize `timestamp` and `level`.
