### PR TITLE
backport some stuff

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -230,17 +230,22 @@ jobs:
         profile: minimal
         override: true
     - name: "Test log support"
-      run: (cd tracing/test-log-support && cargo test)
+      run: cargo test
+      working-directory: "tracing/test-log-support"
     - name: "Test static max level"
-      run: (cd tracing/test_static_max_level_features && cargo test)
+      run: cargo test
+      working-directory: "tracing/test_static_max_level_features"
     - name: "Test tracing-core no-std support"
-      run: (cd tracing-core && cargo test --no-default-features)
+      run: cargo test --no-default-features
+      working-directory: tracing
     - name: "Test tracing no-std support"
-      run: (cd tracing && cargo test --no-default-features)
+      run: cargo test --no-default-features
+      working-directory: tracing
       # this skips running doctests under the `--no-default-features` flag,
       # as rustdoc isn't aware of cargo's feature flags.
     - name: "Test tracing-subscriber with all features disabled"
-      run: (cd tracing-subscriber && cargo test --lib --tests --no-default-features)
+      run: cargo test --lib --tests --no-default-features
+      working-directory: tracing-subscriber
 
   style:
     # Check style.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,10 @@
 [build]
-  command = "rustup install nightly --profile minimal && cargo doc --no-deps && cp -r target/doc _netlify_out"
-  environment = { RUSTDOCFLAGS= "--cfg docsrs -D warnings" }
-  publish = "_netlify_out"
+  command = """
+    rustup install nightly --profile minimal \
+      && cargo doc --no-deps
+    """
+  environment = { RUSTDOCFLAGS= "--cfg docsrs" }
+  publish = "target/doc"
 
 [[redirects]]
   from = "/"

--- a/tracing-log/src/log_tracer.rs
+++ b/tracing-log/src/log_tracer.rs
@@ -183,7 +183,9 @@ impl log::Log for LogTracer {
     }
 
     fn log(&self, record: &log::Record<'_>) {
-        crate::dispatch_record(record);
+        if self.enabled(record.metadata()) {
+            crate::dispatch_record(record);
+        }
     }
 
     fn flush(&self) {}

--- a/tracing-log/tests/log_tracer.rs
+++ b/tracing-log/tests/log_tracer.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 use tracing::subscriber::with_default;
 use tracing_core::span::{Attributes, Record};
-use tracing_core::{span, Event, Level, Metadata, Subscriber};
+use tracing_core::{span, Event, Level, LevelFilter, Metadata, Subscriber};
 use tracing_log::{LogTracer, NormalizeEvent};
 
 struct State {
@@ -24,6 +24,10 @@ impl Subscriber for TestSubscriber {
     fn enabled(&self, meta: &Metadata<'_>) -> bool {
         dbg!(meta);
         true
+    }
+
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        Some(LevelFilter::from_level(Level::INFO))
     }
 
     fn new_span(&self, _span: &Attributes<'_>) -> span::Id {
@@ -63,6 +67,8 @@ fn normalized_metadata() {
     let state = me.clone();
 
     with_default(TestSubscriber(me), || {
+        log::info!("expected info log");
+        log::debug!("unexpected debug log");
         let log = log::Record::builder()
             .args(format_args!("Error!"))
             .level(log::Level::Info)

--- a/tracing-subscriber/src/filter/env/directive.rs
+++ b/tracing-subscriber/src/filter/env/directive.rs
@@ -8,6 +8,7 @@ use tracing_core::{span, Level, Metadata};
 /// A single filtering directive.
 // TODO(eliza): add a builder for programmatically constructing directives?
 #[derive(Debug, Eq, PartialEq)]
+#[cfg_attr(docsrs, doc(cfg(feature = "env-filter")))]
 pub struct Directive {
     in_span: Option<String>,
     fields: FilterVec<field::Match>,

--- a/tracing-subscriber/src/filter/env/field.rs
+++ b/tracing-subscriber/src/filter/env/field.rs
@@ -115,6 +115,7 @@ pub(crate) struct MatchPattern {
 
 /// Indicates that a field name specified in a filter directive was invalid.
 #[derive(Clone, Debug)]
+#[cfg_attr(docsrs, doc(cfg(feature = "env-filter")))]
 pub struct BadName {
     name: String,
 }

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -119,6 +119,7 @@ type FilterVec<T> = Vec<T>;
 
 /// Indicates that an error occurred while parsing a `EnvFilter` from an
 /// environment variable.
+#[cfg_attr(docsrs, doc(cfg(feature = "env-filter")))]
 #[derive(Debug)]
 pub struct FromEnvError {
     kind: ErrorKind,


### PR DESCRIPTION
* ffbf8787 log: fix `LogTracer` not honoring max level filters (#1543)
* cd2af48c subscriber: fix missing `doc(cfg(...))` attributes for `EnvFilter` (#1544)
* d27d0b3f chore: simplify Netlify config (#1541)
* 23f1508f chore(ci): use `working-directory` instead of cd (#1540)