### PR TITLE
chore(ci): turn off `fail-fast` for some build matrix jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,6 +81,7 @@ jobs:
         - log-always
         - std log-always
         - std
+      fail-fast: false
     steps:
     - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
@@ -124,6 +125,7 @@ jobs:
     strategy:
       matrix:
         rust: [stable, beta, nightly]
+      fail-fast: false
     steps:
     - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
@@ -156,6 +158,7 @@ jobs:
         - tracing-serde
         - tracing-subscriber
         - tracing-tower
+      fail-fast: false
     steps:
     - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
The default behavior for GitHub Actions `matrix` strategies is to cancel
all remaining jobs in a `matrix` job if *any* of them fail. However,
this sometimes obscures important information. For example, we have a
step that runs tests on stable, beta, and nightly Rust. In this case,
it's useful to know whether a failure occurred only on nightly, or if it
effects *every* Rust version.

Furthermore, our branch protection settings don't require the nightly
build to pass in order to merge a PR, because there are sometimes
spurious failures due to nightly-specific bugs. We *do* require the
stable build to pass. However, because the `matrix` strategy will cancel
all jobs in the matrix if any of them fails, this means that we
implicitly *do* require the tests to pass on nightly, as if the nightly
job fails, it will also cancel the required stable job.

This commit updates the github actions config to disable failfast for
some build matrices.
