### PR TITLE
chore: several CI fixes & cleanup

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,16 @@
+[advisories]
+ignore = [
+    # Unmaintained advisory for the `net2` crate.
+    #
+    # We ignore this, because `net2` is a transitive dependency of older
+    # versions of `mio`, which we depend on via `tokio` 0.1. `tokio` 0.1 won't
+    # be updated, so as long as `tracing-futures` supports tokio 0.1, we can't
+    # really get rid of the `net2` dependency.
+    #
+    # So, just ignore the warning. It only effects users who are using
+    # compatibility features for *other* unmaintained libraries, anyway.
+    #
+    # TODO: when `tracing-futures` drops support for `tokio` 0.1, we can remove
+    # the `ignore` for this warning, as we will no longer pull `net2`.
+    "RUSTSEC-2020-0016"
+]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,17 +7,32 @@ on:
   pull_request: {}
 
 jobs:
-  check:
-    # Run `cargo check` first to ensure that the pushed code at least compiles.
+  check-msrv:
+    # Run `cargo check` on our minimum supported Rust version (1.42.0).
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [stable, 1.42.0]
+    rust: 1.42.0
     steps:
     - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: ${{ matrix.rust }}
+        toolchain: 1.42.0
+        profile: minimal
+        override: true
+    - name: Check
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --all --bins --tests
+
+  check:
+    # Run `cargo check` first to ensure that the pushed code at least compiles.
+    runs-on: ubuntu-latest
+    rust: stable
+    steps:
+    - uses: actions/checkout@main
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
         profile: minimal
         override: true
     - name: Check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,6 @@ jobs:
   check-msrv:
     # Run `cargo check` on our minimum supported Rust version (1.42.0).
     runs-on: ubuntu-latest
-    rust: 1.42.0
     steps:
     - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
@@ -22,12 +21,11 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: check
-        args: --all --bins --tests
+        args: --all --bins
 
   check:
     # Run `cargo check` first to ensure that the pushed code at least compiles.
     runs-on: ubuntu-latest
-    rust: stable
     steps:
     - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
@@ -138,32 +136,6 @@ jobs:
       with:
         command: test
         args: --all
-
-  test-msrv:
-    # Test against the minimum supported Rust version
-    needs: check
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@main
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 1.42.0
-        profile: minimal
-        override: true
-    # We can't use `cargo test --all`, as that will also compile the examples.
-    # We don't guarantee the examples will work on the MSRV, because they have
-    # external dependencies which may not comply with our MSRV policy, but don't
-    # actually impact users on our MSRV.
-    - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --workspace --lib --tests
-    - name: Run doctests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --workspace --doc
 
   test-build-wasm:
     needs: check

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -48,7 +48,7 @@ log = "0.4"
 
 # inferno example
 inferno = "0.10.0"
