### PR TITLE
docs: remove divs from all notes/warnings

### DIFF
--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -108,14 +108,13 @@
 //! // `my_subscriber` is now the default
 //! ```
 //!
-//! <div class="example-wrap" style="display:inline-block">
 //! <pre class="ignore" style="white-space:normal;font:inherit;">
-//! <strong>Note</strong>:the thread-local scoped dispatcher
-//! (<a href="#fn.with_default"><code>with_default</code></a>) requires the
-//! Rust standard library. <code>no_std</code> users should use
-//! <a href="#fn.set_global_default"><code>set_global_default</code></a>
-//! instead.
-//! </pre></div>
+//!     <strong>Note</strong>:the thread-local scoped dispatcher
+//!     (<a href="#fn.with_default"><code>with_default</code></a>) requires the
+//!     Rust standard library. <code>no_std</code> users should use
+//!     <a href="#fn.set_global_default"><code>set_global_default</code></a>
+//!     instead.
+//! </pre>
 //!
 //! ## Accessing the Default Subscriber
 //!
@@ -208,12 +207,11 @@ pub struct DefaultGuard(Option<Dispatch>);
 /// The default dispatcher is used when creating a new [span] or
 /// [`Event`].
 ///
-/// <div class="example-wrap" style="display:inline-block">
 /// <pre class="ignore" style="white-space:normal;font:inherit;">
-/// <strong>Note</strong>: This function required the Rust standard library.
-/// <code>no_std</code> users should use <a href="../fn.set_global_default.html">
-/// <code>set_global_default</code></a> instead.
-/// </pre></div>
+///     <strong>Note</strong>: This function required the Rust standard library.
+///     <code>no_std</code> users should use <a href="../fn.set_global_default.html">
+///     <code>set_global_default</code></a> instead.
+/// </pre>
 ///
 /// [span]: ../span/index.html
 /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
