### PR TITLE
subscriber: prepare to release 0.2.24

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,32 @@
+# 0.2.24 (September 19, 2021)
+
+This release contains a number of bug fixes, including a fix for
+`tracing-subscriber` failing to compile on the minimum supported Rust version of
+1.42.0. It also adds `IntoIterator` implementations for the `Targets` type.
+
+### Fixed
+
+- Fixed compilation on Rust 1.42.0 ([#1580], [#1581])
+- **registry**: Ensure per-layer filter `enabled` state is cleared when a global
+  filter short-circuits filter evaluation ([#1575])
+- **layer**: Fixed `Layer::on_layer` not being called for `Box`ed `Layer`s,
+  which broke  per-layer filtering ([#1576])
+
+### Added
+
+- **filter**: Added `Targets::iter`, returning an iterator over the set of
+  target-level pairs enabled by a `Targets` filter ([#1574])
+- **filter**:  Added `IntoIterator` implementations for `Targets` and `&Targets`
+  ([#1574])
+
+Thanks to new contributor @connec for contributing to this release!
+
+[#1580]: https://github.com/tokio-rs/tracing/pull/1580
+[#1581]: https://github.com/tokio-rs/tracing/pull/1581
+[#1575]: https://github.com/tokio-rs/tracing/pull/1575
+[#1576]: https://github.com/tokio-rs/tracing/pull/1576
+[#1574]: https://github.com/tokio-rs/tracing/pull/1574
+
 # 0.2.23 (September 16, 2021)
 
 This release fixes a few bugs in the per-layer filtering API added in v0.2.21.

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.23"
+version = "0.2.24"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -21,7 +21,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.2.23
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.24
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -91,7 +91,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.23")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.24")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.2.24 (September 19, 2021)

This release contains a number of bug fixes, including a fix for
`tracing-subscriber` failing to compile on the minimum supported Rust
version of 1.42.0. It also adds `IntoIterator` implementations for the
`Targets` type.

### Fixed

- Fixed compilation on Rust 1.42.0 ([#1580], [#1581])
- **registry**: Ensure per-layer filter `enabled` state is cleared when
  a global filter short-circuits filter evaluation ([#1575])
- **layer**: Fixed `Layer::on_layer` not being called for `Box`ed
  `Layer`s, which broke  per-layer filtering ([#1576])

### Added

- **filter**: Added `Targets::iter`, returning an iterator over the set
  of target-level pairs enabled by a `Targets` filter ([#1574])
- **filter**:  Added `IntoIterator` implementations for `Targets` and
  `&Targets` ([#1574])

Thanks to new contributor @connec for contributing to this release!

[#1580]: https://github.com/tokio-rs/tracing/pull/1580
[#1581]: https://github.com/tokio-rs/tracing/pull/1581
[#1575]: https://github.com/tokio-rs/tracing/pull/1575
[#1576]: https://github.com/tokio-rs/tracing/pull/1576
[#1574]: https://github.com/tokio-rs/tracing/pull/1574