### PR TITLE
attributes: record `f32` and `f64` as `Value`

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -878,7 +878,7 @@ enum RecordType {
 
 impl RecordType {
     /// Array of primitive types which should be recorded as [RecordType::Value].
-    const TYPES_FOR_VALUE: [&'static str; 23] = [
+    const TYPES_FOR_VALUE: [&'static str; 25] = [
         "bool",
         "str",
         "u8",
@@ -889,6 +889,8 @@ impl RecordType {
         "i32",
         "u64",
         "i64",
+        "f32",
+        "f64",
         "usize",
         "isize",
         "NonZeroU8",


### PR DESCRIPTION
Companion PR with #1507.