### PR TITLE
fix msrv (v0.1.x edition)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: check
-        args: --all --bins
+        args: --all
 
   check:
     # Run `cargo check` first to ensure that the pushed code at least compiles.
@@ -37,7 +37,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: check
-        args: --all --bins --tests --benches
+        args: --all --tests --benches
 
   cargo-hack:
     runs-on: ubuntu-latest
@@ -279,4 +279,4 @@ jobs:
       uses: actions-rs/clippy-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all --bins --examples --tests --benches -- -D warnings
+        args: --all --examples --tests --benches -- -D warnings

--- a/tracing-subscriber/src/filter/directive.rs
+++ b/tracing-subscriber/src/filter/directive.rs
@@ -312,16 +312,21 @@ impl FromStr for StaticDirective {
                     ));
                 }
 
+                if !maybe_fields.ends_with("}]") {
+                    return Err(ParseError::msg("expected fields list to end with '}]'"));
+                }
+
                 let fields = maybe_fields
-                    .strip_suffix("}]")
-                    .ok_or_else(|| ParseError::msg("expected fields list to end with '}]'"))?;
-                field_names.extend(fields.split(',').filter_map(|s| {
-                    if s.is_empty() {
-                        None
-                    } else {
-                        Some(String::from(s))
-                    }
-                }));
+                    .trim_end_matches("}]")
+                    .split(',')
+                    .filter_map(|s| {
+                        if s.is_empty() {
+                            None
+                        } else {
+                            Some(String::from(s))
+                        }
+                    });
+                field_names.extend(fields);
             };
             let level = part1.parse()?;
             return Ok(Self {

--- a/tracing-subscriber/src/filter/env/field.rs
+++ b/tracing-subscriber/src/filter/env/field.rs
@@ -219,7 +219,7 @@ impl fmt::Display for ValueMatch {
         match self {
             ValueMatch::Bool(ref inner) => fmt::Display::fmt(inner, f),
             ValueMatch::F64(ref inner) => fmt::Display::fmt(inner, f),
-            ValueMatch::NaN => fmt::Display::fmt(&f64::NAN, f),
+            ValueMatch::NaN => fmt::Display::fmt(&std::f64::NAN, f),
             ValueMatch::I64(ref inner) => fmt::Display::fmt(inner, f),
             ValueMatch::U64(ref inner) => fmt::Display::fmt(inner, f),
             ValueMatch::Pat(ref inner) => fmt::Display::fmt(inner, f),
@@ -355,7 +355,9 @@ impl<'a> Visit for MatchVisitor<'a> {
             Some((ValueMatch::NaN, ref matched)) if value.is_nan() => {
                 matched.store(true, Release);
             }
-            Some((ValueMatch::F64(ref e), ref matched)) if (value - *e).abs() < f64::EPSILON => {
+            Some((ValueMatch::F64(ref e), ref matched))
+                if (value - *e).abs() < std::f64::EPSILON =>
+            {
                 matched.store(true, Release);
             }
             _ => {}

--- a/tracing-subscriber/src/filter/layer_filters.rs
+++ b/tracing-subscriber/src/filter/layer_filters.rs
@@ -409,7 +409,7 @@ where
 
 impl FilterId {
     const fn disabled() -> Self {
-        Self(u64::MAX)
+        Self(std::u64::MAX)
     }
 
     /// Returns a `FilterId` that will consider _all_ spans enabled.
@@ -548,7 +548,7 @@ impl fmt::Binary for FilterId {
 
 impl FilterMap {
     pub(crate) fn set(self, FilterId(mask): FilterId, enabled: bool) -> Self {
-        if mask == u64::MAX {
+        if mask == std::u64::MAX {
             return self;
         }
 
@@ -570,7 +570,7 @@ impl FilterMap {
 
     #[inline]
     pub(crate) fn any_enabled(self) -> bool {
-        self.bits != u64::MAX
+        self.bits != std::u64::MAX
     }
 }
 
@@ -727,8 +727,10 @@ impl FilterState {
     pub(crate) fn filter_map(&self) -> FilterMap {
         let map = self.enabled.get();
         #[cfg(debug_assertions)]
-        if self.counters.in_filter_pass.get() == 0 {
-            debug_assert_eq!(map, FilterMap::default());
+        {
+            if self.counters.in_filter_pass.get() == 0 {
+                debug_assert_eq!(map, FilterMap::default());
+            }
         }
 
         map

--- a/tracing-subscriber/src/layer/context.rs
+++ b/tracing-subscriber/src/layer/context.rs
@@ -295,20 +295,22 @@ where
         // If we found a span, and our per-layer filter enables it, return that
         // span!
         #[cfg(feature = "registry")]
-        if let Some(span) = span?.try_with_filter(self.filter) {
-            Some(span)
-        } else {
-            // Otherwise, the span at the *top* of the stack is disabled by
-            // per-layer filtering, but there may be additional spans in the stack.
-            //
-            // Currently, `LookupSpan` doesn't have a nice way of exposing access to
-            // the whole span stack. However, if we can downcast the innermost
-            // subscriber to a a `Registry`, we can iterate over its current span
-            // stack.
-            //
-            // TODO(eliza): when https://github.com/tokio-rs/tracing/issues/1459 is
-            // implemented, change this to use that instead...
-            self.lookup_current_filtered(subscriber)
+        {
+            if let Some(span) = span?.try_with_filter(self.filter) {
+                Some(span)
+            } else {
+                // Otherwise, the span at the *top* of the stack is disabled by
+                // per-layer filtering, but there may be additional spans in the stack.
+                //
+                // Currently, `LookupSpan` doesn't have a nice way of exposing access to
+                // the whole span stack. However, if we can downcast the innermost
+                // subscriber to a a `Registry`, we can iterate over its current span
+                // stack.
+                //
+                // TODO(eliza): when https://github.com/tokio-rs/tracing/issues/1459 is
+                // implemented, change this to use that instead...
+                self.lookup_current_filtered(subscriber)
+            }
         }
 
         #[cfg(not(feature = "registry"))]

--- a/tracing-subscriber/src/layer/layered.rs
+++ b/tracing-subscriber/src/layer/layered.rs
@@ -449,10 +449,12 @@ where
         // for internal debugging purposes, so only print them if alternate mode
         // is enabled.
         #[cfg(feature = "registry")]
-        if alt {
-            s.field("inner_is_registry", &self.inner_is_registry)
-                .field("has_layer_filter", &self.has_layer_filter)
-                .field("inner_has_layer_filter", &self.inner_has_layer_filter);
+        {
+            if alt {
+                s.field("inner_is_registry", &self.inner_is_registry)
+                    .field("has_layer_filter", &self.has_layer_filter)
+                    .field("inner_has_layer_filter", &self.inner_has_layer_filter);
+            }
         }
 
         s.field("layer", &self.layer)

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -273,10 +273,12 @@ where
             // by the selected filter ID.
 
             #[cfg(feature = "registry")]
-            if !curr.is_enabled_for(self.filter) {
-                // The current span in the chain is disabled for this
-                // filter. Try its parent.
-                continue;
+            {
+                if !curr.is_enabled_for(self.filter) {
+                    // The current span in the chain is disabled for this
+                    // filter. Try its parent.
+                    continue;
+                }
             }
 
             return Some(curr);


### PR DESCRIPTION
Due to the CI issue fixed by PR #1580, we accidentally merged
`tracing-subscriber` changes that don't compile on our MSRV, Rust
1.42.0. This includes:

- use of associated consts on primitive types (`u64::MAX` rather than
  `std::u64::MAX`)
- use of `#[cfg(...)]` on `if` expressions
- use of the `str::strip_suffix` method, which wasn't stable on 1.42.0


This branch backports #1508 to `v0.1.x`, and also fixes additional issues
in code that only exists on `v0.1.x`.

These changes are mostly very simple and mechanical. The only
significant change is changing the `StaticDirective` parsing code to not
use `strip_suffix`, which changes the implementation around a bit...but
it's still pretty straightforward.

This should fix 1.42.0 compatibility.