### PR TITLE
backport commits from main & fix terminology

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -217,6 +217,9 @@ jobs:
 
   features-stable:
     # Feature flag tests that run on stable Rust.
+    # TODO(david): once tracing's MSRV goes up to Rust 1.51, we should be able to switch to 
+    # using cargo's V2 feature resolver (https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions)
+    # and avoid cd'ing into each crate's directory.
     needs: check
     runs-on: ubuntu-latest
     steps:
@@ -234,6 +237,10 @@ jobs:
       run: (cd tracing-core && cargo test --no-default-features)
     - name: "Test tracing no-std support"
       run: (cd tracing && cargo test --no-default-features)
+      # this skips running doctests under the `--no-default-features` flag,
+      # as rustdoc isn't aware of cargo's feature flags.
+    - name: "Test tracing-subscriber with all features disabled"
+      run: (cd tracing-subscriber && cargo test --lib --tests --no-default-features)
 
   style:
     # Check style.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -85,6 +85,7 @@ jobs:
         - log-always
         - std log-always
         - std
+      fail-fast: false
     steps:
     - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
@@ -128,6 +129,7 @@ jobs:
     strategy:
       matrix:
         rust: [stable, beta, nightly]
+      fail-fast: false
     steps:
     - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
@@ -160,6 +162,7 @@ jobs:
         - tracing-serde
         - tracing-subscriber
         - tracing-tower
+      fail-fast: false
     steps:
     - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1

