### PR TITLE
opentelemetry: update to otel v0.16.x

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -51,5 +51,5 @@ inferno = "0.10.0"
 tempdir = "0.3.7"
 
 # opentelemetry example
-opentelemetry = { version = "0.15", default-features = false, features = ["trace"] }
-opentelemetry-jaeger = "0.14"
+opentelemetry = { version = "0.16", default-features = false, features = ["trace"] }
+opentelemetry-jaeger = "0.15"

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2018"
 default = ["tracing-log"]
 
 [dependencies]
-opentelemetry = { version = "0.15", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.16", default-features = false, features = ["trace"] }
 tracing = { path = "../tracing", version = "0.2", default-features = false, features = ["std"] }
 tracing-core = { path = "../tracing-core", version = "0.2" }
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry"] }
@@ -31,7 +31,7 @@ tracing-log = { path = "../tracing-log", version = "0.2", default-features = fal
 [dev-dependencies]
 async-trait = "0.1"
 criterion = { version = "0.3", default_features = false }
-opentelemetry-jaeger = "0.14"
+opentelemetry-jaeger = "0.15"
 
 [lib]
 bench = false

--- a/tracing-opentelemetry/benches/trace.rs
+++ b/tracing-opentelemetry/benches/trace.rs
@@ -13,7 +13,7 @@ fn many_children(c: &mut Criterion) {
 
     group.bench_function("spec_baseline", |b| {
         let provider = TracerProvider::default();
-        let tracer = provider.get_tracer("bench", None);
+        let tracer = provider.tracer("bench", None);
         b.iter(|| {
             fn dummy(tracer: &Tracer, cx: &Context) {
                 for _ in 0..99 {
@@ -41,7 +41,7 @@ fn many_children(c: &mut Criterion) {
 
     {
         let provider = TracerProvider::default();
-        let tracer = provider.get_tracer("bench", None);
+        let tracer = provider.tracer("bench", None);
         let otel_layer = tracing_opentelemetry::subscriber()
             .with_tracer(tracer)
             .with_tracked_inactivity(false);

--- a/tracing-opentelemetry/src/subscriber.rs
+++ b/tracing-opentelemetry/src/subscriber.rs
@@ -1,5 +1,8 @@
 use crate::PreSampledTracer;
-use opentelemetry::{trace as otel, trace::TraceContextExt, Context as OtelContext, Key, KeyValue};
+use opentelemetry::{
+    trace::{self as otel, noop, TraceContextExt},
+    Context as OtelContext, Key, KeyValue,
+};
 use std::fmt;
 use std::marker;
 use std::time::{Instant, SystemTime};
@@ -29,12 +32,12 @@ pub struct OpenTelemetrySubscriber<C, T> {
     _registry: marker::PhantomData<C>,
 }
 
-impl<C> Default for OpenTelemetrySubscriber<C, otel::NoopTracer>
+impl<C> Default for OpenTelemetrySubscriber<C, noop::NoopTracer>
 where
     C: Collect + for<'span> LookupSpan<'span>,
 {
     fn default() -> Self {
-        OpenTelemetrySubscriber::new(otel::NoopTracer::new())
+        OpenTelemetrySubscriber::new(noop::NoopTracer::new())
     }
 }
 
@@ -53,7 +56,7 @@ where
 /// let subscriber = Registry::default().with(tracing_opentelemetry::subscriber());
 /// # drop(subscriber);
 /// ```
-pub fn subscriber<C>() -> OpenTelemetrySubscriber<C, otel::NoopTracer>
+pub fn subscriber<C>() -> OpenTelemetrySubscriber<C, noop::NoopTracer>
 where
     C: Collect + for<'span> LookupSpan<'span>,
 {
@@ -603,7 +606,7 @@ impl Timings {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opentelemetry::trace::{SpanKind, TraceFlags};
+    use opentelemetry::trace::{noop, SpanKind, TraceFlags};
     use std::borrow::Cow;
     use std::sync::{Arc, Mutex};
     use std::time::SystemTime;
@@ -612,9 +615,9 @@ mod tests {
     #[derive(Debug, Clone)]
     struct TestTracer(Arc<Mutex<Option<otel::SpanBuilder>>>);
     impl otel::Tracer for TestTracer {
-        type Span = otel::NoopSpan;
+        type Span = noop::NoopSpan;
         fn invalid(&self) -> Self::Span {
-            otel::NoopSpan::new()
+            noop::NoopSpan::new()
         }
         fn start_with_context<T>(&self, _name: T, _context: OtelContext) -> Self::Span
         where

--- a/tracing-opentelemetry/src/tracer.rs
+++ b/tracing-opentelemetry/src/tracer.rs
@@ -2,7 +2,7 @@ use opentelemetry::sdk::trace::{SamplingDecision, SamplingResult, Tracer, Tracer
 use opentelemetry::{
     trace as otel,
     trace::{
-        SpanBuilder, SpanContext, SpanId, SpanKind, TraceContextExt, TraceFlags, TraceId,
+        noop, SpanBuilder, SpanContext, SpanId, SpanKind, TraceContextExt, TraceFlags, TraceId,
         TraceState,
     },
     Context as OtelContext,
@@ -48,7 +48,7 @@ pub trait PreSampledTracer {
     fn new_span_id(&self) -> otel::SpanId;
 }
 
-impl PreSampledTracer for otel::NoopTracer {
+impl PreSampledTracer for noop::NoopTracer {
     fn sampled_context(&self, builder: &mut otel::SpanBuilder) -> OtelContext {
         builder.parent_context.clone()
     }
@@ -171,7 +171,7 @@ mod tests {
     #[test]
     fn assigns_default_trace_id_if_missing() {
         let provider = TracerProvider::default();
-        let tracer = provider.get_tracer("test", None);
+        let tracer = provider.tracer("test", None);
         let mut builder = SpanBuilder::from_name("empty".to_string());
         builder.span_id = Some(SpanId::from_u64(1));
         builder.trace_id = None;
@@ -211,7 +211,7 @@ mod tests {
             let provider = TracerProvider::builder()
                 .with_config(config().with_sampler(sampler))
                 .build();
-            let tracer = provider.get_tracer("test", None);
+            let tracer = provider.tracer("test", None);
             let mut builder = SpanBuilder::from_name("parent".to_string());
             builder.parent_context = parent_cx;
             builder.sampling_result = previous_sampling_result;

--- a/tracing-opentelemetry/tests/trace_state_propagation.rs
+++ b/tracing-opentelemetry/tests/trace_state_propagation.rs
@@ -115,7 +115,7 @@ fn test_tracer() -> (Tracer, TracerProvider, TestExporter, impl Collect) {
     let provider = TracerProvider::builder()
         .with_simple_exporter(exporter.clone())
         .build();
-    let tracer = provider.get_tracer("test", None);
+    let tracer = provider.tracer("test", None);
     let subscriber = tracing_subscriber::registry().with(subscriber().with_tracer(tracer.clone()));
 
     (tracer, provider, exporter, subscriber)


### PR DESCRIPTION
Updates to the latest otel spec version and addresses small internal method and module updates.