### PR TITLE
Make NoSubscriber public and move it to tracing_core::subscriber

### DIFF
--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -131,7 +131,7 @@
 //! [`Dispatch`]: struct.Dispatch.html
 use crate::{
     callsite, span,
-    subscriber::{self, Subscriber},
+    subscriber::{self, NoSubscriber, Subscriber},
     Event, LevelFilter, Metadata,
 };
 
@@ -659,32 +659,6 @@ where
     fn from(subscriber: S) -> Self {
         Dispatch::new(subscriber)
     }
-}
-
-struct NoSubscriber;
-impl Subscriber for NoSubscriber {
-    #[inline]
-    fn register_callsite(&self, _: &'static Metadata<'static>) -> subscriber::Interest {
-        subscriber::Interest::never()
-    }
-
-    fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
-        span::Id::from_u64(0xDEAD)
-    }
-
-    fn event(&self, _event: &Event<'_>) {}
-
-    fn record(&self, _span: &span::Id, _values: &span::Record<'_>) {}
-
-    fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
-
-    #[inline]
-    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
-        false
-    }
-
-    fn enter(&self, _span: &span::Id) {}
-    fn exit(&self, _span: &span::Id) {}
 }
 
 impl Registrar {

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -404,7 +404,7 @@ impl Dispatch {
     #[inline]
     pub fn none() -> Self {
         Dispatch {
-            subscriber: Arc::new(NoSubscriber),
+            subscriber: Arc::new(NoSubscriber::default()),
         }
     }
 
@@ -763,13 +763,13 @@ mod test {
 
     #[test]
     fn dispatch_is() {
-        let dispatcher = Dispatch::new(NoSubscriber);
+        let dispatcher = Dispatch::new(NoSubscriber::default());
         assert!(dispatcher.is::<NoSubscriber>());
     }
 
     #[test]
     fn dispatch_downcasts() {
-        let dispatcher = Dispatch::new(NoSubscriber);
+        let dispatcher = Dispatch::new(NoSubscriber::default());
         assert!(dispatcher.downcast_ref::<NoSubscriber>().is_some());
     }
 

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -564,6 +564,37 @@ impl Interest {
     }
 }
 
+/// A no-op [`Subscriber`]
+///
+/// [`NoSubscriber`] implements the [`Subscriber`] trait by never being enabled,
+/// never being interested in any callsite, and drops all spans and events.
+#[derive(Debug, Copy, Clone)]
+pub struct NoSubscriber;
+impl Subscriber for NoSubscriber {
+    #[inline]
+    fn register_callsite(&self, _: &'static Metadata<'static>) -> Interest {
+        Interest::never()
+    }
+
+    fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
+        span::Id::from_u64(0xDEAD)
+    }
+
+    fn event(&self, _event: &Event<'_>) {}
+
+    fn record(&self, _span: &span::Id, _values: &span::Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
+
+    #[inline]
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        false
+    }
+
+    fn enter(&self, _span: &span::Id) {}
+    fn exit(&self, _span: &span::Id) {}
+}
+
 impl Subscriber for Box<dyn Subscriber + Send + Sync + 'static> {
     #[inline]
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -569,7 +569,14 @@ impl Interest {
 /// [`NoSubscriber`] implements the [`Subscriber`] trait by never being enabled,
 /// never being interested in any callsite, and drops all spans and events.
 #[derive(Debug, Copy, Clone)]
-pub struct NoSubscriber;
+pub struct NoSubscriber(());
+
+impl Default for NoSubscriber {
+    fn default() -> Self {
+        NoSubscriber(())
+    }
+}
+
 impl Subscriber for NoSubscriber {
     #[inline]
     fn register_callsite(&self, _: &'static Metadata<'static>) -> Interest {


### PR DESCRIPTION
This is useful when you need a placeholder subscriber for something.