### PR TITLE
0.2 edition: subscriber::fmt: print all error sources

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -53,3 +53,7 @@ tempdir = "0.3.7"
 # opentelemetry example
 opentelemetry = { version = "0.15", default-features = false, features = ["trace"] }
 opentelemetry-jaeger = "0.14"
+
+# fmt examples
+snafu = "0.6.10"
+thiserror = "1.0.26"

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -771,7 +771,10 @@ impl<'a> field::Visit for DefaultVisitor<'a> {
 
     fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
         if let Some(source) = value.source() {
-            self.record_debug(field, &format_args!("{}, {}: {}", value, field, source))
+            self.record_debug(
+                field,
+                &format_args!("{} {}.sources={}", value, field, ErrorSourceList(source)),
+            )
         } else {
             self.record_debug(field, &format_args!("{}", value))
         }
@@ -813,6 +816,21 @@ impl<'a> fmt::Debug for DefaultVisitor<'a> {
             .field("is_empty", &self.is_empty)
             .field("result", &self.result)
             .finish()
+    }
+}
+
+/// Renders an error into a list of sources, *including* the error
+struct ErrorSourceList<'a>(&'a (dyn std::error::Error + 'static));
+
+impl<'a> Display for ErrorSourceList<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut list = f.debug_list();
+        let mut curr = Some(self.0);
+        while let Some(curr_err) = curr {
+            list.entry(&format_args!("{}", curr_err));
+            curr = curr_err.source();
+        }
+        list.finish()
     }
 }
 

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -331,12 +331,12 @@ impl<'a> field::Visit for PrettyVisitor<'a> {
             self.record_debug(
                 field,
                 &format_args!(
-                    "{}, {}{}.source{}: {}",
+                    "{}, {}{}.sources{}: {}",
                     value,
                     bold.prefix(),
                     field,
                     bold.infix(self.style),
-                    source,
+                    ErrorSourceList(source),
                 ),
             )
         } else {


### PR DESCRIPTION
Forward-port of #1460 to the 0.2.x (master) branch.