### PR TITLE
subscriber: prepare to release v0.2.21

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,11 +1,60 @@
-# Unreleased
+# 0.2.21 (September 12, 2021)
+
+This release introduces the [`Filter`] trait, a new API for [per-layer
+filtering][plf]. This allows controlling which spans and events are recorded by
+various layers individually, rather than globally.
+
+In addition, it adds a new [`Targets`] filter, which provides a lighter-weight
+version of the filtering provided by [`EnvFilter`], as well as other smaller API
+improvements and fixes.
 
 ### Deprecated
 
 - **registry**: `SpanRef::parent_id`, which cannot properly support per-layer
   filtering. Use `.parent().map(SpanRef::id)` instead. ([#1523])
 
+### Fixed
+
+- **layer** `Context` methods that are provided when the `Subscriber` implements
+  `LookupSpan` no longer require the "registry" feature flag ([#1525])
+- **layer** `fmt::Debug` implementation for `Layered` no longer requires the `S`
+  type parameter to implement `Debug` ([#1528])
+
+### Added
+
+- **registry**: `Filter` trait, `Filtered` type, `Layer::with_filter` method,
+  and other APIs for per-layer filtering ([#1523])
+- **filter**: `FilterFn` and `DynFilterFn` types that implement global (`Layer`)
+  and per-layer (`Filter`) filtering for closures and function pointers
+  ([#1523])
+- **filter**: `Targets` filter, which implements a lighter-weight form of
+  `EnvFilter`-like filtering ([#1550])
+- **env-filter**: Added support for filtering on floating-point values ([#1507])
+- **layer**: `Layer::on_layer` callback, called when layering the `Layer` onto a
+`Subscriber` ([#1523])
+- **layer**: `Layer` implementations for `Box<L>` and `Arc<L>` where `L: Layer`
+  ([#1536])
+- **layer**: `Layer` implementations for `Box<dyn Layer<S> + Send + Sync + 'static>`
+  and `Arc<dyn Layer<S> + Send + Sync + 'static>` ([#1536])
+- A number of small documentation fixes and improvements ([#1553], [#1544],
+  [#1539], [#1524])
+
+Special thanks to new contributors @jsgf and @maxburke for contributing to this
+release!
+
+[`Filter`]: https://docs.rs/tracing-subscriber/0.2.21/tracing_subscriber/layer/trait.Filter.html
+[plf]: https://docs.rs/tracing-subscriber/0.2.21/tracing_subscriber/layer/index.html#per-layer-filtering
+[`Targets`]: https://docs.rs/tracing-subscriber/0.2.21/tracing_subscriber/filter/struct.Targets.html
+[`EnvFilter`]: https://docs.rs/tracing-subscriber/0.2.21/tracing_subscriber/filter/struct.EnvFilter.html
+[#1507]: https://github.com/tokio-rs/tracing/pull/1507
 [#1523]: https://github.com/tokio-rs/tracing/pull/1523
+[#1524]: https://github.com/tokio-rs/tracing/pull/1524
+[#1525]: https://github.com/tokio-rs/tracing/pull/1525
+[#1528]: https://github.com/tokio-rs/tracing/pull/1528
+[#1539]: https://github.com/tokio-rs/tracing/pull/1539
+[#1544]: https://github.com/tokio-rs/tracing/pull/1544
+[#1550]: https://github.com/tokio-rs/tracing/pull/1550
+[#1553]: https://github.com/tokio-rs/tracing/pull/1553
 
 # 0.2.20 (August 17, 2021)
 

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.20"
+version = "0.2.21"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",
@@ -31,7 +31,7 @@ registry = ["sharded-slab", "thread_local"]
 json = ["tracing-serde", "serde", "serde_json"]
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.17" }
+tracing-core = { path = "../tracing-core", version = "0.1.20" }
 
 # only required by the filter feature
 tracing = { optional = true, path = "../tracing", version = "0.1", default-features = false, features = ["std"] }

--- a/tracing-subscriber/src/filter/mod.rs
+++ b/tracing-subscriber/src/filter/mod.rs
@@ -6,7 +6,7 @@
 //! details on filtering spans and events using [`Layer`]s, see the
 //! [`layer` module's documentation].
 //!
-//! [`layer`  module documentation]: crate::layer#filtering-with-layers
+//! [`layer` module's documentation]: crate::layer#filtering-with-layers
 //! [`Layer`]: crate::layer
 mod directive;
 #[cfg(feature = "env-filter")]

--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -796,6 +796,10 @@ where
 
 /// A per-[`Layer`] filter that determines whether a span or event is enabled
 /// for an individual layer.
+///
+/// See [the module-level documentation][plf] for details on using [`Filter`]s.
+///
+/// [plf]: crate::layer#per-layer-filtering
 #[cfg(feature = "registry")]
 #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
 #[cfg_attr(docsrs, doc(notable_trait))]

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -91,7 +91,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.20")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.21")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.2.21 (September 12, 2021)

This release introduces the [`Filter`] trait, a new API for [per-layer
filtering][plf]. This allows controlling which spans and events are
recorded by various layers individually, rather than globally.

In addition, it adds a new [`Targets`] filter, which provides a
lighter-weight version of the filtering provided by [`EnvFilter`], as
well as other smaller API improvements and fixes.

### Deprecated

- **registry**: `SpanRef::parent_id`, which cannot properly support
  per-layer filtering. Use `.parent().map(SpanRef::id)` instead.
  ([#1523])

### Fixed

- **layer** `Context` methods that are provided when the `Subscriber`
  implements `LookupSpan` no longer require the "registry" feature flag
  ([#1525])
- **layer** `fmt::Debug` implementation for `Layered` no longer requires
  the `S` type parameter to implement `Debug` ([#1528])

### Added

- **registry**: `Filter` trait, `Filtered` type, `Layer::with_filter`
  method, and other APIs for per-layer filtering ([#1523])
- **filter**: `FilterFn` and `DynFilterFn` types that implement global
  (`Layer`) and per-layer (`Filter`) filtering for closures and function
  pointers ([#1523])
- **filter**: `Targets` filter, which implements a lighter-weight form
  of `EnvFilter`-like filtering ([#1550])
- **env-filter**: Added support for filtering on floating-point values
  ([#1507])
- **layer**: `Layer::on_layer` callback, called when layering the
  `Layer` onto a `Subscriber` ([#1523])
- **layer**: `Layer` implementations for `Box<L>` and `Arc<L>` where `L:
  Layer` ([#1536])
- **layer**: `Layer` implementations for  `Box<dyn Layer>` and 
  `Arc<dyn Layer>` ([#1536])
- A number of small documentation fixes and improvements ([#1553],
  [#1544], [#1539], [#1524])

Special thanks to new contributors @jsgf and @maxburke for contributing
to this release!

[`Filter`]: https://docs.rs/tracing-subscriber/0.2.21/tracing_subscriber/layer/trait.Filter.html
[plf]: https://docs.rs/tracing-subscriber/0.2.21/tracing_subscriber/layer/index.html#per-layer-filtering
[`Targets`]: https://docs.rs/tracing-subscriber/0.2.21/tracing_subscriber/filter/struct.Targets.html
[`EnvFilter`]: https://docs.rs/tracing-subscriber/0.2.21/tracing_subscriber/filter/struct.EnvFilter.html
[#1507]: #1507
[#1523]: #1523
[#1524]: #1524
[#1525]: #1525
[#1528]: #1528
[#1539]: #1539
[#1544]: #1544
[#1550]: #1550
[#1553]: #1553