### PR TITLE
Help LLVM understand that some spans are never going to do anything

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -403,6 +403,8 @@ fn gen_block(
         .map(|name| quote!(#name))
         .unwrap_or_else(|| quote!(#instrumented_function_name));
 
+    let level = args.level();
+
     // generate this inside a closure, so we can return early on errors.
     let span = (|| {
         // Pull out the arguments-to-be-skipped first, so we can filter results
@@ -448,7 +450,6 @@ fn gen_block(
             }
         }
 
-        let level = args.level();
         let target = args.target();
 
         // filter out skipped fields
@@ -552,8 +553,12 @@ fn gen_block(
         )
     } else {
         quote_spanned!(block.span()=>
-            let __tracing_attr_span = #span;
-            let __tracing_attr_guard = __tracing_attr_span.enter();
+            let __tracing_attr_span;
+            let __tracing_attr_guard;
+            if tracing::level_enabled!(#level) {
+                __tracing_attr_span = #span;
+                __tracing_attr_guard = __tracing_attr_span.enter();
+            }
             #block
         )
     }

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -559,6 +559,8 @@ fn gen_block(
                 __tracing_attr_span = #span;
                 __tracing_attr_guard = __tracing_attr_span.enter();
             }
+            // pacify clippy::suspicious_else_formatting
+            let _ = ();
             #block
         )
     }


### PR DESCRIPTION
## Motivation

Adding `#[instrument(level = "debug")]` attributes to functions in rustc
caused a performance regression (in release, where `debug!` is fully
optimized out) across all crates:
https://github.com/rust-lang/rust/pull/89048#issuecomment-929566530

While trying to debug this, I noticed that spans don't have the same
advantage that events have wrt to how LLVM sees them. Spans (or more
precisely, the enter-guard), will get dropped at the end of the scope,
which throws a spanner into the LLVM optimization pipeline. I am not
entirely sure where the problem is, but I am moderately certain that the
issue is that even entering a dummy span is too much code for LLVM to
reliably (or at all) optimize out.

## Solution

My hope is that in trusting the Rust compiler to generate cool code when using
drop flags, we can essentially generate a drop flag that depends on something we
know (due to events working as expected) to be optimizable.

So instead of doing

```rust
let _x = span!();
let _y = _x.enter();
// lotsa code
drop(_y)
```

we do

```rust
let _x;
let _y;
let must_drop = false;
if level_enabled!(DEBUG) {
    must_drop = true;
    _x = span!();
    _y = _x.enter();
}
// lotsa code
if must_drop {
    drop(_y)
}
```

I believe this will allow LLVM to properly optimize this again. Testing that
right now, but I wanted to open this PR immediately for review.