### PR TITLE
fix: log level filter with trace

### DIFF
--- a/tracing-log/src/log_tracer.rs
+++ b/tracing-log/src/log_tracer.rs
@@ -183,7 +183,9 @@ impl log::Log for LogTracer {
     }
 
     fn log(&self, record: &log::Record<'_>) {
-        crate::dispatch_record(record);
+        if self.enabled(record.metadata()) {
+            crate::dispatch_record(record);
+        }
     }
 
     fn flush(&self) {}

--- a/tracing-log/tests/log_tracer.rs
+++ b/tracing-log/tests/log_tracer.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 use tracing::collect::with_default;
 use tracing_core::span::{Attributes, Record};
-use tracing_core::{span, Collect, Event, Level, Metadata};
+use tracing_core::{span, Collect, Event, Level, LevelFilter, Metadata};
 use tracing_log::{LogTracer, NormalizeEvent};
 
 struct State {
@@ -24,6 +24,10 @@ impl Collect for TestSubscriber {
     fn enabled(&self, meta: &Metadata<'_>) -> bool {
         dbg!(meta);
         true
+    }
+
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        Some(LevelFilter::from_level(Level::INFO))
     }
 
     fn new_span(&self, _span: &Attributes<'_>) -> span::Id {
@@ -67,6 +71,8 @@ fn normalized_metadata() {
     let state = me.clone();
 
     with_default(TestSubscriber(me), || {
+        log::info!("expected info log");
+        log::debug!("unexpected debug log");
         let log = log::Record::builder()
             .args(format_args!("Error!"))
             .level(log::Level::Info)


### PR DESCRIPTION
The `LogTracer::init()` will convert all logs to tracing events, and regardless of the tracing 'Collector' filter, just dispatch all events, cause inconsistent behavior between log and trace.