### PR TITLE
backport changes from `master`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -237,7 +237,7 @@ jobs:
       working-directory: "tracing/test_static_max_level_features"
     - name: "Test tracing-core no-std support"
       run: cargo test --no-default-features
-      working-directory: tracing
+      working-directory: tracing-core
     - name: "Test tracing no-std support"
       run: cargo test --lib --tests --no-default-features
       working-directory: tracing

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -239,7 +239,7 @@ jobs:
       run: cargo test --no-default-features
       working-directory: tracing
     - name: "Test tracing no-std support"
-      run: cargo test --no-default-features
+      run: cargo test --lib --tests --no-default-features
       working-directory: tracing
       # this skips running doctests under the `--no-default-features` flag,
       # as rustdoc isn't aware of cargo's feature flags.

--- a/examples/examples/panic_hook.rs
+++ b/examples/examples/panic_hook.rs
@@ -1,5 +1,9 @@
 //! This example demonstrates how `tracing` events can be recorded from within a
 //! panic hook, capturing the span context in which the program panicked.
+//!
+//! A custom panic hook can also be used to record panics that are captured
+//! using `catch_unwind`, such as when Tokio catches panics in spawned async
+//! tasks. See the `tokio_panic_hook.rs` example for an example of this.
 
 fn main() {
     let subscriber = tracing_subscriber::fmt()

--- a/examples/examples/tokio_panic_hook.rs
+++ b/examples/examples/tokio_panic_hook.rs
@@ -1,0 +1,54 @@
+//! This example demonstrates that a custom panic hook can be used to log panic
+//! messages even when panics are captured (such as when a Tokio task panics).
+//!
+//! This is essentially the same as the `panic_hook.rs` example, but modified to
+//! spawn async tasks using the Tokio runtime rather than panicking in a
+//! synchronous function. See the `panic_hook.rs` example for details on using
+//! custom panic hooks.
+#[tokio::main]
+async fn main() {
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::TRACE)
+        .finish();
+
+    // NOTE: Using `tracing` in a panic hook requires the use of the *global*
+    // trace dispatcher (`tracing::subscriber::set_global_default`), rather than
+    // the per-thread scoped dispatcher
+    // (`tracing::subscriber::with_default`/`set_default`). With the scoped trace
+    // dispatcher, the subscriber's thread-local context may already have been
+    // torn down by unwinding by the time the panic handler is reached.
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+
+    std::panic::set_hook(Box::new(|panic| {
+        if let Some(location) = panic.location() {
+            tracing::error!(
+                message = %panic,
+                panic.file = location.file(),
+                panic.line = location.line(),
+                panic.column = location.column(),
+            );
+        } else {
+            tracing::error!(message = %panic);
+        }
+    }));
+
+    // Spawn tasks to check the numbers from 1-10.
+    let tasks = (0..10)
+        .map(|i| tokio::spawn(check_number(i)))
+        .collect::<Vec<_>>();
+    futures::future::join_all(tasks).await;
+
+    tracing::trace!("all tasks done");
+}
+
+#[tracing::instrument]
+async fn check_number(x: i32) {
+    tracing::trace!("checking number...");
+    tokio::task::yield_now().await;
+
+    if x % 2 == 0 {
+        panic!("I don't work with even numbers!");
+    }
+
+    tracing::info!("number checks out!")
+}

