### PR TITLE
[WIP]  core: add global-scoped dispatcher 

### DIFF
--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -372,6 +372,9 @@ pub fn set_global_scoped(dispatcher: Dispatch) -> DefaultGuard {
     } else {
         None
     };
+
+    EXISTS.store(true, Ordering::Release);
+
     DefaultGuard(GuardInner::Global { prev, state })
 }
 

--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -147,10 +147,12 @@ use core::{
 };
 
 #[cfg(feature = "std")]
+use lazy_static::lazy_static;
+#[cfg(feature = "std")]
 use std::{
     cell::{Cell, RefCell, RefMut},
     error,
-    sync::Weak,
+    sync::{PoisonError, RwLock, Weak},
 };
 
 #[cfg(feature = "alloc")]
@@ -185,7 +187,7 @@ thread_local! {
 }
 
 static EXISTS: AtomicBool = AtomicBool::new(false);
-static GLOBAL_INIT: AtomicUsize = AtomicUsize::new(UNINITIALIZED);
+static GLOBAL_STATE: AtomicUsize = AtomicUsize::new(UNINITIALIZED);
 
 #[cfg(feature = "std")]
 static SCOPED_COUNT: AtomicUsize = AtomicUsize::new(0);
@@ -193,6 +195,8 @@ static SCOPED_COUNT: AtomicUsize = AtomicUsize::new(0);
 const UNINITIALIZED: usize = 0;
 const INITIALIZING: usize = 1;
 const INITIALIZED: usize = 2;
