### PR TITLE
subscriber: add space after level with pretty formatter

### DIFF
--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -115,7 +115,7 @@ where
         };
 
         if self.display_level {
-            write!(writer, "{}", super::FmtLevel::new(meta.level(), self.ansi))?;
+            write!(writer, "{} ", super::FmtLevel::new(meta.level(), self.ansi))?;
         }
 
         if self.display_target {


### PR DESCRIPTION
## Motivation

On v0.1.x,  `tracing_subscriber::fmt`'s `Pretty` formatter is missing
a space after the event's level, when printing levels is enabled.

## Solution

This branch fixes that.

Fixes #1488

Signed-off-by: Eliza Weisman <eliza@buoyant.io>