### PR TITLE
backport `tracing-attributes` bugfixes

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -731,15 +731,16 @@ fn gen_block(
         };
 
         return quote_spanned!(block.span()=>
-            if tracing::level_enabled!(#level) {
-                let __tracing_attr_span = #span;
+            let __tracing_attr_span = #span;
+            let __tracing_instrument_future = #mk_fut;
+            if !__tracing_attr_span.is_disabled() {
                 tracing::Instrument::instrument(
-                    #mk_fut,
+                    __tracing_instrument_future,
                     __tracing_attr_span
                 )
                 .await
             } else {
-                #mk_fut.await
+                __tracing_instrument_future.await
             }
         );
     }

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -730,7 +730,7 @@ fn gen_block(
             )
         };
 
-        return quote_spanned!(block.span()=>
+        return quote!(
             let __tracing_attr_span = #span;
             let __tracing_instrument_future = #mk_fut;
             if !__tracing_attr_span.is_disabled() {
@@ -745,7 +745,7 @@ fn gen_block(
         );
     }
 
-    let span = quote_spanned!(block.span()=>
+    let span = quote!(
         // These variables are left uninitialized and initialized only
         // if the tracing level is statically enabled at this point.
         // While the tracing level is also checked at span creation
@@ -779,7 +779,7 @@ fn gen_block(
         );
     }
 
-    quote_spanned!(block.span()=>
+    quote_spanned!(block.span() =>
         // Because `quote` produces a stream of tokens _without_ whitespace, the
         // `if` and the block will appear directly next to each other. This
         // generates a clippy lint about suspicious `if/else` formatting.

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -761,8 +761,6 @@ fn gen_block(
             __tracing_attr_span = #span;
             __tracing_attr_guard = __tracing_attr_span.enter();
         }
-        // pacify clippy::suspicious_else_formatting
-        let _ = ();
     );
 
     if err {
@@ -781,8 +779,17 @@ fn gen_block(
     }
 
     quote_spanned!(block.span()=>
-        #span
-        #block
+        // Because `quote` produces a stream of tokens _without_ whitespace, the
+        // `if` and the block will appear directly next to each other. This
+        // generates a clippy lint about suspicious `if/else` formatting.
+        // Therefore, suppress the lint inside the generated code...
+        #[allow(clippy::suspicious_else_formatting)]
+        {
+            #span
+            // ...but turn the lint back on inside the function body.
+            #[warn(clippy::suspicious_else_formatting)]
+            #block
+        }
     )
 }
 

--- a/tracing-attributes/tests/async_fn.rs
+++ b/tracing-attributes/tests/async_fn.rs
@@ -15,6 +15,21 @@ async fn test_async_fn(polls: usize) -> Result<(), ()> {
     future.await
 }
 
+// Reproduces a compile error when returning an `impl Trait` from an
+// instrumented async fn (see https://github.com/tokio-rs/tracing/issues/1615)
+#[instrument]
+async fn test_ret_impl_trait(n: i32) -> Result<impl Iterator<Item = i32>, ()> {
+    let n = n;
+    Ok((0..10).filter(move |x| *x < n))
+}
+
+// Reproduces a compile error when returning an `impl Trait` from an
+// instrumented async fn (see https://github.com/tokio-rs/tracing/issues/1615)
+#[instrument(err)]
+async fn test_ret_impl_trait_err(n: i32) -> Result<impl Iterator<Item = i32>, &'static str> {
+    Ok((0..10).filter(move |x| *x < n))
+}
+
 #[instrument]
 async fn test_async_fn_empty() {}
 

--- a/tracing-attributes/tests/async_fn.rs
+++ b/tracing-attributes/tests/async_fn.rs
@@ -33,6 +33,28 @@ async fn test_ret_impl_trait_err(n: i32) -> Result<impl Iterator<Item = i32>, &'
 #[instrument]
 async fn test_async_fn_empty() {}
 
+// Reproduces https://github.com/tokio-rs/tracing/issues/1613
+#[instrument]
+// LOAD-BEARING `#[rustfmt::skip]`! This is necessary to reproduce the bug;
+// with the rustfmt-generated formatting, the lint will not be triggered!
+#[rustfmt::skip]
+#[deny(clippy::suspicious_else_formatting)]
+async fn repro_1613(var: bool) {
+    println!(
+        "{}",
+        if var { "true" } else { "false" }
+    );
+}
+
+// Reproduces https://github.com/tokio-rs/tracing/issues/1613
+// and https://github.com/rust-lang/rust-clippy/issues/7760
+#[instrument]
+#[deny(clippy::suspicious_else_formatting)]
+async fn repro_1613_2() {
+    // hello world
+    // else
+}
+
 #[test]
 fn async_fn_only_enters_for_polls() {
     let (subscriber, handle) = subscriber::mock()

--- a/tracing-attributes/tests/async_fn.rs
+++ b/tracing-attributes/tests/async_fn.rs
@@ -15,6 +15,9 @@ async fn test_async_fn(polls: usize) -> Result<(), ()> {
     future.await
 }
 
+#[instrument]
+async fn test_async_fn_empty() {}
+
 #[test]
 fn async_fn_only_enters_for_polls() {
     let (subscriber, handle) = subscriber::mock()

--- a/tracing-attributes/tests/err.rs
+++ b/tracing-attributes/tests/err.rs
@@ -16,6 +16,12 @@ fn err() -> Result<u8, TryFromIntError> {
     u8::try_from(1234)
 }
 
+#[instrument(err)]
+fn err_suspicious_else() -> Result<u8, TryFromIntError> {
+    {}
+    u8::try_from(1234)
+}
+
 #[test]
 fn test() {
     let span = span::mock().named("err");


### PR DESCRIPTION
this backports bugfixes for issues introduced in `tracing-attributes` v0.1.17 from `master` to `v0.1.x`. in particular, this includes:

* 7b3847fa attributes: remove unnecessary quote_spanned!  (#1617)
* 71915385 attributes: fix compile error with instrumented async functions  (#1616)
* d309e7eb attributes: suppress `clippy::suspicious_else` without nop let (#1614)

i'll rebase and merge this pending CI, since these changes were already approved on `master`.