### PR TITLE
chore: fix several typos in tracing-core and tracing-subscriber

### DIFF
--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -101,7 +101,7 @@ pub trait Subscriber: 'static {
     ///
     /// `Subscriber`s which require their filters to be run every time an event
     /// occurs or a span is entered/exited should return `Interest::sometimes`.
-    /// If a subscriber returns `Interest::sometimes`, then its' [`enabled`] method
+    /// If a subscriber returns `Interest::sometimes`, then its [`enabled`] method
     /// will be called every time an event or span is created from that callsite.
     ///
     /// For example, suppose a sampling subscriber is implemented by
@@ -363,7 +363,7 @@ pub trait Subscriber: 'static {
     #[deprecated(since = "0.1.2", note = "use `Subscriber::try_close` instead")]
     fn drop_span(&self, _id: span::Id) {}
 
-    /// Notifies the subscriber that a [`span ID`] has been dropped, and returns
+    /// Notifies the subscriber that a [span ID] has been dropped, and returns
     /// `true` if there are now 0 IDs that refer to that span.
     ///
     /// Higher-level libraries providing functionality for composing multiple

--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -6,7 +6,7 @@
 //! complete strategy for collecting traces; but it _also_ means that the
 //! `Subscriber` trait cannot easily be composed with other `Subscriber`s.
 //!
-//! In particular, [`Subscriber`]'s are responsible for generating [span IDs] and
+//! In particular, [`Subscriber`]s are responsible for generating [span IDs] and
 //! assigning them to spans. Since these IDs must uniquely identify a span
 //! within the context of the current trace, this means that there may only be
 //! a single `Subscriber` for a given thread at any point in time &mdash;


### PR DESCRIPTION
I noticed a few typos when reading the documentation, so I might as well fix them.