### PR TITLE
opentelemetry: Add extension to link spans

### DIFF
--- a/tracing-opentelemetry/src/span_ext.rs
+++ b/tracing-opentelemetry/src/span_ext.rs
@@ -129,10 +129,10 @@ impl OpenTelemetrySpanExt for tracing::Span {
                         let follows_context = cx.span().span_context().clone();
                         let follows_link =
                             opentelemetry::trace::Link::new(follows_context, Vec::new());
-                        if let Some(ref mut links) = builder.links {
-                            links.push(follows_link);
-                        } else {
-                            builder.links = Some(vec![follows_link]);
+                        builder
+                            .links
+                            .get_or_insert_with(|| Vec::with_capacity(1))
+                            .push(follows_link);
                         }
                     }
                 });


### PR DESCRIPTION
Repeat of #1480 to merge on master.

## Motivation

Discussed in #1121, the opentelemetry specifications allow adding a link to a propagated span and/or a closed span. However, the implemented `on_follows_from` of the `OpenTelemetryLayer` does not allow this.

## Solution

The solution follows the same model as the `set_parent` `Span` extension function.
A `add_link` function that takes the linked span context was added to the `OpenTelemetrySpanExt`.
