### PR TITLE
Add support for visiting floating point values

### DIFF
--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -179,6 +179,11 @@ pub struct Iter {
 /// [set of `Value`s added to a `Span`]: super::collect::Collect::record
 /// [`Event`]: super::event::Event
 pub trait Visit {
+    /// Visit a double-precision floating point value.
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.record_debug(field, &value)
+    }
+
     /// Visit a signed 64-bit integer value.
     fn record_i64(&mut self, field: &Field, value: i64) {
         self.record_debug(field, &value)
@@ -330,6 +335,12 @@ macro_rules! ty_to_nonzero {
 }
 
 macro_rules! impl_one_value {
+    (f32, $op:expr, $record:ident) => {
+        impl_one_value!(normal, f32, $op, $record);
+    };
+    (f64, $op:expr, $record:ident) => {
+        impl_one_value!(normal, f64, $op, $record);
+    };
     (bool, $op:expr, $record:ident) => {
         impl_one_value!(normal, bool, $op, $record);
     };
@@ -382,7 +393,8 @@ impl_values! {
     record_u64(usize, u32, u16, u8 as u64),
     record_i64(i64),
     record_i64(isize, i32, i16, i8 as i64),
-    record_bool(bool)
+    record_bool(bool),
+    record_f64(f64, f32 as f64)
 }
 
 impl<T: crate::sealed::Sealed> crate::sealed::Sealed for Wrapping<T> {}

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -16,9 +16,9 @@
 //! will contain any fields attached to each event.
 //!
 //! `tracing` represents values as either one of a set of Rust primitives
-//! (`i64`, `u64`, `bool`, and `&str`) or using a `fmt::Display` or `fmt::Debug`
-//! implementation. Collectors are provided these primitive value types as
-//! `dyn Value` trait objects.
+//! (`i64`, `u64`, `f64`, `bool`, and `&str`) or using a `fmt::Display` or
+//! `fmt::Debug` implementation. Collectors are provided these primitive
+//! value types as `dyn Value` trait objects.
 //!
 //! These trait objects can be formatted using `fmt::Debug`, but may also be
 //! recorded as typed data by calling the [`Value::record`] method on these

--- a/tracing-opentelemetry/src/subscriber.rs
+++ b/tracing-opentelemetry/src/subscriber.rs
@@ -212,7 +212,7 @@ impl<'a> field::Visit for SpanAttributeVisitor<'a> {
         self.record(KeyValue::new(field.name(), value));
     }
 
-    /// Set attributes on the underlying OpenTelemetry [`Span`] from `i64` values.
+    /// Set attributes on the underlying OpenTelemetry [`Span`] from `f64` values.
     ///
     /// [`Span`]: opentelemetry::trace::Span
     fn record_f64(&mut self, field: &field::Field, value: f64) {

--- a/tracing-opentelemetry/src/subscriber.rs
+++ b/tracing-opentelemetry/src/subscriber.rs
@@ -127,6 +127,21 @@ impl<'a> field::Visit for SpanEventVisitor<'a> {
         }
     }
 
+    /// Record events on the underlying OpenTelemetry [`Span`] from `f64` values.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_f64(&mut self, field: &field::Field, value: f64) {
+        match field.name() {
+            "message" => self.0.name = value.to_string().into(),
+            // Skip fields that are actually log metadata that have already been handled
+            #[cfg(feature = "tracing-log")]
+            name if name.starts_with("log.") => (),
+            name => {
+                self.0.attributes.push(KeyValue::new(name, value));
+            }
+        }
+    }
+
     /// Record events on the underlying OpenTelemetry [`Span`] from `i64` values.
     ///
     /// [`Span`]: opentelemetry::trace::Span
@@ -194,6 +209,13 @@ impl<'a> field::Visit for SpanAttributeVisitor<'a> {
     ///
     /// [`Span`]: opentelemetry::trace::Span
     fn record_bool(&mut self, field: &field::Field, value: bool) {
+        self.record(KeyValue::new(field.name(), value));
+    }
+
+    /// Set attributes on the underlying OpenTelemetry [`Span`] from `i64` values.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_f64(&mut self, field: &field::Field, value: f64) {
         self.record(KeyValue::new(field.name(), value));
     }
 

--- a/tracing-serde/src/lib.rs
+++ b/tracing-serde/src/lib.rs
@@ -403,6 +403,12 @@ where
         }
     }
 
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        if self.state.is_ok() {
+            self.state = self.serializer.serialize_entry(field.name(), &value)
+        }
+    }
+
     fn record_str(&mut self, field: &Field, value: &str) {
         if self.state.is_ok() {
             self.state = self.serializer.serialize_entry(field.name(), &value)
@@ -444,6 +450,12 @@ where
     }
 
     fn record_i64(&mut self, field: &Field, value: i64) {
+        if self.state.is_ok() {
+            self.state = self.serializer.serialize_field(field.name(), &value)
+        }
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
         if self.state.is_ok() {
             self.state = self.serializer.serialize_field(field.name(), &value)
         }

--- a/tracing-subscriber/src/field/debug.rs
+++ b/tracing-subscriber/src/field/debug.rs
@@ -39,6 +39,11 @@ where
     V: Visit,
 {
     #[inline]
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.0.record_f64(field, value)
+    }
+
+    #[inline]
     fn record_i64(&mut self, field: &Field, value: i64) {
         self.0.record_i64(field, value)
     }

--- a/tracing-subscriber/src/field/display.rs
+++ b/tracing-subscriber/src/field/display.rs
@@ -41,6 +41,11 @@ where
     V: Visit,
 {
     #[inline]
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.0.record_f64(field, value)
+    }
+
+    #[inline]
     fn record_i64(&mut self, field: &Field, value: i64) {
         self.0.record_i64(field, value)
     }

--- a/tracing-subscriber/src/filter/env/field.rs
+++ b/tracing-subscriber/src/filter/env/field.rs
@@ -36,20 +36,74 @@ pub(crate) struct MatchVisitor<'a> {
     inner: &'a SpanMatch,
 }
 
-#[derive(Debug, Clone, PartialOrd, PartialEq)]
+#[derive(Debug, Clone)]
 pub(crate) enum ValueMatch {
     Bool(bool),
     F64(f64),
     U64(u64),
     I64(i64),
+    NaN,
     Pat(Box<MatchPattern>),
 }
 
 impl Eq for ValueMatch {}
 
+impl PartialEq for ValueMatch {
+    fn eq(&self, other: &Self) -> bool {
+        use ValueMatch::*;
+        match (self, other) {
+            (Bool(a), Bool(b)) => a.eq(b),
+            (F64(a), F64(b)) => {
+                debug_assert!(!a.is_nan());
+                debug_assert!(!b.is_nan());
+
+                a.eq(b)
+            }
+            (U64(a), U64(b)) => a.eq(b),
+            (I64(a), I64(b)) => a.eq(b),
+            (NaN, NaN) => true,
+            (Pat(a), Pat(b)) => a.eq(b),
+            _ => false,
+        }
+    }
+}
+
 impl Ord for ValueMatch {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap()
+        use ValueMatch::*;
+        match (self, other) {
+            (Bool(this), Bool(that)) => this.cmp(that),
+            (Bool(_), _) => Ordering::Less,
+
+            (F64(this), F64(that)) => this
+                .partial_cmp(that)
+                .expect("`ValueMatch::F64` may not contain `NaN` values"),
+            (F64(_), Bool(_)) => Ordering::Greater,
+            (F64(_), _) => Ordering::Less,
+
+            (NaN, NaN) => Ordering::Equal,
+            (NaN, Bool(_)) | (NaN, F64(_)) => Ordering::Greater,
+            (NaN, _) => Ordering::Less,
+
+            (U64(this), U64(that)) => this.cmp(that),
+            (U64(_), Bool(_)) | (U64(_), F64(_)) | (U64(_), NaN) => Ordering::Greater,
+            (U64(_), _) => Ordering::Less,
+
+            (I64(this), I64(that)) => this.cmp(that),
+            (I64(_), Bool(_)) | (I64(_), F64(_)) | (I64(_), NaN) | (I64(_), U64(_)) => {
+                Ordering::Greater
+            }
+            (I64(_), _) => Ordering::Less,
+
+            (Pat(this), Pat(that)) => this.cmp(that),
+            (Pat(_), _) => Ordering::Greater,
+        }
+    }
+}
+
+impl PartialOrd for ValueMatch {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 
@@ -136,6 +190,14 @@ impl PartialOrd for Match {
 
 // === impl ValueMatch ===
 
+fn value_match_f64(v: f64) -> ValueMatch {
+    if v.is_nan() {
+        ValueMatch::NaN
+    } else {
+        ValueMatch::F64(v)
+    }
+}
+
 impl FromStr for ValueMatch {
     type Err = matchers::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -143,7 +205,7 @@ impl FromStr for ValueMatch {
             .map(ValueMatch::Bool)
             .or_else(|_| s.parse::<u64>().map(ValueMatch::U64))
             .or_else(|_| s.parse::<i64>().map(ValueMatch::I64))
-            .or_else(|_| s.parse::<f64>().map(ValueMatch::F64))
+            .or_else(|_| s.parse::<f64>().map(value_match_f64))
             .or_else(|_| {
                 s.parse::<MatchPattern>()
                     .map(|p| ValueMatch::Pat(Box::new(p)))
@@ -156,6 +218,7 @@ impl fmt::Display for ValueMatch {
         match self {
             ValueMatch::Bool(ref inner) => fmt::Display::fmt(inner, f),
             ValueMatch::F64(ref inner) => fmt::Display::fmt(inner, f),
+            ValueMatch::NaN => fmt::Display::fmt(&f64::NAN, f),
             ValueMatch::I64(ref inner) => fmt::Display::fmt(inner, f),
             ValueMatch::U64(ref inner) => fmt::Display::fmt(inner, f),
             ValueMatch::Pat(ref inner) => fmt::Display::fmt(inner, f),
@@ -288,6 +351,9 @@ impl SpanMatch {
 impl<'a> Visit for MatchVisitor<'a> {
     fn record_f64(&mut self, field: &Field, value: f64) {
         match self.inner.fields.get(field) {
+            Some((ValueMatch::NaN, ref matched)) if value.is_nan() => {
+                matched.store(true, Release);
+            }
             Some((ValueMatch::F64(ref e), ref matched)) if value == *e => {
                 matched.store(true, Release);
             }

--- a/tracing-subscriber/src/filter/env/field.rs
+++ b/tracing-subscriber/src/filter/env/field.rs
@@ -354,7 +354,7 @@ impl<'a> Visit for MatchVisitor<'a> {
             Some((ValueMatch::NaN, ref matched)) if value.is_nan() => {
                 matched.store(true, Release);
             }
-            Some((ValueMatch::F64(ref e), ref matched)) if value == *e => {
+            Some((ValueMatch::F64(ref e), ref matched)) if (value - *e).abs() < f64::EPSILON => {
                 matched.store(true, Release);
             }
             _ => {}

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -425,6 +425,12 @@ impl<'a> crate::field::VisitOutput<fmt::Result> for JsonVisitor<'a> {
 }
 
 impl<'a> field::Visit for JsonVisitor<'a> {
+    /// Visit a double precision floating point value.
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.values
+            .insert(field.name(), serde_json::Value::from(value));
+    }
+
     /// Visit a signed 64-bit integer value.
     fn record_i64(&mut self, field: &Field, value: i64) {
         self.values

--- a/tracing/tests/event.rs
+++ b/tracing/tests/event.rs
@@ -145,6 +145,7 @@ fn one_with_everything() {
                         )))
                         .and(field::mock("foo").with_value(&666))
                         .and(field::mock("bar").with_value(&false))
+                        .and(field::mock("like_a_butterfly").with_value(&42.0))
                         .only(),
                 )
                 .at_level(Level::ERROR)
@@ -157,7 +158,7 @@ fn one_with_everything() {
         event!(
             target: "whatever",
             Level::ERROR,
-            { foo = 666, bar = false },
+            { foo = 666, bar = false, like_a_butterfly = 42.0 },
              "{:#x} make me one with{what:.>20}", 4_277_009_102u64, what = "everything"
         );
     });

--- a/tracing/tests/span.rs
+++ b/tracing/tests/span.rs
@@ -458,6 +458,28 @@ fn move_field_out_of_struct() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn float_values() {
+    let (collector, handle) = collector::mock()
+        .new_span(
+            span::mock().named("foo").with_field(
+                field::mock("x")
+                    .with_value(&3.234)
+                    .and(field::mock("y").with_value(&-1.223))
+                    .only(),
+            ),
+        )
+        .run_with_handle();
+
+    with_default(collector, || {
+        let foo = span!(Level::TRACE, "foo", x = 3.234, y = -1.223);
+        foo.in_scope(|| {});
+    });
+
+    handle.assert_finished();
+}
+
 // TODO(#1138): determine a new syntax for uninitialized span fields, and
 // re-enable these.
 /*

--- a/tracing/tests/support/field.rs
+++ b/tracing/tests/support/field.rs
@@ -19,7 +19,7 @@ pub struct MockField {
     value: MockValue,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum MockValue {
     F64(f64),
     I64(i64),
@@ -31,6 +31,29 @@ pub enum MockValue {
 }
 
 impl Eq for MockValue {}
+
+impl PartialEq for MockValue {
+    fn eq(&self, other: &Self) -> bool {
+        use MockValue::*;
+
+        match (self, other) {
+            (F64(a), F64(b)) => {
+                debug_assert!(!a.is_nan());
+                debug_assert!(!b.is_nan());
+
+                a.eq(b)
+            }
+            (I64(a), I64(b)) => a.eq(b),
+            (U64(a), U64(b)) => a.eq(b),
+            (Bool(a), Bool(b)) => a.eq(b),
+            (Str(a), Str(b)) => a.eq(b),
+            (Debug(a), Debug(b)) => a.eq(b),
+            (Any, _) => true,
+            (_, Any) => true,
+            _ => false,
+        }
+    }
+}
 
 pub fn mock<K>(name: K) -> MockField
 where


### PR DESCRIPTION
## Motivation

Tracing is a really useful framework but a lack of floating point value support for the core visitors means these get coerced unnecessarily to strings.

## Solution

This change adds support for floating point (f64) visitors.