### PR TITLE
chore: remove `--bins` from CI cargo check runs 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: check
-        args: --all --bins
+        args: --all
 
   check:
     # Run `cargo check` first to ensure that the pushed code at least compiles.
@@ -37,7 +37,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: check
-        args: --all --bins --tests --benches
+        args: --all --tests --benches
 
   cargo-hack:
     runs-on: ubuntu-latest
@@ -275,4 +275,4 @@ jobs:
       uses: actions-rs/clippy-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all --bins --examples --tests --benches -- -D warnings
+        args: --all --examples --tests --benches -- -D warnings

--- a/tracing-subscriber/src/filter/env/field.rs
+++ b/tracing-subscriber/src/filter/env/field.rs
@@ -219,7 +219,7 @@ impl fmt::Display for ValueMatch {
         match self {
             ValueMatch::Bool(ref inner) => fmt::Display::fmt(inner, f),
             ValueMatch::F64(ref inner) => fmt::Display::fmt(inner, f),
-            ValueMatch::NaN => fmt::Display::fmt(&f64::NAN, f),
+            ValueMatch::NaN => fmt::Display::fmt(&std::f64::NAN, f),
             ValueMatch::I64(ref inner) => fmt::Display::fmt(inner, f),
             ValueMatch::U64(ref inner) => fmt::Display::fmt(inner, f),
             ValueMatch::Pat(ref inner) => fmt::Display::fmt(inner, f),
@@ -355,7 +355,9 @@ impl<'a> Visit for MatchVisitor<'a> {
             Some((ValueMatch::NaN, ref matched)) if value.is_nan() => {
                 matched.store(true, Release);
             }
-            Some((ValueMatch::F64(ref e), ref matched)) if (value - *e).abs() < f64::EPSILON => {
+            Some((ValueMatch::F64(ref e), ref matched))
+                if (value - *e).abs() < std::f64::EPSILON =>
+            {
                 matched.store(true, Release);
             }
             _ => {}


### PR DESCRIPTION
So...it turns out that passing `--bins` actually makes `cargo check` do
*nothing* on library-only projects without binaries. This
was...surprising.

It turns out that because of this, our MSRV check CI run is basically a
nop, and we accidentally merged code that doesn't compile on 1.42.0. I'm
very dumb lol.

I also fixed the use of `f64::EPSILON` and `f64::NAN` as imports from
the primitive type rather than from the primitive's module. Using `f64::NAN`
rather than `std::f64::NAN` doesn't compile on 1.42.0. 