### PR TITLE
core: impl field::Value for Option<T>

### DIFF
--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -524,7 +524,7 @@ impl<T: fmt::Display> fmt::Display for DisplayValue<T> {
 
 impl<T: fmt::Debug> crate::sealed::Sealed for DebugValue<T> {}
 
-impl<T: fmt::Debug> Value for DebugValue<T>
+impl<T> Value for DebugValue<T>
 where
     T: fmt::Debug,
 {
@@ -543,6 +543,16 @@ impl crate::sealed::Sealed for Empty {}
 impl Value for Empty {
     #[inline]
     fn record(&self, _: &Field, _: &mut dyn Visit) {}
+}
+
+impl<T: Value> crate::sealed::Sealed for Option<T> {}
+
+impl<T: Value> Value for Option<T> {
+    fn record(&self, key: &Field, visitor: &mut dyn Visit) {
+        if let Some(v) = &self {
+            v.record(key, visitor)
+        }
+    }
 }
 
 // ===== impl Field =====

--- a/tracing/tests/event.rs
+++ b/tracing/tests/event.rs
@@ -441,9 +441,6 @@ fn option_ref_values() {
 
     handle.assert_finished();
 }
-
-
-
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn option_ref_mut_values() {

--- a/tracing/tests/event.rs
+++ b/tracing/tests/event.rs
@@ -462,7 +462,7 @@ fn option_ref_mut_values() {
 
     with_default(subscriber, || {
         let some_str = &mut Some("yes");
-        let none_str: &mut ption<&'static str> = &mut None;
+        let none_str: &mut Option<&'static str> = &mut None;
         let some_bool = &mut Some(true);
         let none_bool: &mut Option<bool> = &mut None;
         let some_u64 = &mut Some(42_u64);

--- a/tracing/tests/event.rs
+++ b/tracing/tests/event.rs
@@ -369,3 +369,38 @@ fn explicit_child_at_levels() {
 
     handle.assert_finished();
 }
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn option_values() {
+    let (subscriber, handle) = subscriber::mock()
+        .event(
+            event::mock().with_fields(
+                field::mock("some_str")
+                    .with_value(&"yes")
+                    .and(field::mock("some_bool").with_value(&true))
+                    .and(field::mock("some_u64").with_value(&42_u64)),
+            ),
+        )
+        .done()
+        .run_with_handle();
+
+    with_default(subscriber, || {
+        let some_str = Some("yes");
+        let none_str: Option<&'static str> = None;
+        let some_bool = Some(true);
+        let none_bool: Option<bool> = None;
+        let some_u64 = Some(42_u64);
+        let none_u64: Option<u64> = None;
+        trace!(
+            some_str = some_str,
+            none_str = none_str,
+            some_bool = some_bool,
+            none_bool = none_bool,
+            some_u64 = some_u64,
+            none_u64 = none_u64
+        );
+    });
+
+    handle.assert_finished();
+}

--- a/tracing/tests/event.rs
+++ b/tracing/tests/event.rs
@@ -379,7 +379,8 @@ fn option_values() {
                 field::mock("some_str")
                     .with_value(&"yes")
                     .and(field::mock("some_bool").with_value(&true))
-                    .and(field::mock("some_u64").with_value(&42_u64)),
+                    .and(field::mock("some_u64").with_value(&42_u64))
+                    .only(),
             ),
         )
         .done()
@@ -392,6 +393,80 @@ fn option_values() {
         let none_bool: Option<bool> = None;
         let some_u64 = Some(42_u64);
         let none_u64: Option<u64> = None;
+        trace!(
+            some_str = some_str,
+            none_str = none_str,
+            some_bool = some_bool,
+            none_bool = none_bool,
+            some_u64 = some_u64,
+            none_u64 = none_u64
+        );
+    });
+
+    handle.assert_finished();
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn option_ref_values() {
+    let (subscriber, handle) = subscriber::mock()
+        .event(
+            event::mock().with_fields(
+                field::mock("some_str")
+                    .with_value(&"yes")
+                    .and(field::mock("some_bool").with_value(&true))
+                    .and(field::mock("some_u64").with_value(&42_u64))
+                    .only(),
+            ),
+        )
+        .done()
+        .run_with_handle();
+
+    with_default(subscriber, || {
+        let some_str = &Some("yes");
+        let none_str: &Option<&'static str> = &None;
+        let some_bool = &Some(true);
+        let none_bool: &Option<bool> = &None;
+        let some_u64 = &Some(42_u64);
+        let none_u64: &Option<u64> = &None;
+        trace!(
+            some_str = some_str,
+            none_str = none_str,
+            some_bool = some_bool,
+            none_bool = none_bool,
+            some_u64 = some_u64,
+            none_u64 = none_u64
+        );
+    });
+
+    handle.assert_finished();
+}
+
+
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn option_ref_mut_values() {
+    let (subscriber, handle) = subscriber::mock()
+        .event(
+            event::mock().with_fields(
+                field::mock("some_str")
+                    .with_value(&"yes")
+                    .and(field::mock("some_bool").with_value(&true))
+                    .and(field::mock("some_u64").with_value(&42_u64))
+                    .only(),
+            ),
+        )
+        .done()
+        .run_with_handle();
+
+    with_default(subscriber, || {
+        let some_str = &mut Some("yes");
+        let none_str: &mut ption<&'static str> = &mut None;
+        let some_bool = &mut Some(true);
+        let none_bool: &mut Option<bool> = &mut None;
+        let some_u64 = &mut Some(42_u64);
+        let none_u64: &mut Option<u64> = &mut None;
         trace!(
             some_str = some_str,
             none_str = none_str,

--- a/tracing/tests/event.rs
+++ b/tracing/tests/event.rs
@@ -441,6 +441,7 @@ fn option_ref_values() {
 
     handle.assert_finished();
 }
+
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn option_ref_mut_values() {


### PR DESCRIPTION
I'm very interested in #1393 getting merged. Yep, I'm aware that the `Valuable` work may supersede this, but in the mean time this would be a huge improvement for how we use tracing.

Based on this comment https://github.com/tokio-rs/tracing/pull/1393#pullrequestreview-673362275 by @hawkw it looks like the only thing holding up #1393 is some tests? If so, here is one test. Let me know what other tests you'd like to see and I'll get them added.

I wasn't quite sure how to assert that the mock did _not_ record fields `none_str`, `none_bool`, etc.