### PR TITLE
chore: port Layer (`Subscribe`) change to master

### DIFF
--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -957,7 +957,7 @@ where
     subscriber_impl_body! {}
 }
 
-impl<C> Subscribe<C> for Arc<dyn Subscribe<C>>
+impl<C> Subscribe<C> for Arc<dyn Subscribe<C> + Send + Sync>
 where
     C: Collect,
 {
@@ -972,7 +972,7 @@ where
     subscriber_impl_body! {}
 }
 
-impl<C> Subscribe<C> for Box<dyn Subscribe<C>>
+impl<C> Subscribe<C> for Box<dyn Subscribe<C> + Send + Sync>
 where
     C: Collect,
 {

--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -9,7 +9,7 @@ use tracing_core::{
 
 #[cfg(feature = "registry")]
 use crate::registry::{self, LookupSpan, Registry, SpanRef};
-use std::{any::TypeId, marker::PhantomData, ptr::NonNull};
+use std::{any::TypeId, marker::PhantomData, ops::Deref, ptr::NonNull, sync::Arc};
 
 /// A composable handler for `tracing` events.
 ///
@@ -882,6 +882,101 @@ where
             self.as_ref().and_then(|inner| inner.downcast_raw(id))
         }
     }
+}
+
+macro_rules! subscriber_impl_body {
+    () => {
+        #[inline]
+        fn new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, C>) {
+            self.deref().new_span(attrs, id, ctx)
+        }
+
+        #[inline]
+        fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
+            self.deref().register_callsite(metadata)
+        }
+
+        #[inline]
+        fn enabled(&self, metadata: &Metadata<'_>, ctx: Context<'_, C>) -> bool {
+            self.deref().enabled(metadata, ctx)
+        }
+
+        #[inline]
+        fn max_level_hint(&self) -> Option<LevelFilter> {
+            self.deref().max_level_hint()
+        }
+
+        #[inline]
+        fn on_record(&self, span: &span::Id, values: &span::Record<'_>, ctx: Context<'_, C>) {
+            self.deref().on_record(span, values, ctx)
+        }
+
+        #[inline]
+        fn on_follows_from(&self, span: &span::Id, follows: &span::Id, ctx: Context<'_, C>) {
+            self.deref().on_follows_from(span, follows, ctx)
+        }
+
+        #[inline]
+        fn on_event(&self, event: &Event<'_>, ctx: Context<'_, C>) {
+            self.deref().on_event(event, ctx)
+        }
+
+        #[inline]
+        fn on_enter(&self, id: &span::Id, ctx: Context<'_, C>) {
+            self.deref().on_enter(id, ctx)
+        }
+
+        #[inline]
+        fn on_exit(&self, id: &span::Id, ctx: Context<'_, C>) {
+            self.deref().on_exit(id, ctx)
+        }
+
+        #[inline]
+        fn on_close(&self, id: span::Id, ctx: Context<'_, C>) {
+            self.deref().on_close(id, ctx)
+        }
+
+        #[inline]
+        fn on_id_change(&self, old: &span::Id, new: &span::Id, ctx: Context<'_, C>) {
+            self.deref().on_id_change(old, new, ctx)
+        }
+
+        #[doc(hidden)]
+        #[inline]
+        unsafe fn downcast_raw(&self, id: TypeId) -> std::option::Option<NonNull<()>> {
+            self.deref().downcast_raw(id)
+        }
+    };
+}
+
+impl<S, C> Subscribe<C> for Arc<S>
+where
+    S: Subscribe<C>,
+    C: Collect,
+{
+    subscriber_impl_body! {}
+}
+
+impl<C> Subscribe<C> for Arc<dyn Subscribe<C>>
+where
+    C: Collect,
+{
+    subscriber_impl_body! {}
+}
+
+impl<S, C> Subscribe<C> for Box<S>
+where
+    S: Subscribe<C>,
+    C: Collect,
+{
+    subscriber_impl_body! {}
+}
+
+impl<C> Subscribe<C> for Box<dyn Subscribe<C>>
+where
+    C: Collect,
+{
+    subscriber_impl_body! {}
 }
 
 #[cfg(feature = "registry")]


### PR DESCRIPTION
This PR cherrypicks #1536 and #1547 to the master branch and renames `Layer` to `Subscribe` accordingly.