+#[cfg(feature = "std")]
+const IS_GLOBAL_SCOPED: usize = 3;
 
 static mut GLOBAL_DISPATCH: Dispatch = Dispatch {
     #[cfg(feature = "alloc")]
@@ -200,6 +204,12 @@ static mut GLOBAL_DISPATCH: Dispatch = Dispatch {
     #[cfg(not(feature = "alloc"))]
     collector: &NO_COLLECTOR,
 };
+
+#[cfg(feature = "std")]
+lazy_static! {
+    static ref GLOBAL_SCOPED: RwLock<Dispatch> = RwLock::new(NONE.clone());
+}
+
 static NONE: Dispatch = Dispatch {
     #[cfg(feature = "alloc")]
     collector: Kind::Global(&NO_COLLECTOR),
@@ -234,7 +244,17 @@ struct Entered<'a>(&'a State);
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[derive(Debug)]
-pub struct DefaultGuard(Option<Dispatch>);
+pub struct DefaultGuard(GuardInner);
+
+#[cfg(feature = "std")]
+#[derive(Debug)]
+enum GuardInner {
+    Local(Option<Dispatch>),
+    Global {
+        prev: Option<Dispatch>,
+        state: usize,
+    },
+}
 
 /// Sets this dispatch as the default for the duration of a closure.
 ///
@@ -302,7 +322,7 @@ pub fn set_default(dispatcher: &Dispatch) -> DefaultGuard {
 pub fn set_global_default(dispatcher: Dispatch) -> Result<(), SetGlobalDefaultError> {
     // if `compare_exchange` returns Result::Ok(_), then `new` has been set and
     // `current`—now the prior value—has been returned in the `Ok()` branch.
-    if GLOBAL_INIT
+    if GLOBAL_STATE
         .compare_exchange(
             UNINITIALIZED,
             INITIALIZING,
@@ -330,12 +350,29 @@ pub fn set_global_default(dispatcher: Dispatch) -> Result<(), SetGlobalDefaultEr
         unsafe {
             GLOBAL_DISPATCH = Dispatch { collector };
         }
-        GLOBAL_INIT.store(INITIALIZED, Ordering::SeqCst);
+        GLOBAL_STATE.store(INITIALIZED, Ordering::SeqCst);
         EXISTS.store(true, Ordering::Release);
         Ok(())
     } else {
         Err(SetGlobalDefaultError { _no_construct: () })
     }
+}
+
+/// XXX eliza docs
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+pub fn set_global_scoped(dispatcher: Dispatch) -> DefaultGuard {
+    let state = GLOBAL_STATE.swap(IS_GLOBAL_SCOPED, Ordering::SeqCst);
+    let mut lock = GLOBAL_SCOPED
+        .write()
+        .expect("global dispatch state poisoned");
+    let prev = std::mem::replace(&mut *lock, dispatcher);
+    let prev = if state == IS_GLOBAL_SCOPED {
+        Some(prev)
+    } else {
+        None
+    };
+    DefaultGuard(GuardInner::Global { prev, state })
 }
 
 /// Returns true if a `tracing` dispatcher has ever been set.
@@ -379,7 +416,7 @@ where
     if SCOPED_COUNT.load(Ordering::Acquire) == 0 {
         // fast path if no scoped dispatcher has been set; just use the global
         // default.
-        return f(get_global());
+        return f(&get_global());
     }
 
     // While this guard is active, additional calls to collector functions on
@@ -395,19 +432,14 @@ where
 
     CURRENT_STATE
         .try_with(|state| {
-            if state.can_enter.replace(false) {
-                let _guard = Entered(&state.can_enter);
-
-                let mut default = state.default.borrow_mut();
-
-                if default.is::<NoCollector>() {
-                    // don't redo this call on the next check
-                    *default = get_global().clone();
-                }
-                return f(&*default);
+            if let Some(entered) = state.enter() {
+                return match entered.current() {
+                    Some(ref current) => f(&*current),
+                    None => f(&get_global()),
+                };
+            } else {
+                f(&NONE)
             }
-
-            f(&Dispatch::none())
         })
         .unwrap_or_else(|_| f(&Dispatch::none()))
 }
@@ -423,10 +455,19 @@ where
 #[doc(hidden)]
 #[inline(never)]
 pub fn get_current<T>(f: impl FnOnce(&Dispatch) -> T) -> Option<T> {
+    if SCOPED_COUNT.load(Ordering::Acquire) == 0 {
+        // fast path if no scoped dispatcher has been set; just use the global
+        // default.
+        return Some(f(&get_global()));
+    }
+
     CURRENT_STATE
         .try_with(|state| {
             let entered = state.enter()?;
-            Some(f(&*entered.current()))
+            match entered.current() {
+                Some(ref current) => Some(f(&*current)),
+                None => Some(f(&get_global())),
+            }
         })
         .ok()?
 }
@@ -452,14 +493,19 @@ where
 }
 
 #[inline(always)]
-pub(crate) fn get_global() -> &'static Dispatch {
-    if GLOBAL_INIT.load(Ordering::Acquire) != INITIALIZED {
-        return &NONE;
-    }
-    unsafe {
-        // This is safe given the invariant that setting the global dispatcher
-        // also sets `GLOBAL_INIT` to `INITIALIZED`.
-        &GLOBAL_DISPATCH
+pub(crate) fn get_global() -> Dispatch {
+    match GLOBAL_STATE.load(Ordering::Acquire) {
+        INITIALIZED => unsafe {
+            // This is safe given the invariant that setting the global dispatcher
+            // also sets `GLOBAL_INIT` to `INITIALIZED`.
+            GLOBAL_DISPATCH.clone()
+        },
+        #[cfg(feature = "std")]
+        IS_GLOBAL_SCOPED => GLOBAL_SCOPED
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone(),
+        _ => NONE.clone(),
     }
 }
 
@@ -882,7 +928,7 @@ impl State {
             .ok();
         EXISTS.store(true, Ordering::Release);
         SCOPED_COUNT.fetch_add(1, Ordering::Release);
-        DefaultGuard(prior)
+        DefaultGuard(GuardInner::Local(prior))
     }
 
     #[inline]
@@ -900,15 +946,14 @@ impl State {
 #[cfg(feature = "std")]
 impl<'a> Entered<'a> {
     #[inline]
-    fn current(&self) -> RefMut<'a, Dispatch> {
-        let mut default = self.0.default.borrow_mut();
+    fn current(&self) -> Option<RefMut<'a, Dispatch>> {
+        let default = self.0.default.borrow_mut();
 
         if default.is::<NoCollector>() {
-            // don't redo this call on the next check
-            *default = get_global().clone();
+            return None;
         }
 
-        default
+        Some(default)
     }
 }
 
@@ -926,15 +971,35 @@ impl<'a> Drop for Entered<'a> {
 impl Drop for DefaultGuard {
     #[inline]
     fn drop(&mut self) {
-        SCOPED_COUNT.fetch_sub(1, Ordering::Release);
-        if let Some(dispatch) = self.0.take() {
-            // Replace the dispatcher and then drop the old one outside
-            // of the thread-local context. Dropping the dispatch may
-            // lead to the drop of a collector which, in the process,
-            // could then also attempt to access the same thread local
-            // state -- causing a clash.
-            let prev = CURRENT_STATE.try_with(|state| state.default.replace(dispatch));
-            drop(prev)
+        match self.0 {
+            GuardInner::Local(ref mut dispatch) => {
+                SCOPED_COUNT.fetch_sub(1, Ordering::Release);
+                if let Some(dispatch) = dispatch.take() {
+                    // Replace the dispatcher and then drop the old one outside
+                    // of the thread-local context. Dropping the dispatch may
+                    // lead to the drop of a collector which, in the process,
+                    // could then also attempt to access the same thread local
+                    // state -- causing a clash.
+                    let prev = CURRENT_STATE.try_with(|state| state.default.replace(dispatch));
+                    drop(prev)
+                }
+            }
+            GuardInner::Global {
+                ref mut prev,
+                state,
+            } => {
+                *GLOBAL_SCOPED
+                    .write()
+                    .unwrap_or_else(PoisonError::into_inner) =
+                    prev.take().unwrap_or_else(|| NONE.clone());
+                let did_fetch_add_ok = GLOBAL_STATE.compare_exchange(
+                    IS_GLOBAL_SCOPED,
+                    state,
+                    Ordering::SeqCst,
+                    Ordering::SeqCst,
+                );
+                debug_assert!(!std::thread::panicking() && did_fetch_add_ok.is_ok());
+            }
         }
     }
 }

--- a/tracing/src/dispatch.rs
+++ b/tracing/src/dispatch.rs
@@ -138,18 +138,12 @@
 //! instrumentation.
 //!
 //! [`Collect`]: tracing_core::Collect
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-pub use tracing_core::dispatch::set_default;
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-pub use tracing_core::dispatch::with_default;
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-pub use tracing_core::dispatch::DefaultGuard;
 pub use tracing_core::dispatch::{
     get_default, set_global_default, Dispatch, SetGlobalDefaultError,
 };
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+pub use tracing_core::dispatch::{set_default, set_global_scoped, with_default, DefaultGuard};
 
 /// Private API for internal use by tracing's macros.
 ///

--- a/tracing/tests/global_scoped_is_overridable.rs
+++ b/tracing/tests/global_scoped_is_overridable.rs
@@ -1,0 +1,50 @@
+#![cfg(feature = "std")]
+use std::thread;
+use tracing::dispatch::{self, Dispatch};
+
+mod support;
+
+use self::support::*;
+
+#[test]
+fn global_scoped_is_overridable() {
+    let (global, global_handle) = collector::mock()
+        .event(event::msg("hello from thread 1"))
+        .event(event::msg("hello from thread 2"))
+        .event(event::msg("hello from thread 1 again"))
+        .event(event::msg("hello from thread 1 a third time"))
+        .done()
+        .run_with_handle();
+    let (scoped, scoped_handle) = collector::mock()
+        .event(event::msg("hello scoped, it's me, thread 2"))
+        .event(event::msg("hello scoped, it's me, thread 1"))
+        .done()
+        .run_with_handle();
+
+    let _guard = dispatch::set_global_scoped(Dispatch::new(global));
+
+    tracing::info!("hello from thread 1");
+
+    let scoped = Dispatch::new(scoped);
+    let scoped = thread::spawn(move || {
+        tracing::info!("hello from thread 2");
+        dispatch::with_default(&scoped, || {
+            tracing::info!("hello scoped, it's me, thread 2");
+        });
+        scoped
+    })
+    .join()
+    .expect("thread doesn't panic");
+
+    tracing::info!("hello from thread 1 again");
+
+    {
+        let _guard = dispatch::set_default(&scoped);
+        tracing::info!("hello scoped, it's me, thread 1");
+    }
+
+    tracing::info!("hello from thread 1 a third time");
+
+    global_handle.assert_finished();
+    scoped_handle.assert_finished();
+}

--- a/tracing/tests/global_scoped_is_scoped.rs
+++ b/tracing/tests/global_scoped_is_scoped.rs
@@ -1,0 +1,43 @@
+#![cfg(feature = "std")]
+use std::thread;
+use tracing::dispatch::{self, Dispatch};
+
+mod support;
+
+use self::support::*;
+
+#[test]
+fn global_scoped_is_scoped() {
+    let (collector1, handle1) = collector::mock()
+        .event(event::msg("hello from thread 1"))
+        .event(event::msg("hello from thread 2"))
+        .event(event::msg("hello from thread 1 a third time"))
+        .done()
+        .run_with_handle();
+
+    let (collector2, handle2) = collector::mock()
+        .event(event::msg("hello from thread 3"))
+        .event(event::msg("hello from thread 1 again"))
+        .done()
+        .run_with_handle();
+
+    dispatch::set_global_default(Dispatch::new(collector1)).expect("global default must be set");
+
+    tracing::info!("hello from thread 1");
+    thread::spawn(|| tracing::info!("hello from thread 2"))
+        .join()
+        .unwrap();
+
+    {
+        let _guard = dispatch::set_global_scoped(Dispatch::new(collector2));
+        thread::spawn(|| tracing::info!("hello from thread 3"))
+            .join()
+            .unwrap();
+        tracing::info!("hello from thread 1 again");
+    }
+
+    tracing::info!("hello from thread 1 a third time");
+
+    handle1.assert_finished();
+    handle2.assert_finished();
+}

--- a/tracing/tests/global_scoped_poison.rs
+++ b/tracing/tests/global_scoped_poison.rs
@@ -1,0 +1,32 @@
+#![cfg(feature = "std")]
+use std::thread;
+use tracing::dispatch::{self, Dispatch};
+
+mod support;
+
+use self::support::*;
+
+#[test]
+fn global_scoped_poisoning() {
+    let (collector, handle) = collector::mock()
+        .event(event::msg("hello from thread 1"))
+        .event(event::msg("hello from thread 2"))
+        .event(event::msg("hello from thread 1 again"))
+        .done()
+        .run_with_handle();
+
+    let _guard = dispatch::set_global_scoped(Dispatch::new(collector));
+
+    tracing::info!("hello from thread 1");
+
+    let joined = thread::spawn(|| {
+        tracing::info!("hello from thread 2");
+        panic!("fake panic lol");
+    })
+    .join();
+    assert!(joined.is_err(), "it panicked");
+
+    tracing::info!("hello from thread 1 again");
+
+    handle.assert_finished();
+}

--- a/tracing/tests/support/event.rs
+++ b/tracing/tests/support/event.rs
@@ -20,6 +20,10 @@ pub fn mock() -> MockEvent {
     }
 }
 
+pub fn msg(msg: impl fmt::Display) -> MockEvent {
+    mock().with_fields(field::mock("message").with_value(&tracing::field::display(msg)))
+}
+
 impl MockEvent {
     pub fn named<I>(self, name: I) -> Self
     where


### PR DESCRIPTION
This branch adds the ability to set a scoped dispatcher for all threads
globally, which is unset when a RAII guard is dropped.

The global scoped default is stored in an `RwLock`. However, the
overhead of accessing the `RwLock` should be avoided when the global
scoped dispatcher has never been set. Therefore, this new API is *not* a
replacement for `set_global_default`, as accessing the scoped global
default dispatcher will have increased performance overhead versus
accessing the static global default. Additionally, the scoped default
dispatcher may only be used when the `std` feature is enabled, while the
unscoped static global default may be used in `no_std` environments.

Thus, the new `set_global_scoped` API should only be used when it's
necessary to set and unset multiple global dispatchers, and
`set_global_default` should be used in all other cases.

This is a draft because:
- I have yet to write documentation for the new APIs
- It's unclear whether the ability to do this is really worth the
  complexity added in `tracing-core`, both in terms of the amount of
  code in the `dispatch` module and in terms of API complexity (there
  are now 4 different functions for setting a dispatcher...)

<details>
<summary>criterion benchmark results</summary>

## Before

```
     Running unittests (target/release/deps/global_subscriber-644d3e647b65d97a)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

WARNING: In Criterion.rs 0.4.0, running criterion benchmarks outside of cargo-criterion will become a default optional feature.
The statistical analysis and reporting is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'cargo_bench_support' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
global/collector/span_no_fields
                        time:   [13.806 ns 13.843 ns 13.882 ns]
Found 29 outliers among 100 measurements (29.00%)
  8 (8.00%) low severe
  5 (5.00%) low mild
  7 (7.00%) high mild
  9 (9.00%) high severe
global/collector/event  time:   [18.363 ns 18.425 ns 18.479 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
global/collector/enter_span
                        time:   [2.8698 ns 2.8747 ns 2.8818 ns]
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
global/collector/span_repeatedly
                        time:   [3.4762 us 3.4833 us 3.4905 us]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
global/collector/span_with_fields
                        time:   [46.785 ns 46.856 ns 46.927 ns]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  1 (1.00%) high severe

global/dispatch/get_ref time:   [2.0163 ns 2.0191 ns 2.0226 ns]
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe
global/dispatch/get_clone
                        time:   [8.9843 ns 8.9896 ns 8.9956 ns]
Found 13 outliers among 100 measurements (13.00%)
  4 (4.00%) low severe
  4 (4.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe

     Running unittests (target/release/deps/no_subscriber-614ea688dc9c8eba)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

WARNING: In Criterion.rs 0.4.0, running criterion benchmarks outside of cargo-criterion will become a default optional feature.
The statistical analysis and reporting is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'cargo_bench_support' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
no_subscriber/span      time:   [1.8681 ns 1.8753 ns 1.8827 ns]
Found 11 outliers among 100 measurements (11.00%)
  10 (10.00%) high mild
  1 (1.00%) high severe
no_subscriber/event     time:   [237.01 ps 237.38 ps 237.82 ps]
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
no_subscriber/relaxed_load
                        time:   [487.80 ps 492.57 ps 497.96 ps]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
no_subscriber/acquire_load
                        time:   [462.68 ps 463.81 ps 465.03 ps]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
no_subscriber/log       time:   [236.10 ps 238.26 ps 240.70 ps]
Found 10 outliers among 100 measurements (10.00%)
  7 (7.00%) high mild
  3 (3.00%) high severe

no_subscriber_field/span
                        time:   [1.8620 ns 1.8661 ns 1.8709 ns]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
no_subscriber_field/event
                        time:   [289.92 ps 291.19 ps 293.10 ps]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
no_subscriber_field/log time:   [466.41 ps 467.87 ps 469.66 ps]
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe

     Running unittests (target/release/deps/subscriber-51b0d2495c9ed443)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

WARNING: In Criterion.rs 0.4.0, running criterion benchmarks outside of cargo-criterion will become a default optional feature.
The statistical analysis and reporting is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'cargo_bench_support' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
scoped/subscriber/span_no_fields
                        time:   [21.499 ns 21.640 ns 21.766 ns]
scoped/subscriber/enter_span
                        time:   [3.2577 ns 3.2678 ns 3.2791 ns]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
scoped/subscriber/event time:   [16.280 ns 16.326 ns 16.378 ns]
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  3 (3.00%) high severe
scoped/subscriber/span_repeatedly
                        time:   [3.7232 us 3.7301 us 3.7378 us]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
scoped/subscriber/span_with_fields
                        time:   [57.679 ns 57.723 ns 57.773 ns]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
scoped/subscriber/span_with_fields_record
                        time:   [323.68 ns 323.97 ns 324.29 ns]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

no/dispatch/get_ref     time:   [2.3818 ns 2.3856 ns 2.3894 ns]
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
  9 (9.00%) high severe
no/dispatch/get_clone   time:   [8.9051 ns 8.9341 ns 8.9659 ns]
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) low severe
  3 (3.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

scoped/dispatch/get_ref time:   [3.9818 ns 3.9948 ns 4.0098 ns]
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  6 (6.00%) high severe
scoped/dispatch/get_clone
                        time:   [17.489 ns 17.514 ns 17.540 ns]

     Running unittests (target/release/deps/tracing_appender-4fcf629780e34446)

running 18 tests
test non_blocking::test::backpressure_exerted ... ignored
test non_blocking::test::logs_dropped_if_lossy ... ignored
test non_blocking::test::multi_threaded_writes ... ignored
test rolling::test::test_join_date_never ... ignored
test rolling::test::test_next_date_daily ... ignored
test rolling::test::test_next_date_hourly ... ignored
test rolling::test::test_next_date_minutely ... ignored
test rolling::test::test_next_date_never ... ignored
test rolling::test::test_rotation_path_daily ... ignored
test rolling::test::test_rotation_path_hourly ... ignored
test rolling::test::test_rotation_path_minutely ... ignored
test rolling::test::test_round_date_daily ... ignored
test rolling::test::test_round_date_hourly ... ignored
test rolling::test::test_round_date_minutely ... ignored
test rolling::test::write_daily_log ... ignored
test rolling::test::write_hourly_log ... ignored
test rolling::test::write_minutely_log ... ignored
test rolling::test::write_never_log ... ignored

test result: ok. 0 passed; 0 failed; 18 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/tracing_attributes-1e31b4a0f226ab0d)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/tracing_core-587538a453cdaedf)

running 21 tests
test callsite::tests::linked_list_empty ... ignored
test callsite::tests::linked_list_push ... ignored
test callsite::tests::linked_list_push_several ... ignored
test callsite::tests::linked_list_repeated - should panic ... ignored
test dispatch::test::default_dispatch ... ignored
test dispatch::test::default_no_collector ... ignored
test dispatch::test::dispatch_downcasts ... ignored
test dispatch::test::dispatch_is ... ignored
test dispatch::test::events_dont_infinite_loop ... ignored
test dispatch::test::spans_dont_infinite_loop ... ignored
test field::test::empty_fields_are_skipped ... ignored
test field::test::empty_value_set_is_empty ... ignored
test field::test::fields_from_other_callsets_are_skipped ... ignored
test field::test::record_debug_fn ... ignored
test field::test::sparse_value_sets_are_not_empty ... ignored
test field::test::value_set_with_no_values_is_empty ... ignored
test field::test::value_sets_with_fields_from_other_callsites_are_empty ... ignored
test metadata::tests::filter_level_conversion ... ignored
test metadata::tests::level_filter_is_usize_sized ... ignored
test metadata::tests::level_filter_reprs ... ignored
test metadata::tests::level_from_str ... ignored

test result: ok. 0 passed; 0 failed; 21 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/tracing_error-528504973cad270e)

running 3 tests
test backtrace::tests::capture_empty ... ignored
test backtrace::tests::capture_supported ... ignored
test backtrace::tests::capture_unsupported ... ignored

test result: ok. 0 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/tracing_flame-54ac419cdf5736fe)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/tracing_futures-29e65b5f8c0d408f)

running 4 tests
test tests::futures_01_tests::future_enter_exit_is_reasonable ... ignored
test tests::futures_01_tests::future_error_ends_span ... ignored
test tests::futures_01_tests::span_follows_future_onto_threadpool ... ignored
test tests::futures_01_tests::stream_enter_exit_is_reasonable ... ignored

test result: ok. 0 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/tracing_journald-375256083c8e6484)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/tracing_log-3da796205da99c8b)

running 5 tests
test test::debug_callsite_is_correct ... ignored
test test::error_callsite_is_correct ... ignored
test test::info_callsite_is_correct ... ignored
test test::trace_callsite_is_correct ... ignored
test test::warn_callsite_is_correct ... ignored

test result: ok. 0 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/tracing_macros-29cd8a3ad0edffa4)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/trace-d249036429227e91)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

WARNING: In Criterion.rs 0.4.0, running criterion benchmarks outside of cargo-criterion will become a default optional feature.
The statistical analysis and reporting is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'cargo_bench_support' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
otel_many_children/spec_baseline
                        time:   [22.107 us 22.173 us 22.262 us]
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
otel_many_children/no_data_baseline
                        time:   [27.640 us 27.707 us 27.771 us]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
otel_many_children/data_only_baseline
                        time:   [39.212 us 39.345 us 39.477 us]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
otel_many_children/full time:   [100.89 us 101.07 us 101.29 us]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

     Running unittests (target/release/deps/tracing_serde-e0da2f22339ae83e)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/enter-606f82b40ef7a1c2)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

WARNING: In Criterion.rs 0.4.0, running criterion benchmarks outside of cargo-criterion will become a default optional feature.
The statistical analysis and reporting is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'cargo_bench_support' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
enter/enabled           time:   [13.157 ns 13.182 ns 13.208 ns]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
enter/disabled          time:   [1.8452 ns 1.8591 ns 1.8713 ns]
Found 8 outliers among 100 measurements (8.00%)
  8 (8.00%) low severe

enter_exit/enabled      time:   [68.054 ns 68.241 ns 68.459 ns]
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
enter_exit/disabled     time:   [1.1779 ns 1.1822 ns 1.1888 ns]
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe

enter_many/enabled      time:   [14.517 ns 14.538 ns 14.560 ns]
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
enter_many/disabled     time:   [1.8624 ns 1.8761 ns 1.8886 ns]
Found 21 outliers among 100 measurements (21.00%)
  20 (20.00%) low severe
  1 (1.00%) low mild

     Running unittests (target/release/deps/filter-1aebdb22a20e3a3d)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

WARNING: In Criterion.rs 0.4.0, running criterion benchmarks outside of cargo-criterion will become a default optional feature.
The statistical analysis and reporting is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'cargo_bench_support' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
static/baseline_single_threaded
                        time:   [81.353 ns 81.524 ns 81.707 ns]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
static/single_threaded  time:   [40.788 ns 40.958 ns 41.126 ns]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
static/single_threaded_reload
                        time:   [75.416 ns 75.689 ns 76.001 ns]
Found 23 outliers among 100 measurements (23.00%)
  18 (18.00%) low severe
  2 (2.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
static/enabled_one      time:   [20.314 ns 20.339 ns 20.368 ns]
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  7 (7.00%) high mild
static/enabled_one_reload
                        time:   [37.948 ns 37.991 ns 38.041 ns]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
static/enabled_many     time:   [20.331 ns 20.371 ns 20.418 ns]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
static/enabled_many_reload
                        time:   [37.965 ns 38.003 ns 38.043 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild
static/disabled_level_one
                        time:   [233.66 ps 234.17 ps 234.71 ps]
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
static/disabled_level_one_reload
                        time:   [467.37 ps 469.62 ps 472.37 ps]
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  5 (5.00%) high severe
static/disabled_level_many
                        time:   [233.43 ps 234.03 ps 234.84 ps]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
static/disabled_level_many_reload
                        time:   [465.16 ps 466.08 ps 467.15 ps]
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
static/disabled_one     time:   [465.19 ps 465.90 ps 466.67 ps]
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) low mild
  5 (5.00%) high mild
  1 (1.00%) high severe
static/disabled_one_reload
                        time:   [467.89 ps 468.77 ps 469.86 ps]
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
static/disabled_many    time:   [470.31 ps 472.05 ps 474.29 ps]
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe
static/disabled_many_reload
                        time:   [469.33 ps 471.03 ps 472.79 ps]
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe
static/baseline_multithreaded
                        time:   [5.0729 us 5.1306 us 5.1898 us]
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
static/multithreaded    time:   [5.0866 us 5.1495 us 5.2252 us]
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low severe
  4 (4.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
static/multithreaded_reload
                        time:   [5.3462 us 5.3967 us 5.4548 us]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

dynamic/baseline_single_threaded
                        time:   [118.66 ns 118.87 ns 119.13 ns]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
dynamic/single_threaded time:   [358.87 ns 359.54 ns 360.21 ns]
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe
dynamic/single_threaded_reload
                        time:   [493.05 ns 494.23 ns 495.93 ns]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
dynamic/baseline_multithreaded
                        time:   [5.3465 us 5.3947 us 5.4497 us]
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe
dynamic/multithreaded   time:   [9.5274 us 9.5888 us 9.6455 us]
Found 15 outliers among 100 measurements (15.00%)
  10 (10.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe
dynamic/multithreaded_reload
                        time:   [9.5765 us 9.7255 us 9.9327 us]
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe

mixed/disabled          time:   [35.318 ns 35.407 ns 35.491 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
mixed/disabled_by_level time:   [233.73 ps 234.46 ps 235.28 ps]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe

     Running unittests (target/release/deps/filter_log-6bfb62d97e5b7c21)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

WARNING: In Criterion.rs 0.4.0, running criterion benchmarks outside of cargo-criterion will become a default optional feature.
The statistical analysis and reporting is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'cargo_bench_support' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
log/static/baseline_single_threaded
                        time:   [158.56 ns 158.89 ns 159.27 ns]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
log/static/single_threaded
                        time:   [173.64 ns 174.06 ns 174.44 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
log/static/enabled_one  time:   [46.974 ns 47.068 ns 47.161 ns]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high severe
log/static/enabled_many time:   [47.348 ns 47.421 ns 47.501 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
log/static/disabled_level_one
                        time:   [32.324 ns 32.383 ns 32.430 ns]
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
log/static/disabled_level_many
                        time:   [31.647 ns 31.713 ns 31.776 ns]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
log/static/disabled_one time:   [35.362 ns 35.445 ns 35.540 ns]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
log/static/disabled_many
                        time:   [51.433 ns 51.602 ns 51.803 ns]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
log/static/baseline_multithreaded
                        time:   [4.8832 us 4.9264 us 4.9697 us]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
log/static/multithreaded
                        time:   [5.3601 us 5.4044 us 5.4520 us]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

log/dynamic/baseline_single_threaded
                        time:   [198.26 ns 198.87 ns 199.54 ns]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
log/dynamic/single_threaded
                        time:   [421.07 ns 421.83 ns 422.65 ns]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
log/dynamic/baseline_multithreaded
                        time:   [5.1960 us 5.2628 us 5.3629 us]
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe
log/dynamic/multithreaded
                        time:   [9.5024 us 9.5891 us 9.6762 us]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

log/mixed/disabled      time:   [49.604 ns 49.837 ns 50.078 ns]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
log/mixed/disabled_by_level
                        time:   [31.774 ns 31.840 ns 31.921 ns]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

     Running unittests (target/release/deps/fmt-f500f5f118c2a468)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

WARNING: In Criterion.rs 0.4.0, running criterion benchmarks outside of cargo-criterion will become a default optional feature.
The statistical analysis and reporting is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'cargo_bench_support' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
new_span/single_thread/1
                        time:   [256.44 ns 257.68 ns 258.91 ns]
                        thrpt:  [3.8623 Melem/s 3.8809 Melem/s 3.8996 Melem/s]
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low severe
  7 (7.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
new_span/multithreaded/1
                        time:   [6.8857 us 7.0492 us 7.3297 us]
                        thrpt:  [136.43 Kelem/s 141.86 Kelem/s 145.23 Kelem/s]
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe
new_span/single_thread/10
                        time:   [2.5255 us 2.5352 us 2.5440 us]
                        thrpt:  [3.9308 Melem/s 3.9445 Melem/s 3.9596 Melem/s]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
new_span/multithreaded/10
                        time:   [11.931 us 12.190 us 12.450 us]
                        thrpt:  [803.20 Kelem/s 820.34 Kelem/s 838.14 Kelem/s]
new_span/single_thread/50
                        time:   [12.844 us 12.882 us 12.917 us]
                        thrpt:  [3.8708 Melem/s 3.8814 Melem/s 3.8928 Melem/s]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
new_span/multithreaded/50
                        time:   [38.661 us 40.048 us 41.453 us]
                        thrpt:  [1.2062 Melem/s 1.2485 Melem/s 1.2933 Melem/s]

event/root/single_threaded/1
                        time:   [1.1308 us 1.1340 us 1.1378 us]
                        thrpt:  [878.89 Kelem/s 881.81 Kelem/s 884.30 Kelem/s]
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low mild
  6 (6.00%) high mild
  2 (2.00%) high severe
event/root/multithreaded/1
                        time:   [8.4142 us 8.4670 us 8.5229 us]
                        thrpt:  [117.33 Kelem/s 118.11 Kelem/s 118.85 Kelem/s]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  3 (3.00%) high mild
  1 (1.00%) high severe
event/unique_parent/single_threaded/1
                        time:   [1.5742 us 1.5776 us 1.5809 us]
                        thrpt:  [632.56 Kelem/s 633.86 Kelem/s 635.23 Kelem/s]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) low mild
  2 (2.00%) high mild
event/unique_parent/multithreaded/1
                        time:   [9.4710 us 9.5322 us 9.6011 us]
                        thrpt:  [104.15 Kelem/s 104.91 Kelem/s 105.59 Kelem/s]
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  3 (3.00%) high severe
event/shared_parent/multithreaded/1
                        time:   [9.7332 us 9.8125 us 9.9130 us]
                        thrpt:  [100.88 Kelem/s 101.91 Kelem/s 102.74 Kelem/s]
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe
event/multi-parent/multithreaded/1
                        time:   [13.829 us 13.908 us 13.991 us]
                        thrpt:  [71.474 Kelem/s 71.900 Kelem/s 72.313 Kelem/s]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe
event/root/single_threaded/10
                        time:   [11.624 us 11.642 us 11.658 us]
                        thrpt:  [857.76 Kelem/s 858.99 Kelem/s 860.28 Kelem/s]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high severe
event/root/multithreaded/10
                        time:   [22.300 us 22.422 us 22.541 us]
                        thrpt:  [443.63 Kelem/s 445.99 Kelem/s 448.44 Kelem/s]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
event/unique_parent/single_threaded/10
                        time:   [15.605 us 15.631 us 15.660 us]
                        thrpt:  [638.59 Kelem/s 639.74 Kelem/s 640.83 Kelem/s]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
event/unique_parent/multithreaded/10
                        time:   [29.342 us 29.473 us 29.609 us]
                        thrpt:  [337.74 Kelem/s 339.29 Kelem/s 340.81 Kelem/s]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
event/shared_parent/multithreaded/10
                        time:   [31.704 us 31.889 us 32.113 us]
                        thrpt:  [311.40 Kelem/s 313.59 Kelem/s 315.42 Kelem/s]
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe
event/multi-parent/multithreaded/10
                        time:   [76.388 us 76.759 us 77.124 us]
                        thrpt:  [129.66 Kelem/s 130.28 Kelem/s 130.91 Kelem/s]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
event/root/single_threaded/50
                        time:   [57.001 us 57.099 us 57.195 us]
                        thrpt:  [874.20 Kelem/s 875.68 Kelem/s 877.18 Kelem/s]
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low severe
  8 (8.00%) low mild
  2 (2.00%) high mild
event/root/multithreaded/50
                        time:   [82.790 us 83.229 us 83.659 us]
                        thrpt:  [597.67 Kelem/s 600.75 Kelem/s 603.94 Kelem/s]
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) low mild
  4 (4.00%) high mild
event/unique_parent/single_threaded/50
                        time:   [78.400 us 78.605 us 78.839 us]
                        thrpt:  [634.20 Kelem/s 636.09 Kelem/s 637.76 Kelem/s]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
event/unique_parent/multithreaded/50
                        time:   [114.18 us 114.74 us 115.32 us]
                        thrpt:  [433.59 Kelem/s 435.76 Kelem/s 437.91 Kelem/s]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild
event/shared_parent/multithreaded/50
                        time:   [129.43 us 129.90 us 130.37 us]
                        thrpt:  [383.52 Kelem/s 384.90 Kelem/s 386.31 Kelem/s]
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe
event/multi-parent/multithreaded/50
                        time:   [812.03 us 816.32 us 820.25 us]
                        thrpt:  [60.957 Kelem/s 61.251 Kelem/s 61.574 Kelem/s]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

     Running unittests (target/release/deps/reload-e2693c629922ef45)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

WARNING: In Criterion.rs 0.4.0, running criterion benchmarks outside of cargo-criterion will become a default optional feature.
The statistical analysis and reporting is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'cargo_bench_support' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
reload/complex-collector
                        time:   [1.1968 us 1.2020 us 1.2096 us]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe
reload/complex-collector-reloadable
                        time:   [1.1981 us 1.2007 us 1.2033 us]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low severe
  4 (4.00%) low mild
  1 (1.00%) high severe
```

## After

```

Switched to branch 'eliza/global-scoped'
   Compiling tracing-core v0.2.0 (/home/eliza/Code/tracing/tracing-core)
   Compiling tracing v0.2.0 (/home/eliza/Code/tracing/tracing)
   Compiling tracing-serde v0.2.0 (/home/eliza/Code/tracing/tracing-serde)
   Compiling tracing-log v0.2.0 (/home/eliza/Code/tracing/tracing-log)
   Compiling tracing-subscriber v0.3.0 (/home/eliza/Code/tracing/tracing-subscriber)
   Compiling tracing-futures v0.3.0 (/home/eliza/Code/tracing/tracing-futures)
   Compiling tracing-attributes v0.2.0 (/home/eliza/Code/tracing/tracing-attributes)
   Compiling tracing-tower v0.1.0 (/home/eliza/Code/tracing/tracing-tower)
   Compiling tracing-opentelemetry v0.15.0 (/home/eliza/Code/tracing/tracing-opentelemetry)
   Compiling tracing-appender v0.2.0 (/home/eliza/Code/tracing/tracing-appender)
   Compiling tracing-flame v0.2.0 (/home/eliza/Code/tracing/tracing-flame)
   Compiling tracing-macros v0.1.0 (/home/eliza/Code/tracing/tracing-macros)
   Compiling tracing-journald v0.2.0 (/home/eliza/Code/tracing/tracing-journald)
   Compiling tracing-error v0.2.0 (/home/eliza/Code/tracing/tracing-error)
    Finished bench [optimized] target(s) in 9.53s
     Running unittests (target/release/deps/tracing-0df57f2f758e705b)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/global_subscriber-644d3e647b65d97a)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

WARNING: In Criterion.rs 0.4.0, running criterion benchmarks outside of cargo-criterion will become a default optional feature.
The statistical analysis and reporting is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'cargo_bench_support' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
global/collector/span_no_fields
                        time:   [14.360 ns 14.372 ns 14.386 ns]
                        change: [+2.8844% +3.1732% +3.4373%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
global/collector/event  time:   [15.050 ns 15.064 ns 15.081 ns]
                        change: [-17.711% -17.439% -17.175%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low severe
  5 (5.00%) high mild
  4 (4.00%) high severe
global/collector/enter_span
                        time:   [2.7873 ns 2.7942 ns 2.8017 ns]
                        change: [-2.9659% -2.6144% -2.2593%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
global/collector/span_repeatedly
                        time:   [3.4933 us 3.4980 us 3.5029 us]
                        change: [-0.2317% +0.1618% +0.4858%] (p = 0.39 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild
global/collector/span_with_fields
                        time:   [48.912 ns 49.016 ns 49.103 ns]
                        change: [+3.7303% +4.0135% +4.2758%] (p = 0.00 < 0.05)
                        Performance has regressed.

global/dispatch/get_ref time:   [2.8706 ns 2.8733 ns 2.8766 ns]
                        change: [+41.980% +42.298% +42.582%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) low mild
  1 (1.00%) high mild
  7 (7.00%) high severe
global/dispatch/get_clone
                        time:   [9.6854 ns 9.6966 ns 9.7063 ns]
                        change: [+7.8154% +7.9433% +8.0667%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 15 outliers among 100 measurements (15.00%)
  4 (4.00%) low severe
  8 (8.00%) low mild
  3 (3.00%) high mild

     Running unittests (target/release/deps/no_subscriber-614ea688dc9c8eba)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

WARNING: In Criterion.rs 0.4.0, running criterion benchmarks outside of cargo-criterion will become a default optional feature.
The statistical analysis and reporting is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'cargo_bench_support' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
no_subscriber/span      time:   [1.9087 ns 1.9115 ns 1.9155 ns]
                        change: [+1.9086% +2.2338% +2.5506%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe
no_subscriber/event     time:   [465.21 ps 467.06 ps 469.86 ps]
                        change: [+94.696% +95.572% +96.347%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe
no_subscriber/relaxed_load
                        time:   [469.83 ps 470.16 ps 470.51 ps]
                        change: [-4.8803% -4.0538% -3.2883%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  6 (6.00%) high severe
no_subscriber/acquire_load
                        time:   [470.71 ps 473.14 ps 475.61 ps]
                        change: [+1.1725% +1.5319% +1.8996%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 15 outliers among 100 measurements (15.00%)
  4 (4.00%) low mild
  8 (8.00%) high mild
  3 (3.00%) high severe
no_subscriber/log       time:   [232.94 ps 233.23 ps 233.55 ps]
                        change: [-2.7894% -1.6653% -0.7080%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  4 (4.00%) high severe

no_subscriber_field/span
                        time:   [2.1044 ns 2.1065 ns 2.1087 ns]
                        change: [+12.525% +12.930% +13.445%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low mild
  6 (6.00%) high mild
  3 (3.00%) high severe
no_subscriber_field/event
                        time:   [295.95 ps 297.16 ps 299.09 ps]
                        change: [+2.3375% +2.7777% +3.2551%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 26 outliers among 100 measurements (26.00%)
  2 (2.00%) low severe
  17 (17.00%) low mild
  2 (2.00%) high mild
  5 (5.00%) high severe
no_subscriber_field/log time:   [231.30 ps 231.81 ps 232.35 ps]
                        change: [-50.807% -50.394% -49.836%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe

     Running unittests (target/release/deps/subscriber-51b0d2495c9ed443)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

WARNING: In Criterion.rs 0.4.0, running criterion benchmarks outside of cargo-criterion will become a default optional feature.
The statistical analysis and reporting is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'cargo_bench_support' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
scoped/subscriber/span_no_fields
                        time:   [22.486 ns 22.514 ns 22.537 ns]
                        change: [+4.0132% +4.5517% +5.1014%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) low severe
  2 (2.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe
scoped/subscriber/enter_span
                        time:   [3.3054 ns 3.3131 ns 3.3226 ns]
                        change: [+1.1221% +1.5722% +2.1324%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  8 (8.00%) high severe
scoped/subscriber/event time:   [20.493 ns 20.534 ns 20.573 ns]
                        change: [+25.362% +25.871% +26.350%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high severe
scoped/subscriber/span_repeatedly
                        time:   [3.7637 us 3.7708 us 3.7790 us]
                        change: [+1.0659% +1.2485% +1.4455%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  1 (1.00%) high severe
scoped/subscriber/span_with_fields
                        time:   [56.533 ns 56.768 ns 57.003 ns]
                        change: [-2.1015% -1.7697% -1.4124%] (p = 0.00 < 0.05)
                        Performance has improved.
scoped/subscriber/span_with_fields_record
                        time:   [299.16 ns 299.68 ns 300.26 ns]
                        change: [-7.5092% -7.3357% -7.1552%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

no/dispatch/get_ref     time:   [2.5532 ns 2.5582 ns 2.5637 ns]
                        change: [+6.5790% +6.9921% +7.3749%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
no/dispatch/get_clone   time:   [9.8153 ns 9.8242 ns 9.8329 ns]
                        change: [+9.2889% +9.4977% +9.7278%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) low mild
  1 (1.00%) high mild

scoped/dispatch/get_ref time:   [4.2876 ns 4.3312 ns 4.3829 ns]
                        change: [+8.1890% +10.568% +13.350%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 13 outliers among 100 measurements (13.00%)
  4 (4.00%) high mild
  9 (9.00%) high severe
scoped/dispatch/get_clone
                        time:   [17.571 ns 17.615 ns 17.659 ns]
                        change: [+0.7877% +1.0555% +1.2844%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) low mild
  3 (3.00%) high mild

     Running unittests (target/release/deps/tracing_appender-4fcf629780e34446)

running 18 tests
test non_blocking::test::backpressure_exerted ... ignored
test non_blocking::test::logs_dropped_if_lossy ... ignored
test non_blocking::test::multi_threaded_writes ... ignored
test rolling::test::test_join_date_never ... ignored
test rolling::test::test_next_date_daily ... ignored
test rolling::test::test_next_date_hourly ... ignored
test rolling::test::test_next_date_minutely ... ignored
test rolling::test::test_next_date_never ... ignored
test rolling::test::test_rotation_path_daily ... ignored
test rolling::test::test_rotation_path_hourly ... ignored
test rolling::test::test_rotation_path_minutely ... ignored
test rolling::test::test_round_date_daily ... ignored
test rolling::test::test_round_date_hourly ... ignored
test rolling::test::test_round_date_minutely ... ignored
test rolling::test::write_daily_log ... ignored
test rolling::test::write_hourly_log ... ignored
test rolling::test::write_minutely_log ... ignored
test rolling::test::write_never_log ... ignored

test result: ok. 0 passed; 0 failed; 18 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/tracing_attributes-1e31b4a0f226ab0d)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/tracing_core-587538a453cdaedf)

running 21 tests
test callsite::tests::linked_list_empty ... ignored
test callsite::tests::linked_list_push ... ignored
test callsite::tests::linked_list_push_several ... ignored
test callsite::tests::linked_list_repeated - should panic ... ignored
test dispatch::test::default_dispatch ... ignored
test dispatch::test::default_no_collector ... ignored
test dispatch::test::dispatch_downcasts ... ignored
test dispatch::test::dispatch_is ... ignored
test dispatch::test::events_dont_infinite_loop ... ignored
test dispatch::test::spans_dont_infinite_loop ... ignored
test field::test::empty_fields_are_skipped ... ignored
test field::test::empty_value_set_is_empty ... ignored
test field::test::fields_from_other_callsets_are_skipped ... ignored
test field::test::record_debug_fn ... ignored
test field::test::sparse_value_sets_are_not_empty ... ignored
test field::test::value_set_with_no_values_is_empty ... ignored
test field::test::value_sets_with_fields_from_other_callsites_are_empty ... ignored
test metadata::tests::filter_level_conversion ... ignored
test metadata::tests::level_filter_is_usize_sized ... ignored
test metadata::tests::level_filter_reprs ... ignored
test metadata::tests::level_from_str ... ignored

test result: ok. 0 passed; 0 failed; 21 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/tracing_error-528504973cad270e)

running 3 tests
test backtrace::tests::capture_empty ... ignored
test backtrace::tests::capture_supported ... ignored
test backtrace::tests::capture_unsupported ... ignored

test result: ok. 0 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/tracing_flame-54ac419cdf5736fe)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/tracing_futures-29e65b5f8c0d408f)

running 4 tests
test tests::futures_01_tests::future_enter_exit_is_reasonable ... ignored
test tests::futures_01_tests::future_error_ends_span ... ignored
test tests::futures_01_tests::span_follows_future_onto_threadpool ... ignored
test tests::futures_01_tests::stream_enter_exit_is_reasonable ... ignored

test result: ok. 0 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/tracing_journald-375256083c8e6484)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/tracing_log-3da796205da99c8b)

running 5 tests
test test::debug_callsite_is_correct ... ignored
test test::error_callsite_is_correct ... ignored
test test::info_callsite_is_correct ... ignored
test test::trace_callsite_is_correct ... ignored
test test::warn_callsite_is_correct ... ignored

test result: ok. 0 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/tracing_macros-29cd8a3ad0edffa4)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/trace-d249036429227e91)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

WARNING: In Criterion.rs 0.4.0, running criterion benchmarks outside of cargo-criterion will become a default optional feature.
The statistical analysis and reporting is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'cargo_bench_support' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
otel_many_children/spec_baseline
                        time:   [22.794 us 22.830 us 22.878 us]
                        change: [+2.9685% +3.3178% +3.7401%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
otel_many_children/no_data_baseline
                        time:   [27.995 us 28.048 us 28.104 us]
                        change: [+1.4103% +1.7951% +2.2769%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
otel_many_children/data_only_baseline
                        time:   [39.379 us 39.438 us 39.498 us]
                        change: [+0.1411% +0.4301% +0.7107%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
otel_many_children/full time:   [99.710 us 100.04 us 100.48 us]
                        change: [-0.7772% -0.3856% +0.0101%] (p = 0.05 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

     Running unittests (target/release/deps/tracing_serde-e0da2f22339ae83e)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/release/deps/enter-606f82b40ef7a1c2)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

WARNING: In Criterion.rs 0.4.0, running criterion benchmarks outside of cargo-criterion will become a default optional feature.
The statistical analysis and reporting is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'cargo_bench_support' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
enter/enabled           time:   [13.663 ns 13.751 ns 13.840 ns]
                        change: [+3.0052% +3.4193% +3.8589%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe
enter/disabled          time:   [1.8444 ns 1.8593 ns 1.8736 ns]
                        change: [-3.0277% -0.6056% +1.9904%] (p = 0.67 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) low severe
  5 (5.00%) low mild

enter_exit/enabled      time:   [71.059 ns 71.263 ns 71.467 ns]
                        change: [+3.2790% +3.7084% +4.1591%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
enter_exit/disabled     time:   [1.1867 ns 1.1880 ns 1.1893 ns]
                        change: [-0.1388% +0.2170% +0.5190%] (p = 0.20 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

enter_many/enabled      time:   [14.430 ns 14.489 ns 14.566 ns]
                        change: [-0.7896% -0.4109% -0.0347%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
enter_many/disabled     time:   [1.8088 ns 1.8272 ns 1.8437 ns]
                        change: [-4.4079% -1.6737% +1.1794%] (p = 0.27 > 0.05)
                        No change in performance detected.
Found 16 outliers among 100 measurements (16.00%)
  11 (11.00%) low severe
  5 (5.00%) low mild

     Running unittests (target/release/deps/filter-1aebdb22a20e3a3d)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

WARNING: In Criterion.rs 0.4.0, running criterion benchmarks outside of cargo-criterion will become a default optional feature.
The statistical analysis and reporting is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'cargo_bench_support' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
static/baseline_single_threaded
                        time:   [82.741 ns 82.887 ns 83.096 ns]
                        change: [+1.6592% +2.0277% +2.4993%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 14 outliers among 100 measurements (14.00%)
  7 (7.00%) high mild
  7 (7.00%) high severe
static/single_threaded  time:   [40.885 ns 40.947 ns 41.015 ns]
                        change: [+0.7464% +1.1591% +1.6086%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
static/single_threaded_reload
                        time:   [76.263 ns 76.455 ns 76.671 ns]
                        change: [-0.2786% +0.0106% +0.3087%] (p = 0.95 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
static/enabled_one      time:   [20.650 ns 20.704 ns 20.785 ns]
                        change: [+0.7557% +1.0321% +1.3404%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
static/enabled_one_reload
                        time:   [38.887 ns 38.904 ns 38.923 ns]
                        change: [+2.0526% +2.2112% +2.3565%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe
static/enabled_many     time:   [20.715 ns 20.741 ns 20.769 ns]
                        change: [+1.4314% +1.6471% +1.8508%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe
static/enabled_many_reload
                        time:   [38.322 ns 38.369 ns 38.424 ns]
                        change: [+0.5852% +0.9232% +1.3477%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low severe
  5 (5.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe
static/disabled_level_one
                        time:   [233.10 ps 234.35 ps 236.03 ps]
                        change: [-1.3732% -0.6646% -0.0720%] (p = 0.05 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
static/disabled_level_one_reload
                        time:   [468.49 ps 469.90 ps 471.29 ps]
                        change: [-1.3520% -0.3991% +0.2795%] (p = 0.41 > 0.05)
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  13 (13.00%) high mild
  1 (1.00%) high severe
static/disabled_level_many
                        time:   [232.93 ps 233.50 ps 234.16 ps]
                        change: [-0.1937% +0.4319% +1.2823%] (p = 0.33 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe
static/disabled_level_many_reload
                        time:   [467.46 ps 468.99 ps 470.49 ps]
                        change: [-0.1249% +0.1778% +0.4430%] (p = 0.24 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  9 (9.00%) high mild
  1 (1.00%) high severe
static/disabled_one     time:   [464.49 ps 465.57 ps 466.71 ps]
                        change: [-0.2636% -0.0094% +0.2640%] (p = 0.94 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
static/disabled_one_reload
                        time:   [464.68 ps 465.60 ps 466.67 ps]
                        change: [-1.2630% -0.9667% -0.6891%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
static/disabled_many    time:   [465.07 ps 465.77 ps 466.48 ps]
                        change: [-2.1737% -1.4533% -0.9116%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
static/disabled_many_reload
                        time:   [472.26 ps 474.62 ps 477.53 ps]
                        change: [+0.4575% +1.0326% +1.6801%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) high mild
  9 (9.00%) high severe
static/baseline_multithreaded
                        time:   [4.6284 us 4.7000 us 4.8013 us]
                        change: [-8.7675% -7.2356% -5.6431%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
static/multithreaded    time:   [4.5369 us 4.5774 us 4.6209 us]
                        change: [-10.268% -8.7713% -7.3839%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) low mild
  5 (5.00%) high mild
static/multithreaded_reload
                        time:   [5.0372 us 5.0806 us 5.1255 us]
                        change: [-8.5477% -7.0353% -5.6433%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) low mild

dynamic/baseline_single_threaded
                        time:   [121.26 ns 121.45 ns 121.70 ns]
                        change: [+1.2997% +1.6687% +2.0262%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 21 outliers among 100 measurements (21.00%)
  11 (11.00%) low severe
  7 (7.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe
dynamic/single_threaded time:   [368.52 ns 369.22 ns 369.97 ns]
                        change: [+1.4906% +2.1418% +2.5856%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe
dynamic/single_threaded_reload
                        time:   [487.24 ns 488.78 ns 490.51 ns]
                        change: [-1.7581% -1.3998% -0.9972%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
dynamic/baseline_multithreaded
                        time:   [4.9776 us 5.0202 us 5.0636 us]
                        change: [-7.9248% -5.9234% -4.1231%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  3 (3.00%) high severe
dynamic/multithreaded   time:   [9.4599 us 9.5412 us 9.6193 us]
                        change: [-2.1492% -0.9960% +0.1826%] (p = 0.09 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  6 (6.00%) low mild
  5 (5.00%) high mild
  1 (1.00%) high severe
dynamic/multithreaded_reload
                        time:   [9.3232 us 9.4393 us 9.5590 us]
                        change: [-4.3980% -2.9173% -1.5063%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

mixed/disabled          time:   [32.612 ns 32.803 ns 33.002 ns]
                        change: [-7.2021% -6.6650% -6.1010%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low mild
  5 (5.00%) high mild
  1 (1.00%) high severe
mixed/disabled_by_level time:   [235.65 ps 236.14 ps 236.73 ps]
                        change: [+0.5385% +0.9206% +1.2413%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) low mild
  6 (6.00%) high mild
  4 (4.00%) high severe

     Running unittests (target/release/deps/filter_log-6bfb62d97e5b7c21)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

WARNING: In Criterion.rs 0.4.0, running criterion benchmarks outside of cargo-criterion will become a default optional feature.
The statistical analysis and reporting is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'cargo_bench_support' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
log/static/baseline_single_threaded
                        time:   [161.95 ns 162.10 ns 162.28 ns]
                        change: [+1.4327% +1.9221% +2.6053%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 14 outliers among 100 measurements (14.00%)
  8 (8.00%) high mild
  6 (6.00%) high severe
log/static/single_threaded
                        time:   [175.34 ns 176.07 ns 176.83 ns]
                        change: [+0.8383% +1.8547% +3.1173%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low mild
  7 (7.00%) high mild
  5 (5.00%) high severe
log/static/enabled_one  time:   [48.038 ns 48.163 ns 48.321 ns]
                        change: [+0.2820% +1.5295% +2.3542%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe
log/static/enabled_many time:   [47.180 ns 47.389 ns 47.628 ns]
                        change: [+0.3538% +0.6568% +0.9595%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 17 outliers among 100 measurements (17.00%)
  1 (1.00%) low severe
  14 (14.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
log/static/disabled_level_one
                        time:   [31.765 ns 31.804 ns 31.846 ns]
                        change: [-1.8261% -1.6396% -1.4606%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
log/static/disabled_level_many
                        time:   [31.890 ns 31.997 ns 32.111 ns]
                        change: [+0.1712% +0.4824% +0.7997%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe
log/static/disabled_one time:   [35.564 ns 35.666 ns 35.835 ns]
                        change: [+0.3920% +0.6911% +1.0099%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe
log/static/disabled_many
                        time:   [56.619 ns 56.868 ns 57.204 ns]
                        change: [+9.3419% +9.7761% +10.214%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
log/static/baseline_multithreaded
                        time:   [4.9694 us 5.1051 us 5.2901 us]
                        change: [+0.9500% +2.7082% +5.1152%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe
log/static/multithreaded
                        time:   [5.4341 us 5.4674 us 5.5023 us]
                        change: [+0.3998% +1.5104% +2.7546%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe

log/dynamic/baseline_single_threaded
                        time:   [199.49 ns 199.74 ns 200.00 ns]
                        change: [+0.6759% +1.0437% +1.4062%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
log/dynamic/single_threaded
                        time:   [413.03 ns 414.26 ns 415.70 ns]
                        change: [-2.3663% -2.0294% -1.6809%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe
log/dynamic/baseline_multithreaded
                        time:   [5.1854 us 5.2232 us 5.2649 us]
                        change: [-4.0569% -1.5526% +0.5770%] (p = 0.21 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
log/dynamic/multithreaded
                        time:   [9.6833 us 9.7614 us 9.8474 us]
                        change: [+0.5786% +1.7013% +2.8304%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

log/mixed/disabled      time:   [53.108 ns 53.270 ns 53.445 ns]
                        change: [+5.7163% +6.4745% +7.1742%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
log/mixed/disabled_by_level
                        time:   [31.866 ns 31.976 ns 32.074 ns]
                        change: [-0.6520% -0.3159% +0.0100%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

     Running unittests (target/release/deps/fmt-f500f5f118c2a468)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

WARNING: In Criterion.rs 0.4.0, running criterion benchmarks outside of cargo-criterion will become a default optional feature.
The statistical analysis and reporting is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'cargo_bench_support' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
new_span/single_thread/1
                        time:   [243.01 ns 243.87 ns 244.72 ns]
                        thrpt:  [4.0862 Melem/s 4.1005 Melem/s 4.1151 Melem/s]
                 change:
                        time:   [-6.0909% -5.6995% -5.3010%] (p = 0.00 < 0.05)
                        thrpt:  [+5.5977% +6.0439% +6.4860%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
new_span/multithreaded/1
                        time:   [6.8616 us 6.9118 us 6.9716 us]
                        thrpt:  [143.44 Kelem/s 144.68 Kelem/s 145.74 Kelem/s]
                 change:
                        time:   [-1.9019% +0.3714% +2.3519%] (p = 0.76 > 0.05)
                        thrpt:  [-2.2978% -0.3700% +1.9387%]
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  4 (4.00%) high severe
new_span/single_thread/10
                        time:   [2.3707 us 2.3830 us 2.3970 us]
                        thrpt:  [4.1719 Melem/s 4.1963 Melem/s 4.2181 Melem/s]
                 change:
                        time:   [-6.5609% -6.0798% -5.6163%] (p = 0.00 < 0.05)
                        thrpt:  [+5.9505% +6.4734% +7.0216%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
new_span/multithreaded/10
                        time:   [11.704 us 11.955 us 12.223 us]
                        thrpt:  [818.10 Kelem/s 836.50 Kelem/s 854.38 Kelem/s]
                 change:
                        time:   [-4.2161% -1.9783% +0.4864%] (p = 0.10 > 0.05)
                        thrpt:  [-0.4840% +2.0183% +4.4016%]
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
new_span/single_thread/50
                        time:   [11.821 us 11.900 us 11.985 us]
                        thrpt:  [4.1719 Melem/s 4.2017 Melem/s 4.2297 Melem/s]
                 change:
                        time:   [-9.0068% -8.5176% -8.0010%] (p = 0.00 < 0.05)
                        thrpt:  [+8.6968% +9.3106% +9.8983%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
new_span/multithreaded/50
                        time:   [43.294 us 43.585 us 43.891 us]
                        thrpt:  [1.1392 Melem/s 1.1472 Melem/s 1.1549 Melem/s]
                 change:
                        time:   [+7.0748% +10.636% +14.812%] (p = 0.00 < 0.05)
                        thrpt:  [-12.901% -9.6133% -6.6074%]
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

event/root/single_threaded/1
                        time:   [1.0623 us 1.0656 us 1.0696 us]
                        thrpt:  [934.93 Kelem/s 938.45 Kelem/s 941.39 Kelem/s]
                 change:
                        time:   [-6.3778% -5.9613% -5.5301%] (p = 0.00 < 0.05)
                        thrpt:  [+5.8539% +6.3392% +6.8123%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe
event/root/multithreaded/1
                        time:   [8.5033 us 8.5699 us 8.6446 us]
                        thrpt:  [115.68 Kelem/s 116.69 Kelem/s 117.60 Kelem/s]
                 change:
                        time:   [-0.7661% +0.4125% +1.6093%] (p = 0.50 > 0.05)
                        thrpt:  [-1.5838% -0.4108% +0.7720%]
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low mild
  6 (6.00%) high mild
  1 (1.00%) high severe
event/unique_parent/single_threaded/1
                        time:   [1.5253 us 1.5273 us 1.5297 us]
                        thrpt:  [653.73 Kelem/s 654.74 Kelem/s 655.61 Kelem/s]
                 change:
                        time:   [-3.3970% -3.2404% -3.0673%] (p = 0.00 < 0.05)
                        thrpt:  [+3.1643% +3.3489% +3.5165%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
event/unique_parent/multithreaded/1
                        time:   [9.3561 us 9.4288 us 9.5083 us]
                        thrpt:  [105.17 Kelem/s 106.06 Kelem/s 106.88 Kelem/s]
                 change:
                        time:   [-4.2550% -2.4035% -0.9902%] (p = 0.00 < 0.05)
                        thrpt:  [+1.0002% +2.4627% +4.4441%]
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
event/shared_parent/multithreaded/1
                        time:   [9.6593 us 9.8514 us 10.161 us]
                        thrpt:  [98.419 Kelem/s 101.51 Kelem/s 103.53 Kelem/s]
                 change:
                        time:   [-3.4180% -1.5238% +0.4406%] (p = 0.14 > 0.05)
                        thrpt:  [-0.4387% +1.5474% +3.5390%]
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
event/multi-parent/multithreaded/1
                        time:   [13.701 us 13.770 us 13.848 us]
                        thrpt:  [72.212 Kelem/s 72.621 Kelem/s 72.990 Kelem/s]
                 change:
                        time:   [-1.9811% -1.0808% -0.2556%] (p = 0.01 < 0.05)
                        thrpt:  [+0.2563% +1.0926% +2.0211%]
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
event/root/single_threaded/10
                        time:   [10.592 us 10.608 us 10.625 us]
                        thrpt:  [941.18 Kelem/s 942.66 Kelem/s 944.13 Kelem/s]
                 change:
                        time:   [-8.7253% -8.4738% -8.2212%] (p = 0.00 < 0.05)
                        thrpt:  [+8.9577% +9.2583% +9.5594%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  3 (3.00%) high severe
event/root/multithreaded/10
                        time:   [21.950 us 22.035 us 22.123 us]
                        thrpt:  [452.02 Kelem/s 453.83 Kelem/s 455.58 Kelem/s]
                 change:
                        time:   [-2.8752% -1.9961% -1.1158%] (p = 0.00 < 0.05)
                        thrpt:  [+1.1284% +2.0367% +2.9603%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
event/unique_parent/single_threaded/10
                        time:   [15.275 us 15.305 us 15.343 us]
                        thrpt:  [651.76 Kelem/s 653.39 Kelem/s 654.65 Kelem/s]
                 change:
                        time:   [-3.6827% -3.0136% -2.5477%] (p = 0.00 < 0.05)
                        thrpt:  [+2.6143% +3.1072% +3.8235%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe
event/unique_parent/multithreaded/10
                        time:   [29.015 us 29.155 us 29.305 us]
                        thrpt:  [341.24 Kelem/s 342.99 Kelem/s 344.65 Kelem/s]
                 change:
                        time:   [-1.1691% -0.5328% +0.0801%] (p = 0.11 > 0.05)
                        thrpt:  [-0.0801% +0.5357% +1.1830%]
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
event/shared_parent/multithreaded/10
                        time:   [32.116 us 32.295 us 32.495 us]
                        thrpt:  [307.74 Kelem/s 309.65 Kelem/s 311.37 Kelem/s]
                 change:
                        time:   [+0.5479% +1.1922% +1.8636%] (p = 0.00 < 0.05)
                        thrpt:  [-1.8295% -1.1781% -0.5449%]
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe
event/multi-parent/multithreaded/10
                        time:   [75.560 us 75.848 us 76.132 us]
                        thrpt:  [131.35 Kelem/s 131.84 Kelem/s 132.34 Kelem/s]
                 change:
                        time:   [-1.9575% -1.3102% -0.6722%] (p = 0.00 < 0.05)
                        thrpt:  [+0.6767% +1.3276% +1.9966%]
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
event/root/single_threaded/50
                        time:   [52.480 us 52.635 us 52.802 us]
                        thrpt:  [946.94 Kelem/s 949.94 Kelem/s 952.75 Kelem/s]
                 change:
                        time:   [-7.9030% -7.6409% -7.3610%] (p = 0.00 < 0.05)
                        thrpt:  [+7.9458% +8.2730% +8.5812%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
event/root/multithreaded/50
                        time:   [78.011 us 78.322 us 78.641 us]
                        thrpt:  [635.80 Kelem/s 638.39 Kelem/s 640.94 Kelem/s]
                 change:
                        time:   [-6.6836% -6.0418% -5.4440%] (p = 0.00 < 0.05)
                        thrpt:  [+5.7575% +6.4304% +7.1623%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) low mild
  1 (1.00%) high mild
event/unique_parent/single_threaded/50
                        time:   [74.794 us 75.181 us 75.638 us]
                        thrpt:  [661.04 Kelem/s 665.06 Kelem/s 668.50 Kelem/s]
                 change:
                        time:   [-4.8045% -4.1902% -3.3294%] (p = 0.00 < 0.05)
                        thrpt:  [+3.4440% +4.3734% +5.0470%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
event/unique_parent/multithreaded/50
                        time:   [111.21 us 111.69 us 112.18 us]
                        thrpt:  [445.70 Kelem/s 447.68 Kelem/s 449.61 Kelem/s]
                 change:
                        time:   [-2.9311% -2.1052% -1.1957%] (p = 0.00 < 0.05)
                        thrpt:  [+1.2101% +2.1505% +3.0196%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe
event/shared_parent/multithreaded/50
                        time:   [126.40 us 126.91 us 127.45 us]
                        thrpt:  [392.30 Kelem/s 393.97 Kelem/s 395.56 Kelem/s]
                 change:
                        time:   [-3.2291% -2.6216% -2.0236%] (p = 0.00 < 0.05)
                        thrpt:  [+2.0654% +2.6922% +3.3368%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low severe
event/multi-parent/multithreaded/50
                        time:   [774.26 us 778.08 us 782.21 us]
                        thrpt:  [63.921 Kelem/s 64.261 Kelem/s 64.577 Kelem/s]
                 change:
                        time:   [-5.0241% -4.0596% -3.0771%] (p = 0.00 < 0.05)
                        thrpt:  [+3.1748% +4.2314% +5.2899%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

     Running unittests (target/release/deps/reload-e2693c629922ef45)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

WARNING: In Criterion.rs 0.4.0, running criterion benchmarks outside of cargo-criterion will become a default optional feature.
The statistical analysis and reporting is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'cargo_bench_support' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
reload/complex-collector
                        time:   [1.1720 us 1.1740 us 1.1761 us]
                        change: [-3.0257% -2.6002% -2.2000%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
reload/complex-collector-reloadable
                        time:   [1.1681 us 1.1728 us 1.1777 us]
                        change: [-2.7777% -2.2707% -1.7884%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

```

The benchmark environment is probably fairly noisy (I ran the
benchmarks on my machine, and while I wasn't actively using it, I
forgot to quit Slack in the background), so the sub-%5 performance
differences are probably mostly not meaningful.

</details>