### PR TITLE
[WIP] draft implementation of new `Registry` API

### DIFF
--- a/examples/examples/custom-error.rs
+++ b/examples/examples/custom-error.rs
@@ -4,7 +4,6 @@
 use std::error::Error;
 use std::fmt;
 use tracing_error::{ErrorSubscriber, SpanTrace};
-use tracing_subscriber::prelude::*;
 #[derive(Debug)]
 struct FooError {
     message: &'static str,

--- a/examples/examples/fmt-multiple-writers.rs
+++ b/examples/examples/fmt-multiple-writers.rs
@@ -6,7 +6,7 @@ mod yak_shave;
 
 use std::io;
 use tempdir::TempDir;
-use tracing_subscriber::{fmt, subscribe::CollectExt, EnvFilter};
+use tracing_subscriber::{fmt, EnvFilter};
 
 fn main() {
     let dir = TempDir::new("directory").expect("Failed to create tempdir");

--- a/examples/examples/inferno-flame.rs
+++ b/examples/examples/inferno-flame.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use tempdir::TempDir;
 use tracing::{span, Level};
 use tracing_flame::FlameSubscriber;
-use tracing_subscriber::{prelude::*, registry::Registry};
+use tracing_subscriber::registry::Registry;
 
 static PATH: &str = "flame.folded";
 

--- a/examples/examples/instrumented-error.rs
+++ b/examples/examples/instrumented-error.rs
@@ -4,7 +4,6 @@
 use std::error::Error;
 use std::fmt;
 use tracing_error::{prelude::*, ErrorSubscriber};
-use tracing_subscriber::prelude::*;
 
 #[derive(Debug)]
 struct FooError {

--- a/examples/examples/journald.rs
+++ b/examples/examples/journald.rs
@@ -1,7 +1,5 @@
 #![deny(rust_2018_idioms)]
 use tracing::{error, info};
-use tracing_subscriber::prelude::*;
-
 #[path = "fmt/yak_shave.rs"]
 mod yak_shave;
 

--- a/examples/examples/map-traced-error.rs
+++ b/examples/examples/map-traced-error.rs
@@ -6,7 +6,6 @@
 use std::error::Error;
 use std::fmt;
 use tracing_error::{prelude::*, ErrorSubscriber, TracedError};
-use tracing_subscriber::prelude::*;
 
 fn main() {
     tracing_subscriber::registry()

--- a/examples/examples/opentelemetry-remote-context.rs
+++ b/examples/examples/opentelemetry-remote-context.rs
@@ -3,7 +3,6 @@ use opentelemetry::{global, Context};
 use std::collections::HashMap;
 use tracing::span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
-use tracing_subscriber::subscribe::CollectExt;
 use tracing_subscriber::Registry;
 
 fn make_request(_cx: Context) {

--- a/examples/examples/opentelemetry.rs
+++ b/examples/examples/opentelemetry.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, thread, time::Duration};
 use tracing::{span, trace, warn};
 use tracing_attributes::instrument;
-use tracing_subscriber::prelude::*;
 
 #[instrument]
 #[inline]

--- a/examples/examples/toggle-subscribers.rs
+++ b/examples/examples/toggle-subscribers.rs
@@ -11,7 +11,7 @@
 ///
 use clap::{App, Arg};
 use tracing::info;
-use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt};
+use tracing_subscriber::util::SubscriberInitExt;
 
 #[path = "fmt/yak_shave.rs"]
 mod yak_shave;

--- a/examples/examples/toggle-subscribers.rs
+++ b/examples/examples/toggle-subscribers.rs
@@ -11,7 +11,6 @@
 ///
 use clap::{App, Arg};
 use tracing::info;
-use tracing_subscriber::util::SubscriberInitExt;
 
 #[path = "fmt/yak_shave.rs"]
 mod yak_shave;

--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -267,7 +267,7 @@ mod tests {
     use crate::ErrorSubscriber;
     use tracing::collect::with_default;
     use tracing::{span, Level};
-    use tracing_subscriber::{prelude::*, registry::Registry};
+    use tracing_subscriber::registry::Registry;
 
     #[test]
     fn capture_supported() {

--- a/tracing-flame/tests/collapsed.rs
+++ b/tracing-flame/tests/collapsed.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use tempdir::TempDir;
 use tracing::{span, Level};
 use tracing_flame::FlameSubscriber;
-use tracing_subscriber::{prelude::*, registry::Registry};
+use tracing_subscriber::registry::Registry;
 
 #[test]
 fn capture_supported() {

--- a/tracing-flame/tests/concurrent.rs
+++ b/tracing-flame/tests/concurrent.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use tempdir::TempDir;
 use tracing::{span, Level};
 use tracing_flame::FlameSubscriber;
-use tracing_subscriber::{prelude::*, registry::Registry};
+use tracing_subscriber::registry::Registry;
 
 #[test]
 fn capture_supported() {

--- a/tracing-opentelemetry/benches/trace.rs
+++ b/tracing-opentelemetry/benches/trace.rs
@@ -6,7 +6,6 @@ use opentelemetry::{
 };
 use std::time::SystemTime;
 use tracing::trace_span;
-use tracing_subscriber::prelude::*;
 
 fn many_children(c: &mut Criterion) {
     let mut group = c.benchmark_group("otel_many_children");

--- a/tracing-opentelemetry/src/subscriber.rs
+++ b/tracing-opentelemetry/src/subscriber.rs
@@ -620,7 +620,6 @@ mod tests {
     use std::borrow::Cow;
     use std::sync::{Arc, Mutex};
     use std::time::SystemTime;
-    use tracing_subscriber::prelude::*;
 
     #[derive(Debug, Clone)]
     struct TestTracer(Arc<Mutex<Option<otel::SpanBuilder>>>);

--- a/tracing-opentelemetry/tests/trace_state_propagation.rs
+++ b/tracing-opentelemetry/tests/trace_state_propagation.rs
@@ -13,7 +13,6 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use tracing::Collect;
 use tracing_opentelemetry::{subscriber, OpenTelemetrySpanExt};
-use tracing_subscriber::prelude::*;
 
 #[test]
 fn trace_with_active_otel_context() {

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -874,9 +874,7 @@ mod test {
         let fmt = fmt::Subscriber::default().event_format(f);
         let collect = Registry::default().with(fmt);
         let dispatch = Dispatch::new(collect);
-        assert!(dispatch
-            .downcast_ref::<fmt::Subscriber<Registry>>()
-            .is_some());
+        assert!(dispatch.downcast_ref::<fmt::Subscriber>().is_some());
     }
 
     #[test]

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -61,15 +61,15 @@ use tracing_core::{
 ///
 /// [`Subscriber`]: subscribe::Subscribe
 #[derive(Debug)]
-pub struct Subscriber<S, N = format::DefaultFields, E = format::Format, W = fn() -> io::Stdout> {
+pub struct Subscriber<N = format::DefaultFields, E = format::Format, W = fn() -> io::Stdout> {
     make_writer: W,
     fmt_fields: N,
     fmt_event: E,
     fmt_span: format::FmtSpanConfig,
-    _inner: PhantomData<S>,
+    // _inner: PhantomData<S>,
 }
 
-impl<S> Subscriber<S> {
+impl Subscriber {
     /// Returns a new [`Subscriber`] with the default configuration.
     pub fn new() -> Self {
         Self::default()
@@ -77,9 +77,9 @@ impl<S> Subscriber<S> {
 }
 
 // This needs to be a separate impl block because they place different bounds on the type parameters.
-impl<S, N, E, W> Subscriber<S, N, E, W>
+impl<N, E, W> Subscriber<N, E, W>
 where
-    S: Collect + for<'a> LookupSpan<'a>,
+    // S: Collect + for<'a> LookupSpan<'a>,
     N: for<'writer> FormatFields<'writer> + 'static,
     W: for<'writer> MakeWriter<'writer> + 'static,
 {
@@ -104,22 +104,19 @@ where
     /// ```
     /// [`FormatEvent`]: format::FormatEvent
     /// [`Event`]: tracing::Event
-    pub fn event_format<E2>(self, e: E2) -> Subscriber<S, N, E2, W>
-    where
-        E2: FormatEvent<S, N> + 'static,
-    {
+    pub fn event_format<E2>(self, e: E2) -> Subscriber<N, E2, W> {
         Subscriber {
             fmt_fields: self.fmt_fields,
             fmt_event: e,
             fmt_span: self.fmt_span,
             make_writer: self.make_writer,
-            _inner: self._inner,
+            // _inner: self._inner,
         }
     }
 }
 
 // This needs to be a separate impl block because they place different bounds on the type parameters.
-impl<S, N, E, W> Subscriber<S, N, E, W> {
+impl<N, E, W> Subscriber<N, E, W> {
     /// Sets the [`MakeWriter`] that the [`Subscriber`] being built will use to write events.
     ///
     /// # Examples
@@ -139,7 +136,7 @@ impl<S, N, E, W> Subscriber<S, N, E, W> {
     ///
     /// [`MakeWriter`]: super::writer::MakeWriter
     /// [`Subscriber`]: super::Subscriber
-    pub fn with_writer<W2>(self, make_writer: W2) -> Subscriber<S, N, E, W2>
+    pub fn with_writer<W2>(self, make_writer: W2) -> Subscriber<N, E, W2>
     where
         W2: for<'writer> MakeWriter<'writer> + 'static,
     {
@@ -148,7 +145,6 @@ impl<S, N, E, W> Subscriber<S, N, E, W> {
             fmt_event: self.fmt_event,
             fmt_span: self.fmt_span,
             make_writer,
-            _inner: self._inner,
         }
     }
 
@@ -174,18 +170,17 @@ impl<S, N, E, W> Subscriber<S, N, E, W> {
     /// [capturing]:
     /// https://doc.rust-lang.org/book/ch11-02-running-tests.html#showing-function-output
     /// [`TestWriter`]: super::writer::TestWriter
-    pub fn with_test_writer(self) -> Subscriber<S, N, E, TestWriter> {
+    pub fn with_test_writer(self) -> Subscriber<N, E, TestWriter> {
         Subscriber {
             fmt_fields: self.fmt_fields,
             fmt_event: self.fmt_event,
             fmt_span: self.fmt_span,
             make_writer: TestWriter::default(),
-            _inner: self._inner,
         }
     }
 }
 
-impl<S, N, L, T, W> Subscriber<S, N, format::Format<L, T>, W>
+impl<N, L, T, W> Subscriber<N, format::Format<L, T>, W>
 where
     N: for<'writer> FormatFields<'writer> + 'static,
 {
@@ -200,24 +195,22 @@ where
     /// [`timer`]: super::time::FormatTime
     /// [`ChronoUtc`]: super::time::ChronoUtc
     /// [`ChronoLocal`]: super::time::ChronoLocal
-    pub fn with_timer<T2>(self, timer: T2) -> Subscriber<S, N, format::Format<L, T2>, W> {
+    pub fn with_timer<T2>(self, timer: T2) -> Subscriber<N, format::Format<L, T2>, W> {
         Subscriber {
             fmt_event: self.fmt_event.with_timer(timer),
             fmt_fields: self.fmt_fields,
             fmt_span: self.fmt_span,
             make_writer: self.make_writer,
-            _inner: self._inner,
         }
     }
 
     /// Do not emit timestamps with spans and event.
-    pub fn without_time(self) -> Subscriber<S, N, format::Format<L, ()>, W> {
+    pub fn without_time(self) -> Subscriber<N, format::Format<L, ()>, W> {
         Subscriber {
             fmt_event: self.fmt_event.without_time(),
             fmt_fields: self.fmt_fields,
             fmt_span: self.fmt_span.without_time(),
             make_writer: self.make_writer,
-            _inner: self._inner,
         }
     }
 
@@ -272,7 +265,7 @@ where
     /// Enable ANSI terminal colors for formatted output.
     #[cfg(feature = "ansi")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
-    pub fn with_ansi(self, ansi: bool) -> Subscriber<S, N, format::Format<L, T>, W> {
+    pub fn with_ansi(self, ansi: bool) -> Subscriber<N, format::Format<L, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.with_ansi(ansi),
             ..self
@@ -280,7 +273,7 @@ where
     }
 
     /// Sets whether or not an event's target is displayed.
-    pub fn with_target(self, display_target: bool) -> Subscriber<S, N, format::Format<L, T>, W> {
+    pub fn with_target(self, display_target: bool) -> Subscriber<N, format::Format<L, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.with_target(display_target),
             ..self
@@ -288,7 +281,7 @@ where
     }
 
     /// Sets whether or not an event's level is displayed.
-    pub fn with_level(self, display_level: bool) -> Subscriber<S, N, format::Format<L, T>, W> {
+    pub fn with_level(self, display_level: bool) -> Subscriber<N, format::Format<L, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.with_level(display_level),
             ..self
@@ -302,7 +295,7 @@ where
     pub fn with_thread_ids(
         self,
         display_thread_ids: bool,
-    ) -> Subscriber<S, N, format::Format<L, T>, W> {
+    ) -> Subscriber<N, format::Format<L, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.with_thread_ids(display_thread_ids),
             ..self
@@ -316,7 +309,7 @@ where
     pub fn with_thread_names(
         self,
         display_thread_names: bool,
-    ) -> Subscriber<S, N, format::Format<L, T>, W> {
+    ) -> Subscriber<N, format::Format<L, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.with_thread_names(display_thread_names),
             ..self
@@ -324,7 +317,7 @@ where
     }
 
     /// Sets the subscriber being built to use a [less verbose formatter](format::Compact).
-    pub fn compact(self) -> Subscriber<S, N, format::Format<format::Compact, T>, W>
+    pub fn compact(self) -> Subscriber<N, format::Format<format::Compact, T>, W>
     where
         N: for<'writer> FormatFields<'writer> + 'static,
     {
@@ -333,20 +326,18 @@ where
             fmt_fields: self.fmt_fields,
             fmt_span: self.fmt_span,
             make_writer: self.make_writer,
-            _inner: self._inner,
         }
     }
 
     /// Sets the subscriber being built to use an [excessively pretty, human-readable formatter](crate::fmt::format::Pretty).
     #[cfg(feature = "ansi")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
-    pub fn pretty(self) -> Subscriber<S, format::Pretty, format::Format<format::Pretty, T>, W> {
+    pub fn pretty(self) -> Subscriber<format::Pretty, format::Format<format::Pretty, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.pretty(),
             fmt_fields: format::Pretty::default(),
             fmt_span: self.fmt_span,
             make_writer: self.make_writer,
-            _inner: self._inner,
         }
     }
 
@@ -367,27 +358,26 @@ where
     ///
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
-    pub fn json(self) -> Subscriber<S, format::JsonFields, format::Format<format::Json, T>, W> {
+    pub fn json(self) -> Subscriber<format::JsonFields, format::Format<format::Json, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.json(),
             fmt_fields: format::JsonFields::new(),
             fmt_span: self.fmt_span,
             make_writer: self.make_writer,
-            _inner: self._inner,
         }
     }
 }
 
 #[cfg(feature = "json")]
 #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
-impl<S, T, W> Subscriber<S, format::JsonFields, format::Format<format::Json, T>, W> {
+impl<T, W> Subscriber<format::JsonFields, format::Format<format::Json, T>, W> {
     /// Sets the JSON subscriber being built to flatten event metadata.
     ///
     /// See [`format::Json`]
     pub fn flatten_event(
         self,
         flatten_event: bool,
-    ) -> Subscriber<S, format::JsonFields, format::Format<format::Json, T>, W> {
+    ) -> Subscriber<format::JsonFields, format::Format<format::Json, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.flatten_event(flatten_event),
             fmt_fields: format::JsonFields::new(),
@@ -402,7 +392,7 @@ impl<S, T, W> Subscriber<S, format::JsonFields, format::Format<format::Json, T>,
     pub fn with_current_span(
         self,
         display_current_span: bool,
-    ) -> Subscriber<S, format::JsonFields, format::Format<format::Json, T>, W> {
+    ) -> Subscriber<format::JsonFields, format::Format<format::Json, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.with_current_span(display_current_span),
             fmt_fields: format::JsonFields::new(),
@@ -417,7 +407,7 @@ impl<S, T, W> Subscriber<S, format::JsonFields, format::Format<format::Json, T>,
     pub fn with_span_list(
         self,
         display_span_list: bool,
-    ) -> Subscriber<S, format::JsonFields, format::Format<format::Json, T>, W> {
+    ) -> Subscriber<format::JsonFields, format::Format<format::Json, T>, W> {
         Subscriber {
             fmt_event: self.fmt_event.with_span_list(display_span_list),
             fmt_fields: format::JsonFields::new(),
@@ -426,10 +416,10 @@ impl<S, T, W> Subscriber<S, format::JsonFields, format::Format<format::Json, T>,
     }
 }
 
-impl<S, N, E, W> Subscriber<S, N, E, W> {
+impl<N, E, W> Subscriber<N, E, W> {
     /// Sets the field formatter that the subscriber being built will use to record
     /// fields.
-    pub fn fmt_fields<N2>(self, fmt_fields: N2) -> Subscriber<S, N2, E, W>
+    pub fn fmt_fields<N2>(self, fmt_fields: N2) -> Subscriber<N2, E, W>
     where
         N2: for<'writer> FormatFields<'writer> + 'static,
     {
@@ -438,32 +428,31 @@ impl<S, N, E, W> Subscriber<S, N, E, W> {
             fmt_fields,
             fmt_span: self.fmt_span,
             make_writer: self.make_writer,
-            _inner: self._inner,
         }
     }
 }
 
-impl<S> Default for Subscriber<S> {
+impl Default for Subscriber {
     fn default() -> Self {
         Subscriber {
             fmt_fields: format::DefaultFields::default(),
             fmt_event: format::Format::default(),
             fmt_span: format::FmtSpanConfig::default(),
             make_writer: io::stdout,
-            _inner: PhantomData,
         }
     }
 }
 
-impl<S, N, E, W> Subscriber<S, N, E, W>
+impl<N, E, W> Subscriber<N, E, W>
 where
-    S: Collect + for<'a> LookupSpan<'a>,
     N: for<'writer> FormatFields<'writer> + 'static,
-    E: FormatEvent<S, N> + 'static,
     W: for<'writer> MakeWriter<'writer> + 'static,
 {
     #[inline]
-    fn make_ctx<'a>(&'a self, ctx: Context<'a, S>) -> FmtContext<'a, S, N> {
+    fn make_ctx<'a, S>(&'a self, ctx: Context<'a, S>) -> FmtContext<'a, S, N>
+    where
+        S: Collect + for<'spans> LookupSpan<'spans>,
+    {
         FmtContext {
             ctx,
             fmt_fields: &self.fmt_fields,
@@ -536,7 +525,7 @@ macro_rules! with_event_from_span {
     };
 }
 
-impl<S, N, E, W> subscribe::Subscribe<S> for Subscriber<S, N, E, W>
+impl<S, N, E, W> subscribe::Subscribe<S> for Subscriber<N, E, W>
 where
     S: Collect + for<'a> LookupSpan<'a>,
     N: for<'writer> FormatFields<'writer> + 'static,
@@ -876,27 +865,26 @@ mod test {
     fn impls() {
         let f = Format::default().with_timer(time::Uptime::default());
         let fmt = fmt::Subscriber::default().event_format(f);
-        let subscriber = fmt.with_collector(Registry::default());
-        let _dispatch = Dispatch::new(subscriber);
+        let collect = Registry::default().with(fmt);
+        let _dispatch = Dispatch::new(collect);
 
         let f = format::Format::default();
         let fmt = fmt::Subscriber::default().event_format(f);
-        let subscriber = fmt.with_collector(Registry::default());
-        let _dispatch = Dispatch::new(subscriber);
+        let collect = Registry::default().with(fmt);
+        let _dispatch = Dispatch::new(collect);
 
         let f = format::Format::default().compact();
         let fmt = fmt::Subscriber::default().event_format(f);
-        let subscriber = fmt.with_collector(Registry::default());
-        let _dispatch = Dispatch::new(subscriber);
+        let collect = Registry::default().with(fmt);
+        let _dispatch = Dispatch::new(collect);
     }
 
     #[test]
     fn fmt_subscriber_downcasts() {
         let f = format::Format::default();
         let fmt = fmt::Subscriber::default().event_format(f);
-        let subscriber = fmt.with_collector(Registry::default());
-
-        let dispatch = Dispatch::new(subscriber);
+        let collect = Registry::default().with(fmt);
+        let dispatch = Dispatch::new(collect);
         assert!(dispatch
             .downcast_ref::<fmt::Subscriber<Registry>>()
             .is_some());
@@ -906,8 +894,8 @@ mod test {
     fn fmt_subscriber_downcasts_to_parts() {
         let f = format::Format::default();
         let fmt = fmt::Subscriber::default().event_format(f);
-        let subscriber = fmt.with_collector(Registry::default());
-        let dispatch = Dispatch::new(subscriber);
+        let collect = Registry::default().with(fmt);
+        let dispatch = Dispatch::new(collect);
         assert!(dispatch.downcast_ref::<format::DefaultFields>().is_some());
         assert!(dispatch.downcast_ref::<format::Format>().is_some())
     }
@@ -916,8 +904,8 @@ mod test {
     fn is_lookup_span() {
         fn assert_lookup_span<T: for<'a> crate::registry::LookupSpan<'a>>(_: T) {}
         let fmt = fmt::Subscriber::default();
-        let subscriber = fmt.with_collector(Registry::default());
-        assert_lookup_span(subscriber)
+        let collect = Registry::default().with(fmt);
+        assert_lookup_span(collect)
     }
 
     fn sanitize_timings(s: String) -> String {

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -841,7 +841,6 @@ mod test {
     use crate::fmt::{
         self,
         format::{self, test::MockTime, Format},
-        subscribe::Subscribe as _,
         test::{MockMakeWriter, MockWriter},
         time,
     };

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -549,6 +549,7 @@ where
     W: for<'writer> MakeWriter<'writer> + 'static,
     F: Subscribe<registry::SpanStore> + Send + Sync + 'static,
     Registry<Layered<F, Subscriber<N, E, W>>>: Collect + Send + Sync + 'static,
+    tracing_core::Dispatch: From<Collector<N, E, F, W>>,
 {
     /// Finish the builder, returning a new `FmtCollector`.
     pub fn finish(self) -> Collector<N, E, F, W> {
@@ -567,11 +568,10 @@ where
     /// because a global collector was already installed by another
     /// call to `try_init`.
     pub fn try_init(self) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-        // use crate::util::SubscriberInitExt;
-        // self.finish().try_init()?;
+        use crate::util::SubscriberInitExt;
+        self.finish().try_init()?;
 
-        // Ok(())
-        todo!("eliza do this")
+        Ok(())
     }
 
     /// Install this collector as the global default.

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -284,7 +284,10 @@
 //!     https://docs.rs/tracing/latest/tracing/trait.Collect.html
 //! [`tracing`]: https://crates.io/crates/tracing
 use std::{any::TypeId, error::Error, io, ptr::NonNull};
-use tracing_core::{collect::Interest, span, Event, Metadata};
+use tracing_core::{
+    collect::{Collect, Interest},
+    span, Event, Metadata,
+};
 
 mod fmt_subscriber;
 pub mod format;
@@ -292,11 +295,11 @@ pub mod time;
 pub mod writer;
 pub use fmt_subscriber::{FmtContext, FormattedFields, Subscriber};
 
-use crate::subscribe::Subscribe as _;
 use crate::{
     filter::LevelFilter,
-    registry::{LookupSpan, Registry},
+    registry::{self, LookupSpan, Registry},
     reload, subscribe,
+    subscribe::{CollectExt, Layered, Subscribe},
 };
 
 #[doc(inline)]
@@ -316,13 +319,8 @@ pub struct Collector<
     F = LevelFilter,
     W = fn() -> io::Stdout,
 > {
-    inner: subscribe::Layered<F, Formatter<N, E, W>>,
+    inner: Registry<Layered<F, Layered<Subscriber<N, E, W>, subscribe::Identity>>>,
 }
-
-/// A collector that logs formatted representations of `tracing` events.
-/// This type only logs formatted events; it does not perform any filtering.
-pub type Formatter<N = format::DefaultFields, E = format::Format, W = fn() -> io::Stdout> =
-    subscribe::Layered<fmt_subscriber::Subscriber<Registry, N, E, W>, Registry>;
 
 /// Configures and constructs `Collector`s.
 #[derive(Debug)]
@@ -333,7 +331,7 @@ pub struct CollectorBuilder<
     W = fn() -> io::Stdout,
 > {
     filter: F,
-    inner: Subscriber<Registry, N, E, W>,
+    inner: Subscriber<N, E, W>,
 }
 
 /// Returns a new [`CollectorBuilder`] for configuring a [formatting collector].
@@ -410,7 +408,7 @@ pub fn fmt() -> CollectorBuilder {
 ///
 /// [formatting subscriber]: Subscriber
 /// [composed]: super::subscribe
-pub fn subscriber<S>() -> Subscriber<S> {
+pub fn subscriber() -> Subscriber {
     Subscriber::default()
 }
 
@@ -446,10 +444,10 @@ impl<N, E, F, W> tracing_core::Collect for Collector<N, E, F, W>
 where
     N: for<'writer> FormatFields<'writer> + 'static,
     E: FormatEvent<Registry, N> + 'static,
-    F: subscribe::Subscribe<Formatter<N, E, W>> + 'static,
+    F: Subscribe<crate::registry::SpanStore> + 'static,
     W: for<'writer> MakeWriter<'writer> + 'static,
-    subscribe::Layered<F, Formatter<N, E, W>>: tracing_core::Collect,
-    fmt_subscriber::Subscriber<Registry, N, E, W>: subscribe::Subscribe<Registry>,
+    Subscriber<N, E, W>: Subscribe<Registry>,
+    Registry<Layered<F, Layered<Subscriber<N, E, W>>>>: Collect + 'static,
 {
     #[inline]
     fn register_callsite(&self, meta: &'static Metadata<'static>) -> Interest {
@@ -523,9 +521,9 @@ where
 
 impl<'a, N, E, F, W> LookupSpan<'a> for Collector<N, E, F, W>
 where
-    subscribe::Layered<F, Formatter<N, E, W>>: LookupSpan<'a>,
+    Registry<Layered<F, Layered<Subscriber<N, E, W>>>>: LookupSpan<'a>,
 {
-    type Data = <subscribe::Layered<F, Formatter<N, E, W>> as LookupSpan<'a>>::Data;
+    type Data = <Registry<Layered<F, Layered<Subscriber<N, E, W>>>> as LookupSpan<'a>>::Data;
 
     fn span_data(&'a self, id: &span::Id) -> Option<Self::Data> {
         self.inner.span_data(id)
@@ -546,18 +544,15 @@ impl Default for CollectorBuilder {
 impl<N, E, F, W> CollectorBuilder<N, E, F, W>
 where
     N: for<'writer> FormatFields<'writer> + 'static,
-    E: FormatEvent<Registry, N> + 'static,
+    E: FormatEvent<registry::SpanStore, N> + 'static,
     W: for<'writer> MakeWriter<'writer> + 'static,
-    F: subscribe::Subscribe<Formatter<N, E, W>> + Send + Sync + 'static,
-    fmt_subscriber::Subscriber<Registry, N, E, W>:
-        subscribe::Subscribe<Registry> + Send + Sync + 'static,
+    F: Subscribe<registry::SpanStore> + Send + Sync + 'static,
+    Registry<Layered<F, Subscriber<N, E, W>>>: Collect + Send + Sync + 'static,
 {
     /// Finish the builder, returning a new `FmtCollector`.
     pub fn finish(self) -> Collector<N, E, F, W> {
-        let collector = self.inner.with_collector(Registry::default());
-        Collector {
-            inner: self.filter.with_collector(collector),
-        }
+        let inner = Registry::default().with(self.inner).with(self.filter);
+        Collector { inner }
     }
 
     /// Install this collector as the global default if one is
@@ -571,10 +566,11 @@ where
     /// because a global collector was already installed by another
     /// call to `try_init`.
     pub fn try_init(self) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-        use crate::util::SubscriberInitExt;
-        self.finish().try_init()?;
+        // use crate::util::SubscriberInitExt;
+        // self.finish().try_init()?;
 
-        Ok(())
+        // Ok(())
+        todo!("eliza do this")
     }
 
     /// Install this collector as the global default.
@@ -593,11 +589,14 @@ where
 impl<N, E, F, W> From<CollectorBuilder<N, E, F, W>> for tracing_core::Dispatch
 where
     N: for<'writer> FormatFields<'writer> + 'static,
-    E: FormatEvent<Registry, N> + 'static,
+    E: FormatEvent<registry::SpanStore, N> + 'static,
     W: for<'writer> MakeWriter<'writer> + 'static,
-    F: subscribe::Subscribe<Formatter<N, E, W>> + Send + Sync + 'static,
-    fmt_subscriber::Subscriber<Registry, N, E, W>:
-        subscribe::Subscribe<Registry> + Send + Sync + 'static,
+    Collector<N, E, F, W>: tracing_core::Collect + Send + Sync + 'static,
+    Registry<Layered<F, Subscriber<N, E, W>>>: Collect + Send + Sync + 'static,
+    F: Subscribe<registry::SpanStore> + Send + Sync + 'static,
+    //     F: subscribe::Subscribe<Formatter<N, E, W>> + Send + Sync + 'static,
+    //     fmt_subscriber::Subscriber<Registry, N, E, W>:
+    //         subscribe::Subscribe<Registry> + Send + Sync + 'static,
 {
     fn from(builder: CollectorBuilder<N, E, F, W>) -> tracing_core::Dispatch {
         tracing_core::Dispatch::new(builder.finish())
@@ -829,8 +828,8 @@ impl<T, F, W> CollectorBuilder<format::JsonFields, format::Format<format::Json, 
 }
 
 impl<N, E, F, W> CollectorBuilder<N, E, reload::Subscriber<F>, W>
-where
-    Formatter<N, E, W>: tracing_core::Collect + 'static,
+// where
+// Formatter<N, E, W>: tracing_core::Collect + 'static,
 {
     /// Returns a `Handle` that may be used to reload the constructed collector's
     /// filter.
@@ -924,8 +923,8 @@ impl<N, E, F, W> CollectorBuilder<N, E, F, W> {
         self,
         filter: impl Into<crate::EnvFilter>,
     ) -> CollectorBuilder<N, E, crate::EnvFilter, W>
-    where
-        Formatter<N, E, W>: tracing_core::Collect + 'static,
+// where
+    //     Formatter<N, E, W>: tracing_core::Collect + 'static,
     {
         let filter = filter.into();
         CollectorBuilder {

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -300,7 +300,7 @@ use crate::{
     filter::LevelFilter,
     registry::{self, LookupSpan, Registry},
     reload, subscribe,
-    subscribe::{CollectExt, Layered, Subscribe},
+    subscribe::{Layered, Subscribe},
 };
 
 #[doc(inline)]

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -404,7 +404,6 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{
-        prelude::*,
         registry::LookupSpan,
         subscribe::{Context, Subscribe},
     };

--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -8,8 +8,8 @@ use tracing_core::{
 };
 
 #[cfg(feature = "registry")]
-use crate::registry::{self, LookupSpan, Registry, SpanRef};
-use std::{any::TypeId, marker::PhantomData, ptr::NonNull};
+use crate::registry::{self, LookupSpan, SpanRef};
+use std::{any::TypeId, ptr::NonNull};
 
 /// A composable handler for `tracing` events.
 ///
@@ -206,7 +206,9 @@ where
     C: Collect,
     Self: 'static,
 {
-    fn register(&mut self, collector: &mut C) {}
+    fn register(&mut self, collector: &mut C) {
+        let _ = collector;
+    }
 
     /// Registers a new callsite with this subscriber, returning whether or not
     /// the subscriber is interested in being notified about the callsite, similarly

--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -1244,165 +1244,169 @@ impl Identity {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    // use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Mutex};
 
-    // use super::*;
+    use super::*;
 
-    // pub(crate) struct NopCollector;
+    pub(crate) struct NopCollector;
 
-    // impl Collect for NopCollector {
-    //     fn register_callsite(&self, _: &'static Metadata<'static>) -> Interest {
-    //         Interest::never()
-    //     }
+    impl Collect for NopCollector {
+        fn register_callsite(&self, _: &'static Metadata<'static>) -> Interest {
+            Interest::never()
+        }
 
-    //     fn enabled(&self, _: &Metadata<'_>) -> bool {
-    //         false
-    //     }
+        fn enabled(&self, _: &Metadata<'_>) -> bool {
+            false
+        }
 
-    //     fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
-    //         span::Id::from_u64(1)
-    //     }
+        fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
+            span::Id::from_u64(1)
+        }
 
-    //     fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
-    //     fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
-    //     fn event(&self, _: &Event<'_>) {}
-    //     fn enter(&self, _: &span::Id) {}
-    //     fn exit(&self, _: &span::Id) {}
-    //     fn current_span(&self) -> span::Current {
-    //         span::Current::unknown()
-    //     }
-    // }
+        fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
+        fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
+        fn event(&self, _: &Event<'_>) {}
+        fn enter(&self, _: &span::Id) {}
+        fn exit(&self, _: &span::Id) {}
+        fn current_span(&self) -> span::Current {
+            span::Current::unknown()
+        }
+    }
 
-    // struct NopSubscriber;
-    // impl<C: Collect> Subscribe<C> for NopSubscriber {}
+    struct NopSubscriber;
+    impl<C: Collect> Subscribe<C> for NopSubscriber {}
 
-    // #[allow(dead_code)]
-    // struct NopSubscriber2;
-    // impl<C: Collect> Subscribe<C> for NopSubscriber2 {}
+    #[allow(dead_code)]
+    struct NopSubscriber2;
+    impl<C: Collect> Subscribe<C> for NopSubscriber2 {}
 
-    // /// A subscriber that holds a string.
-    // ///
-    // /// Used to test that pointers returned by downcasting are actually valid.
-    // struct StringSubscriber(String);
-    // impl<C: Collect> Subscribe<C> for StringSubscriber {}
-    // struct StringSubscriber2(String);
-    // impl<C: Collect> Subscribe<C> for StringSubscriber2 {}
+    /// A subscriber that holds a string.
+    ///
+    /// Used to test that pointers returned by downcasting are actually valid.
+    struct StringSubscriber(String);
+    impl<C: Collect> Subscribe<C> for StringSubscriber {}
+    struct StringSubscriber2(String);
+    impl<C: Collect> Subscribe<C> for StringSubscriber2 {}
 
-    // struct StringSubscriber3(String);
-    // impl<C: Collect> Subscribe<C> for StringSubscriber3 {}
+    struct StringSubscriber3(String);
+    impl<C: Collect> Subscribe<C> for StringSubscriber3 {}
 
-    // pub(crate) struct StringCollector(String);
+    pub(crate) struct StringCollector(String);
 
-    // impl Collect for StringCollector {
-    //     fn register_callsite(&self, _: &'static Metadata<'static>) -> Interest {
-    //         Interest::never()
-    //     }
+    impl Collect for StringCollector {
+        fn register_callsite(&self, _: &'static Metadata<'static>) -> Interest {
+            Interest::never()
+        }
 
-    //     fn enabled(&self, _: &Metadata<'_>) -> bool {
-    //         false
-    //     }
+        fn enabled(&self, _: &Metadata<'_>) -> bool {
+            false
+        }
 
-    //     fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
-    //         span::Id::from_u64(1)
-    //     }
+        fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
+            span::Id::from_u64(1)
+        }
 
-    //     fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
-    //     fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
-    //     fn event(&self, _: &Event<'_>) {}
-    //     fn enter(&self, _: &span::Id) {}
-    //     fn exit(&self, _: &span::Id) {}
-    //     fn current_span(&self) -> span::Current {
-    //         span::Current::unknown()
-    //     }
-    // }
+        fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
+        fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
+        fn event(&self, _: &Event<'_>) {}
+        fn enter(&self, _: &span::Id) {}
+        fn exit(&self, _: &span::Id) {}
+        fn current_span(&self) -> span::Current {
+            span::Current::unknown()
+        }
+    }
 
-    // fn assert_collector(_s: impl Collect) {}
+    fn assert_collector(_s: impl Collect) {}
 
-    // #[test]
-    // fn subscriber_is_collector() {
-    //     let s = NopSubscriber.with_collector(NopCollector);
-    //     assert_collector(s)
-    // }
+    #[test]
+    fn subscriber_is_collector() {
+        let s = NopSubscriber.with_collector(NopCollector);
+        assert_collector(s)
+    }
 
-    // #[test]
-    // fn two_subscribers_are_collector() {
-    //     let s = NopSubscriber
-    //         .and_then(NopSubscriber)
-    //         .with_collector(NopCollector);
-    //     assert_collector(s)
-    // }
+    #[test]
+    fn two_subscribers_are_collector() {
+        // let s = NopSubscriber
+        //     .and_then(NopSubscriber)
+        //     .with_collector(NopCollector);
+        // assert_collector(s)
 
-    // #[test]
-    // fn three_subscribers_are_collector() {
-    //     let s = NopSubscriber
-    //         .and_then(NopSubscriber)
-    //         .and_then(NopSubscriber)
-    //         .with_collector(NopCollector);
-    //     assert_collector(s)
-    // }
+        todo!("eliza")
+    }
 
-    // #[test]
-    // fn downcasts_to_collector() {
-    //     let s = NopSubscriber
-    //         .and_then(NopSubscriber)
-    //         .and_then(NopSubscriber)
-    //         .with_collector(StringCollector("collector".into()));
-    //     let collector =
-    //         <dyn Collect>::downcast_ref::<StringCollector>(&s).expect("collector should downcast");
-    //     assert_eq!(&collector.0, "collector");
-    // }
+    #[test]
+    fn three_subscribers_are_collector() {
+        // let s = NopSubscriber
+        //     .and_then(NopSubscriber)
+        //     .and_then(NopSubscriber)
+        //     .with_collector(NopCollector);
+        // assert_collector(s)
+        todo!("eliza")
+    }
 
-    // #[test]
-    // fn downcasts_to_subscriber() {
-    //     let s = StringSubscriber("subscriber_1".into())
-    //         .and_then(StringSubscriber2("subscriber_2".into()))
-    //         .and_then(StringSubscriber3("subscriber_3".into()))
-    //         .with_collector(NopCollector);
-    //     let subscriber = <dyn Collect>::downcast_ref::<StringSubscriber>(&s)
-    //         .expect("subscriber 2 should downcast");
-    //     assert_eq!(&subscriber.0, "subscriber_1");
-    //     let subscriber = <dyn Collect>::downcast_ref::<StringSubscriber2>(&s)
-    //         .expect("subscriber 2 should downcast");
-    //     assert_eq!(&subscriber.0, "subscriber_2");
-    //     let subscriber = <dyn Collect>::downcast_ref::<StringSubscriber3>(&s)
-    //         .expect("subscriber 3 should downcast");
-    //     assert_eq!(&subscriber.0, "subscriber_3");
-    // }
+    #[test]
+    fn downcasts_to_collector() {
+        // let s = NopSubscriber
+        //     .and_then(NopSubscriber)
+        //     .and_then(NopSubscriber)
+        //     .with_collector(StringCollector("collector".into()));
+        // let collector =
+        //     <dyn Collect>::downcast_ref::<StringCollector>(&s).expect("collector should downcast");
+        // assert_eq!(&collector.0, "collector");
+        todo!("eliza")
+    }
 
-    // #[test]
-    // fn context_event_span() {
-    //     let last_event_span = Arc::new(Mutex::new(None));
+    #[test]
+    fn downcasts_to_subscriber() {
+        let s = crate::registry()
+            .with(StringSubscriber("subscriber_1".into()))
+            .with(StringSubscriber2("subscriber_2".into()))
+            .with(StringSubscriber3("subscriber_3".into()));
+        let subscriber = <dyn Collect>::downcast_ref::<StringSubscriber>(&s)
+            .expect("subscriber 2 should downcast");
+        assert_eq!(&subscriber.0, "subscriber_1");
+        let subscriber = <dyn Collect>::downcast_ref::<StringSubscriber2>(&s)
+            .expect("subscriber 2 should downcast");
+        assert_eq!(&subscriber.0, "subscriber_2");
+        let subscriber = <dyn Collect>::downcast_ref::<StringSubscriber3>(&s)
+            .expect("subscriber 3 should downcast");
+        assert_eq!(&subscriber.0, "subscriber_3");
+    }
 
-    //     struct RecordingSubscriber {
-    //         last_event_span: Arc<Mutex<Option<&'static str>>>,
-    //     }
+    #[test]
+    fn context_event_span() {
+        let last_event_span = Arc::new(Mutex::new(None));
 
-    //     impl<S> Subscribe<S> for RecordingSubscriber
-    //     where
-    //         S: Collect + for<'lookup> LookupSpan<'lookup>,
-    //     {
-    //         fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
-    //             let span = ctx.event_span(event);
-    //             *self.last_event_span.lock().unwrap() = span.map(|s| s.name());
-    //         }
-    //     }
+        struct RecordingSubscriber {
+            last_event_span: Arc<Mutex<Option<&'static str>>>,
+        }
 
-    //     tracing::collect::with_default(
-    //         crate::registry().with(RecordingSubscriber {
-    //             last_event_span: last_event_span.clone(),
-    //         }),
-    //         || {
-    //             tracing::info!("no span");
-    //             assert_eq!(*last_event_span.lock().unwrap(), None);
+        impl<S> Subscribe<S> for RecordingSubscriber
+        where
+            S: Collect + for<'lookup> LookupSpan<'lookup>,
+        {
+            fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+                let span = ctx.event_span(event);
+                *self.last_event_span.lock().unwrap() = span.map(|s| s.name());
+            }
+        }
 
-    //             let parent = tracing::info_span!("explicit");
-    //             tracing::info!(parent: &parent, "explicit span");
-    //             assert_eq!(*last_event_span.lock().unwrap(), Some("explicit"));
+        tracing::collect::with_default(
+            crate::registry().with(RecordingSubscriber {
+                last_event_span: last_event_span.clone(),
+            }),
+            || {
+                tracing::info!("no span");
+                assert_eq!(*last_event_span.lock().unwrap(), None);
 
-    //             let _guard = tracing::info_span!("contextual").entered();
-    //             tracing::info!("contextual span");
-    //             assert_eq!(*last_event_span.lock().unwrap(), Some("contextual"));
-    //         },
-    //     );
-    // }
+                let parent = tracing::info_span!("explicit");
+                tracing::info!(parent: &parent, "explicit span");
+                assert_eq!(*last_event_span.lock().unwrap(), Some("explicit"));
+
+                let _guard = tracing::info_span!("contextual").entered();
+                tracing::info!("contextual span");
+                assert_eq!(*last_event_span.lock().unwrap(), Some("contextual"));
+            },
+        );
+    }
 }

--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -749,6 +749,21 @@ where
     }
 
     #[inline]
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        // TODO(eliza): per-layer filtering
+        self.subscriber
+            .max_level_hint()
+            .map(|outer_hint| {
+                if let Some(inner_hint) = self.inner.max_level_hint() {
+                    std::cmp::max(outer_hint, inner_hint)
+                } else {
+                    outer_hint
+                }
+            })
+            .or_else(|| self.inner.max_level_hint())
+    }
+
+    #[inline]
     fn new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, C>) {
         self.inner.new_span(attrs, id, ctx.clone());
         self.subscriber.new_span(attrs, id, ctx);

--- a/tracing-subscriber/src/util.rs
+++ b/tracing-subscriber/src/util.rs
@@ -98,7 +98,7 @@ pub struct TryInitError {
 // ==== impl TryInitError ====
 
 impl TryInitError {
-    fn new(e: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
+    pub(crate) fn new(e: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
         Self { inner: e.into() }
     }
 }

--- a/tracing-subscriber/tests/registry_max_level_hint.rs
+++ b/tracing-subscriber/tests/registry_max_level_hint.rs
@@ -1,4 +1,4 @@
-use tracing_subscriber::{filter::LevelFilter, prelude::*};
+use tracing_subscriber::filter::LevelFilter;
 
 #[test]
 fn registry_sets_max_level_hint() {

--- a/tracing-subscriber/tests/registry_with_subscriber.rs
+++ b/tracing-subscriber/tests/registry_with_subscriber.rs
@@ -1,6 +1,4 @@
 use tracing_futures::{Instrument, WithCollector};
-use tracing_subscriber::prelude::*;
-
 #[tokio::test]
 async fn future_with_subscriber() {
     let _default = tracing_subscriber::registry().init();


### PR DESCRIPTION
This branch is a draft implementation of a potential redesign of the
`tracing-subscriber` Registry API. In the new design, a `Registry` is a
type which _wraps_ a stack of subscribers and a span store, rather than
a span store that sits at the bottom of a stack of subscribers.

There are several advantages of the new design:

- The complex code around tracking span closure can be made much
  simpler, and the `CloseGuard` type removed.
- Composing a stack of subscribers no longer requires extension traits
  for the `with` method; it is now simply called on the concrete
  `Registry` type. This makes the API much simpler and more or less
  obviates the need for a prelude.
- There is now the ability to easily add a hook that's run when a layer
  is added to a `Registry`, with the opportunity to easily mutate the
  registry. This can be used for things like pre-registering filters, in a
  future per-layer filtering API.

This is still a draft because there are some things that have yet to be
figured out. In particular, the `Context::event` method doesn't work yet.