-tempdir = "0.3.7"
+tempfile = "3"
 
 # opentelemetry example
 opentelemetry = { version = "0.16", default-features = false, features = ["trace"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -36,7 +36,7 @@ env_logger = "0.8"
 # tower examples
 tower = { version = "0.4.4", features = ["full"] }
 http = "0.2"
-hyper = { version = "0.14", features = ["full"] }
+hyper = { version = "0.14.11", features = ["full"] }
 rand = "0.7"
 bytes = "1"
 argh = "0.1.5"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -39,7 +39,7 @@ http = "0.2"
 hyper = { version = "0.14", features = ["full"] }
 rand = "0.7"
 bytes = "1"
-clap = "2.33"
+argh = "0.1.5"
 
 # sloggish example
 ansi_term = "0.12"

--- a/examples/examples/fmt-multiple-writers.rs
+++ b/examples/examples/fmt-multiple-writers.rs
@@ -5,11 +5,10 @@
 mod yak_shave;
 
 use std::io;
-use tempdir::TempDir;
 use tracing_subscriber::{fmt, subscribe::CollectExt, EnvFilter};
 
 fn main() {
-    let dir = TempDir::new("directory").expect("Failed to create tempdir");
+    let dir = tempfile::tempdir().expect("Failed to create tempdir");
 
     let file_appender = tracing_appender::rolling::hourly(dir, "example.log");
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);

--- a/examples/examples/futures-proxy-server.rs
+++ b/examples/examples/futures-proxy-server.rs
@@ -25,7 +25,7 @@
 
 #![deny(rust_2018_idioms)]
 
-use clap::{arg_enum, value_t, App, Arg, ArgMatches};
+use argh::FromArgs;
 use futures::{future::try_join, prelude::*};
 use std::net::SocketAddr;
 use tokio::{
@@ -70,61 +70,50 @@ async fn transfer(mut inbound: TcpStream, proxy_addr: SocketAddr) -> Result<(), 
     Ok(())
 }
 
-arg_enum! {
-    #[derive(PartialEq, Debug)]
-    pub enum LogFormat {
-        Plain,
-        Json,
-    }
+#[derive(FromArgs)]
+#[argh(description = "Proxy server example")]
+pub struct Args {
+    /// how to format the logs.
+    #[argh(option, default = "LogFormat::Plain")]
+    log_format: LogFormat,
+
+    /// address to listen on.
+    #[argh(option, default = "default_listen_addr()")]
+    listen_addr: SocketAddr,
+
+    /// address to proxy to.
+    #[argh(option, default = "default_server_addr()")]
+    server_addr: SocketAddr,
+}
+
+#[derive(PartialEq, Debug)]
+pub enum LogFormat {
+    Plain,
+    Json,
+}
+
+fn default_listen_addr() -> SocketAddr {
+    SocketAddr::from(([127, 0, 0, 1], 8081))
+}
+
+fn default_server_addr() -> SocketAddr {
+    SocketAddr::from(([127, 0, 0, 1], 3000))
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    let matches = App::new("Proxy Server Example")
-        .version("1.0")
-        .arg(
-            Arg::with_name("log_format")
-                .possible_values(&LogFormat::variants())
-                .case_insensitive(true)
-                .long("log_format")
-                .value_name("log_format")
-                .help("Formatting of the logs")
-                .required(false)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("listen_addr")
-                .long("listen_addr")
-                .help("Address to listen on")
-                .takes_value(true)
-                .required(false),
-        )
-        .arg(
-            Arg::with_name("server_addr")
-                .long("server_addr")
-                .help("Address to proxy to")
-                .takes_value(false)
-                .required(false),
-        )
-        .get_matches();
+    let args: Args = argh::from_env();
+    set_global_default(args.log_format)?;
 
-    set_global_default(&matches)?;
+    let listener = TcpListener::bind(&args.listen_addr).await?;
 
-    let listen_addr = matches.value_of("listen_addr").unwrap_or("127.0.0.1:8081");
-    let listen_addr = listen_addr.parse::<SocketAddr>()?;
-
-    let server_addr = matches.value_of("server_addr").unwrap_or("127.0.0.1:3000");
-    let server_addr = server_addr.parse::<SocketAddr>()?;
-
-    let listener = TcpListener::bind(&listen_addr).await?;
-
-    info!("Listening on: {}", listen_addr);
-    info!("Proxying to: {}", server_addr);
+    info!("Listening on: {}", args.listen_addr);
+    info!("Proxying to: {}", args.server_addr);
 
     while let Ok((inbound, client_addr)) = listener.accept().await {
         info!(client.addr = %client_addr, "client connected");
 
-        let transfer = transfer(inbound, server_addr).map(|r| {
+        let transfer = transfer(inbound, args.server_addr).map(|r| {
             if let Err(err) = r {
                 // Don't panic, maybe the client just disconnected too soon
                 debug!(error = %err);
@@ -137,11 +126,11 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-fn set_global_default(matches: &ArgMatches<'_>) -> Result<(), Error> {
+fn set_global_default(format: LogFormat) -> Result<(), Error> {
     let filter = tracing_subscriber::EnvFilter::from_default_env()
-        .add_directive("proxy_server=trace".parse()?);
+        .add_directive(concat!(module_path!(), "=trace").parse()?);
     let builder = tracing_subscriber::fmt().with_env_filter(filter);
-    match value_t!(matches, "log_format", LogFormat).unwrap_or(LogFormat::Plain) {
+    match format {
         LogFormat::Json => {
             builder.json().try_init()?;
         }
@@ -150,4 +139,15 @@ fn set_global_default(matches: &ArgMatches<'_>) -> Result<(), Error> {
         }
     }
     Ok(())
+}
+
+impl std::str::FromStr for LogFormat {
+    type Err = &'static str;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim() {
+            s if s.eq_ignore_ascii_case("plain") => Ok(Self::Plain),
+            s if s.eq_ignore_ascii_case("json") => Ok(Self::Json),
+            _ => Err("expected either `plain` or `json`"),
+        }
+    }
 }

--- a/examples/examples/inferno-flame.rs
+++ b/examples/examples/inferno-flame.rs
@@ -1,9 +1,11 @@
-use std::fs::File;
-use std::io::{BufReader, BufWriter};
-use std::path::Path;
-use std::thread::sleep;
-use std::time::Duration;
-use tempdir::TempDir;
+use std::{
+    env,
+    fs::File,
+    io::{BufReader, BufWriter},
+    path::{Path, PathBuf},
+    thread::sleep,
+    time::Duration,
+};
 use tracing::{span, Level};
 use tracing_flame::FlameSubscriber;
 use tracing_subscriber::{prelude::*, registry::Registry};
@@ -20,11 +22,12 @@ fn setup_global_collector(dir: &Path) -> impl Drop {
     _guard
 }
 
-fn make_flamegraph(dir: &Path) {
-    let inf = File::open(dir.join(PATH)).unwrap();
+fn make_flamegraph(tmpdir: &Path, out: &Path) {
+    println!("outputting flamegraph to {}", out.display());
+    let inf = File::open(tmpdir.join(PATH)).unwrap();
     let reader = BufReader::new(inf);
 
-    let out = File::create(dir.join("inferno.svg")).unwrap();
+    let out = File::create(out).unwrap();
     let writer = BufWriter::new(out);
 
     let mut opts = inferno::flamegraph::Options::default();
@@ -32,8 +35,19 @@ fn make_flamegraph(dir: &Path) {
 }
 
 fn main() {
+    let out = if let Some(arg) = env::args().nth(1) {
+        PathBuf::from(arg)
+    } else {
+        let mut path = env::current_dir().expect("failed to read current directory");
+        path.push("tracing-flame-inferno.svg");
+        path
+    };
+
     // setup the flame layer
-    let tmp_dir = TempDir::new("flamegraphs").unwrap();
+    let tmp_dir = tempfile::Builder::new()
+        .prefix("flamegraphs")
+        .tempdir()
+        .expect("failed to create temporary directory");
     let guard = setup_global_collector(tmp_dir.path());
 
     // do a bunch of span entering and exiting to simulate a program running
@@ -52,5 +66,5 @@ fn main() {
     // drop the guard to make sure the layer flushes its output then read the
     // output to create the flamegraph
     drop(guard);
-    make_flamegraph(tmp_dir.path());
+    make_flamegraph(tmp_dir.path(), out.as_ref());
 }

--- a/examples/examples/toggle-subscribers.rs
+++ b/examples/examples/toggle-subscribers.rs
@@ -6,28 +6,28 @@
 /// You can run this example by running the following command in a terminal
 ///
 /// ```
-/// cargo run --example toggle-layers -- json
+/// cargo run --example toggle-subscribers -- --json
 /// ```
 ///
-use clap::{App, Arg};
+use argh::FromArgs;
 use tracing::info;
 use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt};
 
 #[path = "fmt/yak_shave.rs"]
 mod yak_shave;
 
-fn main() {
-    let matches = App::new("fmt optional Example")
-        .version("1.0")
-        .arg(
-            Arg::with_name("json")
-                .help("Enabling json formatting of logs")
-                .required(false)
-                .takes_value(false),
-        )
-        .get_matches();
+#[derive(FromArgs)]
+/// Subscriber toggling example.
+struct Args {
+    /// enable JSON log format
+    #[argh(switch, short = 'j')]
+    json: bool,
+}
 
-    let (json, plain) = if matches.is_present("json") {
+fn main() {
+    let args: Args = argh::from_env();
+
+    let (json, plain) = if args.json {
         (Some(tracing_subscriber::fmt::subscriber().json()), None)
     } else {
         (None, Some(tracing_subscriber::fmt::subscriber()))

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -31,4 +31,4 @@ features = ["fmt"]
 
 [dev-dependencies]
 tracing = { path = "../tracing", version = "0.2" }
-tempdir = "0.3"
+tempfile = "3"

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -343,7 +343,6 @@ mod test {
     use super::*;
     use std::fs;
     use std::io::Write;
-    use tempdir::TempDir;
 
     fn find_str_in_log(dir_path: &Path, expected_value: &str) -> bool {
         let dir_contents = fs::read_dir(dir_path).expect("Failed to read directory");
@@ -367,7 +366,8 @@ mod test {
         appender.flush().expect("Failed to flush!");
     }
 
-    fn test_appender(rotation: Rotation, directory: TempDir, file_prefix: &str) {
+    fn test_appender(rotation: Rotation, file_prefix: &str) {
+        let directory = tempfile::tempdir().expect("failed to create tempdir");
         let mut appender = RollingFileAppender::new(rotation, directory.path(), file_prefix);
 
         let expected_value = "Hello";
@@ -381,38 +381,22 @@ mod test {
 
     #[test]
     fn write_minutely_log() {
-        test_appender(
-            Rotation::HOURLY,
-            TempDir::new("minutely").expect("Failed to create tempdir"),
-            "minutely.log",
-        );
+        test_appender(Rotation::HOURLY, "minutely.log");
     }
 
     #[test]
     fn write_hourly_log() {
-        test_appender(
-            Rotation::HOURLY,
-            TempDir::new("hourly").expect("Failed to create tempdir"),
-            "hourly.log",
-        );
+        test_appender(Rotation::HOURLY, "hourly.log");
     }
 
     #[test]
     fn write_daily_log() {
-        test_appender(
-            Rotation::DAILY,
-            TempDir::new("daily").expect("Failed to create tempdir"),
-            "daily.log",
-        );
+        test_appender(Rotation::DAILY, "daily.log");
     }
 
     #[test]
     fn write_never_log() {
-        test_appender(
-            Rotation::NEVER,
-            TempDir::new("never").expect("Failed to create tempdir"),
-            "never.log",
-        );
+        test_appender(Rotation::NEVER, "never.log");
     }
 
     #[test]

--- a/tracing-flame/Cargo.toml
+++ b/tracing-flame/Cargo.toml
@@ -30,4 +30,4 @@ tracing = { path = "../tracing", version = "0.2", default-features = false, feat
 lazy_static = "1.3.0"
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempfile = "3"

--- a/tracing-flame/tests/collapsed.rs
+++ b/tracing-flame/tests/collapsed.rs
@@ -1,6 +1,5 @@
 use std::thread::sleep;
 use std::time::Duration;
-use tempdir::TempDir;
 use tracing::{span, Level};
 use tracing_flame::FlameSubscriber;
 use tracing_subscriber::{prelude::*, registry::Registry};
@@ -8,7 +7,10 @@ use tracing_subscriber::{prelude::*, registry::Registry};
 #[test]
 fn capture_supported() {
     {
-        let tmp_dir = TempDir::new("flamegraphs").unwrap();
+        let tmp_dir = tempfile::Builder::new()
+            .prefix("tracing-flamegraph-test-")
+            .tempdir()
+            .expect("failed to create tempdir");
         let (flame_layer, _guard) =
             FlameSubscriber::with_file(tmp_dir.path().join("tracing.folded")).unwrap();
 
@@ -37,5 +39,7 @@ fn capture_supported() {
         }
 
         sleep(Duration::from_millis(500));
+
+        tmp_dir.close().expect("failed to delete tempdir");
     }
 }

--- a/tracing-flame/tests/concurrent.rs
+++ b/tracing-flame/tests/concurrent.rs
@@ -1,13 +1,15 @@
 use std::thread::sleep;
 use std::time::Duration;
-use tempdir::TempDir;
 use tracing::{span, Level};
 use tracing_flame::FlameSubscriber;
 use tracing_subscriber::{prelude::*, registry::Registry};
 
 #[test]
 fn capture_supported() {
-    let tmp_dir = TempDir::new("flamegraphs").unwrap();
+    let tmp_dir = tempfile::Builder::new()
+        .prefix("tracing-flamegraph-test-")
+        .tempdir()
+        .expect("failed to create tempdir");
     let path = tmp_dir.path().join("tracing.folded");
     let (flame_layer, flame_guard) = FlameSubscriber::with_file(&path).unwrap();
 
@@ -37,4 +39,6 @@ fn capture_supported() {
     let traces = std::fs::read_to_string(&path).unwrap();
     println!("{}", traces);
     assert_eq!(5, traces.lines().count());
+
+    tmp_dir.close().expect("failed to delete tempdir");
 }


### PR DESCRIPTION
This branch contains several commits that should fix some CI failures and warnings. I'll rebase-merge this.

List of commits:
* 1e2b4d7d chore: ignore unmaintained warning for `net2` in `cargo audit`

  `cargo audit` currently emits a warning that the `net2` crate is 
  unmaintained. We only depend on `net2` as a transitive dependency of 
  older versions of `mio`, which we depend on via `tokio` 0.1.
  `tracing-futures` has feature flags for supporting `tokio` 0.1, which
  we can't remove until the next breaking change. `tokio` 0.1 won't be 
  updated, so as long as `tracing-futures` supports tokio 0.1, we can't 
  really get rid of the `net2` dependency.

  Therefore, this commit adds a `.cargo/audit.toml` to just ignore the 
  warning. It only effects users who are using compatibility features
  for
  *other* unmaintained libraries, anyway. Eventually, when we drop
  `tokio` 0.1 support entirely, we can remove the `ignore` for this
  warning.

* da8b8044 examples: use `tempfile` in `inferno-flame`

  This commit updates the `inferno-flame` example to use the `tempfile` 
  crate as a replacement for the unmaintained `tempdir` crate.

  Also, the previous version of the example output the flamegraph inside 
  the temporary directory. Since the temporary directory is cleaned up 
  when the program exits, this means the user can't actually look at the 
  flamegraph when running this example. I've changed the example to put
  the flamegraph in the current working dir instead, so the user can
  look at it.

  Signed-off-by: Eliza Weisman <eliza@buoyant.io>

* c0295a79 flame: replace `tempdir` with `tempfile`

  Similarly, `tracing-flame`'s tests also use the unmaintained `tempdir` 
  crate. This commit replaces it with `tempfile`.

  Signed-off-by: Eliza Weisman <eliza@buoyant.io>

* db24fe3b appender: replace `tempdir` with `tempfile`

  `tracing-appender`'s tests use the `tempdir` crate, which is no longer 
  actively maintained, and `cargo audit` complains about it. The
  `tempfile` crate is the suggested replacement.

  This commit replaces `tempdir` with `tempfile` in the tests for
  `tracing-appender`.

  Signed-off-by: Eliza Weisman <eliza@buoyant.io>

* 6108cd7e examples: bump `hyper` dep to 0.14.11

  This version includes patches for a couple of RUSTSEC advisories that
  `cargo audit` is mad about. These aren't actually security-critical, 
  since the affected hyper versions are only used in examples, not in 
  actual`tracing` crates, but bumping makes `cargo audit` chill out. And 
  we should keep up to date regardless.

  Signed-off-by: Eliza Weisman <eliza@buoyant.io>

* a084e052 chore: don't check benches on MSRV

  Currently, CI runs `cargo check --all --bins --tests --benches` on our 
  MSRV. This is failing, because the latest `criterion` version now 
  depends on a revision of `bitflags` that doesn't build on Rust 1.42.0
  (due to `const fn`s not being const on 1.42.0).

  We *could* solve this by bumping our MSRV to a version where the 
  appropriate functions are `const fn`, or we could use a `=` dependency 
  to pin to a specific older version of `bitflags` that compiles on 
  1.42.0. However, both of these solutions seem kind of unfortunate.

  This commit just removes the `--benches` from the MSRV `cargo check` 
  run. The benchmarks are an internal development tool, not an
  officially supported part of `tracing`. Users on 1.42.0 can still
  depend on
  `tracing` and use it in their code even if the benchmarks don't
  compile on their (fairly old) Rust version. Therefore, it should be
  fine to just remove the benchmarks from the MSRV check.

  I split the MSRV and stable `cargo check` jobs into separate jobs, so
  we still check that commits don't break the benchmarks on stable Rust.

  Signed-off-by: Eliza Weisman <eliza@buoyant.io>

* 3db469df examples: use `argh` instead of `clap`

  Currently, there are a few examples that include CLI argument parsing. 
  These currently use the `clap` crate. `clap` is one of the most
  flexible and full-featured argument parsing libraries in Rust.
  However, or perhaps *because* of this, `clap` is also a fairly
  heavy-weight dependency which pulls in a lot of transitive deps.

  We don't *need* most of `clap`'s features for the very simple argument 
  parsing in these examples. Therefore, this commit replaces `clap` with
  `argh`, which is a much lighter dependency.

  Also, `clap` is currently pulling a version of `bitflags` that breaks 
  our MSRV...

  Signed-off-by: Eliza Weisman <eliza@buoyant.io>
