### PR TITLE
subscriber: prepare to release v0.2.23

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 0.2.23 (September 16, 2021)
+
+This release fixes a few bugs in the per-layer filtering API added in v0.2.21.
+
+### Fixed
+
+- **env-filter**: Fixed excessive `EnvFilter` memory use ([#1568])
+- **filter**: Fixed a panic that may occur in debug mode when using per-layer
+  filters together with global filters ([#1569])
+- Fixed incorrect documentation formatting ([#1572])
+
+[#1568]: https://github.com/tokio-rs/tracing/pull/1568
+[#1569]: https://github.com/tokio-rs/tracing/pull/1569
+[#1572]: https://github.com/tokio-rs/tracing/pull/1572
+
 # 0.2.22 (September 13, 2021)
 
 This fixes a regression where the `filter::ParseError` type was accidentally

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.22"
+version = "0.2.23"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -21,7 +21,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.2.18
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.23
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -91,7 +91,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.22")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.23")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.2.23 (September 16, 2021)

This release fixes a few bugs in the per-layer filtering API added in
v0.2.21.

### Fixed

- **env-filter**: Fixed excessive `EnvFilter` memory use ([#1568])
- **filter**: Fixed a panic that may occur in debug mode when using
  per-layer filters together with global filters ([#1569])
- Fixed incorrect documentation formatting ([#1572])

[#1568]: https://github.com/tokio-rs/tracing/pull/1568
[#1569]: https://github.com/tokio-rs/tracing/pull/1569
[#1572]: https://github.com/tokio-rs/tracing/pull/1572