### PR TITLE
subscriber: remove `Subscribe` impls for `Arc`s

### DIFF
--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -9,7 +9,7 @@ use tracing_core::{
 
 #[cfg(feature = "registry")]
 use crate::registry::{self, LookupSpan, Registry, SpanRef};
-use std::{any::TypeId, marker::PhantomData, ops::Deref, ptr::NonNull, sync::Arc};
+use std::{any::TypeId, marker::PhantomData, ops::Deref, ptr::NonNull};
 
 /// A composable handler for `tracing` events.
 ///
@@ -947,21 +947,6 @@ macro_rules! subscriber_impl_body {
             self.deref().downcast_raw(id)
         }
     };
-}
-
-impl<S, C> Subscribe<C> for Arc<S>
-where
-    S: Subscribe<C>,
-    C: Collect,
-{
-    subscriber_impl_body! {}
-}
-
-impl<C> Subscribe<C> for Arc<dyn Subscribe<C> + Send + Sync>
-where
-    C: Collect,
-{
-    subscriber_impl_body! {}
 }
 
 impl<S, C> Subscribe<C> for Box<S>


### PR DESCRIPTION
Implementing `Subscribe` for `Arc`s, which are immutable, breaks the
ability to implement `Subscribe::on_layer` with a mutable reference.
This is necessary for per-layer filtering. See
https://github.com/tokio-rs/tracing/pull/1576#discussion_r711609810 for
details. Therefore, the `Layer` impls for `Arc`s should not be used.

In 0.3, we have the opportunity to remove these APIs. Therefore, this PR
removes them.
