### PR TITLE
subscriber: fix filter::ParseError accidentally being renamed 

### DIFF
--- a/tracing-subscriber/src/filter/env/directive.rs
+++ b/tracing-subscriber/src/filter/env/directive.rs
@@ -1,5 +1,5 @@
 use super::FilterVec;
-pub(crate) use crate::filter::directive::{DirectiveParseError, StaticDirective};
+pub(crate) use crate::filter::directive::{ParseError, StaticDirective};
 use crate::filter::{
     directive::{DirectiveSet, Match},
     env::{field, FieldMap},
@@ -145,7 +145,7 @@ impl Match for Directive {
 }
 
 impl FromStr for Directive {
-    type Err = DirectiveParseError;
+    type Err = ParseError;
     fn from_str(from: &str) -> Result<Self, Self::Err> {
         lazy_static! {
             static ref DIRECTIVE_RE: Regex = Regex::new(
@@ -183,9 +183,7 @@ impl FromStr for Directive {
                 "#).unwrap();
         }
 
-        let caps = DIRECTIVE_RE
-            .captures(from)
-            .ok_or_else(DirectiveParseError::new)?;
+        let caps = DIRECTIVE_RE.captures(from).ok_or_else(ParseError::new)?;
 
         if let Some(level) = caps
             .name("global_level")

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     layer::{Context, Layer},
     sync::RwLock,
 };
-use directive::DirectiveParseError;
+use directive::ParseError;
 use std::{cell::RefCell, collections::HashMap, env, error::Error, fmt, str::FromStr};
 use tracing_core::{
     callsite,
@@ -131,7 +131,7 @@ pub struct FromEnvError {
 
 #[derive(Debug)]
 enum ErrorKind {
-    Parse(DirectiveParseError),
+    Parse(ParseError),
     Env(env::VarError),
 }
 
@@ -170,7 +170,7 @@ impl EnvFilter {
 
     /// Returns a new `EnvFilter` from the directives in the given string,
     /// or an error if any are invalid.
-    pub fn try_new<S: AsRef<str>>(dirs: S) -> Result<Self, directive::DirectiveParseError> {
+    pub fn try_new<S: AsRef<str>>(dirs: S) -> Result<Self, directive::ParseError> {
         let directives = dirs
             .as_ref()
             .split(',')
@@ -489,7 +489,7 @@ impl<S: Subscriber> Layer<S> for EnvFilter {
 }
 
 impl FromStr for EnvFilter {
-    type Err = directive::DirectiveParseError;
+    type Err = directive::ParseError;
 
     fn from_str(spec: &str) -> Result<Self, Self::Err> {
         Self::try_new(spec)
@@ -540,8 +540,8 @@ impl fmt::Display for EnvFilter {
 
 // ===== impl FromEnvError =====
 
-impl From<directive::DirectiveParseError> for FromEnvError {
-    fn from(p: directive::DirectiveParseError) -> Self {
+impl From<directive::ParseError> for FromEnvError {
+    fn from(p: directive::ParseError) -> Self {
         Self {
             kind: ErrorKind::Parse(p),
         }

--- a/tracing-subscriber/src/filter/mod.rs
+++ b/tracing-subscriber/src/filter/mod.rs
@@ -17,7 +17,7 @@ mod layer_filters;
 mod level;
 mod targets;
 
-pub use self::directive::DirectiveParseError;
+pub use self::directive::ParseError;
 pub use self::filter_fn::*;
 #[cfg(not(feature = "registry"))]
 pub(crate) use self::has_plf_stubs::*;

--- a/tracing-subscriber/src/filter/targets.rs
+++ b/tracing-subscriber/src/filter/targets.rs
@@ -1,6 +1,6 @@
 use crate::{
     filter::{
-        directive::{DirectiveParseError, DirectiveSet, StaticDirective},
+        directive::{DirectiveSet, ParseError, StaticDirective},
         LevelFilter,
     },
     layer,
@@ -302,7 +302,7 @@ where
 }
 
 impl FromStr for Targets {
-    type Err = DirectiveParseError;
+    type Err = ParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         s.split(',')
             .map(StaticDirective::from_str)


### PR DESCRIPTION
I accidentally renamed this type in PR #1550 after getting confused by a
renaming import that I thought was publicly re-exported, but it wasn't
actually..sorry about that!

This commit renames (or...un-renames?) the type. Whoopsie!

Fixes #1557