### PR TITLE
tracing: add `Span::or_current` to help with efficient propagation

### DIFF
--- a/examples/examples/tower-load.rs
+++ b/examples/examples/tower-load.rs
@@ -41,7 +41,9 @@ use std::{
 };
 use tokio::{time, try_join};
 use tower::{Service, ServiceBuilder, ServiceExt};
-use tracing::{self, debug, error, info, span, trace, warn, Instrument as _, Level, Span};
+use tracing::{
+    self, debug, error, info, info_span, span, trace, warn, Instrument as _, Level, Span,
+};
 use tracing_subscriber::{filter::EnvFilter, reload::Handle};
 use tracing_tower::{request_span, request_span::make};
 
@@ -359,7 +361,7 @@ async fn load_gen(addr: SocketAddr) -> Result<(), Err> {
             .instrument(span)
             .await
         }
-        .instrument(span!(target: "gen", Level::INFO, "generated_request", remote.addr=%addr));
+        .instrument(info_span!(target: "gen", "generated_request", remote.addr=%addr).or_current());
         tokio::spawn(f);
     }
 }

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -947,8 +947,8 @@ impl Span {
     /// // ...
     ///
     /// // If DEBUG is enabled, then "child" will be enabled, and `or_current`
-    /// returns "child". Otherwise, if DEBUG is not enabled, "child" will be
-    /// disabled, and `or_current` returns "parent".
+    /// // returns "child". Otherwise, if DEBUG is not enabled, "child" will be
+    /// // disabled, and `or_current` returns "parent".
     /// let child_span = tracing::debug_span!("child").or_current();
     ///
     /// std::thread::spawn(move || {

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -902,7 +902,8 @@ impl Span {
     }
 
     /// Returns this span, if it was [enabled] by the current [collector], or
-    /// the [current span] (whose lexical distance may be further than expected), if this span [is disabled].
+    /// the [current span] (whose lexical distance may be further than expected),
+    ///  if this span [is disabled].
     ///
     /// This method can be useful when propagating spans to spawned threads or
     /// [async tasks]. Consider the following:

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -902,10 +902,10 @@ impl Span {
     }
 
     /// Returns this span, if it was [enabled] by the current [collector], or
-    /// the [current span], if this span [is disabled].
+    /// the [current span] (whose lexical distance may be further than expected), if this span [is disabled].
     ///
     /// This method can be useful when propagating spans to spawned threads or
-    /// [async tasks]. For example, consider the following:
+    /// [async tasks]. Consider the following:
     ///
     /// ```
     /// let _parent_span = tracing::info_span!("parent").entered();
@@ -927,7 +927,7 @@ impl Span {
     /// the "parent" and "child" spans will be enabled. Thus, when the "spawaned
     /// a thread!" event occurs, it will be inside of the "child" span. Because
     /// "parent" is the parent of "child", the event will _also_ be inside of
-    /// "child".
+    /// "parent".
     ///
     /// However, if the collector only enables the [`INFO`] level, the "child"
     /// span will be disabled. When the thread is spawned, the
@@ -966,7 +966,7 @@ impl Span {
     /// use tracing::Instrument;
     /// # // lol
     /// # mod tokio {
-    /// #     pub(super) fn spawn(_ impl std::future::Future) {}
+    /// #     pub(super) fn spawn(_: impl std::future::Future) {}
     /// # }
     ///
     /// let _parent_span = tracing::info_span!("parent").entered();
@@ -993,7 +993,7 @@ impl Span {
     /// use tracing::Instrument;
     /// # // lol
     /// # mod tokio {
-    /// #     pub(super) fn spawn(_ impl std::future::Future) {}
+    /// #     pub(super) fn spawn(_: impl std::future::Future) {}
     /// # }
     /// async fn my_async_fn() {
     ///     // ...

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -901,6 +901,134 @@ impl Span {
         }
     }
 
+    /// Returns this span, if it was [enabled] by the current [collector], or
+    /// the [current span], if this span [is disabled].
+    ///
+    /// This method can be useful when propagating spans to spawned threads or
+    /// [async tasks]. For example, consider the following:
+    ///
+    /// ```
+    /// let _parent_span = tracing::info_span!("parent").entered();
+    ///
+    /// // ...
+    ///
+    /// let child_span = tracing::debug_span!("child");
+    ///
+    /// std::thread::spawn(move || {
+    ///     let _entered = child_span.entered();
+    ///
+    ///     tracing::info!("spawned a thread!");
+    ///
+    ///     // ...
+    /// });
+    /// ```
+    ///
+    /// If the current [collector] enables the [`DEBUG`] level, then both
+    /// the "parent" and "child" spans will be enabled. Thus, when the "spawaned
+    /// a thread!" event occurs, it will be inside of the "child" span. Because
+    /// "parent" is the parent of "child", the event will _also_ be inside of
+    /// "child".
+    ///
+    /// However, if the collector only enables the [`INFO`] level, the "child"
+    /// span will be disabled. When the thread is spawned, the
+    /// `child_span.entered()` call will do nothing, since "child" is not
+    /// enabled. In this case, the "spawned a thread!" event occurs outside of
+    /// *any* span, since the "child" span was responsible for propagating its
+    /// parent to the spawned thread.
+    ///
+    /// If this is not the desired behavior, `Span::or_current` can be used to
+    /// ensure that the "parent" span is propagated in both cases, either as a
+    /// parent of "child" _or_ directly. For example:
+    ///
+    /// ```
+    /// let _parent_span = tracing::info_span!("parent").entered();
+    ///
+    /// // ...
+    ///
+    /// // If DEBUG is enabled, then "child" will be enabled, and `or_current`
+    /// returns "child". Otherwise, if DEBUG is not enabled, "child" will be
+    /// disabled, and `or_current` returns "parent".
+    /// let child_span = tracing::debug_span!("child").or_current();
+    ///
+    /// std::thread::spawn(move || {
+    ///     let _entered = child_span.entered();
+    ///
+    ///     tracing::info!("spawned a thread!");
+    ///
+    ///     // ...
+    /// });
+    /// ```
+    ///
+    /// When spawning [asynchronous tasks][async tasks], `Span::or_current` can
+    /// be used similarly, in combination with [`instrument`]:
+    ///
+    /// ```
+    /// use tracing::Instrument;
+    /// # // lol
+    /// # mod tokio {
+    /// #     pub(super) fn spawn(_ impl std::future::Future) {}
+    /// # }
+    ///
+    /// let _parent_span = tracing::info_span!("parent").entered();
+    ///
+    /// // ...
+    ///
+    /// let child_span = tracing::debug_span!("child");
+    ///
+    /// tokio::spawn(
+    ///     async {
+    ///         tracing::info!("spawned a task!");
+    ///
+    ///         // ...
+    ///
+    ///     }.instrument(child_span.or_current())
+    /// );
+    /// ```
+    ///
+    /// In general, `or_current` should be preferred over nesting an
+    /// [`instrument`]  call inside of an [`in_current_span`] call, as using
+    /// `or_current` will be more efficient.
+    ///
+    /// ```
+    /// use tracing::Instrument;
+    /// # // lol
+    /// # mod tokio {
+    /// #     pub(super) fn spawn(_ impl std::future::Future) {}
+    /// # }
+    /// async fn my_async_fn() {
+    ///     // ...
+    /// }
+    ///
+    /// let _parent_span = tracing::info_span!("parent").entered();
+    ///
+    /// // Do this:
+    /// tokio::spawn(
+    ///     my_async_fn().instrument(tracing::debug_span!("child").or_current())
+    /// );
+    ///
+    /// // ...rather than this:
+    /// tokio::spawn(
+    ///     my_async_fn()
+    ///         .instrument(tracing::debug_span!("child"))
+    ///         .in_current_span()
+    /// );
+    /// ```
+    ///
+    /// [enabled]: crate::collect::Collect::enabled
+    /// [collector]: crate::collect::Collect
+    /// [current span]: Span::current
+    /// [is disabled]: Span::is_disabled
+    /// [`INFO`]: crate::Level::INFO
+    /// [`DEBUG`]: crate::Level::DEBUG
+    /// [async tasks]: std::task
+    /// [`instrument`]: crate::instrument::Instrument
+    pub fn or_current(self) -> Self {
+        if self.is_disabled() {
+            return Self::current();
+        }
+        self
+    }
+
     #[inline]
     fn do_enter(&self) {
         if let Some(inner) = self.inner.as_ref() {


### PR DESCRIPTION
This adds a new `Span::or_current` method that returns the span it's
called on, if that span is enabled, or the current span if that span
is not enabled.

This should provide a more efficient alternative to writing code like
```rust
tokio::spawn(
    future
        .instrument(some_span)
        .in_current_span()
);
```
since it doesn't wrap the future in two different spans which are
(potentially) both entered on polls. It's also a little more concise
to write, which (hopefully) will encourage people to use it instead
of the less efficient alternative.

`Span::or_current` may be useful in other cases as well.