### PR TITLE
docs: fix a typo in tracing's changelog

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -8,7 +8,7 @@ span is disabled.
 ### Changed
 
 - `tracing-core`: updated to v0.1.21
-- `tracing-attributes`: updated to v0.1.19
+- `tracing-attributes`: updated to v0.1.18
 
 ### Added
 


### PR DESCRIPTION
tracing-attributes v0.1.18 was released yesterday not v0.1.19