@@ -233,12 +231,11 @@ pub fn with_default<T>(dispatcher: &Dispatch, f: impl FnOnce() -> T) -> T {
 /// Sets the dispatch as the default dispatch for the duration of the lifetime
 /// of the returned DefaultGuard
 ///
-/// <div class="example-wrap" style="display:inline-block">
 /// <pre class="ignore" style="white-space:normal;font:inherit;">
-/// <strong>Note</strong>: This function required the Rust standard library.
-/// <code>no_std</code> users should use <a href="../fn.set_global_default.html">
-/// <code>set_global_default</code></a> instead.
-/// </pre></div>
+///     <strong>Note</strong>: This function required the Rust standard library.
+///     <code>no_std</code> users should use <a href="../fn.set_global_default.html">
+///     <code>set_global_default</code></a> instead.
+/// </pre>
 ///
 /// [`set_global_default`]: ../fn.set_global_default.html
 #[cfg(feature = "std")]
@@ -258,12 +255,11 @@ pub fn set_default(dispatcher: &Dispatch) -> DefaultGuard {
 /// Can only be set once; subsequent attempts to set the global default will fail.
 /// Returns `Err` if the global default has already been set.
 ///
-///
-/// </div><div class="example-wrap" style="display:inline-block"><pre class="compile_fail" style="white-space:normal;font:inherit;">
-/// <strong>Warning</strong>: In general, libraries should <em>not</em> call
-/// <code>set_global_default()</code>! Doing so will cause conflicts when
-/// executables that depend on the library try to set the default later.
-/// </pre></div>
+/// <pre class="compile_fail" style="white-space:normal;font:inherit;">
+///     <strong>Warning</strong>: In general, libraries should <em>not</em> call
+///     <code>set_global_default()</code>! Doing so will cause conflicts when
+///     executables that depend on the library try to set the default later.
+/// </pre>
 ///
 /// [span]: ../span/index.html
 /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
@@ -572,13 +568,14 @@ impl Dispatch {
     /// must as well.
     ///
     /// This calls the [`drop_span`] function on the [`Subscriber`] that this
-    ///  `Dispatch` forwards to.
+    /// `Dispatch` forwards to.
     ///
-    /// <div class="example-wrap" style="display:inline-block"><pre class="compile_fail" style="white-space:normal;font:inherit;">
-    /// <strong>Deprecated</strong>: The <a href="#method.try_close"><code>try_close</code></a>
-    /// method is functionally identical, but returns <code>true</code> if the span is now closed.
-    /// It should be used instead of this method.
-    /// </pre></div>
+    /// <pre class="compile_fail" style="white-space:normal;font:inherit;">
+    ///     <strong>Deprecated</strong>: The <a href="#method.try_close"><code>
+    ///     try_close</code></a> method is functionally identical, but returns
+    ///     <code>true</code> if the span is now closed. It should be used
+    ///     instead of this method.
+    /// </pre>
     ///
     /// [span ID]: ../span/struct.Id.html
     /// [`Subscriber`]: ../subscriber/trait.Subscriber.html

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -35,15 +35,15 @@ use crate::stdlib::{
 /// _significantly_ lower than that of creating the actual span. Therefore,
 /// filtering is based on metadata, rather than on the constructed span.
 ///
-/// <div class="example-wrap" style="display:inline-block">
 /// <pre class="ignore" style="white-space:normal;font:inherit;">
-/// <strong>Note</strong>: Although instances of <code>Metadata</code> cannot
-/// be compared directly, they provide a method <a href="struct.Metadata.html#method.id">
-/// <code>id</code></a>, returning an opaque <a href="../callsite/struct.Identifier.html">
-/// callsite identifier</a>  which uniquely identifies the callsite where the metadata
-/// originated. This can be used to determine if two <code>Metadata</code> correspond to
-/// the same callsite.
-/// </pre></div>
+///     <strong>Note</strong>: Although instances of <code>Metadata</code>
+///     cannot be compared directly, they provide a method
+///     <a href="struct.Metadata.html#method.id"><code>id</code></a>, returning
+///     an opaque <a href="../callsite/struct.Identifier.html">callsite
+///     identifier</a>which uniquely identifies the callsite where the metadata
+///     originated. This can be used to determine if two <code>Metadata</code>
+///     correspond to the same callsite.
+/// </pre>
 ///
 /// [span]: ../span/index.html
 /// [event]: ../event/index.html

--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -61,9 +61,9 @@ enum CurrentInner {
 impl Id {
     /// Constructs a new span ID from the given `u64`.
     ///
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
-    /// <strong>Note</strong>: Span IDs must be greater than zero.</pre></div>
+    ///     <strong>Note</strong>: Span IDs must be greater than zero.
+    /// </pre>
     ///
     /// # Panics
     /// - If the provided `u64` is 0.

--- a/tracing-subscriber/src/layer/context.rs
+++ b/tracing-subscriber/src/layer/context.rs
@@ -183,13 +183,13 @@ where
     /// });
     /// ```
     ///
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
-    /// <strong>Note</strong>: This requires the wrapped subscriber to implement the
-    /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
-    /// See the documentation on <a href="./struct.Context.html"><code>Context</code>'s
-    /// declaration</a> for details.
-    /// </pre></div>
+    ///     <strong>Note</strong>: This requires the wrapped subscriber to
+    ///     implement the <a href="../registry/trait.LookupSpan.html"><code>
+    ///     LookupSpan</code></a> trait. See the documentation on
+    ///     <a href="./struct.Context.html"><code>Context</code>'s
+    ///     declaration</a> for details.
+    /// </pre>
     #[inline]
     pub fn event_span(&self, event: &Event<'_>) -> Option<SpanRef<'_, S>>
     where
@@ -223,13 +223,13 @@ where
     /// If this returns `None`, then no span exists for that ID (either it has
     /// closed or the ID is invalid).
     ///
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
-    /// <strong>Note</strong>: This requires the wrapped subscriber to implement the
-    /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
-    /// See the documentation on <a href="./struct.Context.html"><code>Context</code>'s
-    /// declaration</a> for details.
-    /// </pre></div>
+    ///     <strong>Note</strong>: This requires the wrapped subscriber to
+    ///     implement the <a href="../registry/trait.LookupSpan.html"><code>
+    ///     LookupSpan</code></a> trait. See the documentation on
+    ///     <a href="./struct.Context.html"><code>Context</code>'s
+    ///     declaration</a> for details.
+    /// </pre>
     ///
     /// [stored data]: ../registry/struct.SpanRef.html
     #[inline]
@@ -248,13 +248,13 @@ where
 
     /// Returns `true` if an active span exists for the given `Id`.
     ///
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
-    /// <strong>Note</strong>: This requires the wrapped subscriber to implement the
-    /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
-    /// See the documentation on <a href="./struct.Context.html"><code>Context</code>'s
-    /// declaration</a> for details.
-    /// </pre></div>
+    ///     <strong>Note</strong>: This requires the wrapped subscriber to
+    ///     implement the <a href="../registry/trait.LookupSpan.html"><code>
+    ///     LookupSpan</code></a> trait. See the documentation on
+    ///     <a href="./struct.Context.html"><code>Context</code>'s
+    ///     declaration</a> for details.
+    /// </pre>
     #[inline]
     pub fn exists(&self, id: &span::Id) -> bool
     where
@@ -268,13 +268,13 @@ where
     ///
     /// If this returns `None`, then we are not currently within a span.
     ///
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
-    /// <strong>Note</strong>: This requires the wrapped subscriber to implement the
-    /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
-    /// See the documentation on <a href="./struct.Context.html"><code>Context</code>'s
-    /// declaration</a> for details.
-    /// </pre></div>
+    ///     <strong>Note</strong>: This requires the wrapped subscriber to
+    ///     implement the <a href="../registry/trait.LookupSpan.html"><code>
+    ///     LookupSpan</code></a> trait. See the documentation on
+    ///     <a href="./struct.Context.html"><code>Context</code>'s
+    ///     declaration</a> for details.
+    /// </pre>
     ///
     /// [stored data]: ../registry/struct.SpanRef.html
     #[inline]
@@ -343,13 +343,13 @@ where
     ///
     /// If this iterator is empty, then there are no spans in the current context.
     ///
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
-    /// <strong>Note</strong>: This requires the wrapped subscriber to implement the
-    /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
-    /// See the documentation on <a href="./struct.Context.html"><code>Context</code>'s
-    /// declaration</a> for details.
-    /// </pre></div>
+    ///     <strong>Note</strong>: This requires the wrapped subscriber to
+    ///     implement the <a href="../registry/trait.LookupSpan.html"><code>
+    ///     LookupSpan</code></a> trait. See the documentation on
+    ///     <a href="./struct.Context.html"><code>Context</code>'s
+    ///     declaration</a> for details.
+    /// </pre>
     ///
     /// [stored data]: ../registry/struct.SpanRef.html
     #[deprecated(
@@ -375,27 +375,20 @@ where
     /// current context, starting with the specified span and ending with the
     /// root of the trace tree and ending with the current span.
     ///
-    /// <div class="information">
-    ///     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>
-    /// </div>
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: Compared to <a href="#method.scope"><code>scope</code></a> this
     /// returns the spans in reverse order (from leaf to root). Use
     /// <a href="../registry/struct.Scope.html#method.from_root"><code>Scope::from_root</code></a>
     /// in case root-to-leaf ordering is desired.
-    /// </pre></div>
+    /// </pre>
     ///
-    /// <div class="information">
-    ///     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>
-    /// </div>
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
-    /// <strong>Note</strong>: This requires the wrapped subscriber to implement the
-    /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
-    /// See the documentation on <a href="./struct.Context.html"><code>Context</code>'s
-    /// declaration</a> for details.
-    /// </pre></div>
+    ///     <strong>Note</strong>: This requires the wrapped subscriber to
+    ///     implement the <a href="../registry/trait.LookupSpan.html"><code>
+    ///     LookupSpan</code></a> trait. See the documentation on
+    ///     <a href="./struct.Context.html"><code>Context</code>'s
+    ///     declaration</a> for details.
+    /// </pre>
     ///
     /// [stored data]: ../registry/struct.SpanRef.html
     pub fn span_scope(&self, id: &span::Id) -> Option<registry::Scope<'_, S>>
@@ -409,21 +402,20 @@ where
     /// current context, starting with the parent span of the specified event,
     /// and ending with the root of the trace tree and ending with the current span.
     ///
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: Compared to <a href="#method.scope"><code>scope</code></a> this
     /// returns the spans in reverse order (from leaf to root). Use
     /// <a href="../registry/struct.Scope.html#method.from_root"><code>Scope::from_root</code></a>
     /// in case root-to-leaf ordering is desired.
-    /// </pre></div>
+    /// </pre>
     ///
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
-    /// <strong>Note</strong>: This requires the wrapped subscriber to implement the
-    /// <a href="../registry/trait.LookupSpan.html"><code>LookupSpan</code></a> trait.
-    /// See the documentation on <a href="./struct.Context.html"><code>Context</code>'s
-    /// declaration</a> for details.
-    /// </pre></div>
+    ///     <strong>Note</strong>: This requires the wrapped subscriber to
+    ///     implement the <a href="../registry/trait.LookupSpan.html"><code>
+    ///     LookupSpan</code></a> trait. See the documentation on
+    ///     <a href="./struct.Context.html"><code>Context</code>'s
+    ///     declaration</a> for details.
+    /// </pre>
     ///
     /// [stored data]: ../registry/struct.SpanRef.html
     pub fn event_scope(&self, event: &Event<'_>) -> Option<registry::Scope<'_, S>>

--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -210,14 +210,13 @@
 //! function pointer. In addition, when more control is required, the [`Filter`]
 //! trait may also be implemented for user-defined types.
 //!
-//! <div class="example-wrap" style="display:inline-block">
 //! <pre class="compile_fail" style="white-space:normal;font:inherit;">
 //!     <strong>Warning</strong>: Currently, the <a href="../struct.Registry.html">
 //!     <code>Registry</code></a> type defined in this crate is the only root
 //!     <code>Subscriber</code> capable of supporting <code>Layer</code>s with
 //!     per-layer filters. In the future, new APIs will be added to allow other
 //!     root <code>Subscriber</code>s to support per-layer filters.
-//! </pre></div>
+//! </pre>
 //!
 //! For example, to generate an HTTP access log based on spans with
 //! the `http_access` target, while logging other spans and events to
@@ -483,7 +482,6 @@ where
     /// By default, this returns [`Interest::always()`] if [`self.enabled`] returns
     /// true, or [`Interest::never()`] if it returns false.
     ///
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: This method (and <a href="#method.enabled">
     /// <code>Layer::enabled</code></a>) determine whether a span or event is
@@ -496,7 +494,7 @@ where
     /// <a href="#method.on_enter"><code>on_enter</code></a>,
     /// <a href="#method.on_exit"><code>on_exit</code></a>, and other notification
     /// methods.
-    /// </pre></div>
+    /// </pre>
     ///
     /// See [the trait-level documentation] for more information on filtering
     /// with `Layer`s.
@@ -532,7 +530,6 @@ where
     /// By default, this always returns `true`, allowing the wrapped subscriber
     /// to choose to disable the span.
     ///
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: This method (and <a href="#method.register_callsite">
     /// <code>Layer::register_callsite</code></a>) determine whether a span or event is
@@ -545,7 +542,7 @@ where
     /// <a href="#method.on_enter"><code>on_enter</code></a>,
     /// <a href="#method.on_exit"><code>on_exit</code></a>, and other notification
     /// methods.
-    /// </pre></div>
+    /// </pre>
     ///
     ///
     /// See [the trait-level documentation] for more information on filtering
@@ -831,7 +828,6 @@ pub trait Filter<S> {
     /// never enable a particular callsite, providing an implementation of this
     /// function is recommended.
     ///
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: If a <code>Filter</code> will perform
     /// <em>dynamic filtering</em> that depends on the current context in which
@@ -842,7 +838,6 @@ pub trait Filter<S> {
     /// <code>enabled</code> method may not be called when a particular instance
     /// of that span or event is recorded.
     /// </pre>
-    /// </div>
     ///
     /// This method is broadly similar to [`Subscriber::register_callsite`];
     /// however, since the returned value represents only the interest of

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -98,14 +98,13 @@ pub trait LookupSpan<'a> {
 
     /// Returns the [`SpanData`] for a given `Id`, if it exists.
     ///
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
     /// <strong>Note</strong>: users of the <code>LookupSpan</code> trait should
     /// typically call the <a href="#method.span"><code>span</code></a> method rather
     /// than this method. The <code>span</code> method is implemented by
     /// <em>calling</em> <code>span_data</code>, but returns a reference which is
     /// capable of performing more sophisiticated queries.
-    /// </pre></div>
+    /// </pre>
     ///
     /// [`SpanData`]: trait.SpanData.html
     fn span_data(&'a self, id: &Id) -> Option<Self::Data>;

--- a/tracing/src/dispatcher.rs
+++ b/tracing/src/dispatcher.rs
@@ -107,13 +107,13 @@
 //!
 //! // `my_subscriber` is now the default
 //! ```
-//! <div class="example-wrap" style="display:inline-block">
+//!
 //! <pre class="ignore" style="white-space:normal;font:inherit;">
 //! <strong>Note</strong>: The thread-local scoped dispatcher (<code>with_default</code>)
 //! requires the Rust standard library. <code>no_std</code> users should
 //! use <a href="fn.set_global_default.html"><code>set_global_default</code></a>
 //! instead.
-//! </pre></div>
+//! </pre>
 //!
 //! ## Accessing the Default Subscriber
 //!

--- a/tracing/src/field.rs
+++ b/tracing/src/field.rs
@@ -5,7 +5,6 @@ use crate::Metadata;
 
 /// Trait implemented to allow a type to be used as a field key.
 ///
-/// <div class="example-wrap" style="display:inline-block">
 /// <pre class="ignore" style="white-space:normal;font:inherit;">
 /// <strong>Note</strong>: Although this is implemented for both the
 /// <a href="./struct.Field.html"><code>Field</code></a> type <em>and</em> any

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -51,13 +51,13 @@
 //! The [`span` module][span]'s documentation provides further details on how to
 //! use spans.
 //!
-//! </div><div class="example-wrap" style="display:inline-block"><pre class="compile_fail" style="white-space:normal;font:inherit;">
+//! <pre class="compile_fail" style="white-space:normal;font:inherit;">
 //!     <strong>Warning</strong>: In asynchronous code that uses async/await syntax,
 //!     <code>Span::enter</code> may produce incorrect traces if the returned drop
 //!     guard is held across an await point. See
 //!     <a href="span/struct.Span.html#in-asynchronous-code">the method documentation</a>
 //!     for details.
-//! </pre></div>
+//! </pre>
 //!
 //! ## Events
 //!
@@ -576,12 +576,11 @@
 //! # }
 //! ```
 //!
-//! <div class="information">
-//! </div><div class="example-wrap" style="display:inline-block"><pre class="compile_fail" style="white-space:normal;font:inherit;">
-//! <strong>Warning</strong>: In general, libraries should <em>not</em> call
-//! <code>set_global_default()</code>! Doing so will cause conflicts when
-//! executables that depend on the library try to set the default later.
-//! </pre></div>
+//! <pre class="compile_fail" style="white-space:normal;font:inherit;">
+//!     <strong>Warning</strong>: In general, libraries should <em>not</em> call
+//!     <code>set_global_default()</code>! Doing so will cause conflicts when
+//!     executables that depend on the library try to set the default later.
+//! </pre>
 //!
 //! This subscriber will be used as the default in all threads for the
 //! remainder of the duration of the program, similar to setting the logger
@@ -767,12 +766,11 @@
 //! [`tracing-elastic-apm`]: https://crates.io/crates/tracing-elastic-apm
 //! [Elastic APM]: https://www.elastic.co/apm
 //!
-//! <div class="example-wrap" style="display:inline-block">
 //! <pre class="ignore" style="white-space:normal;font:inherit;">
-//! <strong>Note</strong>: Some of these ecosystem crates are currently
-//! unreleased and/or in earlier stages of development. They may be less stable
-//! than <code>tracing</code> and <code>tracing-core</code>.
-//! </pre></div>
+//!     <strong>Note</strong>: Some of these ecosystem crates are currently
+//!     unreleased and/or in earlier stages of development. They may be less stable
+//!     than <code>tracing</code> and <code>tracing-core</code>.
+//! </pre>
 //!
 //! ## Crate Feature Flags
 //!
@@ -800,14 +798,10 @@
 //!   tracing = { version = "0.1.27", default-features = false }
 //!   ```
 //!
-//! <div class="information">
-//!     <div class="tooltip ignore" style="">ⓘ<span class="tooltiptext">Note</span></div>
-//! </div>
-//! <div class="example-wrap" style="display:inline-block">
 //! <pre class="ignore" style="white-space:normal;font:inherit;">
-//! <strong>Note</strong>: <code>tracing</code>'s <code>no_std</code> support
-//! requires <code>liballoc</code>.
-//! </pre></div>
+//!     <strong>Note</strong>: <code>tracing</code>'s <code>no_std</code> support
+//!     requires <code>liballoc</code>.
+//! </pre>
 //!
 //! ## Supported Rust Versions
 //!

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -119,13 +119,12 @@
 //! });
 //! ```
 //!
-//! <div class="example-wrap" style="display:inline-block">
 //! <pre class="ignore" style="white-space:normal;font:inherit;">
-//! <strong>Note</strong>: Since entering a span takes <code>&self</code>, and
-//! <code>Span</code>s are <code>Clone</code>, <code>Send</code>, and
-//! <code>Sync</code>, it is entirely valid for multiple threads to enter the
-//! same span concurrently.
-//! </pre></div>
+//!     <strong>Note</strong>: Since entering a span takes <code>&self</code>, and
+//!     <code>Span</code>s are <code>Clone</code>, <code>Send</code>, and
+//!     <code>Sync</code>, it is entirely valid for multiple threads to enter the
+//!     same span concurrently.
+//! </pre>
 //!
 //! ## Span Relationships
 //!
@@ -649,7 +648,7 @@ impl Span {
     ///       // This is okay! The span has already been exited before we reach
     ///       // the await point.
     ///       some_other_async_function(some_value).await;
-    ///  
+    ///
     ///       // ...
     ///   }
     ///   ```
@@ -658,7 +657,7 @@ impl Span {
     ///   attaching a span to a future (async function or block). This will
     ///   enter the span _every_ time the future is polled, and exit it whenever
     ///   the future yields.
-    ///   
+    ///
     ///   `Instrument` can be used with an async block inside an async function:
     ///   ```ignore
     ///   # use tracing::info_span;
@@ -705,13 +704,13 @@ impl Span {
     ///   # async fn some_other_async_function() {}
     ///   #[tracing::instrument(level = "info")]
     ///   async fn my_async_function() {
-    ///   
+    ///
     ///       // This is correct! If we yield here, the span will be exited,
     ///       // and re-entered when we resume.
     ///       some_other_async_function().await;
     ///
     ///       // ...
-    ///    
+    ///
     ///   }
     ///   ```
     ///
@@ -789,6 +788,14 @@ impl Span {
     /// Enters this span, consuming it and returning a [guard][`EnteredSpan`]
     /// that will exit the span when dropped.
     ///
+    /// <pre class="compile_fail" style="white-space:normal;font:inherit;">
+    ///     <strong>Warning</strong>: In asynchronous code that uses async/await syntax,
+    ///     <code>Span::entered</code> may produce incorrect traces if the returned drop
+    ///     guard is held across an await point. See <a href="#in-asynchronous-code">the
+    ///     <code>Span::enter</code> documentation</a> for details.
+    /// </pre>
+    ///
+    ///
     /// If this span is enabled by the current subscriber, then this function will
     /// call [`Subscriber::enter`] with the span's [`Id`], and dropping the guard
     /// will call [`Subscriber::exit`]. If the span is disabled, this does
@@ -813,22 +820,13 @@ impl Span {
     /// Furthermore, `entered` may be used when the span must be stored in some
     /// other struct or be passed to a function while remaining entered.
     ///
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
-    ///
-    /// **Note**: The returned [`EnteredSpan`] guard does not
-    /// implement `Send`. Dropping the guard will exit *this* span,
-    /// and if the guard is sent to another thread and dropped there, that thread may
-    /// never have entered this span. Thus, `EnteredSpan`s should not be sent
-    /// between threads.
-    ///
-    /// </pre></div>
-    ///
-    /// **Warning**: in asynchronous code that uses [async/await syntax][syntax],
-    /// [`Span::entered`] should be used very carefully or avoided entirely. Holding
-    /// the drop guard returned by `Span::entered` across `.await` points will
-    /// result in incorrect traces. See the documentation for the
-    /// [`Span::enter`] method for details.
+    ///     <strong>Note</strong>: The returned <a href="../struct.EnteredSpan.html">
+    ///     <code>EnteredSpan</a></code> guard does not implement <code>Send</code>.
+    ///     Dropping the guard will exit <em>this</em> span, and if the guard is sent
+    ///     to another thread and dropped there, that thread may never have entered
+    ///     this span. Thus, <code>EnteredSpan</code>s should not be sent between threads.
+    /// </pre>
     ///
     /// [syntax]: https://rust-lang.github.io/async-book/01_getting_started/04_async_await_primer.html
     ///
@@ -1159,14 +1157,15 @@ impl Span {
     /// }
     /// ```
     ///
-    /// <div class="example-wrap" style="display:inline-block">
     /// <pre class="ignore" style="white-space:normal;font:inherit;">
-    /// <strong>Note</strong>: The fields associated with a span are part of its
-    /// <a href="../struct.Metadata.html"><code>Metadata</code></a>.
-    /// The <a href="../struct.Metadata.html"><code>Metadata</code></a>. describing a particular
-    /// span is constructed statically when the span is created and cannot be extended later to
-    /// add new fields. Therefore, you cannot record a value for a field that was not specified
-    /// when the span was created:</pre></div>
+    ///     <strong>Note</strong>: The fields associated with a span are part
+    ///     of its <a href="../struct.Metadata.html"><code>Metadata</code></a>.
+    ///     The <a href="../struct.Metadata.html"><code>Metadata</code></a>
+    ///     describing a particular span is constructed statically when the span
+    ///     is created and cannot be extended later to add new fields. Therefore,
+    ///     you cannot record a value for a field that was not specified when the
+    ///     span was created:
+    /// </pre>
     ///
     /// ```
     /// use tracing::{trace_span, field};


### PR DESCRIPTION
This branch removes the HTML `<div>` tags from the warning and note
blocks in the documentation, because they're screwing up RustDoc
rendering on docs.rs. We had done this previously on the `master`
branch, but apparently it never made it to `v0.1.x`.

This should fix #1571 once a new `tracing` version is published.
