### PR TITLE
subscriber: prepare to release v0.2.20

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -19,6 +19,7 @@
 [#1483]: https://github.com/tokio-rs/tracing/pull/1483
 [#1463]: https://github.com/tokio-rs/tracing/pull/1463
 [#1453]: https://github.com/tokio-rs/tracing/pull/1453
+[#1498]: https://github.com/tokio-rs/tracing/pull/1498
 
 Thanks to new contributors @joshtriplett and @lerouxgd, and returning
 contributor @teozkr, for contributing to this release!

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -21,7 +21,7 @@
 [#1453]: https://github.com/tokio-rs/tracing/pull/1453
 [#1498]: https://github.com/tokio-rs/tracing/pull/1498
 
-Thanks to new contributors @joshtriplett and @lerouxgd, and returning
+Thanks to new contributors @joshtriplett and @lerouxrgd, and returning
 contributor @teozkr, for contributing to this release!
 
 # 0.2.19 (June 25, 2021)

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,28 @@
+# 0.2.20 (August 17, 2021)
+
+### Fixed
+
+- **fmt**: Fixed `fmt` printing only the first `source` for errors with a chain
+  of sources ([#1460])
+- **fmt**: Fixed missing space between level and event in the `Pretty` formatter
+  ([#1498])
+- **json**: Fixed `Json` formatter not honoring `without_time` and `with_level`
+  configurations ([#1463])
+
+### Added
+
+- **registry**: Improved panic message when cloning a span whose ID doesn't
+  exist, to aid in debugging issues with multiple subscribers ([#1483])
+- **registry**: Improved documentation on span ID generation ([#1453])
+
+[#1460]: https://github.com/tokio-rs/tracing/pull/1460
+[#1483]: https://github.com/tokio-rs/tracing/pull/1483
+[#1463]: https://github.com/tokio-rs/tracing/pull/1463
+[#1453]: https://github.com/tokio-rs/tracing/pull/1453
+
+Thanks to new contributors @joshtriplett and @lerouxgd, and returning
+contributor @teozkr, for contributing to this release!
+
 # 0.2.19 (June 25, 2021)
 
 ### Deprecated
@@ -22,7 +47,7 @@
   `with_filter`, `and`, and `or_else` combinators ([#1274])
 - **fmt**: `MakeWriter` implementation for `Arc<W> where &W: io::Write`
   ([#1274])
-  
+
 Thanks to @teozkr and @Folyd for contributing to this release!
 
 [#1413]: https://github.com/tokio-rs/tracing/pull/1413

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.19"
+version = "0.2.20"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -67,7 +67,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.19")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.20")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.2.20 (August 17, 2021)
### Fixed

- **fmt**: Fixed `fmt` printing only the first `source` for errors with
  a chain of sources ([#1460])
- **fmt**: Fixed missing space between level and event in the `Pretty`
  formatter ([#1498])
- **json**: Fixed `Json` formatter not honoring `without_time` and
  `with_level` configurations ([#1463])

### Added

- **registry**: Improved panic message when cloning a span whose ID
  doesn't exist, to aid in debugging issues with multiple subscribers
  ([#1483])
- **registry**: Improved documentation on span ID generation ([#1453])

Thanks to new contributors @joshtriplett and @lerouxrgd, and returning
contributor @teozkr, for contributing to this release!

[#1460]: https://github.com/tokio-rs/tracing/pull/1460
[#1483]: https://github.com/tokio-rs/tracing/pull/1483
[#1463]: https://github.com/tokio-rs/tracing/pull/1463
[#1453]: https://github.com/tokio-rs/tracing/pull/1453
[#1498]: https://github.com/tokio-rs/tracing/pull/1498