--- a/tracing-appender/src/inner.rs
+++ b/tracing-appender/src/inner.rs
@@ -64,7 +64,12 @@ impl InnerAppender {
             self.next_date = self.rotation.next_date(&now);
 
             match create_writer(&self.log_directory, &filename) {
-                Ok(writer) => self.writer = writer,
+                Ok(writer) => {
+                    if let Err(err) = self.writer.flush() {
+                        eprintln!("Couldn't flush previous writer: {}", err);
+                    }
+                    self.writer = writer
+                }
                 Err(err) => eprintln!("Couldn't create writer for logs: {}", err),
             }
         }

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -118,7 +118,7 @@ pub struct Iter {
 /// }
 ///
 /// impl<'a> Visit for StringVisitor<'a> {
-///     fn record_debug(&mut self, field: &Field, value: &fmt::Debug) {
+///     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
 ///         write!(self.string, "{} = {:?}; ", field.name(), value).unwrap();
 ///     }
 /// }

--- a/tracing-core/src/spin/once.rs
+++ b/tracing-core/src/spin/once.rs
@@ -1,6 +1,9 @@
 use core::cell::UnsafeCell;
 use core::fmt;
-use core::sync::atomic::{spin_loop_hint as cpu_relax, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicUsize, Ordering};
+// TODO(eliza): replace with `core::hint::spin_loop` once our MSRV supports it.
+#[allow(deprecated)]
+use core::sync::atomic::spin_loop_hint as cpu_relax;
 
 /// A synchronization primitive which can be used to run a one-time global
 /// initialization. Unlike its std equivalent, this is generalized so that the

--- a/tracing-core/src/spin/once.rs
+++ b/tracing-core/src/spin/once.rs
@@ -76,24 +76,32 @@ impl<T> Once<T> {
         let mut status = self.state.load(Ordering::SeqCst);
 
         if status == INCOMPLETE {
-            status = self
-                .state
-                .compare_and_swap(INCOMPLETE, RUNNING, Ordering::SeqCst);
-            if status == INCOMPLETE {
-                // We init
-                // We use a guard (Finish) to catch panics caused by builder
-                let mut finish = Finish {
-                    state: &self.state,
-                    panicked: true,
-                };
-                unsafe { *self.data.get() = Some(builder()) };
-                finish.panicked = false;
+            status = match self.state.compare_exchange(
+                INCOMPLETE,
+                RUNNING,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(status) => {
+                    debug_assert_eq!(
+                        status, INCOMPLETE,
+                        "if compare_exchange succeeded, previous status must be incomplete",
+                    );
+                    // We init
+                    // We use a guard (Finish) to catch panics caused by builder
+                    let mut finish = Finish {
+                        state: &self.state,
+                        panicked: true,
+                    };
+                    unsafe { *self.data.get() = Some(builder()) };
+                    finish.panicked = false;
 
-                status = COMPLETE;
-                self.state.store(status, Ordering::SeqCst);
+                    self.state.store(COMPLETE, Ordering::SeqCst);
 
-                // This next line is strictly an optimization
-                return self.force_get();
+                    // This next line is strictly an optimization
+                    return self.force_get();
+                }
+                Err(status) => status,
             }
         }
 
@@ -101,6 +109,8 @@ impl<T> Once<T> {
             match status {
                 INCOMPLETE => unreachable!(),
                 RUNNING => {
+                    // TODO(eliza): replace with `core::hint::spin_loop` once our MSRV supports it.
+                    #[allow(deprecated)]
                     // We spin
                     cpu_relax();
                     status = self.state.load(Ordering::SeqCst)
@@ -126,7 +136,12 @@ impl<T> Once<T> {
         loop {
             match self.state.load(Ordering::SeqCst) {
                 INCOMPLETE => return None,
-                RUNNING => cpu_relax(), // We spin
+
+                RUNNING => {
+                    // TODO(eliza): replace with `core::hint::spin_loop` once our MSRV supports it.
+                    #[allow(deprecated)]
+                    cpu_relax() // We spin
+                }
                 COMPLETE => return Some(self.force_get()),
                 PANICKED => panic!("Once has panicked"),
                 _ => unsafe { unreachable() },

--- a/tracing/src/instrument.rs
+++ b/tracing/src/instrument.rs
@@ -1,20 +1,24 @@
 use crate::stdlib::pin::Pin;
 use crate::stdlib::task::{Context, Poll};
 use crate::stdlib::{future::Future, marker::Sized};
-use crate::{dispatcher, span::Span, Dispatch};
+use crate::{
+    dispatcher::{self, Dispatch},
+    span::Span,
+};
 use pin_project_lite::pin_project;
 
-/// Attaches spans to a `std::future::Future`.
+/// Attaches spans to a [`std::future::Future`].
 ///
 /// Extension trait allowing futures to be
 /// instrumented with a `tracing` [span].
 ///
-/// [span]:  ../struct.Span.html
+/// [span]: super::Span
 pub trait Instrument: Sized {
-    /// Instruments this type with the provided `Span`, returning an
+    /// Instruments this type with the provided [`Span`], returning an
     /// `Instrumented` wrapper.
     ///
-    /// The attached `Span` will be [entered] every time the instrumented `Future` is polled.
+    /// The attached [`Span`] will be [entered] every time the instrumented
+    /// [`Future`] is polled.
     ///
     /// # Examples
     ///
@@ -38,7 +42,7 @@ pub trait Instrument: Sized {
     /// `instrument` to ensure that the [current span] is attached to the
     /// future if the span passed to `instrument` is [disabled]:
     ///
-    /// ```W
+    /// ```
     /// use tracing::Instrument;
     /// # mod tokio {
     /// #     pub(super) fn spawn(_: impl std::future::Future) {}
@@ -74,17 +78,16 @@ pub trait Instrument: Sized {
     /// [`Span::or_current`]: super::Span::or_current()
     /// [current span]: super::Span::current()
     /// [disabled]: super::Span::is_disabled()
+    /// [`Future`]: std::future::Future
     fn instrument(self, span: Span) -> Instrumented<Self> {
         Instrumented { inner: self, span }
     }
 
-    /// Instruments this type with the [current] `Span`, returning an
+    /// Instruments this type with the [current] [`Span`], returning an
     /// `Instrumented` wrapper.
     ///
-    /// If the instrumented type is a future, stream, or sink, the attached `Span`
-    /// will be [entered] every time it is polled. If the instrumented type
-    /// is a future executor, every future spawned on that executor will be
-    /// instrumented by the attached `Span`.
+    /// The attached [`Span`] will be [entered] every time the instrumented
+    /// [`Future`] is polled.
     ///
     /// This can be used to propagate the current span when spawning a new future.
     ///
@@ -93,6 +96,9 @@ pub trait Instrument: Sized {
     /// ```rust
     /// use tracing::Instrument;
     ///
+    /// # mod tokio {
+    /// #     pub(super) fn spawn(_: impl std::future::Future) {}
+    /// # }
     /// # async fn doc() {
     /// let span = tracing::info_span!("my_span");
     /// let _enter = span.enter();
@@ -107,8 +113,10 @@ pub trait Instrument: Sized {
     /// # }
     /// ```
     ///
-    /// [current]: ../struct.Span.html#method.current
-    /// [entered]: ../struct.Span.html#method.enter
+    /// [current]: super::Span::current()
+    /// [entered]: super::Span::enter()
+    /// [`Span`]: crate::Span
+    /// [`Future`]: std::future::Future
     #[inline]
     fn in_current_span(self) -> Instrumented<Self> {
         self.instrument(Span::current())
@@ -117,63 +125,133 @@ pub trait Instrument: Sized {
 
 /// Extension trait allowing futures to be instrumented with
 /// a `tracing` [`Subscriber`].
-///
-/// [`Subscriber`]: ../trait.Subscriber.html
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub trait WithSubscriber: Sized {
     /// Attaches the provided [`Subscriber`] to this type, returning a
-    /// `WithDispatch` wrapper.
+    /// [`WithDispatch`] wrapper.
     ///
-    /// The attached subscriber will be set as the [default] when the returned `Future` is polled.
+    /// The attached [`Subscriber`] will be set as the [default] when the returned
+    /// [`Future`] is polled.
     ///
-    /// [`Subscriber`]: ../trait.Subscriber.html
-    /// [default]: https://docs.rs/tracing/latest/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// # Examples
+    ///
+    /// ```
+    /// # use tracing::subscriber::NoSubscriber as MySubscriber;
+    /// # use tracing::subscriber::NoSubscriber as MyOtherSubscriber;
+    /// # async fn docs() {
+    /// use tracing::instrument::WithSubscriber;
+    ///
+    /// // Set the default `Subscriber`
+    /// let _default = tracing::subscriber::set_default(MySubscriber::default());
+    ///
+    /// tracing::info!("this event will be recorded by the default `Subscriber`");
+    ///
+    /// // Create a different `Subscriber` and attach it to a future.
+    /// let other_subscriber = MyOtherSubscriber::default();
+    /// let future = async {
+    ///     tracing::info!("this event will be recorded by the other `Subscriber`");
+    ///     // ...
+    /// };
+    ///
+    /// future
+    ///     // Attach the other `Subscriber` to the future before awaiting it
+    ///     .with_subscriber(other_subscriber)
+    ///     .await;
+    ///
+    /// // Once the future has completed, we return to the default `Subscriber`.
+    /// tracing::info!("this event will be recorded by the default `Subscriber`");
+    /// # }
+    /// ```
+    ///
+    /// [`Subscriber`]: super::Subscriber
+    /// [default]: crate::dispatcher#setting-the-default-subscriber
+    /// [`Future`]: std::future::Future
     fn with_subscriber<S>(self, subscriber: S) -> WithDispatch<Self>
     where
         S: Into<Dispatch>,
     {
         WithDispatch {
             inner: self,
-            dispatch: subscriber.into(),
+            dispatcher: subscriber.into(),
         }
     }
 
     /// Attaches the current [default] [`Subscriber`] to this type, returning a
-    /// `WithDispatch` wrapper.
+    /// [`WithDispatch`] wrapper.
     ///
-    /// When the wrapped type is a future, stream, or sink, the attached
-    /// subscriber will be set as the [default] while it is being polled.
-    /// When the wrapped type is an executor, the subscriber will be set as the
-    /// default for any futures spawned on that executor.
+    /// The attached `Subscriber` will be set as the [default] when the returned
+    /// [`Future`] is polled.
     ///
     /// This can be used to propagate the current dispatcher context when
-    /// spawning a new future.
+    /// spawning a new future that may run on a different thread.
     ///
-    /// [`Subscriber`]: ../trait.Subscriber.html
-    /// [default]: https://docs.rs/tracing/latest/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// # Examples
+    ///
+    /// ```
+    /// # mod tokio {
+    /// #     pub(super) fn spawn(_: impl std::future::Future) {}
+    /// # }
+    /// # use tracing::subscriber::NoSubscriber as MySubscriber;
+    /// # async fn docs() {
+    /// use tracing::instrument::WithSubscriber;
+    ///
+    /// // Using `set_default` (rather than `set_global_default`) sets the
+    /// // default `Subscriber` for *this* thread only.
+    /// let _default = tracing::subscriber::set_default(MySubscriber::default());
+    ///
+    /// let future = async {
+    ///     // ...
+    /// };
+    ///
+    /// // If a multi-threaded async runtime is in use, this spawned task may
+    /// // run on a different thread, in a different default `Subscriber`'s context.
+    /// tokio::spawn(future);
+    ///
+    /// // However, calling `with_current_subscriber` on the future before
+    /// // spawning it, ensures that the current thread's default `Subscriber` is
+    /// // propagated to the spawned task, regardless of where it executes:
+    /// # let future = async { };
+    /// tokio::spawn(future.with_current_subscriber());
+    /// # }
+    /// ```
+    /// [`Subscriber`]: super::Subscriber
+    /// [default]: crate::dispatcher#setting-the-default-subscriber
+    /// [`Future`]: std::future::Future
     #[inline]
     fn with_current_subscriber(self) -> WithDispatch<Self> {
         WithDispatch {
             inner: self,
-            dispatch: dispatcher::get_default(|default| default.clone()),
+            dispatcher: crate::dispatcher::get_default(|default| default.clone()),
         }
     }
 }
 
-impl<T: Sized> WithSubscriber for T {}
-
 pin_project! {
-    /// A future that has been instrumented with a `tracing` subscriber.
+    /// A [`Future`] that has been instrumented with a `tracing` [`Subscriber`].
+    ///
+    /// This type is returned by the [`WithSubscriber`] extension trait. See that
+    /// trait's documentation for details.
+    ///
+    /// [`Future`]: std::future::Future
+    /// [`Subscriber`]: crate::Subscriber
     #[derive(Clone, Debug)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub struct WithDispatch<T> {
         #[pin]
         inner: T,
-        dispatch: Dispatch,
+        dispatcher: Dispatch,
     }
 }
 
 pin_project! {
-    /// A future that has been instrumented with a `tracing` span.
+    /// A [`Future`] that has been instrumented with a `tracing` [`Span`].
+    ///
+    /// This type is returned by the [`Instrument`] extension trait. See that
+    /// trait's documentation for details.
+    ///
+    /// [`Future`]: std::future::Future
+    /// [`Span`]: crate::Span
     #[derive(Debug, Clone)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct Instrumented<T> {
@@ -182,6 +260,8 @@ pin_project! {
         span: Span,
     }
 }
+
+// === impl Instrumented ===
 
 impl<T: Future> Future for Instrumented<T> {
     type Output = T::Output;
@@ -204,6 +284,61 @@ impl<T> Instrumented<T> {
     /// Mutably borrows the `Span` that this type is instrumented by.
     pub fn span_mut(&mut self) -> &mut Span {
         &mut self.span
+    }
+
+    /// Borrows the wrapped type.
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+
+    /// Mutably borrows the wrapped type.
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    /// Get a pinned reference to the wrapped type.
+    pub fn inner_pin_ref(self: Pin<&Self>) -> Pin<&T> {
+        self.project_ref().inner
+    }
+
+    /// Get a pinned mutable reference to the wrapped type.
+    pub fn inner_pin_mut(self: Pin<&mut Self>) -> Pin<&mut T> {
+        self.project().inner
+    }
+
+    /// Consumes the `Instrumented`, returning the wrapped type.
+    ///
+    /// Note that this drops the span.
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+// === impl WithDispatch ===
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl<T: Future> Future for WithDispatch<T> {
+    type Output = T::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let dispatcher = this.dispatcher;
+        let future = this.inner;
+        let _default = dispatcher::set_default(dispatcher);
+        future.poll(cx)
+    }
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl<T: Sized> WithSubscriber for T {}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl<T> WithDispatch<T> {
+    /// Borrows the [`Dispatch`] that is entered when this type is polled.
+    pub fn dispatcher(&self) -> &Dispatch {
+        &self.dispatcher
     }
 
     /// Borrows the wrapped type.

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -171,7 +171,7 @@
 //! ```
 //!
 //! For functions which don't have built-in tracing support and can't have
-//! the `#[instrument]` attribute applied (such as from an external crate,
+//! the `#[instrument]` attribute applied (such as from an external crate),
 //! the [`Span` struct][`Span`] has a [`in_scope()` method][`in_scope`]
 //! which can be used to easily wrap synchonous code in a span.
 //!


### PR DESCRIPTION
this backports the following changes from `master` to `v0.1.x`:

* 21ddd96a attributes: skip `async` spans if level disabled (#1607)
* d3fa53f5 tracing: add missing `Future` impl for `WithDispatch` (#1602)
* 37c4b5cd appender: explicitly flush previous BufWriter before dropping (#1604)
* a674278a core: additional deprecation fixes (#1606)
* cd8b24a6 core: fix `spin_loop_hint` deprecation (#1603)
* 47eac483 docs: add a parenthesis (#1597)
* b6544e74 core: fix missing `dyn` in `Visit` docs example (#1595)
* 72b07a14 examples: add `tokio_panic_hook` example (#1593)

Of these commits, only #1602 required meaningful modification for v0.1.x
(beyond tracking renamings). It was necessary to change the feature
flagging of `WithDispatch`/`WithSubscriber` from the version on
`master`, so that  the `Future` impl requires the "std" feature flag,
but the `WithSubscriber` trait and `WithDispatch` type do not. This is
because requiring the feature flag for these definitions would
*technically* be a breaking change, since they were previously published
without the feature flag and could e.g. be imported...even though they
were totally useless. Sigh.