### PR TITLE
implement stricter env filter parsing

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -24,7 +24,7 @@ keywords = ["logging", "tracing", "metrics", "subscriber"]
 [features]
 
 default = ["env-filter", "smallvec", "fmt", "ansi", "chrono", "tracing-log", "json"]
-env-filter = ["matchers", "regex", "lazy_static", "tracing"]
+env-filter = ["matchers", "tracing"]
 fmt = ["registry"]
 ansi = ["fmt", "ansi_term"]
 registry = ["sharded-slab", "thread_local"]
@@ -36,9 +36,7 @@ tracing-core = { path = "../tracing-core", version = "0.2" }
 # only required by the filter feature
 tracing = { optional = true, path = "../tracing", version = "0.2", default-features = false, features = ["std"] }
 matchers = { optional = true, version = "0.1.0" }
-regex = { optional = true, version = "1", default-features = false, features = ["std"] }
 smallvec = { optional = true, version = "1" }
-lazy_static = { optional = true, version = "1" }
 
 # fmt
 tracing-log = { path = "../tracing-log", version = "0.2", optional = true, default-features = false, features = ["log-tracer", "std"] }

--- a/tracing-subscriber/src/filter/env/parsing.rs
+++ b/tracing-subscriber/src/filter/env/parsing.rs
@@ -1,0 +1,642 @@
+use super::{
+    super::level::{self, LevelFilter},
+    field::{Match, ValueMatch},
+    Directive, FilterVec,
+};
+use std::{borrow::Cow, error::Error, str::FromStr};
+
+fn parse_level_filter(s: &str) -> Result<LevelFilter, <LevelFilter as FromStr>::Err> {
+    if s.is_empty() {
+        Ok(LevelFilter::TRACE)
+    } else {
+        s.parse()
+    }
+}
+
+/// Macro to select execution path with the index of the first occurance of
+/// some given reserved syntax character, or EOI if no characters present.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let source: &str;
+/// # source = "";
+/// switch_syntax!(source => |i| {
+///     '(' | ')' => println!("paren at index {}", i),
+///     '[' | ']' => println!("brack at index {}", i),
+///     '{' | '}' => println!("brace at index {}", i),
+///     _ => println!("EOI at index {}", i),
+/// });
+/// ```
+macro_rules! switch_syntax {
+    ($haystack:expr => |$ix:ident| {
+        $($($needle:tt)|+ => $expr:expr),* $(,)?
+    }) => {{
+        let haystack: &str = &$haystack;
+        match find_syntax(haystack) {
+            $((ix, $(switch_syntax!(@syntax $needle))|+) => {
+                #[allow(unused_variables)]
+                let $ix = ix;
+                $expr
+            })*
+        }
+    }};
+
+    (@syntax '[') => (Some(Syntax::LBrack));
+    (@syntax ']') => (Some(Syntax::RBrack));
+    (@syntax '{') => (Some(Syntax::LBrace));
+    (@syntax '}') => (Some(Syntax::RBrace));
+    (@syntax '=') => (Some(Syntax::Equal));
+    (@syntax ',') => (Some(Syntax::Comma));
+    (@syntax '"') => (Some(Syntax::Quote));
+    (@syntax '/') => (Some(Syntax::Slash));
+    (@syntax _) => (None);
+    (@syntax $other:literal) => (compile_error!(concat!("unknown syntax character `", $other, "`")));
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Syntax {
+    LBrack = b'[',
+    RBrack = b']',
+    LBrace = b'{',
+    RBrace = b'}',
+    Equal = b'=',
+    Comma = b',',
+    Quote = b'"',
+    Slash = b'/',
+}
+
+fn find_syntax(haystack: &str) -> (usize, Option<Syntax>) {
+    use Syntax::*;
+    haystack
+        .bytes()
+        .enumerate()
+        .find_map(|(i, b)| match b {
+            b'[' => Some((i, LBrack)),
+            b']' => Some((i, RBrack)),
+            b'{' => Some((i, LBrace)),
+            b'}' => Some((i, RBrace)),
+            b'=' => Some((i, Equal)),
+            b',' => Some((i, Comma)),
+            b'"' => Some((i, Quote)),
+            b'/' => Some((i, Slash)),
+            _ => None,
+        })
+        .map_or_else(|| (haystack.len(), None), |(i, c)| (i, Some(c)))
+}
+
+#[derive(Debug)]
+pub(super) enum ParseErrorKind {
+    Field(Box<dyn Error + Send + Sync>),
+    Level(level::ParseError),
+    UnexpectedSyntax(char),
+    Other,
+}
+
+/// Parse a single directive off the front of the source string.
+///
+/// Returns the parsed directive or a parse error, along with the index of
+/// the start of the next directive, making an attempt at error recovery
+/// in the face of reasonably recoverable parser errors.
+///
+/// # Syntax
+///
+/// ```text
+/// target[span{field=value}]=level
+/// ```
+///
+/// All of the directive fields are optional, and multiple `field=value` pairs
+/// may be provided, so the following are also valid directives:
+///
+/// ```text
+/// target
+/// =level
+/// [{}]
+/// [{field=value,field=value}]
+/// ```
+#[allow(unused)]
+pub(super) fn parse_one_directive(source: &str) -> (Result<Directive, ParseErrorKind>, usize) {
+    fn try_recover_with(source: &str, at: usize, syntax: Syntax) -> usize {
+        let (i, next_syntax) = find_syntax(&source[at..]);
+        if next_syntax == Some(syntax) {
+            at + i + 1
+        } else {
+            source.len()
+        }
+    }
+
+    fn parse_at_span(
+        source: &str,
+        target: Option<String>,
+    ) -> (Result<Directive, ParseErrorKind>, usize) {
+        assert_eq!(source.as_bytes()[0], b'[');
+
+        if source[1..].starts_with('"') {
+            return match parse_one_quote_string(&source[1..]) {
+                (None, _) => (Err(ParseErrorKind::Other), source.len()),
+                (Some(quoted), after_quoted) => match source.as_bytes().get(1 + after_quoted) {
+                    None => (Err(ParseErrorKind::Other), source.len()),
+                    Some(&syntax @ (b'/' | b'[' | b'}' | b'"' | b',' | b'=')) => (
+                        Err(ParseErrorKind::UnexpectedSyntax(syntax as char)),
+                        source.len(),
+                    ),
+                    Some(b']') => {
+                        let (parsed, after_parsed) = parse_at_level(
+                            &source[1 + after_quoted + 1..],
+                            Some(quoted.into()),
+                            FilterVec::new(),
+                            target,
+                        );
+                        (parsed, 1 + after_parsed + 1)
+                    }
+                    Some(b'{') => {
+                        let (fields, after_fields) = parse_at_fields(&source[1 + after_quoted..]);
+                        match fields {
+                            Err(e) => (Err(e), source.len()),
+                            Ok(fields) => {
+                                let (parsed, after_parsed) = parse_at_level(
+                                    &source[1 + after_quoted + after_fields..],
+                                    Some(quoted.into()),
+                                    FilterVec::new(),
+                                    target,
+                                );
+                                (parsed, 1 + after_quoted + after_fields + after_parsed)
+                            }
+                        }
+                    }
+                    _ => (
+                        Err(ParseErrorKind::Other),
+                        try_recover_with(source, 1 + after_quoted, Syntax::Comma),
+                    ),
+                },
+            };
+        }
+
+        switch_syntax!(&source[1..] => |i| {
+            '/' => (Err(ParseErrorKind::UnexpectedSyntax('/')), source.len()),
+            '[' => (Err(ParseErrorKind::UnexpectedSyntax('[')), source.len()),
+            '}' => (Err(ParseErrorKind::UnexpectedSyntax('}')), source.len()),
+            '"' => (Err(ParseErrorKind::UnexpectedSyntax('"')), source.len()),
+            ',' => (Err(ParseErrorKind::UnexpectedSyntax(',')), source.len()),
+            '=' => (Err(ParseErrorKind::UnexpectedSyntax('=')), source.len()),
+            ']' => {
+                let (parsed, after_parsed) = parse_at_level(
+                    &source[1 + i + 1..],
+                    Some(source[1..1 + i].trim()).filter(|s| !s.is_empty()).map(Into::into),
+                    FilterVec::new(),
+                    target,
+                );
+                (parsed, 1 + i + 1 + after_parsed)
+            },
+            '{' => {
+                let (fields, after_fields) = parse_at_fields(&source[1 + i..]);
+                match fields {
+                    Err(e) => (Err(e), source.len()),
+                    Ok(fields) => {
+                        let (parsed, after_parsed) = parse_at_level(
+                            &source[1 + i + after_fields..],
+                            Some(source[1..1 + i].trim()).filter(|s| !s.is_empty()).map(Into::into),
+                            fields,
+                            target,
+                        );
+                        (parsed, 1 + i + after_fields + after_parsed)
+                    }
+                }
+            },
+            _ => (Err(ParseErrorKind::Other), source.len()),
+        })
+    }
+
+    // NB: includes parsing the comma, if present
+    fn parse_at_field(source: &str) -> (Result<Match, ParseErrorKind>, usize) {
+        let mut cursor = 0;
+
+        let name = if source.starts_with('"') {
+            match parse_one_quote_string(source) {
+                (None, _) => return (Err(ParseErrorKind::Other), source.len()),
+                (Some(quoted), after_quoted) => {
+                    cursor = after_quoted;
+                    quoted.into()
+                }
+            }
+        } else {
+            let (syntax_at, _) = find_syntax(source);
+            cursor = syntax_at;
+            source[..cursor].trim().into()
+        };
+
+        match source.as_bytes().get(cursor) {
+            None => (Err(ParseErrorKind::Other), source.len()),
+            Some(b',') => (Ok(Match { name, value: None }), cursor + 1),
+            Some(b'}') => (Ok(Match { name, value: None }), cursor),
+            Some(b'=') => {
+                cursor += 1;
+                if source[cursor..].starts_with('"') {
+                    match parse_one_quote_string(&source[cursor..]) {
+                        (None, _) => (Err(ParseErrorKind::Other), source.len()),
+                        (Some(quoted), after_quoted) => {
+                            // Prefer env filter syntax error
+                            cursor += after_quoted;
+                            match source.as_bytes().get(cursor) {
+                                None => (Err(ParseErrorKind::Other), source.len()),
+                                Some(b',') => (
+                                    Ok(Match { name, value: None }).and_then(|mut m| {
+                                        m.value = Some(
+                                            quoted
+                                                .parse::<ValueMatch>()
+                                                .map_err(|e| ParseErrorKind::Field(e.into()))?,
+                                        );
+                                        Ok(m)
+                                    }),
+                                    cursor + 1,
+                                ),
+                                Some(b'}') => (
+                                    Ok(Match { name, value: None }).and_then(|mut m| {
+                                        m.value = Some(
+                                            quoted
+                                                .parse::<ValueMatch>()
+                                                .map_err(|e| ParseErrorKind::Field(e.into()))?,
+                                        );
+                                        Ok(m)
+                                    }),
+                                    cursor,
+                                ),
+                                _ => (Err(ParseErrorKind::Other), source.len()),
+                            }
+                        }
+                    }
+                } else {
+                    switch_syntax!(&source[cursor..] => |i| {
+                        '/' => (Err(ParseErrorKind::UnexpectedSyntax('/')), source.len()),
+                        '[' => (Err(ParseErrorKind::UnexpectedSyntax('[')), source.len()),
+                        '"' => (Err(ParseErrorKind::UnexpectedSyntax('"')), source.len()),
+                        '{' => (Err(ParseErrorKind::UnexpectedSyntax('{')), source.len()),
+                        '=' => (Err(ParseErrorKind::UnexpectedSyntax('=')), source.len()),
+                        ']' => (Err(ParseErrorKind::UnexpectedSyntax(']')), source.len()),
+                        '}' => match source[cursor..][..i].trim().parse() {
+                            Ok(value) => (Ok(Match { name, value: Some(value) }), cursor + i),
+                            Err(e) => (Err(ParseErrorKind::Field(e.into())), source.len()),
+                        },
+                        ',' => match source[cursor..][..i].trim().parse() {
+                            Ok(value) => (Ok(Match { name, value: Some(value) }), cursor + i + 1),
+                            Err(e) => (Err(ParseErrorKind::Field(e.into())), source.len()),
+                        },
+                        _ => (Err(ParseErrorKind::Other), source.len()),
+                    })
+                }
+            }
+            _ => (Err(ParseErrorKind::Other), source.len()),
+        }
+    }
+
+    // NB: includes parsing the rbrack, if present
+    fn parse_at_fields(source: &str) -> (Result<FilterVec<Match>, ParseErrorKind>, usize) {
+        assert_eq!(source.as_bytes()[0], b'{');
+
+        let mut fields = FilterVec::new();
+        let mut cursor = 1;
+        while source.as_bytes().get(cursor) != Some(&b'}') {
+            let (parsed, after_parsed) = parse_at_field(&source[cursor..]);
+            match parsed {
+                Err(e) => {
+                    return (
+                        Err(e),
+                        try_recover_with(source, cursor + after_parsed, Syntax::RBrace),
+                    )
+                }
+                Ok(field) => {
+                    fields.push(field);
+                    cursor += after_parsed;
+                }
+            }
+        }
+        if source.as_bytes().get(cursor + 1) == Some(&b']') {
+            (Ok(fields), cursor + 1 + 1)
+        } else {
+            (Err(ParseErrorKind::Other), source.len())
+        }
+    }
+
+    fn parse_at_level(
+        source: &str,
+        in_span: Option<String>,
+        fields: FilterVec<Match>,
+        target: Option<String>,
+    ) -> (Result<Directive, ParseErrorKind>, usize) {
+        if !source.starts_with('=') {
+            // NB: parse_at_comma handles syntax/comma after the level
+            return (
+                Ok(Directive {
+                    in_span,
+                    fields,
+                    target,
+                    level: LevelFilter::TRACE,
+                }),
+                0,
+            );
+        }
+
+        if source[1..].starts_with('"') {
+            return match parse_one_quote_string(&source[1..]) {
+                (None, _) => (Err(ParseErrorKind::Other), source.len()),
+                (Some(quoted), after_quoted) => match parse_level_filter(&quoted) {
+                    // NB: parse_at_comma handles syntax/comma after the level
+                    Ok(level) => (
+                        Ok(Directive {
+                            in_span,
+                            fields,
+                            target,
+                            level,
+                        }),
+                        1 + after_quoted,
+                    ),
+                    Err(err) => (Err(ParseErrorKind::Level(err)), 1 + after_quoted),
+                },
+            };
+        }
+
+        switch_syntax!(&source[1..] => |i| {
+            // Prefer syntax error over potential level parse error
+            '/' => (Err(ParseErrorKind::UnexpectedSyntax('/')), source.len()),
+            '[' => (Err(ParseErrorKind::UnexpectedSyntax('[')), source.len()),
+            '"' => (Err(ParseErrorKind::UnexpectedSyntax('"')), source.len()),
+            '{' => (Err(ParseErrorKind::UnexpectedSyntax('{')), source.len()),
+            '}' => (Err(ParseErrorKind::UnexpectedSyntax('}')), 1 + i),
+            '=' => (Err(ParseErrorKind::UnexpectedSyntax('=')), 1 + i),
+            ']' => (Err(ParseErrorKind::UnexpectedSyntax(']')), 1 + i),
+            ',' | _ => match parse_level_filter(&source[1..1 + i]) {
+                Ok(level) => (
+                    Ok(Directive {
+                        in_span,
+                        fields,
+                        target,
+                        level,
+                    }),
+                    1 + i,
+                ),
+                Err(err) => (Err(ParseErrorKind::Level(err)), 1 + i),
+            },
+        })
+    }
+
+    fn parse_at_comma(
+        source: &str,
+        i: usize,
+        directive: Result<Directive, ParseErrorKind>,
+    ) -> (Result<Directive, ParseErrorKind>, usize) {
+        match source[i..].as_bytes().get(0) {
+            None => (directive, i),
+            Some(b',') => (directive, i + 1),
+            Some(&syntax @ (b'[' | b'{' | b'"' | b'/')) => (
+                Err(ParseErrorKind::UnexpectedSyntax(syntax as char)),
+                source.len(),
+            ),
+            Some(&syntax @ (b']' | b'}' | b'=')) => (
+                Err(ParseErrorKind::UnexpectedSyntax(syntax as char)),
+                try_recover_with(source, i + 1, Syntax::Comma),
+            ),
+            _ => (
+                Err(ParseErrorKind::Other),
+                try_recover_with(source, i, Syntax::Comma),
+            ),
+        }
+    }
+
+    if source.starts_with('"') {
+        return match parse_one_quote_string(source) {
+            (None, after) => (Err(ParseErrorKind::Other), after),
+            (Some(quoted), after_quoted) => match source.as_bytes().get(after_quoted) {
+                None => (
+                    Ok(Directive {
+                        in_span: None,
+                        fields: FilterVec::new(),
+                        target: Some(quoted.to_string()),
+                        level: LevelFilter::TRACE,
+                    }),
+                    after_quoted,
+                ),
+                Some(b',') => (
+                    Ok(Directive {
+                        in_span: None,
+                        fields: FilterVec::new(),
+                        target: Some(quoted.to_string()),
+                        level: LevelFilter::TRACE,
+                    }),
+                    after_quoted + 1,
+                ),
+                Some(&syntax @ (b'/' | b'{')) => (
+                    Err(ParseErrorKind::UnexpectedSyntax(syntax as char)),
+                    source.len(),
+                ),
+                Some(&syntax @ (b']' | b'}')) => (
+                    Err(ParseErrorKind::UnexpectedSyntax(syntax as char)),
+                    try_recover_with(source, after_quoted + 1, Syntax::Comma),
+                ),
+                Some(b'[') => {
+                    let (parsed, after_parsed) =
+                        parse_at_span(&source[after_quoted..], Some(quoted.into()));
+                    parse_at_comma(source, after_parsed, parsed)
+                }
+                Some(b'=') => {
+                    let (parsed, after_parsed) = parse_at_level(
+                        &source[after_quoted..],
+                        None,
+                        FilterVec::new(),
+                        Some(quoted.into()),
+                    );
+                    parse_at_comma(source, after_parsed, parsed)
+                }
+                Some(b'"') => (Err(ParseErrorKind::UnexpectedSyntax('"')), source.len()),
+                _ => (
+                    Err(ParseErrorKind::Other),
+                    try_recover_with(source, after_quoted, Syntax::Comma),
+                ),
+            },
+        };
+    }
+
+    switch_syntax!(source => |i| {
+        '/' => (Err(ParseErrorKind::UnexpectedSyntax('/')), source.len()),
+        '"' => (Err(ParseErrorKind::UnexpectedSyntax('}')), source.len()),
+        '{' => (Err(ParseErrorKind::UnexpectedSyntax('{')), source.len()),
+        '}' => (Err(ParseErrorKind::UnexpectedSyntax('}')), try_recover_with(source, i + 1, Syntax::Comma)),
+        ']' => (Err(ParseErrorKind::UnexpectedSyntax(']')), try_recover_with(source, i + 1, Syntax::Comma)),
+        ',' => (parse_one_directive(&source[..i]).0, i + 1),
+        '[' => {
+            let (parsed, after_parsed) = parse_at_span(
+                &source[i..],
+                Some(source[..i].trim()).filter(|s| !s.is_empty()).map(Into::into),
+            );
+            parse_at_comma(source, i + after_parsed, parsed)
+        },
+        '=' => {
+            let (parsed, after_parsed) = parse_at_level(
+                &source[i..],
+                None,
+                FilterVec::new(),
+                Some(source[..i].trim()).filter(|s| !s.is_empty()).map(Into::into),
+            );
+            parse_at_comma(source, i + after_parsed, parsed)
+        },
+        _ => match parse_level_filter(source.trim()) {
+            Ok(level) => (Ok(Directive {
+                in_span: None,
+                fields: FilterVec::new(),
+                target: None,
+                level,
+            }), source.len()),
+            Err(_) => (Ok(Directive {
+                in_span: None,
+                fields: FilterVec::new(),
+                target: Some(source.trim().to_string()),
+                level: LevelFilter::TRACE,
+            }), source.len()),
+        }
+    })
+}
+
+/// Parse a single quote string off the front of the source string.
+///
+/// Returns the unquoted string, if terminated, as well as the index after the
+/// parsed string.
+///
+/// Currently has no escape syntax.
+fn parse_one_quote_string(source: &str) -> (Option<Cow<'_, str>>, usize) {
+    assert!(source.starts_with('"'));
+    match source[1..].find('"') {
+        None => (None, source.len()),
+        Some(i) => (Some(source[1..1 + i].into()), 1 + i + 1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_quote_parsing() {
+        macro_rules! check {
+            ($source:expr => $expected:expr, $expected_after:expr) => {{
+                let source: &str = $source;
+                let expected: Option<&str> = $expected;
+                let expected_after: &str = $expected_after;
+                let (parsed, parsed_len) = parse_one_quote_string(source);
+                assert_eq!(
+                    (parsed, &source[parsed_len..]),
+                    (expected.map(Into::into), expected_after),
+                    "\nexpected {:?} to parse",
+                    source,
+                );
+            }};
+        }
+
+        check!(r#""hello""# => Some("hello"), "");
+        check!(r#""hello"world"# => Some("hello"), "world");
+        check!(r#""hello"# => None, "");
+    }
+
+    #[test]
+    fn test_directive_parsing() {
+        macro_rules! check_pass {
+            ($source:expr => $expected:expr, $expected_after:expr) => {{
+                let source: &str = $source;
+                let expected: Directive = $expected;
+                let expected_after: &str = $expected_after;
+                let (parsed, parsed_len) = parse_one_directive(source);
+                let parsed = parsed.unwrap_or_else(|e| {
+                    panic!("Failed to parse directive {:?} with err {:?}", source, e)
+                });
+                assert_eq!(
+                    (parsed, &source[parsed_len..]),
+                    (expected, expected_after),
+                    "\nexpected {:?} to parse",
+                    source,
+                );
+            }};
+        }
+
+        macro_rules! collect {
+            [$($expr:expr),* $(,)?] => {
+                IntoIterator::into_iter([$($expr),*]).collect()
+            }
+        }
+
+        check_pass!("hello" => Directive {
+            in_span: None,
+            fields: collect![],
+            target: Some("hello".into()),
+            level: LevelFilter::TRACE
+        }, "");
+
+        check_pass!("info" => Directive {
+            in_span: None,
+            fields: collect![],
+            target: None,
+            level: LevelFilter::INFO
+        }, "");
+
+        check_pass!("INFO" => Directive {
+            in_span: None,
+            fields: collect![],
+            target: None,
+            level: LevelFilter::INFO
+        }, "");
+
+        check_pass!("hello=debug" => Directive {
+            in_span: None,
+            fields: collect![],
+            target: Some("hello".into()),
+            level: LevelFilter::DEBUG
+        }, "");
+
+        check_pass!("hello,std::option" => Directive {
+            in_span: None,
+            fields: collect![],
+            target: Some("hello".into()),
+            level: LevelFilter::TRACE
+        }, "std::option");
+
+        check_pass!("error,hello=warn" => Directive {
+            in_span: None,
+            fields: collect![],
+            target: None,
+            level: LevelFilter::ERROR
+        }, "hello=warn");
+
+        check_pass!("tokio::net=info" => Directive {
+            in_span: None,
+            fields: collect![],
+            target: Some("tokio::net".into()),
+            level: LevelFilter::INFO
+        }, "");
+
+        check_pass!("my_crate[span_a]=trace" => Directive {
+            in_span: Some("span_a".into()),
+            fields: collect![],
+            target: Some("my_crate".into()),
+            level: LevelFilter::TRACE
+        }, "");
+
+        check_pass!("[span_b{name}]" => Directive {
+            in_span: Some("span_b".into()),
+            fields: collect![Match { name: "name".into(), value: None }],
+            target: None,
+            level: LevelFilter::TRACE
+        }, "");
+
+        check_pass!(r#"[span_b{name=bob}]"# => Directive {
+            in_span: Some("span_b".into()),
+            fields: collect![Match { name: "name".into(), value: Some("bob".parse().unwrap()) }],
+            target: None,
+            level: LevelFilter::TRACE
+        }, "");
+
+        check_pass!(r#"[span_b{name="bob"}]"# => Directive {
+            in_span: Some("span_b".into()),
+            fields: collect![Match { name: "name".into(), value: Some("bob".parse().unwrap()) }],
+            target: None,
+            level: LevelFilter::TRACE
+        }, "");
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

I'm working on a system that records tracing events in-process and displays them in a window, allowing filtering with `EnvFilter`-like syntax. As such I needed to parse the syntax, and the current parsing routine in tracing-subscriber is... subpar to say the least. Due to the way the regex are written/used, you can pretty trivially construct directive strings with very odd parses (e.g. `[[[span[[]` which parses as `[span]`, or `[{{{a}}}]` which parses as `[]`).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

As such, I wrote a stricter parser for the format for my own use, and this PR polishes it up to the level to use it as the env filter parser for tracing.

Also, fixes #1584.

## Solution

Implement a better parser and use it!

-----

### Important breaking behavior change note

Beyond the obvious changes in how things parse, there's a subtle one: `[{name="bob"}]`. Previously, this would parse as a directive to match field `name` against the regex `"bob"`. Now, as quotes are semantic, it parses as a directive to match field `name` against the regex `bob`. Also note that filter regexes are anchored on both sides: this is a big behavior change!

For how this corresponds to captures, as of master 0fa74b9caee1dbb01b8d67ed1e526061ab7156b6:
- `tracing::*_span!("f", name="bob")` (captured by-`Value`) matches the regex `bob` and pretty displays as `name: "bob"`,
- `tracing::*_span!("f", name=%"bob")` (captured by-`Display`) matches the regex `bob` and pretty displays as `name: bob`,
- `tracing::*_span!("f", name=?"bob")` (captured by-`Debug`) matches the regex `"bob"` and pretty displays as `name: "bob"`, and
- `#[tracing::instrument] fn f(name: &str); f("bob")` matches the regex `bob`.

In all cases, the obnoxiously pretty formatter says `in f with name: "bob"` (i.e. when printed no visual difference is made between the methods of capture).

Since string arguments are already captured by-`Value` and matched without strings in master, this will make filters with `"bob"` go from matching spans capturing strings by-`Debug` (rare?) to capturing strings by-anything-else (common). If they want the current behavior, they would have to use a regex hex escape currently.

Plus, if I'm not mistaken, pre #1378, argument strings _were captured by-`Debug`_, not by-`Value`, so they would need to be matched as `"bob"`. This means #1378 broke behavior there, and this PR returns to `"bob"` matching an argument captured string.

### Test changes

- `tracing_subscriber::filter::env::directive::parse_directives_with_special_characters_in_span_name`: `"/=[}` are now forbidden in (unquoted) span names.
- `tracing_subscriber::filter::env::callsite_enabled_includes_span_directive_multiple_fields`: previously, the directive didn't parse at all (#1584) and thus the test was completely broken; now the directive parses and the interest is sometimes (which I think is correct).
- `tracing_subscriber::filter::env::roundtrip`: previously, the directive was `[span1{foo=1}]=error,[span2{bar=2 baz=false}],crate2[{quux="quuux"}]=debug`, which included the problematic directive `[{bar=2 baz=false}]`; this has been changed to `[{bar=2, baz=false}]`, with the alternative which would continue to parse successfully being `[{bar="2 baz=false"}]` or `[{"bar=2 baz"=false}]`.
- New tests in `tracing_subscriber::filter::env::parsing`.

### Remaining work / decision items

- More tests, always.
- Should quoted field value directives always behave as a regex match instead of a value match? This seems reasonable to me, but as currently implemented, quotes are purely a syntax escape feature, and have no semantic meaning (i.e. `val="3"` is equivalent to `val=3`, and performs a structural match). Of note is that all structurally matched values can be spelled without reserved syntax, though this may potentially change with [more structural captures](https://github.com/tokio-rs/tracing/issues/1570).
- Quoted directive fields currently have no escape syntax -- every character is literal other than `"`, which is disallowed (ends the quoted field).
- Mark me as CODEOWNER for `tracing_subscriber::filter::env::parsing`

### Future work

- Use `/`? It's reserved currently as it is [used by env_logger to specify a (global) regex filter for log messages](https://docs.rs/env_logger/0.9.0/env_logger/#filtering-results).
- Support multiple span filters in a single directive? What semantics would that have?
- Autoref specialization in `#[tracing::instrument]` to mitigate the big behavior change, discussed above.
- Make it possible (somehow) to use `EnvFilter` to filter third-party things that "quack like `SpanRef<'_>`/`Event<'_>`". This is actually my motivating factor in writing a new parser, to implement env-filter like filtering of serialized events/spans.

<details><summary>Original PR message</summary>

[`parse-env-filter`](https://crates.io/crates/parse-env-filter) is essentially part of this PR ([github](https://github.com/CAD97/tracing-utils/tree/main/libs/parse-env-filter)); I can inline the implementation here if desired, but I'll also be using the implementation separately, so it'd be nicer for me if it can live in a dedicated crate, either within this repo or in a repo I own.

### Remaining work

This isn't quite mergable in its current state yet. Known deficiencies that should be fixed before merging:

- The current implementation always splits the env filter string into multiple directives on each `,`. (This means a parsed env filter can't support multiple field bounds, even though `Directive` nominally supports it! Whoops...) While `parse-env-filter` properly handles comma-separated field directives (and span directives, which would be a new feature), this PR currently still does the top-level `split(',')` for convenience of implementation.
- `parse-env-filter` currently completely bails on a directive containing the `"` (or `/`) character. This is because I haven't (but plan to) implement some form of quoting for the fields of the directive, so that the fields may contain syntax characters within the quotes. The exact quoting syntax needs to be decided, and the implementation work needs to happen. `/` is reserved because of [`env_logger`'s syntax](https://docs.rs/env_logger/0.7.1/env_logger/#filtering-results); this one might be desirable to keep as an error because of that?
- `parse-env-filter` doesn't do any error recovery; it just bails upon bad syntax and calls the rest of the directive string invalid. The current impl can recover, as every `,` is treated as the start of a new directive. Allowing `,` inside a directive, mismatched brackets, and more, causes error recovery to continue parsing directives a much harder task, though. `parse-env-filter`'s behavior matches `try_new`'s, but `new`'s behavior of "best effort parse" is at odds with `parse-env-filter`'s goal of more strict, well-defined parsing.
- `parse-env-filter` deliberately does no whitespace trimming; whitespace is provided as part of the directives. `EnvFilter` needs to decide if it wants to trim whitespace, and do so if it wants to.

### Known test failures

- `filter::env::directive::test::parse_directives_with_special_characters_in_span_name`: special characters include `"` (parser support todo) and `[`/`{`/`/`/`, which are deliberately disallowed. How to handle `"` quoting should be decided, I need to then implement `"` handling, and the forbidden nature of `[`/`{` is an ideological question: `parse-env-filter` aims to be strict and validate, whereas the current impl is more forgiving and loose with the filter syntax.
- `filter::env::tests::callsite_enabled_includes_span_directive_field`: test includes quoted field value (parser support todo)
- `filter::env::tests::roundtrip`: test includes quoted field value (parser support todo), and the formatting of the directive which is being checked to roundtrip includes the quotes as well, so this is more inherent a problem than the previous tests

-----

r? @hawkw 

### Immediate discussion items:

- Decide what (if any) quoting syntax with `"` is desired for env filter directives
- Decide where on the strict-permissive parser axis we _want_ `EnvFilter` to fall
  - Decide how `EnvFilter::new` should do recovery along that axis
- Decide on how to treat `/`
- Decide if we actually want multiple span/field directives in a single directive (and what the semantics of it are<sub>, though I'm here for the parser, not the filtering</sub>)
  - Multiple spans: `target[span1,span2]=level`
  - Multiple fields: `target[span{field1=value1, field2=value2}]`
- Decide what (if any) whitespace trimming (e.g. after `,`) should be done