--- a/examples/examples/fmt-multiple-writers.rs
+++ b/examples/examples/fmt-multiple-writers.rs
@@ -17,7 +17,7 @@ fn main() {
         .with(EnvFilter::from_default_env().add_directive(tracing::Level::TRACE.into()))
         .with(fmt::Layer::new().with_writer(io::stdout))
         .with(fmt::Layer::new().with_writer(non_blocking));
-    tracing::subscriber::set_global_default(subscriber).expect("Unable to set a global collector");
+    tracing::subscriber::set_global_default(subscriber).expect("Unable to set a global subscriber");
 
     let number_of_yaks = 3;
     // this creates a new event, outside of any spans.

--- a/examples/examples/fmt-pretty.rs
+++ b/examples/examples/fmt-pretty.rs
@@ -8,7 +8,7 @@ fn main() {
         .with_thread_names(true)
         // enable everything
         .with_max_level(tracing::Level::TRACE)
-        // sets this to be the default, global collector for this application.
+        // sets this to be the default, global subscriber for this application.
         .init();
 
     let number_of_yaks = 3;

--- a/examples/examples/fmt.rs
+++ b/examples/examples/fmt.rs
@@ -6,7 +6,7 @@ fn main() {
     tracing_subscriber::fmt()
         // enable everything
         .with_max_level(tracing::Level::TRACE)
-        // sets this to be the default, global collector for this application.
+        // sets this to be the default, global subscriber for this application.
         .init();
 
     let number_of_yaks = 3;

--- a/examples/examples/tower-load.rs
+++ b/examples/examples/tower-load.rs
@@ -41,7 +41,9 @@ use std::{
 };
 use tokio::{time, try_join};
 use tower::{Service, ServiceBuilder, ServiceExt};
-use tracing::{self, debug, error, info, span, trace, warn, Instrument as _, Level, Span};
+use tracing::{
+    self, debug, error, info, info_span, span, trace, warn, Instrument as _, Level, Span,
+};
 use tracing_subscriber::{filter::EnvFilter, reload::Handle};
 use tracing_tower::{request_span, request_span::make};
 
@@ -368,7 +370,7 @@ async fn load_gen(addr: SocketAddr) -> Result<(), Err> {
             .instrument(span)
             .await
         }
-        .instrument(span!(target: "gen", Level::INFO, "generated_request", remote.addr=%addr));
+        .instrument(info_span!(target: "gen", "generated_request", remote.addr=%addr).or_current());
         tokio::spawn(f);
     }
 }

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -1067,7 +1067,7 @@ enum RecordType {
 
 impl RecordType {
     /// Array of primitive types which should be recorded as [RecordType::Value].
-    const TYPES_FOR_VALUE: [&'static str; 23] = [
+    const TYPES_FOR_VALUE: &'static [&'static str] = &[
         "bool",
         "str",
         "u8",
@@ -1078,6 +1078,8 @@ impl RecordType {
         "i32",
         "u64",
         "i64",
+        "f32",
+        "f64",
         "usize",
         "isize",
         "NonZeroU8",

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -16,9 +16,9 @@
 //! will contain any fields attached to each event.
 //!
 //! `tracing` represents values as either one of a set of Rust primitives
-//! (`i64`, `u64`, `bool`, and `&str`) or using a `fmt::Display` or `fmt::Debug`
-//! implementation. `Subscriber`s are provided these primitive value types as
-//! `dyn Value` trait objects.
+//! (`i64`, `u64`, `f64`, `bool`, and `&str`) or using a `fmt::Display` or
+//! `fmt::Debug` implementation. `Subscriber`s are provided these primitive
+//! value types as `dyn Value` trait objects.
 //!
 //! These trait objects can be formatted using `fmt::Debug`, but may also be
 //! recorded as typed data by calling the [`Value::record`] method on these
@@ -184,6 +184,11 @@ pub struct Iter {
 /// [`Event`]: ../event/struct.Event.html
 /// [`ValueSet`]: struct.ValueSet.html
 pub trait Visit {
+    /// Visit a double-precision floating point value.
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.record_debug(field, &value)
+    }
+
     /// Visit a signed 64-bit integer value.
     fn record_i64(&mut self, field: &Field, value: i64) {
         self.record_debug(field, &value)
@@ -335,6 +340,12 @@ macro_rules! ty_to_nonzero {
 }
 
 macro_rules! impl_one_value {
+    (f32, $op:expr, $record:ident) => {
+        impl_one_value!(normal, f32, $op, $record);
+    };
+    (f64, $op:expr, $record:ident) => {
+        impl_one_value!(normal, f64, $op, $record);
+    };
     (bool, $op:expr, $record:ident) => {
         impl_one_value!(normal, bool, $op, $record);
     };
@@ -387,7 +398,8 @@ impl_values! {
     record_u64(usize, u32, u16, u8 as u64),
     record_i64(i64),
     record_i64(isize, i32, i16, i8 as i64),
-    record_bool(bool)
+    record_bool(bool),
+    record_f64(f64, f32 as f64)
 }
 
 impl<T: crate::sealed::Sealed> crate::sealed::Sealed for Wrapping<T> {}

--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -127,6 +127,21 @@ impl<'a> field::Visit for SpanEventVisitor<'a> {
         }
     }
 
+    /// Record events on the underlying OpenTelemetry [`Span`] from `f64` values.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_f64(&mut self, field: &field::Field, value: f64) {
+        match field.name() {
+            "message" => self.0.name = value.to_string().into(),
+            // Skip fields that are actually log metadata that have already been handled
+            #[cfg(feature = "tracing-log")]
+            name if name.starts_with("log.") => (),
+            name => {
+                self.0.attributes.push(KeyValue::new(name, value));
+            }
+        }
+    }
+
     /// Record events on the underlying OpenTelemetry [`Span`] from `i64` values.
     ///
     /// [`Span`]: opentelemetry::trace::Span
@@ -194,6 +209,13 @@ impl<'a> field::Visit for SpanAttributeVisitor<'a> {
     ///
     /// [`Span`]: opentelemetry::trace::Span
     fn record_bool(&mut self, field: &field::Field, value: bool) {
+        self.record(KeyValue::new(field.name(), value));
+    }
+
+    /// Set attributes on the underlying OpenTelemetry [`Span`] from `f64` values.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_f64(&mut self, field: &field::Field, value: f64) {
         self.record(KeyValue::new(field.name(), value));
     }
 

--- a/tracing-opentelemetry/src/span_ext.rs
+++ b/tracing-opentelemetry/src/span_ext.rs
@@ -138,9 +138,9 @@ impl OpenTelemetrySpanExt for tracing::Span {
         if cx.is_valid() {
             let mut cx = Some(cx);
             let mut att = Some(attributes);
-            self.with_subscriber(move |(id, collector)| {
-                if let Some(get_context) = collector.downcast_ref::<WithContext>() {
-                    get_context.with_context(collector, id, move |builder, _tracer| {
+            self.with_subscriber(move |(id, subscriber)| {
+                if let Some(get_context) = subscriber.downcast_ref::<WithContext>() {
+                    get_context.with_context(subscriber, id, move |builder, _tracer| {
                         if let Some(cx) = cx.take() {
                             let attr = att.take().unwrap_or_default();
                             let follows_link = opentelemetry::trace::Link::new(cx, attr);

--- a/tracing-opentelemetry/src/span_ext.rs
+++ b/tracing-opentelemetry/src/span_ext.rs
@@ -1,5 +1,5 @@
 use crate::layer::WithContext;
-use opentelemetry::Context;
+use opentelemetry::{trace::SpanContext, Context, KeyValue};
 
 /// Utility functions to allow tracing [`Span`]s to accept and return
 /// [OpenTelemetry] [`Context`]s.
@@ -41,6 +41,50 @@ pub trait OpenTelemetrySpanExt {
     /// Span::current().set_parent(parent_context);
     /// ```
     fn set_parent(&self, cx: Context);
+
+    /// Associates `self` with a given OpenTelemetry trace, using the provided
+    /// followed span [`SpanContext`].
+    ///
+    /// [`SpanContext`]: opentelemetry::trace::SpanContext
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use opentelemetry::{propagation::TextMapPropagator, trace::TraceContextExt};
+    /// use opentelemetry::sdk::propagation::TraceContextPropagator;
+    /// use tracing_opentelemetry::OpenTelemetrySpanExt;
+    /// use std::collections::HashMap;
+    /// use tracing::Span;
+    ///
+    /// // Example carrier, could be a framework header map that impls otel's `Extract`.
+    /// let mut carrier = HashMap::new();
+    ///
+    /// // Propagator can be swapped with b3 propagator, jaeger propagator, etc.
+    /// let propagator = TraceContextPropagator::new();
+    ///
+    /// // Extract otel context of linked span via the chosen propagator
+    /// let linked_span_otel_context = propagator.extract(&carrier);
+    ///
+    /// // Extract the linked span context from the otel context
+    /// let linked_span_context = linked_span_otel_context.span().span_context().clone();
+    ///
+    /// // Generate a tracing span as usual
+    /// let app_root = tracing::span!(tracing::Level::INFO, "app_start");
+    ///
+    /// // Assign linked trace from external context
+    /// app_root.add_link(linked_span_context);
+    ///
+    /// // Or if the current span has been created elsewhere:
+    /// let linked_span_context = linked_span_otel_context.span().span_context().clone();
+    /// Span::current().add_link(linked_span_context);
+    /// ```
+    fn add_link(&self, cx: SpanContext);
+
+    /// Associates `self` with a given OpenTelemetry trace, using the provided
+    /// followed span [`SpanContext`] and attributes.
+    ///
+    /// [`SpanContext`]: opentelemetry::trace::SpanContext
+    fn add_link_with_attributes(&self, cx: SpanContext, attributes: Vec<KeyValue>);
 
     /// Extracts an OpenTelemetry [`Context`] from `self`.
     ///
@@ -84,6 +128,31 @@ impl OpenTelemetrySpanExt for tracing::Span {
                 });
             }
         });
+    }
+
+    fn add_link(&self, cx: SpanContext) {
+        self.add_link_with_attributes(cx, Vec::new())
+    }
+
+    fn add_link_with_attributes(&self, cx: SpanContext, attributes: Vec<KeyValue>) {
+        if cx.is_valid() {
+            let mut cx = Some(cx);
+            let mut att = Some(attributes);
+            self.with_subscriber(move |(id, collector)| {
+                if let Some(get_context) = collector.downcast_ref::<WithContext>() {
+                    get_context.with_context(collector, id, move |builder, _tracer| {
+                        if let Some(cx) = cx.take() {
+                            let attr = att.take().unwrap_or_default();
+                            let follows_link = opentelemetry::trace::Link::new(cx, attr);
+                            builder
+                                .links
+                                .get_or_insert_with(|| Vec::with_capacity(1))
+                                .push(follows_link);
+                        }
+                    });
+                }
+            });
+        }
     }
 
     fn context(&self) -> Context {

--- a/tracing-serde/src/lib.rs
+++ b/tracing-serde/src/lib.rs
@@ -384,6 +384,12 @@ where
         }
     }
 
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        if self.state.is_ok() {
+            self.state = self.serializer.serialize_entry(field.name(), &value)
+        }
+    }
+
     fn record_str(&mut self, field: &Field, value: &str) {
         if self.state.is_ok() {
             self.state = self.serializer.serialize_entry(field.name(), &value)
@@ -425,6 +431,12 @@ where
     }
 
     fn record_i64(&mut self, field: &Field, value: i64) {
+        if self.state.is_ok() {
+            self.state = self.serializer.serialize_field(field.name(), &value)
+        }
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
         if self.state.is_ok() {
             self.state = self.serializer.serialize_field(field.name(), &value)
         }

--- a/tracing-subscriber/src/field/debug.rs
+++ b/tracing-subscriber/src/field/debug.rs
@@ -39,6 +39,11 @@ where
     V: Visit,
 {
     #[inline]
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.0.record_f64(field, value)
+    }
+
+    #[inline]
     fn record_i64(&mut self, field: &Field, value: i64) {
         self.0.record_i64(field, value)
     }

--- a/tracing-subscriber/src/field/display.rs
+++ b/tracing-subscriber/src/field/display.rs
@@ -41,6 +41,11 @@ where
     V: Visit,
 {
     #[inline]
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.0.record_f64(field, value)
+    }
+
+    #[inline]
     fn record_i64(&mut self, field: &Field, value: i64) {
         self.0.record_i64(field, value)
     }

--- a/tracing-subscriber/src/filter/env/field.rs
+++ b/tracing-subscriber/src/filter/env/field.rs
@@ -36,12 +36,75 @@ pub(crate) struct MatchVisitor<'a> {
     inner: &'a SpanMatch,
 }
 
-#[derive(Debug, Clone, PartialOrd, Ord, Eq, PartialEq)]
+#[derive(Debug, Clone)]
 pub(crate) enum ValueMatch {
     Bool(bool),
+    F64(f64),
     U64(u64),
     I64(i64),
+    NaN,
     Pat(Box<MatchPattern>),
+}
+
+impl Eq for ValueMatch {}
+
+impl PartialEq for ValueMatch {
+    fn eq(&self, other: &Self) -> bool {
+        use ValueMatch::*;
+        match (self, other) {
+            (Bool(a), Bool(b)) => a.eq(b),
+            (F64(a), F64(b)) => {
+                debug_assert!(!a.is_nan());
+                debug_assert!(!b.is_nan());
+
+                a.eq(b)
+            }
+            (U64(a), U64(b)) => a.eq(b),
+            (I64(a), I64(b)) => a.eq(b),
+            (NaN, NaN) => true,
+            (Pat(a), Pat(b)) => a.eq(b),
+            _ => false,
+        }
+    }
+}
+
+impl Ord for ValueMatch {
+    fn cmp(&self, other: &Self) -> Ordering {
+        use ValueMatch::*;
+        match (self, other) {
+            (Bool(this), Bool(that)) => this.cmp(that),
+            (Bool(_), _) => Ordering::Less,
+
+            (F64(this), F64(that)) => this
+                .partial_cmp(that)
+                .expect("`ValueMatch::F64` may not contain `NaN` values"),
+            (F64(_), Bool(_)) => Ordering::Greater,
+            (F64(_), _) => Ordering::Less,
+
+            (NaN, NaN) => Ordering::Equal,
+            (NaN, Bool(_)) | (NaN, F64(_)) => Ordering::Greater,
+            (NaN, _) => Ordering::Less,
+
+            (U64(this), U64(that)) => this.cmp(that),
+            (U64(_), Bool(_)) | (U64(_), F64(_)) | (U64(_), NaN) => Ordering::Greater,
+            (U64(_), _) => Ordering::Less,
+
+            (I64(this), I64(that)) => this.cmp(that),
+            (I64(_), Bool(_)) | (I64(_), F64(_)) | (I64(_), NaN) | (I64(_), U64(_)) => {
+                Ordering::Greater
+            }
+            (I64(_), _) => Ordering::Less,
+
+            (Pat(this), Pat(that)) => this.cmp(that),
+            (Pat(_), _) => Ordering::Greater,
+        }
+    }
+}
+
+impl PartialOrd for ValueMatch {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -127,6 +190,14 @@ impl PartialOrd for Match {
 
 // === impl ValueMatch ===
 
+fn value_match_f64(v: f64) -> ValueMatch {
+    if v.is_nan() {
+        ValueMatch::NaN
+    } else {
+        ValueMatch::F64(v)
+    }
+}
+
 impl FromStr for ValueMatch {
     type Err = matchers::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -134,6 +205,7 @@ impl FromStr for ValueMatch {
             .map(ValueMatch::Bool)
             .or_else(|_| s.parse::<u64>().map(ValueMatch::U64))
             .or_else(|_| s.parse::<i64>().map(ValueMatch::I64))
+            .or_else(|_| s.parse::<f64>().map(value_match_f64))
             .or_else(|_| {
                 s.parse::<MatchPattern>()
                     .map(|p| ValueMatch::Pat(Box::new(p)))
@@ -145,6 +217,8 @@ impl fmt::Display for ValueMatch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ValueMatch::Bool(ref inner) => fmt::Display::fmt(inner, f),
+            ValueMatch::F64(ref inner) => fmt::Display::fmt(inner, f),
+            ValueMatch::NaN => fmt::Display::fmt(&f64::NAN, f),
             ValueMatch::I64(ref inner) => fmt::Display::fmt(inner, f),
             ValueMatch::U64(ref inner) => fmt::Display::fmt(inner, f),
             ValueMatch::Pat(ref inner) => fmt::Display::fmt(inner, f),
@@ -275,6 +349,18 @@ impl SpanMatch {
 }
 
 impl<'a> Visit for MatchVisitor<'a> {
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        match self.inner.fields.get(field) {
+            Some((ValueMatch::NaN, ref matched)) if value.is_nan() => {
+                matched.store(true, Release);
+            }
+            Some((ValueMatch::F64(ref e), ref matched)) if (value - *e).abs() < f64::EPSILON => {
+                matched.store(true, Release);
+            }
+            _ => {}
+        }
+    }
+
     fn record_i64(&mut self, field: &Field, value: i64) {
         use std::convert::TryInto;
 

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -261,7 +261,7 @@ impl EnvFilter {
             #[cfg(feature = "ansi_term")]
             use ansi_term::{Color, Style};
             // NOTE: We can't use a configured `MakeWriter` because the EnvFilter
-            // has no knowledge of any underlying subscriber or collector, which
+            // has no knowledge of any underlying subscriber or subscriber, which
             // may or may not use a `MakeWriter`.
             let warn = |msg: &str| {
                 #[cfg(not(feature = "ansi_term"))]

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -431,6 +431,12 @@ impl<'a> crate::field::VisitOutput<fmt::Result> for JsonVisitor<'a> {
 }
 
 impl<'a> field::Visit for JsonVisitor<'a> {
+    /// Visit a double precision floating point value.
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.values
+            .insert(field.name(), serde_json::Value::from(value));
+    }
+
     /// Visit a signed 64-bit integer value.
     fn record_i64(&mut self, field: &Field, value: i64) {
         self.values

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -27,7 +27,7 @@
 //!
 //! ## Filtering Events with Environment Variables
 //!
-//! The default collector installed by `init` enables you to filter events
+//! The default subscriber installed by `init` enables you to filter events
 //! at runtime using environment variables (using the [`EnvFilter`]).
 //!
 //! The filter syntax is a superset of the [`env_logger`] syntax.
@@ -52,7 +52,7 @@
 //! You can create one by calling:
 //!
 //! ```rust
-//! let collector = tracing_subscriber::fmt()
+//! let subscriber = tracing_subscriber::fmt()
 //!     // ... add configuration
 //!     .finish();
 //! ```
@@ -336,7 +336,7 @@ pub struct SubscriberBuilder<
 ///     .with_target(false)
 ///     .with_timer(tracing_subscriber::fmt::time::uptime())
 ///     .with_level(true)
-///     // Set the collector as the default.
+///     // Set the subscriber as the default.
 ///     .init();
 /// ```
 ///
@@ -347,11 +347,11 @@ pub struct SubscriberBuilder<
 ///
 /// fn init_subscriber() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 ///     tracing_subscriber::fmt()
-///         // Configure the collector to emit logs in JSON format.
+///         // Configure the subscriber to emit logs in JSON format.
 ///         .json()
-///         // Configure the collector to flatten event fields in the output JSON objects.
+///         // Configure the subscriber to flatten event fields in the output JSON objects.
 ///         .flatten_event(true)
-///         // Set the collector as the default, returning an error if this fails.
+///         // Set the subscriber as the default, returning an error if this fails.
 ///         .try_init()?;
 ///
 ///     Ok(())

--- a/tracing/src/instrument.rs
+++ b/tracing/src/instrument.rs
@@ -34,7 +34,46 @@ pub trait Instrument: Sized {
     /// # }
     /// ```
     ///
-    /// [entered]: ../struct.Span.html#method.enter
+    /// The [`Span::or_current`] combinator can be used in combination with
+    /// `instrument` to ensure that the [current span] is attached to the
+    /// future if the span passed to `instrument` is [disabled]:
+    ///
+    /// ```W
+    /// use tracing::Instrument;
+    /// # mod tokio {
+    /// #     pub(super) fn spawn(_: impl std::future::Future) {}
+    /// # }
+    ///
+    /// let my_future = async {
+    ///     // ...
+    /// };
+    ///
+    /// let outer_span = tracing::info_span!("outer").entered();
+    ///
+    /// // If the "my_future" span is enabled, then the spawned task will
+    /// // be within both "my_future" *and* "outer", since "outer" is
+    /// // "my_future"'s parent. However, if "my_future" is disabled,
+    /// // the spawned task will *not* be in any span.
+    /// tokio::spawn(
+    ///     my_future
+    ///         .instrument(tracing::debug_span!("my_future"))
+    /// );
+    ///
+    /// // Using `Span::or_current` ensures the spawned task is instrumented
+    /// // with the current span, if the new span passed to `instrument` is
+    /// // not enabled. This means that if the "my_future"  span is disabled,
+    /// // the spawned task will still be instrumented with the "outer" span:
+    /// # let my_future = async {};
+    /// tokio::spawn(
+    ///    my_future
+    ///         .instrument(tracing::debug_span!("my_future").or_current())
+    /// );
+    /// ```
+    ///
+    /// [entered]: super::Span::enter()
+    /// [`Span::or_current`]: super::Span::or_current()
+    /// [current span]: super::Span::current()
+    /// [disabled]: super::Span::is_disabled()
     fn instrument(self, span: Span) -> Instrumented<Self> {
         Instrumented { inner: self, span }
     }

--- a/tracing/tests/event.rs
+++ b/tracing/tests/event.rs
@@ -145,6 +145,7 @@ fn one_with_everything() {
                         )))
                         .and(field::mock("foo").with_value(&666))
                         .and(field::mock("bar").with_value(&false))
+                        .and(field::mock("like_a_butterfly").with_value(&42.0))
                         .only(),
                 )
                 .at_level(Level::ERROR)
@@ -157,7 +158,7 @@ fn one_with_everything() {
         event!(
             target: "whatever",
             Level::ERROR,
-            { foo = 666, bar = false },
+            { foo = 666, bar = false, like_a_butterfly = 42.0 },
              "{:#x} make me one with{what:.>20}", 4_277_009_102u64, what = "everything"
         );
     });

--- a/tracing/tests/span.rs
+++ b/tracing/tests/span.rs
@@ -458,6 +458,28 @@ fn move_field_out_of_struct() {
     handle.assert_finished();
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn float_values() {
+    let (collector, handle) = collector::mock()
+        .new_span(
+            span::mock().named("foo").with_field(
+                field::mock("x")
+                    .with_value(&3.234)
+                    .and(field::mock("y").with_value(&-1.223))
+                    .only(),
+            ),
+        )
+        .run_with_handle();
+
+    with_default(collector, || {
+        let foo = span!(Level::TRACE, "foo", x = 3.234, y = -1.223);
+        foo.in_scope(|| {});
+    });
+
+    handle.assert_finished();
+}
+
 // TODO(#1138): determine a new syntax for uninitialized span fields, and
 // re-enable these.
 /*

--- a/tracing/tests/span.rs
+++ b/tracing/tests/span.rs
@@ -461,7 +461,7 @@ fn move_field_out_of_struct() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn float_values() {
-    let (collector, handle) = collector::mock()
+    let (subscriber, handle) = subscriber::mock()
         .new_span(
             span::mock().named("foo").with_field(
                 field::mock("x")
@@ -472,7 +472,7 @@ fn float_values() {
         )
         .run_with_handle();
 
-    with_default(collector, || {
+    with_default(subscriber, || {
         let foo = span!(Level::TRACE, "foo", x = 3.234, y = -1.223);
         foo.in_scope(|| {});
     });

--- a/tracing/tests/support/field.rs
+++ b/tracing/tests/support/field.rs
@@ -19,14 +19,40 @@ pub struct MockField {
     value: MockValue,
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
 pub enum MockValue {
+    F64(f64),
     I64(i64),
     U64(u64),
     Bool(bool),
     Str(String),
     Debug(String),
     Any,
+}
+
+impl Eq for MockValue {}
+
+impl PartialEq for MockValue {
+    fn eq(&self, other: &Self) -> bool {
+        use MockValue::*;
+
+        match (self, other) {
+            (F64(a), F64(b)) => {
+                debug_assert!(!a.is_nan());
+                debug_assert!(!b.is_nan());
+
+                a.eq(b)
+            }
+            (I64(a), I64(b)) => a.eq(b),
+            (U64(a), U64(b)) => a.eq(b),
+            (Bool(a), Bool(b)) => a.eq(b),
+            (Str(a), Str(b)) => a.eq(b),
+            (Debug(a), Debug(b)) => a.eq(b),
+            (Any, _) => true,
+            (_, Any) => true,
+            _ => false,
+        }
+    }
 }
 
 pub fn mock<K>(name: K) -> MockField
@@ -120,6 +146,7 @@ impl Expect {
 impl fmt::Display for MockValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            MockValue::F64(v) => write!(f, "f64 = {:?}", v),
             MockValue::I64(v) => write!(f, "i64 = {:?}", v),
             MockValue::U64(v) => write!(f, "u64 = {:?}", v),
             MockValue::Bool(v) => write!(f, "bool = {:?}", v),
@@ -136,6 +163,11 @@ pub struct CheckVisitor<'a> {
 }
 
 impl<'a> Visit for CheckVisitor<'a> {
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.expect
+            .compare_or_panic(field.name(), &value, &self.ctx[..])
+    }
+
     fn record_i64(&mut self, field: &Field, value: i64) {
         self.expect
             .compare_or_panic(field.name(), &value, &self.ctx[..])
@@ -180,6 +212,10 @@ impl<'a> From<&'a dyn Value> for MockValue {
         }
 
         impl Visit for MockValueBuilder {
+            fn record_f64(&mut self, _: &Field, value: f64) {
+                self.value = Some(MockValue::F64(value));
+            }
+
             fn record_i64(&mut self, _: &Field, value: i64) {
                 self.value = Some(MockValue::I64(value));
             }


### PR DESCRIPTION
This backports the following commits from master:

* 151c0628 tracing: add `Span::or_current` to help with efficient propagation (#1538)
* c5ba3d36 chore: run tracing-subscriber's tests under `--no-default-features` (#1537)
* 7657fe08 chore(ci): turn off `fail-fast` for some build matrix jobs (#1530)
* 9cd3c567 attributes: record `f32` and `f64` as `Value` (#1522)
* c90e5c8c core: add support for visiting floating point values (#1507)
* d394efa8 opentelemetry: Add extension to link spans (#1516)

Additionally, I also fixed a few instances where we were accidentally using v0.2 names ("collector" rather than "subscriber") on v0.1.x.