### PR TITLE
subscriber: call `inner` instead of `subscriber`

### DIFF
--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -722,7 +722,7 @@ where
     fn enabled(&self, metadata: &Metadata<'_>, ctx: Context<'_, C>) -> bool {
         if self.subscriber.enabled(metadata, ctx.clone()) {
             // if the outer subscriber enables the callsite metadata, ask the inner subscriber.
-            self.subscriber.enabled(metadata, ctx)
+            self.inner.enabled(metadata, ctx)
         } else {
             // otherwise, the callsite is disabled by this subscriber
             false


### PR DESCRIPTION
Resolves #1515. I'm pretty sure that I introduced this during the great `Layer` -> `Subscribe` renaming, so that's my bad.