### PR TITLE
chore: run tracing-subscriber's tests under `--no-default-features`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -230,6 +230,10 @@ jobs:
       run: (cd tracing-core && cargo test --no-default-features)
     - name: "Test tracing no-std support"
       run: (cd tracing && cargo test --no-default-features)
+      # this skips running doctests under the `--no-default-features` flag,
+      # as rustdoc isn't aware of cargo's feature flags.
+    - name: "Test tracing-subscriber with all features disabled"
+      run: (cd tracing-subscriber && cargo test --lib --tests --no-default-features)
   style:
     # Check style.
     needs: check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -213,6 +213,9 @@ jobs:
 
   features-stable:
     # Feature flag tests that run on stable Rust.
+    # TODO(david): once tracing's MSRV goes up to Rust 1.51, we should be able to switch to 
+    # using cargo's V2 feature resolver (https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions)
+    # and avoid cd'ing into each crate's directory.
     needs: check
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -116,7 +116,7 @@ jobs:
         override: true
     - name: cargo check
       working-directory: tracing-subscriber
-      run: cargo test --lib --tests --no-default-features --features "${{ matrix.featureset }}"
+      run: cargo check --no-default-features --features "${{ matrix.featureset }}"
 
   test-versions:
     # Test against the stable, beta, and nightly Rust toolchains on ubuntu-latest.
@@ -233,7 +233,10 @@ jobs:
       run: (cd tracing-core && cargo test --no-default-features)
     - name: "Test tracing no-std support"
       run: (cd tracing && cargo test --no-default-features)
-
+      # this skips running doctests under the `--no-default-features` flag,
+      # as rustdoc isn't aware of cargo's feature flags.
+    - name: "Test tracing-subscriber with all features disabled"
+      run: (cd tracing-subscriber && cargo test --lib --tests --no-default-features)
   style:
     # Check style.
     needs: check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -116,7 +116,7 @@ jobs:
         override: true
     - name: cargo check
       working-directory: tracing-subscriber
-      run: cargo check --no-default-features --features "${{ matrix.featureset }}"
+      run: cargo test --lib --tests --no-default-features --features "${{ matrix.featureset }}"
 
   test-versions:
     # Test against the stable, beta, and nightly Rust toolchains on ubuntu-latest.
@@ -233,10 +233,7 @@ jobs:
       run: (cd tracing-core && cargo test --no-default-features)
     - name: "Test tracing no-std support"
       run: (cd tracing && cargo test --no-default-features)
-      # this skips running doctests under the `--no-default-features` flag,
-      # as rustdoc isn't aware of cargo's feature flags.
-    - name: "Test tracing-subscriber with all features disabled"
-      run: (cd tracing-subscriber && cargo test --lib --tests --no-default-features)
+
   style:
     # Check style.
     needs: check


### PR DESCRIPTION
## Motivation

When reviewing https://github.com/tokio-rs/tracing/pull/1523, I suggested that the examples use `fmt::Layer` directly to allow readers to copy-and-paste examples into their own code. However, @hawkw pointed out that rustdoc doesn't receive feature flags from Cargo, which means that running tracing-subscriber's tests under `--no-default-features` would fail.

## Solution

It turned out that that we're only running `cargo check --no-default-features` for tracing-subscriber. Running `cargo test --no-default-features` resulted in compilation failures, but it seems like nobody noticed. Building on https://github.com/tokio-rs/tracing/pull/1532, this branch argues that running tracing-subscriber's tests under `cargo test --lib --tests --no-default-features` is _probably_ fine if we're able to skip the doctests (which are _not_ aware of Cargo's feature flags).
