### PR TITLE
subscriber: clear `enabled` filter map when short circuiting

### DIFF
--- a/tracing-subscriber/src/filter/layer_filters.rs
+++ b/tracing-subscriber/src/filter/layer_filters.rs
@@ -705,7 +705,10 @@ impl FilterState {
     /// This resets the [`FilterMap`] and current [`Interest`] as well as
     /// clearing the debug counters.
     pub(crate) fn clear_enabled() {
-        FILTERING.try_with(|filtering| {
+        // Drop the `Result` returned by `try_with` --- if we are in the middle
+        // a panic and the thread-local has been torn down, that's fine, just
+        // ignore it ratehr than panicking.
+        let _ = FILTERING.try_with(|filtering| {
             filtering.enabled.set(FilterMap::default());
 
             #[cfg(debug_assertions)]

--- a/tracing-subscriber/src/filter/layer_filters.rs
+++ b/tracing-subscriber/src/filter/layer_filters.rs
@@ -700,6 +700,19 @@ impl FilterState {
         }
     }
 
+    /// Clears the current in-progress filter state.
+    ///
+    /// This resets the [`FilterMap`] and current [`Interest`] as well as
+    /// clearing the debug counters.
+    pub(crate) fn clear_enabled() {
+        FILTERING.try_with(|filtering| {
+            filtering.enabled.set(FilterMap::default());
+
+            #[cfg(debug_assertions)]
+            filtering.counters.in_filter_pass.set(0);
+        });
+    }
+
     pub(crate) fn take_interest() -> Option<Interest> {
         FILTERING
             .try_with(|filtering| {

--- a/tracing-subscriber/src/layer/layered.rs
+++ b/tracing-subscriber/src/layer/layered.rs
@@ -80,6 +80,13 @@ where
             self.inner.enabled(metadata)
         } else {
             // otherwise, the callsite is disabled by the layer
+
+            // If per-layer filters are in use, and we are short-circuiting
+            // (rather than calling into the inner type), clear the current
+            // per-layer filter `enabled` state.
+            #[cfg(feature = "registry")]
+            filter::FilterState::clear_enabled();
+
             false
         }
     }


### PR DESCRIPTION
This is essentially the same change as #1569, but for `enabled` states
rather than `register_callsite`. When a global filter returns `false`
from `enabled`, ensure that the per-layer filter `FilterMap` and debug
counters are cleared, so that they are empty on the next `enabled` call.

See #1563