### PR TITLE
tracing: prepare to release v0.1.27 

### DIFF
--- a/tracing-core/CHANGELOG.md
+++ b/tracing-core/CHANGELOG.md
@@ -15,8 +15,8 @@ typed values rather than with `fmt::Debug`. Additionally, it adds
 Thanks to new contributors @jsgf and @maxburke for contributing to this
 release!
 
-[#1549]: https://github.com/tokio-rs/tracing/pull/1549 [#1507]:
-https://github.com/tokio-rs/tracing/pull/1507
+[#1549]: https://github.com/tokio-rs/tracing/pull/1549 
+[#1507]: https://github.com/tokio-rs/tracing/pull/1507
 
 # 0.1.19 (August 17, 2021)
 ### Added

--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,52 @@
+# 0.1.27 (September 13, 2021)
+
+This release adds a new [`Span::or_current`] method to aid in efficiently
+propagating span contexts to spawned threads or tasks. Additionally, it updates
+the [`tracing-core`] version to [0.1.20] and the [`tracing-attributes`] version to
+[0.1.16], ensuring that a number of new features in those crates are present.
+
+### Fixed
+
+- **instrument**: Added missing `WithSubscriber` implementations for futures and
+  other types ([#1424])
+
+### Added
+
+- `Span::or_current` method, to help with efficient span context propagation
+  ([#1538])
+- **attributes**: add `skip_all` option to `#[instrument]` ([#1548])
+- **attributes**: record primitive types as primitive values rather than as
+  `fmt::Debug` ([#1378])
+- **core**: `NoSubscriber`, a no-op `Subscriber` implementation
+  ([#1549])
+- **core**: Added `Visit::record_f64` and support for recording floating-point
+  values ([#1507], [#1522])
+- A large number of documentation improvements and fixes ([#1369], [#1398],
+  [#1435], [#1442], [#1524], [#1556])
+
+Thanks to new contributors @dzvon and @mbergkvist, as well as @teozkr,
+@maxburke, @LukeMathWalker, and @jsgf, for contributing to this
+release!
+
+[`Span::or_current`]: https://docs.rs/tracing/0.1.27/tracing/struct.Span.html#method.or_current
+[`tracing-core`]: https://crates.io/crates/tracing-core
+[`tracing-attributes`]: https://crates.io/crates/tracing-attributes
+[`tracing-core`]: https://crates.io/crates/tracing-core
+[0.1.20]: https://github.com/tokio-rs/tracing/releases/tag/tracing-core-0.1.20
+[0.1.16]: https://github.com/tokio-rs/tracing/releases/tag/tracing-attributes-0.1.16
+[#1424]: https://github.com/tokio-rs/tracing/pull/1424
+[#1538]: https://github.com/tokio-rs/tracing/pull/1538
+[#1548]: https://github.com/tokio-rs/tracing/pull/1548
+[#1378]: https://github.com/tokio-rs/tracing/pull/1378
+[#1507]: https://github.com/tokio-rs/tracing/pull/1507
+[#1522]: https://github.com/tokio-rs/tracing/pull/1522
+[#1369]: https://github.com/tokio-rs/tracing/pull/1369
+[#1398]: https://github.com/tokio-rs/tracing/pull/1398
+[#1435]: https://github.com/tokio-rs/tracing/pull/1435
+[#1442]: https://github.com/tokio-rs/tracing/pull/1442
+[#1524]: https://github.com/tokio-rs/tracing/pull/1524
+[#1556]: https://github.com/tokio-rs/tracing/pull/1556
+
 # 0.1.26 (April 30, 2021)
 
 ### Fixed

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -29,7 +29,7 @@ edition = "2018"
 [dependencies]
 tracing-core = { path = "../tracing-core", version = "0.1.20", default-features = false }
 log = { version = "0.4", optional = true }
-tracing-attributes = { path = "../tracing-attributes", version = "0.1.15", optional = true }
+tracing-attributes = { path = "../tracing-attributes", version = "0.1.16", optional = true }
 cfg-if = "1.0.0"
 pin-project-lite = "0.2"
 

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -27,7 +27,7 @@ keywords = ["logging", "tracing", "metrics", "async"]
 edition = "2018"
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.18", default-features = false }
+tracing-core = { path = "../tracing-core", version = "0.1.20", default-features = false }
 log = { version = "0.4", optional = true }
 tracing-attributes = { path = "../tracing-attributes", version = "0.1.15", optional = true }
 cfg-if = "1.0.0"

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.26"
+version = "0.1.27"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -16,9 +16,9 @@ Application-level tracing for Rust.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.26
+[crates-url]: https://crates.io/crates/tracing/0.1.27
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.26
+[docs-url]: https://docs.rs/tracing/0.1.27
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -251,7 +251,7 @@ my_future
 is as long as the future's.
 
 The second, and preferred, option is through the
-[`#[instrument]`](https://docs.rs/tracing/0.1.26/tracing/attr.instrument.html)
+[`#[instrument]`](https://docs.rs/tracing/0.1.27/tracing/attr.instrument.html)
 attribute:
 
 ```rust
@@ -298,7 +298,7 @@ span.in_scope(|| {
 // Dropping the span will close it, indicating that it has ended.
 ```
 
-The [`#[instrument]`](https://docs.rs/tracing/0.1.26/tracing/attr.instrument.html) attribute macro
+The [`#[instrument]`](https://docs.rs/tracing/0.1.27/tracing/attr.instrument.html) attribute macro
 can reduce some of this boilerplate:
 
 ```rust

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -797,7 +797,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing = { version = "0.1.26", default-features = false }
+//!   tracing = { version = "0.1.27", default-features = false }
 //!   ```
 //!
 //! <div class="information">
@@ -853,7 +853,7 @@
 //! [flags]: #crate-feature-flags
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.26")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.27")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.1.27 (September 13, 2021)

This release adds a new [`Span::or_current`] method to aid in
efficiently propagating span contexts to spawned threads or tasks.
Additionally, it updates the [`tracing-core`] version to [0.1.20] and
the [`tracing-attributes`] version to [0.1.16], ensuring that a number
of new features in those crates are present.

### Fixed

- **instrument**: Added missing `WithSubscriber` implementations for
  futures and other types (#1424)

### Added

- `Span::or_current` method, to help with efficient span context
  propagation (#1538)
- **attributes**: add `skip_all` option to `#[instrument]` (#1548)
- **attributes**: record primitive types as primitive values rather than
  as `fmt::Debug` (#1378)
- **core**: `NoSubscriber`, a no-op `Subscriber` implementation
  (#1549)
- **core**: Added `Visit::record_f64` and support for recording
  floating-point values (#1507, #1522)
- A large number of documentation improvements and fixes (#1369,
  #1398, #1435, #1442, #1524, #1556)

Thanks to new contributors @dzvon and @mbergkvist, as well as @teozkr,
@maxburke, @LukeMathWalker, and @jsgf, for contributing to this release!

[`Span::or_current`]: https://docs.rs/tracing/0.1.27/tracing/struct.Span.html#method.or_current
[`tracing-core`]: https://crates.io/crates/tracing-core
[`tracing-attributes`]: https://crates.io/crates/tracing-attributes
[`tracing-core`]: https://crates.io/crates/tracing-core
[0.1.20]: https://github.com/tokio-rs/tracing/releases/tag/tracing-core-0.1.20
[0.1.16]: https://github.com/tokio-rs/tracing/releases/tag/tracing-attributes-0.1.16