### PR TITLE
subscriber: prepare to release 0.2.25

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 0.2.25 (October 5, 2021)
+
+This release fixes an issue where a `Layer` implementation's custom
+`downcast_raw` implementation was lost when wrapping that layer with a per-layer
+filter.
+
+### Fixed
+
+- **registry**: Forward `Filtered::downcast_raw` to wrapped `Layer` ([#1619])
+
+### Added
+
+- Documentation improvements ([#1596], [#1601])
+
+Thanks to @bryanburgers for contributing to this release!
+
+[#1619]: https://github.com/tokio-rs/tracing/pull/1619
+[#1601]: https://github.com/tokio-rs/tracing/pull/1601
+[#1596]: https://github.com/tokio-rs/tracing/pull/1596
+
 # 0.2.24 (September 19, 2021)
 
 This release contains a number of bug fixes, including a fix for

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.2.24"
+version = "0.2.25"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -21,7 +21,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.2.24
+[docs-url]: https://docs.rs/tracing-subscriber/0.2.25
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -91,7 +91,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`registry`]: registry/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.24")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.2.25")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.2.25 (October 5, 2021)

This release fixes an issue where a `Layer` implementation's custom
`downcast_raw` implementation was lost when wrapping that layer with a
per-layer filter.

### Fixed

- **registry**: Forward `Filtered::downcast_raw` to wrapped `Layer`
  ([#1619])

### Added

- Documentation improvements ([#1596], [#1601])

Thanks to @bryanburgers for contributing to this release!

[#1619]: https://github.com/tokio-rs/tracing/pull/1619
[#1601]: https://github.com/tokio-rs/tracing/pull/1601
[#1596]: https://github.com/tokio-rs/tracing/pull/1596