### PR TITLE
subscriber: add feature flags to tests

### DIFF
--- a/tracing-subscriber/src/layer.rs
+++ b/tracing-subscriber/src/layer.rs
@@ -1301,7 +1301,6 @@ impl Identity {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::sync::{Arc, Mutex};
 
     use super::*;
 
@@ -1419,7 +1418,9 @@ pub(crate) mod tests {
     }
 
     #[test]
+    #[cfg(feature = "registry")]
     fn context_event_span() {
+        use std::sync::{Arc, Mutex};
         let last_event_span = Arc::new(Mutex::new(None));
 
         struct RecordingLayer {

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -474,7 +474,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "registry"))]
 mod tests {
     use crate::{
         layer::{Context, Layer},

--- a/tracing-subscriber/tests/duplicate_spans.rs
+++ b/tracing-subscriber/tests/duplicate_spans.rs
@@ -1,3 +1,4 @@
+#![cfg(all(feature = "env-filter", feature = "fmt"))]
 mod support;
 use tracing::{self, subscriber::with_default, Span};
 use tracing_subscriber::{filter::EnvFilter, FmtSubscriber};

--- a/tracing-subscriber/tests/field_filter.rs
+++ b/tracing-subscriber/tests/field_filter.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "env-filter")]
 mod support;
 use self::support::*;
 use tracing::{self, subscriber::with_default, Level};

--- a/tracing-subscriber/tests/filter.rs
+++ b/tracing-subscriber/tests/filter.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "env-filter")]
+
 mod support;
 use self::support::*;
 use tracing::{self, subscriber::with_default, Level};

--- a/tracing-subscriber/tests/filter_log.rs
+++ b/tracing-subscriber/tests/filter_log.rs
@@ -1,3 +1,4 @@
+#![cfg(all(feature = "env-filter", feature = "tracing-log"))]
 mod support;
 use self::support::*;
 use tracing::{self, Level};

--- a/tracing-subscriber/tests/fmt_max_level_hint.rs
+++ b/tracing-subscriber/tests/fmt_max_level_hint.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "fmt")]
 use tracing_subscriber::filter::LevelFilter;
 
 #[test]

--- a/tracing-subscriber/tests/registry_max_level_hint.rs
+++ b/tracing-subscriber/tests/registry_max_level_hint.rs
@@ -1,3 +1,4 @@
+#![cfg(all(feature = "registry", feature = "fmt"))]
 use tracing_subscriber::{filter::LevelFilter, prelude::*};
 
 #[test]

--- a/tracing-subscriber/tests/registry_with_subscriber.rs
+++ b/tracing-subscriber/tests/registry_with_subscriber.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "registry")]
 use tracing_futures::{Instrument, WithSubscriber};
 use tracing_subscriber::prelude::*;
 

--- a/tracing-subscriber/tests/reload.rs
+++ b/tracing-subscriber/tests/reload.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "reload")]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tracing_core::{
     span::{Attributes, Id, Record},

--- a/tracing-subscriber/tests/same_len_filters.rs
+++ b/tracing-subscriber/tests/same_len_filters.rs
@@ -1,6 +1,6 @@
 // These tests include field filters with no targets, so they have to go in a
 // separate file.
-
+#![cfg(feature = "env-filter")]
 mod support;
 use self::support::*;
 use tracing::{self, subscriber::with_default, Level};

--- a/tracing-subscriber/tests/utils.rs
+++ b/tracing-subscriber/tests/utils.rs
@@ -19,6 +19,7 @@ fn init_ext_works() {
 }
 
 #[test]
+#[cfg(feature = "fmt")]
 fn builders_are_init_ext() {
     tracing_subscriber::fmt().set_default();
     let _ = tracing_subscriber::fmt()
@@ -28,6 +29,7 @@ fn builders_are_init_ext() {
 }
 
 #[test]
+#[cfg(all(feature = "fmt", feature = "env-filter"))]
 fn layered_is_init_ext() {
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer())


### PR DESCRIPTION
## Motivation

Currently we can't run

```bash
cargo test -p tracing-subscriber --no-default-features
```

successfully, because there are a bunch of tests for feature flagged
APIs that are always enabled.

## Solution

This commit adds feature flags to the modules and/or individual test
cases that test feature-flagged APIs.

There are still a few doctests that use feature-flagged APIs, and will
fail with `--no-default-features`. These are primarily the examples for
various `Layer::context` methods that rely on `LookupSpan`, and use the
`Registry` type, as it's the only subscriber that *implements*
`LookupSpan`. We could consider changing these examples, either by
removing the actual use of the layers in them, or by changing them to
use a mocked-out version of the registry. However, I think it's nicer to
show how the API would be used in real life. Perhaps we should just run

```bash
cargo test -p tracing-subscriber --no-default-features--tests --lib
```

to ignore doctests when testing without default features.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>