### PR TITLE
subscriber: prepare to release 0.2.22

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.2.22 (September 13, 2021)
+
+This fixes a regression where the `filter::ParseError` type was accidentally
+renamed.
+
+### Fixed
+
+- **filter**: Fix `filter::ParseError` accidentally being renamed to
+  `filter::DirectiveParseError` ([#1558])
+
+[#1558]: https://github.com/tokio-rs/tracing/pull/1558
+
 # 0.2.21 (September 12, 2021)
 
 This release introduces the [`Filter`] trait, a new API for [per-layer

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.21"
+version = "0.2.22"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -91,7 +91,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.21")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.22")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.2.22 (September 13, 2021)

This fixes a regression where the `filter::ParseError` type was
accidentally renamed.

### Fixed

- **filter**: Fix `filter::ParseError` accidentally being renamed to
  `filter::DirectiveParseError` ([#1558])

[#1558]: https://github.com/tokio-rs/tracing/pull/1558