### PR TITLE
tracing: add missing `Future` impl for `WithDispatch`

### DIFF
--- a/tracing/src/instrument.rs
+++ b/tracing/src/instrument.rs
@@ -233,10 +233,9 @@ pub trait WithCollector: Sized {
     /// // run on a different thread, in a different default collector's context.
     /// tokio::spawn(future);
     ///
-    /// // However, if we call `with_current_collector` on the future before
-    /// // spawning it, we can ensure that the current thread's default
-    /// // collector is propagated to the spawned task, regardless of where
-    /// // it executes:
+    /// // However, calling `with_current_collector` on the future before
+    /// // spawning it, ensures that the current thread's default collector is 
+    /// // propagated to the spawned task, regardless of where it executes:
     /// # let future = async { };
     /// tokio::spawn(future.with_current_collector());
     /// # }

--- a/tracing/src/instrument.rs
+++ b/tracing/src/instrument.rs
@@ -1,8 +1,11 @@
-use crate::{dispatch, span::Span, Dispatch};
+use crate::span::Span;
 use core::pin::Pin;
 use core::task::{Context, Poll};
 use core::{future::Future, marker::Sized};
 use pin_project_lite::pin_project;
+
+#[cfg(feature = "std")]
+use crate::dispatch::{self, Dispatch};
 
 /// Attaches spans to a [`std::future::Future`].
 ///
@@ -123,6 +126,9 @@ pub trait Instrument: Sized {
 /// Extension trait allowing futures to be instrumented with
 /// a `tracing` collector.
 ///
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub trait WithCollector: Sized {
     /// Attaches the provided [collector] to this type, returning a
     /// [`WithDispatch`] wrapper.
@@ -252,6 +258,7 @@ pub trait WithCollector: Sized {
     }
 }
 
+#[cfg(feature = "std")]
 pin_project! {
     /// A [`Future`] that has been instrumented with a `tracing` [collector].
     ///
@@ -262,6 +269,7 @@ pin_project! {
     /// [collector]: crate::Collector
     #[derive(Clone, Debug)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub struct WithDispatch<T> {
         #[pin]
         inner: T,
@@ -341,6 +349,8 @@ impl<T> Instrumented<T> {
 
 // === impl WithDispatch ===
 
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<T: Future> Future for WithDispatch<T> {
     type Output = T::Output;
 
@@ -353,8 +363,12 @@ impl<T: Future> Future for WithDispatch<T> {
     }
 }
 
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<T: Sized> WithCollector for T {}
 
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<T> WithDispatch<T> {
     /// Borrows the [`Dispatch`] that is entered when this type is polled.
     pub fn dispatch(&self) -> &Dispatch {

--- a/tracing/src/instrument.rs
+++ b/tracing/src/instrument.rs
@@ -234,7 +234,7 @@ pub trait WithCollector: Sized {
     /// tokio::spawn(future);
     ///
     /// // However, calling `with_current_collector` on the future before
-    /// // spawning it, ensures that the current thread's default collector is 
+    /// // spawning it, ensures that the current thread's default collector is
     /// // propagated to the spawned task, regardless of where it executes:
     /// # let future = async { };
     /// tokio::spawn(future.with_current_collector());
@@ -348,7 +348,8 @@ impl<T: Future> Future for WithDispatch<T> {
         let this = self.project();
         let dispatch = this.dispatch;
         let future = this.inner;
-        dispatch::with_default(dispatch, || future.poll(cx))
+        let _default = dispatch::set_default(dispatch);
+        future.poll(cx)
     }
 }
 

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -1022,7 +1022,8 @@ impl Span {
     /// [`INFO`]: crate::Level::INFO
     /// [`DEBUG`]: crate::Level::DEBUG
     /// [async tasks]: std::task
-    /// [`instrument`]: crate::instrument::Instrument
+    /// [`instrument`]: crate::instrument::Instrument::instrument
+    /// [`in_current_span`]: crate::instrument::Instrument::in_current_span
     pub fn or_current(self) -> Self {
         if self.is_disabled() {
             return Self::current();


### PR DESCRIPTION
## Motivation

The version of `WithCollector` in `tracing::instrument` (rather than in
`tracing-futures`) is currently...useless, since there is no `Future`
impl for the `WithDispatch` type. This means that calling
`with_collector` on a `Future` returns a value that _isn't_ a `Future`.
Additionally, the `WithCollector` trait isn't actually implemented for
anything (although this was fixed on v0.1.x).

## Solution

This branch adds the missing implementations. I also improved the docs a
bit.