### PR TITLE
attributes: skip `async` spans if level disabled

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -533,18 +533,15 @@ fn gen_block(
         };
 
         return quote_spanned!(block.span()=>
-            let __tracing_attr_span = #span;
-            // See comment on the default case at the end of this function
-            // for why we do this a bit roundabout.
-            let fut = #mk_fut;
             if tracing::level_enabled!(#level) {
+                let __tracing_attr_span = #span;
                 tracing::Instrument::instrument(
-                    fut,
+                    #mk_fut,
                     __tracing_attr_span
                 )
                 .await
             } else {
-                fut.await
+                #mk_fut.await
             }
         );
     }


### PR DESCRIPTION
## Motivation

In #1600, the `instrument` code generation was changed to avoid ever
constructing a `Span` struct if the level is explicitly disabled.
However, for `async` functions, `#[instrument]` will currently still
create the span, but simply skips constructing an `Instrument` future if
the level is disabled.

## Solution

This branch changes the `#[instrument]` code generation for async blocks
to totally skip constructing the span if the level is disabled. I also
simplfied the code generation a bit by combining the shared code between
the `err` and non-`err` cases, reducing code duplication a bit.