### PR TITLE
explicitly flush previous BufWriter before dropping

### DIFF
--- a/tracing-appender/src/inner.rs
+++ b/tracing-appender/src/inner.rs
@@ -64,7 +64,12 @@ impl InnerAppender {
             self.next_date = self.rotation.next_date(&now);
 
             match create_writer(&self.log_directory, &filename) {
-                Ok(writer) => self.writer = writer,
+                Ok(writer) => {
+                    if let Err(err) = self.writer.flush() {
+                        eprintln!("Couldn't flush previous writer: {}", err);
+                    }
+                    self.writer = writer
+                }
                 Err(err) => eprintln!("Couldn't create writer for logs: {}", err),
             }
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

When a RollingFileAppender is refreshed, the previous `BufWriter` may encounter and suppress errors in `drop`.

From https://doc.rust-lang.org/std/io/struct.BufWriter.html:

> It is critical to call flush before BufWriter<W> is dropped. Though dropping will attempt to flush the contents of the buffer, any errors that happen in the process of dropping will be ignored.

## Solution

Explicitly flush the previous buffer before dropping, printing any error to stderr.
