### PR TITLE
feat: allow creating SpanTrace from Span directly

### DIFF
--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -68,6 +68,11 @@ pub struct SpanTrace {
 // === impl SpanTrace ===
 
 impl SpanTrace {
+    /// Create a new span trace with the given span as the innermost span.
+    pub fn new(span: Span) -> Self {
+        SpanTrace { span }
+    }
+
     /// Capture the current span trace.
     ///
     /// # Examples
@@ -95,9 +100,7 @@ impl SpanTrace {
     /// }
     /// ```
     pub fn capture() -> Self {
-        SpanTrace {
-            span: Span::current(),
-        }
+        SpanTrace::new(Span::current())
     }
 
     /// Apply a function to all captured spans in the trace until it returns


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

I'm writing a tracing subscriber layer that captures tracing events to display in an in-program UI in a somewhat structured manner; as such I don't want to just use the fmt layer's format-to-a-single-string approach, and instead capture (currently) the event metadata, fields, timestamp, thread, and spantrace, to be displayed in a filterable/searchable/interactable manner later.

Currently, the only way to capture a `SpanTrace` is via `SpanTrace::capture`. This (rightfully) captures the `SpanTrace` of the current execution. However, I'm currently inside `Subscribe::on_event`; I have the span right here! Even if `Span::current` happens to be the same during `on_event` as when the event was fired, it seems more "proper" to create a `SpanTrace` from the span passed in to me, rather than looking up `Span::current`.

## Solution

The actual code change is almost trivial: all that needs to happen is to expose a `SpanTrace::new` that takes a `Span` in addition to the existing `SpanTrace::current`.
