### PR TITLE
subscriber: add `Targets::targets` method to iterate directives

### DIFF
--- a/tracing-subscriber/src/filter/directive.rs
+++ b/tracing-subscriber/src/filter/directive.rs
@@ -112,6 +112,19 @@ impl<T: Match + Ord> Extend<T> for DirectiveSet<T> {
     }
 }
 
+impl<T> IntoIterator for DirectiveSet<T> {
+    type Item = T;
+
+    #[cfg(feature = "smallvec")]
+    type IntoIter = smallvec::IntoIter<[T; 8]>;
+    #[cfg(not(feature = "smallvec"))]
+    type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.directives.into_iter()
+    }
+}
+
 // === impl Statics ===
 
 impl DirectiveSet<StaticDirective> {

--- a/tracing-subscriber/src/filter/mod.rs
+++ b/tracing-subscriber/src/filter/mod.rs
@@ -15,7 +15,7 @@ mod filter_fn;
 #[cfg(feature = "registry")]
 mod layer_filters;
 mod level;
-mod targets;
+pub mod targets;
 
 pub use self::directive::ParseError;
 pub use self::filter_fn::*;

--- a/tracing-subscriber/src/filter/targets.rs
+++ b/tracing-subscriber/src/filter/targets.rs
@@ -13,7 +13,7 @@ use crate::{
     layer,
 };
 use std::{
-    iter::{Extend, FromIterator},
+    iter::{Extend, FilterMap, FromIterator},
     str::FromStr,
 };
 use tracing_core::{Interest, Metadata, Subscriber};
@@ -423,7 +423,7 @@ impl<'a> IntoIterator for &'a Targets {
 #[derive(Debug)]
 pub struct IntoIter(
     #[allow(clippy::type_complexity)] // alias indirection would probably make this more confusing
-    std::iter::FilterMap<
+    FilterMap<
         <DirectiveSet<StaticDirective> as IntoIterator>::IntoIter,
         fn(StaticDirective) -> Option<(String, LevelFilter)>,
     >,
@@ -460,7 +460,7 @@ impl Iterator for IntoIter {
 /// [`iter`]: Targets::iter
 #[derive(Debug)]
 pub struct Iter<'a>(
-    std::iter::FilterMap<
+    FilterMap<
         std::slice::Iter<'a, StaticDirective>,
         fn(&'a StaticDirective) -> Option<(&'a str, LevelFilter)>,
     >,

--- a/tracing-subscriber/src/filter/targets.rs
+++ b/tracing-subscriber/src/filter/targets.rs
@@ -385,11 +385,7 @@ impl IntoIterator for Targets {
     type IntoIter = IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
-        fn unpack(directive: StaticDirective) -> Option<(String, LevelFilter)> {
-            let level = directive.level;
-            directive.target.map(move |target| (target, level))
-        }
-        IntoIter(self.0.into_iter().filter_map(unpack))
+        IntoIter::new(self)
     }
 }
 
@@ -399,13 +395,7 @@ impl<'a> IntoIterator for &'a Targets {
     type IntoIter = Iter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
-        fn unpack(directive: &StaticDirective) -> Option<(&str, LevelFilter)> {
-            directive
-                .target
-                .as_deref()
-                .map(|target| (target, directive.level))
-        }
-        Iter(self.0.iter().filter_map(unpack))
+        Iter::new(self)
     }
 }
 
@@ -439,6 +429,15 @@ pub struct IntoIter(
     >,
 );
 
+impl IntoIter {
+    fn new(targets: Targets) -> Self {
+        Self(targets.0.into_iter().filter_map(|directive| {
+            let level = directive.level;
+            directive.target.map(|target| (target, level))
+        }))
+    }
+}
+
 impl Iterator for IntoIter {
     type Item = (String, LevelFilter);
 
@@ -462,6 +461,17 @@ pub struct Iter<'a>(
         fn(&'a StaticDirective) -> Option<(&'a str, LevelFilter)>,
     >,
 );
+
+impl<'a> Iter<'a> {
+    fn new(targets: &'a Targets) -> Self {
+        Self(targets.0.iter().filter_map(|directive| {
+            directive
+                .target
+                .as_deref()
+                .map(|target| (target, directive.level))
+        }))
+    }
+}
 
 impl<'a> Iterator for Iter<'a> {
     type Item = (&'a str, LevelFilter);

--- a/tracing-subscriber/src/filter/targets.rs
+++ b/tracing-subscriber/src/filter/targets.rs
@@ -1,9 +1,10 @@
-//! A filter that enables or disables spans and events based on their [target] and [level].
+//! A [filter] that enables or disables spans and events based on their [target] and [level].
 //!
 //! See [`Targets`] for details.
 //!
 //! [target]: tracing_core::Metadata::target
 //! [level]: tracing_core::Level
+//! [filter]: crate::layer#filtering-with-layers
 
 use crate::{
     filter::{

--- a/tracing-subscriber/src/filter/targets.rs
+++ b/tracing-subscriber/src/filter/targets.rs
@@ -444,6 +444,10 @@ impl Iterator for IntoIter {
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
 }
 
 /// A borrowing iterator over the [target]-[level] pairs of a `Targets` filter.
@@ -478,6 +482,10 @@ impl<'a> Iterator for Iter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
     }
 }
 

--- a/tracing-subscriber/src/filter/targets.rs
+++ b/tracing-subscriber/src/filter/targets.rs
@@ -1,3 +1,10 @@
+//! A filter that enables or disables spans and events based on their [target] and [level].
+//!
+//! See [`Targets`] for details.
+//!
+//! [target]: tracing_core::Metadata::target
+//! [level]: tracing_core::Level
+
 use crate::{
     filter::{
         directive::{DirectiveSet, ParseError, StaticDirective},
@@ -266,6 +273,34 @@ impl Targets {
         self
     }
 
+    /// Returns an iterator over the [target]-[`LevelFilter`] pairs in this filter.
+    ///
+    /// The order of iteration is undefined.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tracing_subscriber::filter::{Targets, LevelFilter};
+    /// use tracing_core::Level;
+    ///
+    /// let filter = Targets::new()
+    ///     .with_target("my_crate", Level::INFO)
+    ///     .with_target("my_crate::interesting_module", Level::DEBUG);
+    ///
+    /// let mut targets: Vec<_> = filter.iter().collect();
+    /// targets.sort();
+    ///
+    /// assert_eq!(targets, vec![
+    ///     ("my_crate", LevelFilter::INFO),
+    ///     ("my_crate::interesting_module", LevelFilter::DEBUG),
+    /// ]);
+    /// ```
+    ///
+    /// [target]: tracing_core::Metadata::target
+    pub fn iter(&self) -> Iter<'_> {
+        self.into_iter()
+    }
+
     #[inline]
     fn interested(&self, metadata: &'static Metadata<'static>) -> Interest {
         if self.0.enabled(metadata) {
@@ -344,20 +379,59 @@ impl<S> layer::Filter<S> for Targets {
     }
 }
 
+impl<'a> IntoIterator for &'a Targets {
+    type Item = (&'a str, LevelFilter);
+
+    type IntoIter = Iter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        fn unpack(directive: &StaticDirective) -> Option<(&str, LevelFilter)> {
+            directive
+                .target
+                .as_deref()
+                .map(|target| (target, directive.level))
+        }
+        Iter(self.0.iter().filter_map(unpack))
+    }
+}
+
+/// A borrowing iterator over the [target]-[level] pairs of a `Targets` filter.
+///
+/// This struct is created by [`iter`] method of [`Targets`], or from the `IntoIterator`
+/// implementation for `&Targets`.
+///
+/// [target]: tracing_core::Metadata::target
+/// [level]: tracing_core::Level
+/// [`iter`]: Targets::iter
+#[derive(Debug)]
+pub struct Iter<'a>(
+    std::iter::FilterMap<
+        std::slice::Iter<'a, StaticDirective>,
+        fn(&'a StaticDirective) -> Option<(&'a str, LevelFilter)>,
+    >,
+);
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = (&'a str, LevelFilter);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::filter::directive::FilterVec;
 
-    fn expect_parse(s: &str) -> FilterVec<StaticDirective> {
+    fn expect_parse(s: &str) -> Targets {
         match dbg!(s).parse::<Targets>() {
             Err(e) => panic!("string {:?} did not parse successfully: {}", s, e),
-            Ok(e) => e.0.into_vec(),
+            Ok(e) => e,
         }
     }
 
     fn expect_parse_ralith(s: &str) {
-        let dirs = expect_parse(s);
+        let dirs = expect_parse(s).0.into_vec();
         assert_eq!(dirs.len(), 2, "\nparsed: {:#?}", dirs);
         assert_eq!(dirs[0].target, Some("server".to_string()));
         assert_eq!(dirs[0].level, LevelFilter::DEBUG);
@@ -369,7 +443,7 @@ mod tests {
     }
 
     fn expect_parse_level_directives(s: &str) {
-        let dirs = expect_parse(s);
+        let dirs = expect_parse(s).0.into_vec();
         assert_eq!(dirs.len(), 6, "\nparsed: {:#?}", dirs);
 
         assert_eq!(dirs[0].target, Some("crate3::mod2::mod1".to_string()));
@@ -414,7 +488,9 @@ mod tests {
 
     #[test]
     fn expect_parse_valid() {
-        let dirs = expect_parse("crate1::mod1=error,crate1::mod2,crate2=debug,crate3=off");
+        let dirs = expect_parse("crate1::mod1=error,crate1::mod2,crate2=debug,crate3=off")
+            .0
+            .into_vec();
         assert_eq!(dirs.len(), 4, "\nparsed: {:#?}", dirs);
         assert_eq!(dirs[0].target, Some("crate1::mod2".to_string()));
         assert_eq!(dirs[0].level, LevelFilter::TRACE);
@@ -455,6 +531,25 @@ mod tests {
             "crate1::mod1=1,crate1::mod2=2,crate1::mod2::mod3=3,crate2=4,\
              crate3=5,crate3::mod2::mod1=0",
         )
+    }
+
+    #[test]
+    fn targets_iter() {
+        let filter = expect_parse("crate1::mod1=error,crate1::mod2,crate2=debug,crate3=off")
+            .with_default(LevelFilter::WARN);
+
+        let mut targets: Vec<_> = filter.iter().collect();
+        targets.sort();
+
+        assert_eq!(
+            targets,
+            vec![
+                ("crate1::mod1", LevelFilter::ERROR),
+                ("crate1::mod2", LevelFilter::TRACE),
+                ("crate2", LevelFilter::DEBUG),
+                ("crate3", LevelFilter::OFF),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
There's currently no way to get the registered directives from a `Targets` instance, which is a barrier to some use-cases such as combining user-supplied directives with application-supplied defaults.

This commit adds a `Targets::targets` method, which returns an iterator of `(&str, LevelFilter)` pairs, one for each directive (excluding the default level, whose `target` is `None`).

Items are yielded as per the underlying `DirectiveSet::directives`, which would yield itms in specifity order (as constructed by
`DirectiveSet::add`). However, the order has been left explicitly undefined in the documentation for `Targets::targets` on the basis that this is an implementation detail that may change.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

As hinted in the commit message, my use-case is to have an application-supplied 'base' `Targets` filter, which can then be extended/overridden by a user-supplied filter parsed from `RUST_LOG` (e.g.).

Sadly, there's currently no way of getting the directives out of a `Targets` instance, nor to re-serialize to the string representation. Thus, the only way to implement the above would be to manually parse the user-supplied filters in the application, which is shame since it duplicates the implementation here and would be prone to drift/subtle incompatibilities.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The proposed solution is to add a method to `Targets` to retrieve the underlying directives.

```rust
// application-defined defaults, for a useful level of information
let mut filter = Targets::new()
    .with_target("my_crate", LevelFilter::INFO)
    .with_target("important_dependency", LevelFilter::INFO);

if let Ok(overrides) = std::env::var("RUST_LOG") {
    let overrides: Targets = overrides.parse().unwrap();

    // merge user-supplied overrides, which can enable additional tracing or disable default tracing
    filter.extend(overrides.targets());
    //                      ^^^^^^^^^ this is new
}
```

For this PR, I've gone for `fn targets(&self) -> impl Iterator<Item = (&str, LevelFilter)> + '_`, e.g. a method `targets` that returns an iterator over the pairs of `(target, filter)` in the underlying directives. The iterator excludes any default level(s) where `target` would be `None`. This matches nicely with the `FromIterator` and `Extend` impls, which use `(impl Into<String>, impl Into<LevelFilter>)`.

There are, of course, a number of other ways this could be achieved. Some alternatives I considered:

- An iterator over `(String, LevelFilter)`, whilst a more direct correspondence to `FromIterator` and `Extend` impls, would lead to redundant cloning. In particular, `&str` impl `Into<String>`, so the iterator is compatible with `Targets::with_targets`, `Extend`, and `FromIterator`.
- Different method names, such as `directives`. `directives` is perhaps more aligned with the implementation, but the API talks of adding `targets`, so the chosen name seems a better fit.
- Implementing `IntoIterator` for `&Targets`. This felt like a more heavyweight option, and to be usable there would need to be some kind of `iter(&self)` method anyway. Given that the default level (if any) isn't included in the iteration, it felt better to go for some target-specific.
- Implementing `Display` for `Targets`. This would allow multiple `Targets` to be stringified and joined with `,`, then parsed back up to a combined `Targets`. However this approach feels inefficient and introduces additional type-level fallibility (hypothetical parse errors have to be dealt with even if the combined targets were all valid).

Obviously happy to bike-shed anything here, opening a PR seemed like a good way to explain the use-case along with a possible solution!