### PR TITLE
opentelemetry: prepare to release v0.14.0

### DIFF
--- a/tracing-opentelemetry/CHANGELOG.md
+++ b/tracing-opentelemetry/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 0.14.0 (July 9, 2021)
+
+### Breaking Changes
+
+- Upgrade to `v0.15.0` of `opentelemetry` ([#1441])
+  For list of breaking changes in OpenTelemetry, see the
+  [v0.14.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/CHANGELOG.md#v0140).
+
+### Added
+
+- Spans now include Opentelemetry `code.namespace`, `code.filepath`, and
+  `code.lineno` attributes ([#1411])
+
+### Changed
+
+- Improve performance by pre-allocating attribute `Vec`s ([#1327])
+
+Thanks to @Drevoed, @lilymara-onesignal, and @Folyd for contributing
+to this release!
+
+[#1441]: https://github.com/tokio-rs/tracing/pull/1441
+[#1411]: https://github.com/tokio-rs/tracing/pull/1411
+[#1327]: https://github.com/tokio-rs/tracing/pull/1327
+
 # 0.13.0 (May 15, 2021)
 
 ### Breaking Changes

--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -17,9 +17,9 @@ Utilities for adding [OpenTelemetry] interoperability to [`tracing`].
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-opentelemetry.svg
-[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.13.0
+[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.14.0
 [docs-badge]: https://docs.rs/tracing-opentelemetry/badge.svg
-[docs-url]: https://docs.rs/tracing-opentelemetry/0.13.0/tracing_opentelemetry
+[docs-url]: https://docs.rs/tracing-opentelemetry/0.14.0/tracing_opentelemetry
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_opentelemetry
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -92,7 +92,7 @@
 //!
 #![deny(unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.13.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.14.0")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.14.0 (July 9, 2021)

### Breaking Changes

- Upgrade to `v0.15.0` of `opentelemetry` ([#1441])
  For list of breaking changes in OpenTelemetry, see the
  [v0.14.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/CHANGELOG.md#v0140).

### Added

- Spans now include Opentelemetry `code.namespace`, `code.filepath`, and
  `code.lineno` attributes ([#1411])

### Changed

- Improve performance by pre-allocating attribute `Vec`s ([#1327])

Thanks to @Drevoed, @lilymara-onesignal, and @Folyd for contributing
to this release!

Closes #1462