### PR TITLE
attributes: add `err(Debug)` meta to use `Debug` impl

### DIFF
--- a/tracing-attributes/tests/err.rs
+++ b/tracing-attributes/tests/err.rs
@@ -187,16 +187,14 @@ fn test_err_dbg() {
         .new_span(span.clone())
         .enter(span.clone())
         .event(
-            event::mock()
-                .at_level(Level::ERROR)
-                .with_fields(
-                    field::mock("error")
-                        // use the actual error value that will be emitted, so
-                        // that this test doesn't break if the standard library
-                        // changes the `fmt::Debug` output from the error type
-                        // in the future.
-                        .with_value(&tracing::field::debug(u8::try_from(1234).unwrap_err()))
-                )
+            event::mock().at_level(Level::ERROR).with_fields(
+                field::mock("error")
+                    // use the actual error value that will be emitted, so
+                    // that this test doesn't break if the standard library
+                    // changes the `fmt::Debug` output from the error type
+                    // in the future.
+                    .with_value(&tracing::field::debug(u8::try_from(1234).unwrap_err())),
+            ),
         )
         .exit(span.clone())
         .drop_span(span)
@@ -212,13 +210,12 @@ fn test_err_display_default() {
     let (collector, handle) = collector::mock()
         .new_span(span.clone())
         .enter(span.clone())
-        .event(event::mock()
-            .at_level(Level::ERROR)
-            .with_fields(
+        .event(
+            event::mock().at_level(Level::ERROR).with_fields(
                 field::mock("error")
                     // by default, errors will be emitted with their display values
-                    .with_value(&tracing::field::display(u8::try_from(1234).unwrap_err()))
-            )
+                    .with_value(&tracing::field::display(u8::try_from(1234).unwrap_err())),
+            ),
         )
         .exit(span.clone())
         .drop_span(span)


### PR DESCRIPTION
## Motivation

This PR attempts to solve https://github.com/tokio-rs/tracing/issues/1630 by introducing `err_dbg` meta to `intrument` attribute macro. As `err` meta causes the error (`e`) returned by instrumented function to be passed to `tracing::error!(error = %e)` i.e. makes it use the `Display` implementation of `e`, the newly added `err_dbg` makes expands to `tracing::error!(error = ?e)` which makes the `error!` macro to use `Debug` implementation for `e`. `err` and `err_dbg` are mutually exclusive, adding both will create a compilation error.

As tried to describe, for some types implementing `Error` it might be more suitable to use `Debug` implementation as in the case of `eyre::Result`. This frees us to manually go over the error chain and print them all, so that `instrument` attribute macro would do it for us.

## Solution

- Added a custom keyword `err_db` similar to `err`,
- Add `err_dbg` field to `InstrumentArgs`,
- Add parsing for `err_dbg` arg and check for conflicts with `err`,
- Generate `tracing::error!(error = ?e)` when `err_dbg` is `true` and `tracing::error!(error = %e)` when `err` is `true`,
- Interpolate generated `err_block` into `Err` branches in both async and sync return positions, if `err` or `err_dbg` is `true`.

Even though I copied one of the tests, I'm not sure if it helps to check the new behavior. I manually tested it using VSCode/rust-analyzer's "Expand macro recursively" facility. But I am open to better test suggestions.