### PR TITLE
tower: drop `http` from default features

### DIFF
--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["logging", "tracing"]
 license = "MIT"
 
 [features]
-default = ["tower-layer", "tower-make", "http"]
+default = ["tower-layer", "tower-make"]
 tower-make = [
     "tower_make",
     "pin-project-lite",


### PR DESCRIPTION
## Motivation

Currently, our MSRV CI build is broken because of the `tracing-tower`
crate, which depends on `http`. The latest `http` release broke support
for Rust 1.42.0.

Since the `tracing-tower` crate is unreleased and is probably never
going to be published in its current form (see #238), this isn't
actually an issue, but the CI breakage is quite sad. I'm working on an
upstream PR to `tower` to add tracing support there, so we can
eventually deprecate the `tracing-tower` crate and direct users to
upstream. However, that's not quite ready.

Also, we should probably just drop the `http` support from
`tracing-tower` entirely, since tracing HTTP requests with `Tower`
services is probably better served by the `tower-http` crate's [`trace`
middleware][1]. This middleware is significantly more featureful.

[1]: https://docs.rs/tower-http/0.1.1/tower_http/trace/index.html

## Solution

For now, this branch just makes the `http` feature flag on
`tracing-tower` off by default, instead of on by default. This may break
git deps, but this crate was never officially stable. Doing this should
fix CI.

## Alternatives

We could also just modify the `check-msrv` CI job to test every crate
_except_ for `tracing-tower`. This would be a bit of a pain but wouldn't
break any git deps that use tracing-tower's http feature...