### PR TITLE
chore: simplify Netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,10 @@
 [build]
-  command = "rustup install nightly --profile minimal && cargo doc --no-deps && cp -r target/doc _netlify_out"
+  command = """
+    rustup install nightly --profile minimal \
+      && cargo doc --no-deps
+    """
   environment = { RUSTDOCFLAGS= "--cfg docsrs" }
-  publish = "_netlify_out"
+  publish = "target/doc"
 
 [[redirects]]
   from = "/"


### PR DESCRIPTION
Previously, the Netlify configuration copied the docs into a
`_netlify_out` dir as a workaround for netlify/build-image#505. This
upstream issue was fixed back in January, so this workaround hasn't been
necessary for a while. Therefore, we can remove this extra complexity
from our configuration.

I also changed the build script to a multi-line string which I think is
a bit nicer.