### PR TITLE
attributes: speculatively expand when parsing fails

### DIFF
--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -103,7 +103,7 @@ pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 #[must_use]
 #[derive(Debug)]
 pub struct WorkerGuard {
-    guard: Option<JoinHandle<()>>,
+    _guard: Option<JoinHandle<()>>,
     sender: Sender<Msg>,
     shutdown: Sender<()>,
 }
@@ -250,7 +250,7 @@ impl<'a> MakeWriter<'a> for NonBlocking {
 impl WorkerGuard {
     fn new(handle: JoinHandle<()>, sender: Sender<Msg>, shutdown: Sender<()>) -> Self {
         WorkerGuard {
-            guard: Some(handle),
+            _guard: Some(handle),
             sender,
             shutdown,
         }


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/tracing/issues/1633.

I intentially did not open a PR because the code isn't really polished and I wasn't sure if that is the right approach. I just needed something quickly to improve my rust-analyzer experience with a project. But here we go...

TODO: Check approach, polish/optimize code (eg. I wasn't sure if cloning a `TokenStream` is "zero/low-cost").