### PR TITLE
subscriber: add lifetime parameter to `MakeWriter` (#781)

### DIFF
--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -240,10 +240,10 @@ impl std::io::Write for NonBlocking {
     }
 }
 
-impl MakeWriter for NonBlocking {
+impl<'a> MakeWriter<'a> for NonBlocking {
     type Writer = NonBlocking;
 
-    fn make_writer(&self) -> Self::Writer {
+    fn make_writer(&'a self) -> Self::Writer {
         self.clone()
     }
 }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1316,13 +1316,15 @@ impl Display for TimingDisplay {
 
 #[cfg(test)]
 pub(super) mod test {
-
-    use crate::fmt::{test::MockWriter, time::FormatTime};
-    use lazy_static::lazy_static;
-    use tracing::{self, subscriber::with_default};
+    use crate::fmt::{test::MockMakeWriter, time::FormatTime};
+    use tracing::{
+        self,
+        dispatcher::{set_default, Dispatch},
+        subscriber::with_default,
+    };
 
     use super::{FmtSpan, TimingDisplay};
-    use std::{fmt, sync::Mutex};
+    use std::fmt;
 
     pub(crate) struct MockTime;
     impl FormatTime for MockTime {
@@ -1334,13 +1336,9 @@ pub(super) mod test {
     #[test]
     fn disable_everything() {
         // This test reproduces https://github.com/tokio-rs/tracing/issues/1354
-        lazy_static! {
-            static ref BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-        }
-
-        let make_writer = || MockWriter::new(&BUF);
+        let make_writer = MockMakeWriter::default();
         let subscriber = crate::fmt::Subscriber::builder()
-            .with_writer(make_writer)
+            .with_writer(make_writer.clone())
             .without_time()
             .with_level(false)
             .with_target(false)
@@ -1348,151 +1346,93 @@ pub(super) mod test {
             .with_thread_names(false);
         #[cfg(feature = "ansi")]
         let subscriber = subscriber.with_ansi(false);
-
-        with_default(subscriber.finish(), || {
-            tracing::info!("hello");
-        });
-
-        let actual = String::from_utf8(BUF.try_lock().unwrap().to_vec()).unwrap();
-        assert_eq!("hello\n", actual.as_str());
+        run_test(subscriber, make_writer, "hello\n")
     }
 
     #[cfg(feature = "ansi")]
     #[test]
     fn with_ansi_true() {
-        lazy_static! {
-            static ref BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-        }
-
-        let make_writer = || MockWriter::new(&BUF);
-        let expected = "\u{1b}[2mfake time\u{1b}[0m \u{1b}[32m INFO\u{1b}[0m tracing_subscriber::fmt::format::test: some ansi test\n";
-        test_ansi(make_writer, expected, true, &BUF);
+        let expected = "\u{1b}[2mfake time\u{1b}[0m \u{1b}[32m INFO\u{1b}[0m tracing_subscriber::fmt::format::test: hello\n";
+        test_ansi(true, expected);
     }
 
     #[cfg(feature = "ansi")]
     #[test]
     fn with_ansi_false() {
-        lazy_static! {
-            static ref BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-        }
-
-        let make_writer = || MockWriter::new(&BUF);
-        let expected = "fake time  INFO tracing_subscriber::fmt::format::test: some ansi test\n";
-
-        test_ansi(make_writer, expected, false, &BUF);
+        let expected = "fake time  INFO tracing_subscriber::fmt::format::test: hello\n";
+        test_ansi(false, expected);
     }
 
     #[cfg(not(feature = "ansi"))]
     #[test]
     fn without_ansi() {
-        lazy_static! {
-            static ref BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-        }
-
-        let make_writer = || MockWriter::new(&BUF);
-        let expected = "fake time  INFO tracing_subscriber::fmt::format::test: some ansi test\n";
+        let make_writer = MockMakeWriter::default();
+        let expected = "fake time  INFO tracing_subscriber::fmt::format::test: hello\n";
         let subscriber = crate::fmt::Subscriber::builder()
             .with_writer(make_writer)
-            .with_timer(MockTime)
-            .finish();
-
-        with_default(subscriber, || {
-            tracing::info!("some ansi test");
-        });
-
-        let actual = String::from_utf8(BUF.try_lock().unwrap().to_vec()).unwrap();
-        assert_eq!(expected, actual.as_str());
-    }
-
-    #[cfg(feature = "ansi")]
-    fn test_ansi<T>(make_writer: T, expected: &str, is_ansi: bool, buf: &Mutex<Vec<u8>>)
-    where
-        T: crate::fmt::MakeWriter + Send + Sync + 'static,
-    {
-        let subscriber = crate::fmt::Subscriber::builder()
-            .with_writer(make_writer)
-            .with_ansi(is_ansi)
-            .with_timer(MockTime)
-            .finish();
-
-        with_default(subscriber, || {
-            tracing::info!("some ansi test");
-        });
-
-        let actual = String::from_utf8(buf.try_lock().unwrap().to_vec()).unwrap();
-        assert_eq!(expected, actual.as_str());
+            .with_timer(MockTime);
+        run_test(subscriber, make_writer, expected);
     }
 
     #[test]
     fn without_level() {
-        lazy_static! {
-            static ref BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-        }
-
-        let make_writer = || MockWriter::new(&BUF);
+        let make_writer = MockMakeWriter::default();
         let subscriber = crate::fmt::Subscriber::builder()
-            .with_writer(make_writer)
+            .with_writer(make_writer.clone())
             .with_level(false)
             .with_ansi(false)
-            .with_timer(MockTime)
-            .finish();
+            .with_timer(MockTime);
+        let expected = "fake time tracing_subscriber::fmt::format::test: hello\n";
 
-        with_default(subscriber, || {
-            tracing::info!("hello");
-        });
-        let actual = String::from_utf8(BUF.try_lock().unwrap().to_vec()).unwrap();
-        assert_eq!(
-            "fake time tracing_subscriber::fmt::format::test: hello\n",
-            actual.as_str()
-        );
+        run_test(subscriber, make_writer, expected);
+    }
+
+    #[cfg(feature = "ansi")]
+    fn test_ansi(is_ansi: bool, expected: &str) {
+        let make_writer = MockMakeWriter::default();
+        let subscriber = crate::fmt::Subscriber::builder()
+            .with_writer(make_writer.clone())
+            .with_ansi(is_ansi)
+            .with_timer(MockTime);
+        run_test(subscriber, make_writer, expected)
+    }
+
+    fn run_test(subscriber: impl Into<Dispatch>, buf: MockMakeWriter, expected: &str) {
+        let _default = set_default(&subscriber.into());
+        tracing::info!("hello");
+        assert_eq!(expected, buf.get_string())
     }
 
     #[test]
     fn overridden_parents() {
-        lazy_static! {
-            static ref BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-        }
-
-        let make_writer = || MockWriter::new(&BUF);
-        let subscriber = crate::fmt::Subscriber::builder()
-            .with_writer(make_writer)
+        let make_writer = MockMakeWriter::default();
+        let collector = crate::fmt::Subscriber::builder()
+            .with_writer(make_writer.clone())
             .with_level(false)
             .with_ansi(false)
             .with_timer(MockTime)
             .finish();
 
-        with_default(subscriber, || {
+        with_default(collector, || {
             let span1 = tracing::info_span!("span1");
             let span2 = tracing::info_span!(parent: &span1, "span2");
             tracing::info!(parent: &span2, "hello");
         });
-        let actual = String::from_utf8(BUF.try_lock().unwrap().to_vec()).unwrap();
         assert_eq!(
             "fake time span1:span2: tracing_subscriber::fmt::format::test: hello\n",
-            actual.as_str()
+            make_writer.get_string()
         );
     }
 
     #[test]
     fn overridden_parents_in_scope() {
-        lazy_static! {
-            static ref BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-        }
-
-        let make_writer = || MockWriter::new(&BUF);
+        let make_writer = MockMakeWriter::default();
         let subscriber = crate::fmt::Subscriber::builder()
-            .with_writer(make_writer)
+            .with_writer(make_writer.clone())
             .with_level(false)
             .with_ansi(false)
             .with_timer(MockTime)
             .finish();
-
-        let actual = || {
-            let mut buf = BUF.try_lock().unwrap();
-            let val = String::from_utf8(buf.to_vec()).unwrap();
-            buf.clear();
-            val
-        };
 
         with_default(subscriber, || {
             let span1 = tracing::info_span!("span1");
@@ -1503,13 +1443,13 @@ pub(super) mod test {
             tracing::info!("hello");
             assert_eq!(
                 "fake time span3: tracing_subscriber::fmt::format::test: hello\n",
-                actual().as_str()
+                make_writer.get_string().as_str()
             );
 
             tracing::info!(parent: &span2, "hello");
             assert_eq!(
                 "fake time span1:span2: tracing_subscriber::fmt::format::test: hello\n",
-                actual().as_str()
+                make_writer.get_string().as_str()
             );
         });
     }

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -429,7 +429,7 @@ where
     N: for<'writer> FormatFields<'writer> + 'static,
     E: FormatEvent<Registry, N> + 'static,
     F: layer::Layer<Formatter<N, E, W>> + 'static,
-    W: MakeWriter + 'static,
+    W: for<'writer> MakeWriter<'writer> + 'static,
     layer::Layered<F, Formatter<N, E, W>>: tracing_core::Subscriber,
     fmt_layer::Layer<Registry, N, E, W>: layer::Layer<Registry>,
 {
@@ -529,7 +529,7 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W>
 where
     N: for<'writer> FormatFields<'writer> + 'static,
     E: FormatEvent<Registry, N> + 'static,
-    W: MakeWriter + 'static,
+    W: for<'writer> MakeWriter<'writer> + 'static,
     F: layer::Layer<Formatter<N, E, W>> + Send + Sync + 'static,
     fmt_layer::Layer<Registry, N, E, W>: layer::Layer<Registry> + Send + Sync + 'static,
 {
@@ -576,7 +576,7 @@ impl<N, E, F, W> From<SubscriberBuilder<N, E, F, W>> for tracing_core::Dispatch
 where
     N: for<'writer> FormatFields<'writer> + 'static,
     E: FormatEvent<Registry, N> + 'static,
-    W: MakeWriter + 'static,
+    W: for<'writer> MakeWriter<'writer> + 'static,
     F: layer::Layer<Formatter<N, E, W>> + Send + Sync + 'static,
     fmt_layer::Layer<Registry, N, E, W>: layer::Layer<Registry> + Send + Sync + 'static,
 {
@@ -985,7 +985,7 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
     where
         E2: FormatEvent<Registry, N> + 'static,
         N: for<'writer> FormatFields<'writer> + 'static,
-        W: MakeWriter + 'static,
+        W: for<'writer> MakeWriter<'writer> + 'static,
     {
         SubscriberBuilder {
             filter: self.filter,
@@ -1008,7 +1008,7 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
     where
         E2: FormatEvent<Registry, N> + 'static,
         N: for<'writer> FormatFields<'writer> + 'static,
-        W: MakeWriter + 'static,
+        W: for<'writer> MakeWriter<'writer> + 'static,
     {
         self.event_format(fmt_event)
     }
@@ -1031,7 +1031,7 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
     /// [`MakeWriter`]: trait.MakeWriter.html
     pub fn with_writer<W2>(self, make_writer: W2) -> SubscriberBuilder<N, E, F, W2>
     where
-        W2: MakeWriter + 'static,
+        W2: for<'writer> MakeWriter<'writer> + 'static,
     {
         SubscriberBuilder {
             filter: self.filter,
@@ -1141,16 +1141,16 @@ mod test {
     };
     use std::{
         io,
-        sync::{Mutex, MutexGuard, TryLockError},
+        sync::{Arc, Mutex, MutexGuard, TryLockError},
     };
     use tracing_core::dispatcher::Dispatch;
 
-    pub(crate) struct MockWriter<'a> {
-        buf: &'a Mutex<Vec<u8>>,
+    pub(crate) struct MockWriter {
+        buf: Arc<Mutex<Vec<u8>>>,
     }
 
-    impl<'a> MockWriter<'a> {
-        pub(crate) fn new(buf: &'a Mutex<Vec<u8>>) -> Self {
+    impl MockWriter {
+        pub(crate) fn new(buf: Arc<Mutex<Vec<u8>>>) -> Self {
             Self { buf }
         }
 
@@ -1161,12 +1161,12 @@ mod test {
             }
         }
 
-        pub(crate) fn buf(&self) -> io::Result<MutexGuard<'a, Vec<u8>>> {
+        pub(crate) fn buf(&self) -> io::Result<MutexGuard<'_, Vec<u8>>> {
             self.buf.try_lock().map_err(Self::map_error)
         }
     }
 
-    impl<'a> io::Write for MockWriter<'a> {
+    impl io::Write for MockWriter {
         fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
             self.buf()?.write(buf)
         }
@@ -1176,31 +1176,35 @@ mod test {
         }
     }
 
-    #[derive(Clone)]
-    pub(crate) struct MockMakeWriter<'a> {
-        buf: &'a Mutex<Vec<u8>>,
+    #[derive(Clone, Default)]
+    pub(crate) struct MockMakeWriter {
+        buf: Arc<Mutex<Vec<u8>>>,
     }
 
-    impl<'a> MockMakeWriter<'a> {
-        pub(crate) fn new(buf: &'a Mutex<Vec<u8>>) -> Self {
+    impl MockMakeWriter {
+        pub(crate) fn new(buf: Arc<Mutex<Vec<u8>>>) -> Self {
             Self { buf }
         }
 
-        pub(crate) fn buf(&self) -> MutexGuard<'a, Vec<u8>> {
+        pub(crate) fn buf(&self) -> MutexGuard<'_, Vec<u8>> {
             self.buf.lock().unwrap()
         }
 
         pub(crate) fn get_string(&self) -> String {
-            String::from_utf8(self.buf.lock().unwrap().clone())
-                .expect("subscriber must write valid UTF-8")
+            let mut buf = self.buf.lock().expect("lock shouldn't be poisoned");
+            let string = std::str::from_utf8(&buf[..])
+                .expect("formatter should not have produced invalid utf-8")
+                .to_owned();
+            buf.clear();
+            string
         }
     }
 
-    impl<'a> MakeWriter for MockMakeWriter<'a> {
-        type Writer = MockWriter<'a>;
+    impl<'a> MakeWriter<'a> for MockMakeWriter {
+        type Writer = MockWriter;
 
-        fn make_writer(&self) -> Self::Writer {
-            MockWriter::new(self.buf)
+        fn make_writer(&'a self) -> Self::Writer {
+            MockWriter::new(self.buf.clone())
         }
     }
 

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -4,30 +4,20 @@
 use std::{
     fmt::Debug,
     io::{self, Write},
-    sync::Arc,
+    sync::{Arc, Mutex, MutexGuard},
 };
 use tracing_core::Metadata;
 
 /// A type that can create [`io::Write`] instances.
 ///
-/// `MakeWriter` is used by [`fmt::Subscriber`] or [`fmt::Layer`] to print
+/// `MakeWriter` is used by [`fmt::Layer`] or [`fmt::Subscriber`] to print
 /// formatted text representations of [`Event`]s.
 ///
 /// This trait is already implemented for function pointers and
 /// immutably-borrowing closures that return an instance of [`io::Write`], such
-/// as [`io::stdout`] and [`io::stderr`].
-///
-/// The [`MakeWriter::make_writer_for`] method takes [`Metadata`] describing a
-/// span or event and returns a writer. `MakeWriter`s can optionally provide
-/// implementations of this method with behaviors that differ based on the span
-/// or event being written. For example, events at different [levels] might be
-/// written to different output streams, or data from different [targets] might
-/// be written to separate log files. When the `MakeWriter` has no custom
-/// behavior based on metadata, the default implementation of `make_writer_for`
-/// simply calls `self.make_writer()`, ignoring the metadata. Therefore, when
-/// metadata _is_ available, callers should prefer to call `make_writer_for`,
-/// passing in that metadata, so that the `MakeWriter` implementation can choose
-/// the appropriate behavior.
+/// as [`io::stdout`] and [`io::stderr`]. Additionally, it is implemented for
+/// [`std::sync::Mutex`][mutex] when the tyoe inside the mutex implements
+/// [`io::Write`].
 ///
 /// # Examples
 ///
@@ -75,6 +65,23 @@ use tracing_core::Metadata;
 /// # drop(subscriber);
 /// ```
 ///
+/// A single instance of a type implementing [`io::Write`] may be used as a
+/// `MakeWriter` by wrapping it in a [`Mutex`][mutex]. For example, we could
+/// write to a file like so:
+///
+/// ```
+/// use std::{fs::File, sync::Mutex};
+///
+/// # fn docs() -> Result<(), Box<dyn std::error::Error>> {
+/// let log_file = File::create("my_cool_trace.log")?;
+/// let subscriber = tracing_subscriber::fmt()
+///     .with_writer(Mutex::new(log_file))
+///     .finish();
+/// # drop(subscriber);
+/// # Ok(())
+/// # }
+/// ```
+///
 /// [`io::Write`]: std::io::Write
 /// [`fmt::Layer`]: crate::fmt::Layer
 /// [`fmt::Subscriber`]: crate::fmt::Subscriber
@@ -86,7 +93,7 @@ use tracing_core::Metadata;
 /// [`Metadata`]: tracing_core::Metadata
 /// [levels]: tracing_core::Level
 /// [targets]: tracing_core::Metadata::target
-pub trait MakeWriter {
+pub trait MakeWriter<'a> {
     /// The concrete [`io::Write`] implementation returned by [`make_writer`].
     ///
     /// [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
@@ -106,7 +113,7 @@ pub trait MakeWriter {
     /// [`fmt::Layer`]: crate::fmt::Layer
     /// [`fmt::Subscriber`]: crate::fmt::Subscriber
     /// [`io::Write`]: std::io::Write
-    fn make_writer(&self) -> Self::Writer;
+    fn make_writer(&'a self) -> Self::Writer;
 
     /// Returns a [`Writer`] for writing data from the span or event described
     /// by the provided [`Metadata`].
@@ -126,64 +133,67 @@ pub trait MakeWriter {
     /// at lower levels to stdout:
     ///
     /// ```
-    /// use std::io::{self, Stdout, Stderr};
+    /// use std::io::{self, Stdout, Stderr, StdoutLock, StderrLock};
     /// use tracing_subscriber::fmt::writer::MakeWriter;
     /// use tracing_core::{Metadata, Level};
     ///
-    /// pub struct MyMakeWriter {}
+    /// pub struct MyMakeWriter {
+    ///     stdout: Stdout,
+    ///     stderr: Stderr,
+    /// }
     ///
     /// /// A lock on either stdout or stderr, depending on the verbosity level
     /// /// of the event being written.
-    /// pub enum Stdio {
-    ///     Stdout(Stdout),
-    ///     Stderr(Stderr),
+    /// pub enum StdioLock<'a> {
+    ///     Stdout(StdoutLock<'a>),
+    ///     Stderr(StderrLock<'a>),
     /// }
     ///
-    /// impl io::Write for Stdio {
+    /// impl<'a> io::Write for StdioLock<'a> {
     ///     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
     ///         match self {
-    ///             Stdio::Stdout(io) => io.write(buf),
-    ///             Stdio::Stderr(io) => io.write(buf),
+    ///             StdioLock::Stdout(lock) => lock.write(buf),
+    ///             StdioLock::Stderr(lock) => lock.write(buf),
     ///         }
     ///     }
     ///
     ///     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
     ///         // ...
     ///         # match self {
-    ///         #     Stdio::Stdout(io) => io.write_all(buf),
-    ///         #     Stdio::Stderr(io) => io.write_all(buf),
+    ///         #     StdioLock::Stdout(lock) => lock.write_all(buf),
+    ///         #     StdioLock::Stderr(lock) => lock.write_all(buf),
     ///         # }
     ///     }
     ///
     ///     fn flush(&mut self) -> io::Result<()> {
     ///         // ...
     ///         # match self {
-    ///         #     Stdio::Stdout(io) => io.flush(),
-    ///         #     Stdio::Stderr(io) => io.flush(),
+    ///         #     StdioLock::Stdout(lock) => lock.flush(),
+    ///         #     StdioLock::Stderr(lock) => lock.flush(),
     ///         # }
     ///     }
     /// }
     ///
-    /// impl MakeWriter for MyMakeWriter {
-    ///     type Writer = Stdio;
+    /// impl<'a> MakeWriter<'a> for MyMakeWriter {
+    ///     type Writer = StdioLock<'a>;
     ///
-    ///     fn make_writer(&self) -> Self::Writer {
+    ///     fn make_writer(&'a self) -> Self::Writer {
     ///         // We must have an implementation of `make_writer` that makes
     ///         // a "default" writer without any configuring metadata. Let's
     ///         // just return stdout in that case.
-    ///         Stdio::Stdout(io::stdout())
+    ///         StdioLock::Stdout(self.stdout.lock())
     ///     }
     ///
-    ///     fn make_writer_for(&self, meta: &Metadata<'_>) -> Self::Writer {
+    ///     fn make_writer_for(&'a self, meta: &Metadata<'_>) -> Self::Writer {
     ///         // Here's where we can implement our special behavior. We'll
     ///         // check if the metadata's verbosity level is WARN or ERROR,
     ///         // and return stderr in that case.
     ///         if meta.level() <= &Level::WARN {
-    ///             return Stdio::Stderr(io::stderr());
+    ///             return StdioLock::Stderr(self.stderr.lock());
     ///         }
     ///
     ///         // Otherwise, we'll return stdout.
-    ///         Stdio::Stdout(io::stdout())
+    ///         StdioLock::Stdout(self.stdout.lock())
     ///     }
     /// }
     /// ```
@@ -193,7 +203,7 @@ pub trait MakeWriter {
     /// [make_writer]: MakeWriter::make_writer
     /// [`WARN`]: tracing_core::Level::WARN
     /// [`ERROR`]: tracing_core::Level::ERROR
-    fn make_writer_for(&self, meta: &Metadata<'_>) -> Self::Writer {
+    fn make_writer_for(&'a self, meta: &Metadata<'_>) -> Self::Writer {
         let _ = meta;
         self.make_writer()
     }
@@ -205,7 +215,7 @@ pub trait MakeWriter {
 /// This is not intended to be implemented directly for user-defined
 /// [`MakeWriter`]s; instead, it should be imported when the desired methods are
 /// used.
-pub trait MakeWriterExt: MakeWriter {
+pub trait MakeWriterExt<'a>: MakeWriter<'a> {
     /// Wraps `self` and returns a [`MakeWriter`] that will only write output
     /// for events at or below the provided verbosity [`Level`]. For instance,
     /// `Level::TRACE` is considered to be _more verbose` than `Level::INFO`.
@@ -443,7 +453,7 @@ pub trait MakeWriterExt: MakeWriter {
     fn and<B>(self, other: B) -> Tee<Self, B>
     where
         Self: Sized,
-        B: MakeWriter + Sized,
+        B: MakeWriter<'a> + Sized,
     {
         Tee::new(self, other)
     }
@@ -473,8 +483,8 @@ pub trait MakeWriterExt: MakeWriter {
     /// [own]: EitherWriter::none
     fn or_else<W, B>(self, other: B) -> OrElse<Self, B>
     where
-        Self: MakeWriter<Writer = OptionalWriter<W>> + Sized,
-        B: MakeWriter + Sized,
+        Self: MakeWriter<'a, Writer = OptionalWriter<W>> + Sized,
+        B: MakeWriter<'a> + Sized,
         W: Write,
     {
         OrElse::new(self, other)
@@ -530,7 +540,7 @@ pub struct TestWriter {
 /// [`Subscriber`]: tracing::Subscriber
 /// [`io::Write`]: std::io::Write
 pub struct BoxMakeWriter {
-    inner: Box<dyn MakeWriter<Writer = Box<dyn Write + 'static>> + Send + Sync>,
+    inner: Box<dyn for<'a> MakeWriter<'a, Writer = Box<dyn Write + 'a>> + Send + Sync>,
     name: &'static str,
 }
 
@@ -627,33 +637,56 @@ pub struct Tee<A, B> {
     b: B,
 }
 
-impl<F, W> MakeWriter for F
-where
-    F: Fn() -> W,
-    W: io::Write,
-{
-    type Writer = W;
-
-    fn make_writer(&self) -> Self::Writer {
-        (self)()
-    }
-}
-
-impl<W> MakeWriter for Arc<W>
-where
-    for<'a> &'a W: io::Write,
-{
-    type Writer = ArcWriter<W>;
-    fn make_writer(&self) -> Self::Writer {
-        ArcWriter(self.clone())
-    }
-}
+/// A type implementing [`io::Write`] for a [`MutexGuard`] where the type
+/// inside the [`Mutex`] implements [`io::Write`].
+///
+/// This is used by the [`MakeWriter`] implementation for [`Mutex`], because
+/// [`MutexGuard`] itself will not implement [`io::Write`] — instead, it
+/// _dereferences_ to a type implementing [`io::Write`]. Because [`MakeWriter`]
+/// requires the `Writer` type to implement [`io::Write`], it's necessary to add
+/// a newtype that forwards the trait implementation.
+///
+/// [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
+/// [`MutexGuard`]: https://doc.rust-lang.org/std/sync/struct.MutexGuard.html
+/// [`Mutex`]: https://doc.rust-lang.org/std/sync/struct.Mutex.html
+/// [`MakeWriter`]: trait.MakeWriter.html
+#[derive(Debug)]
+pub struct MutexGuardWriter<'a, W>(MutexGuard<'a, W>);
 
 /// Implements [`std::io::Write`] for an [`Arc`]<W> where `&W: Write`.
 ///
 /// This is an implementation detail of the [`MakeWriter`] impl for [`Arc`].
 #[derive(Clone, Debug)]
 pub struct ArcWriter<W>(Arc<W>);
+
+impl<'a, F, W> MakeWriter<'a> for F
+where
+    F: Fn() -> W,
+    W: io::Write,
+{
+    type Writer = W;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        (self)()
+    }
+}
+
+impl<'a, W> MakeWriter<'a> for Arc<W>
+where
+    &'a W: io::Write + 'a,
+{
+    type Writer = &'a W;
+    fn make_writer(&'a self) -> Self::Writer {
+        &*self
+    }
+}
+
+impl<'a> MakeWriter<'a> for std::fs::File {
+    type Writer = &'a std::fs::File;
+    fn make_writer(&'a self) -> Self::Writer {
+        self
+    }
+}
 
 // === impl TestWriter ===
 
@@ -676,13 +709,15 @@ impl io::Write for TestWriter {
     }
 }
 
-impl MakeWriter for TestWriter {
+impl<'a> MakeWriter<'a> for TestWriter {
     type Writer = Self;
 
-    fn make_writer(&self) -> Self::Writer {
+    fn make_writer(&'a self) -> Self::Writer {
         Self::default()
     }
 }
+
+// === impl BoxMakeWriter ===
 
 impl BoxMakeWriter {
     /// Constructs a `BoxMakeWriter` wrapping a type implementing [`MakeWriter`].
@@ -690,8 +725,7 @@ impl BoxMakeWriter {
     /// [`MakeWriter`]: trait.MakeWriter.html
     pub fn new<M>(make_writer: M) -> Self
     where
-        M: MakeWriter + Send + Sync + 'static,
-        M::Writer: Write + 'static,
+        M: for<'a> MakeWriter<'a> + Send + Sync + 'static,
     {
         Self {
             inner: Box::new(Boxed(make_writer)),
@@ -708,35 +742,72 @@ impl Debug for BoxMakeWriter {
     }
 }
 
-impl MakeWriter for BoxMakeWriter {
-    type Writer = Box<dyn Write>;
+impl<'a> MakeWriter<'a> for BoxMakeWriter {
+    type Writer = Box<dyn Write + 'a>;
 
-    fn make_writer(&self) -> Self::Writer {
+    fn make_writer(&'a self) -> Self::Writer {
         self.inner.make_writer()
     }
 
-    fn make_writer_for(&self, meta: &Metadata<'_>) -> Self::Writer {
+    fn make_writer_for(&'a self, meta: &Metadata<'_>) -> Self::Writer {
         self.inner.make_writer_for(meta)
     }
 }
 
 struct Boxed<M>(M);
 
-impl<M> MakeWriter for Boxed<M>
+impl<'a, M> MakeWriter<'a> for Boxed<M>
 where
-    M: MakeWriter,
-    M::Writer: Write + 'static,
+    M: MakeWriter<'a>,
 {
-    type Writer = Box<dyn Write>;
+    type Writer = Box<dyn Write + 'a>;
 
-    fn make_writer(&self) -> Self::Writer {
+    fn make_writer(&'a self) -> Self::Writer {
         let w = self.0.make_writer();
         Box::new(w)
     }
+}
 
-    fn make_writer_for(&self, meta: &Metadata<'_>) -> Self::Writer {
-        let w = self.0.make_writer_for(meta);
-        Box::new(w)
+// === impl Mutex/MutexGuardWriter ===
+
+impl<'a, W> MakeWriter<'a> for Mutex<W>
+where
+    W: io::Write + 'a,
+{
+    type Writer = MutexGuardWriter<'a, W>;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        MutexGuardWriter(self.lock().expect("lock poisoned"))
+    }
+}
+
+impl<'a, W> io::Write for MutexGuardWriter<'a, W>
+where
+    W: io::Write,
+{
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        self.0.write_vectored(bufs)
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.0.write_all(buf)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, fmt: std::fmt::Arguments<'_>) -> io::Result<()> {
+        self.0.write_fmt(fmt)
     }
 }
 
@@ -824,29 +895,28 @@ impl<T> From<Option<T>> for OptionalWriter<T> {
 
 impl<M> WithMaxLevel<M> {
     /// Wraps the provided [`MakeWriter`] with a maximum [`Level`], so that it
-    /// returns [`OptionalWriter::none`][own] for spans and events whose level is
+    /// returns [`OptionalWriter::none`] for spans and events whose level is
     /// more verbose than the maximum level.
     ///
     /// See [`MakeWriterExt::with_max_level`] for details.
     ///
     /// [`Level`]: tracing_core::Level
-    /// [own]: EitherWriter::none
     pub fn new(make: M, level: tracing_core::Level) -> Self {
         Self { make, level }
     }
 }
 
-impl<M: MakeWriter> MakeWriter for WithMaxLevel<M> {
+impl<'a, M: MakeWriter<'a>> MakeWriter<'a> for WithMaxLevel<M> {
     type Writer = OptionalWriter<M::Writer>;
 
     #[inline]
-    fn make_writer(&self) -> Self::Writer {
+    fn make_writer(&'a self) -> Self::Writer {
         // If we don't know the level, assume it's disabled.
         OptionalWriter::none()
     }
 
     #[inline]
-    fn make_writer_for(&self, meta: &Metadata<'_>) -> Self::Writer {
+    fn make_writer_for(&'a self, meta: &Metadata<'_>) -> Self::Writer {
         if meta.level() <= &self.level {
             return OptionalWriter::some(self.make.make_writer_for(meta));
         }
@@ -858,29 +928,28 @@ impl<M: MakeWriter> MakeWriter for WithMaxLevel<M> {
 
 impl<M> WithMinLevel<M> {
     /// Wraps the provided [`MakeWriter`] with a minimum [`Level`], so that it
-    /// returns [`OptionalWriter::none`][own] for spans and events whose level is
+    /// returns [`OptionalWriter::none`] for spans and events whose level is
     /// less verbose than the maximum level.
     ///
     /// See [`MakeWriterExt::with_min_level`] for details.
     ///
     /// [`Level`]: tracing_core::Level
-    /// [own]: EitherWriter::none
     pub fn new(make: M, level: tracing_core::Level) -> Self {
         Self { make, level }
     }
 }
 
-impl<M: MakeWriter> MakeWriter for WithMinLevel<M> {
+impl<'a, M: MakeWriter<'a>> MakeWriter<'a> for WithMinLevel<M> {
     type Writer = OptionalWriter<M::Writer>;
 
     #[inline]
-    fn make_writer(&self) -> Self::Writer {
+    fn make_writer(&'a self) -> Self::Writer {
         // If we don't know the level, assume it's disabled.
         OptionalWriter::none()
     }
 
     #[inline]
-    fn make_writer_for(&self, meta: &Metadata<'_>) -> Self::Writer {
+    fn make_writer_for(&'a self, meta: &Metadata<'_>) -> Self::Writer {
         if meta.level() >= &self.level {
             return OptionalWriter::some(self.make.make_writer_for(meta));
         }
@@ -907,20 +976,20 @@ impl<M, F> WithFilter<M, F> {
     }
 }
 
-impl<M, F> MakeWriter for WithFilter<M, F>
+impl<'a, M, F> MakeWriter<'a> for WithFilter<M, F>
 where
-    M: MakeWriter,
+    M: MakeWriter<'a>,
     F: Fn(&Metadata<'_>) -> bool,
 {
     type Writer = OptionalWriter<M::Writer>;
 
     #[inline]
-    fn make_writer(&self) -> Self::Writer {
+    fn make_writer(&'a self) -> Self::Writer {
         OptionalWriter::some(self.make.make_writer())
     }
 
     #[inline]
-    fn make_writer_for(&self, meta: &Metadata<'_>) -> Self::Writer {
+    fn make_writer_for(&'a self, meta: &Metadata<'_>) -> Self::Writer {
         if (self.filter)(meta) {
             OptionalWriter::some(self.make.make_writer_for(meta))
         } else {
@@ -937,27 +1006,25 @@ impl<A, B> Tee<A, B> {
     /// outputs.
     ///
     /// See the documentation for [`MakeWriterExt::and`] for details.
-    ///
-    /// [writers]: std::io::Write
     pub fn new(a: A, b: B) -> Self {
         Self { a, b }
     }
 }
 
-impl<A, B> MakeWriter for Tee<A, B>
+impl<'a, A, B> MakeWriter<'a> for Tee<A, B>
 where
-    A: MakeWriter,
-    B: MakeWriter,
+    A: MakeWriter<'a>,
+    B: MakeWriter<'a>,
 {
     type Writer = Tee<A::Writer, B::Writer>;
 
     #[inline]
-    fn make_writer(&self) -> Self::Writer {
+    fn make_writer(&'a self) -> Self::Writer {
         Tee::new(self.a.make_writer(), self.b.make_writer())
     }
 
     #[inline]
-    fn make_writer_for(&self, meta: &Metadata<'_>) -> Self::Writer {
+    fn make_writer_for(&'a self, meta: &Metadata<'_>) -> Self::Writer {
         Tee::new(self.a.make_writer_for(meta), self.b.make_writer_for(meta))
     }
 }
@@ -1012,26 +1079,26 @@ where
 
 impl<A, B> OrElse<A, B> {
     /// Combines
-    pub fn new<W>(inner: A, or_else: B) -> Self
+    pub fn new<'a, W>(inner: A, or_else: B) -> Self
     where
-        A: MakeWriter<Writer = OptionalWriter<W>>,
-        B: MakeWriter,
+        A: MakeWriter<'a, Writer = OptionalWriter<W>>,
+        B: MakeWriter<'a>,
         W: Write,
     {
         Self { inner, or_else }
     }
 }
 
-impl<A, B, W> MakeWriter for OrElse<A, B>
+impl<'a, A, B, W> MakeWriter<'a> for OrElse<A, B>
 where
-    A: MakeWriter<Writer = OptionalWriter<W>>,
-    B: MakeWriter,
+    A: MakeWriter<'a, Writer = OptionalWriter<W>>,
+    B: MakeWriter<'a>,
     W: io::Write,
 {
     type Writer = EitherWriter<W, B::Writer>;
 
     #[inline]
-    fn make_writer(&self) -> Self::Writer {
+    fn make_writer(&'a self) -> Self::Writer {
         match self.inner.make_writer() {
             EitherWriter::A(writer) => EitherWriter::A(writer),
             EitherWriter::B(_) => EitherWriter::B(self.or_else.make_writer()),
@@ -1039,7 +1106,7 @@ where
     }
 
     #[inline]
-    fn make_writer_for(&self, meta: &Metadata<'_>) -> Self::Writer {
+    fn make_writer_for(&'a self, meta: &Metadata<'_>) -> Self::Writer {
         match self.inner.make_writer_for(meta) {
             EitherWriter::A(writer) => EitherWriter::A(writer),
             EitherWriter::B(_) => EitherWriter::B(self.or_else.make_writer_for(meta)),
@@ -1081,43 +1148,31 @@ where
 
 // === blanket impls ===
 
-impl<M> MakeWriterExt for M where M: MakeWriter {}
-
+impl<'a, M> MakeWriterExt<'a> for M where M: MakeWriter<'a> {}
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::fmt::format::Format;
     use crate::fmt::test::{MockMakeWriter, MockWriter};
     use crate::fmt::Subscriber;
-    use lazy_static::lazy_static;
-    use std::sync::{
-        atomic::{AtomicBool, Ordering},
-        Mutex,
-    };
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
     use tracing::{debug, error, info, trace, warn, Level};
     use tracing_core::dispatcher::{self, Dispatch};
 
     fn test_writer<T>(make_writer: T, msg: &str, buf: &Mutex<Vec<u8>>)
     where
-        T: MakeWriter + Send + Sync + 'static,
+        T: for<'writer> MakeWriter<'writer> + Send + Sync + 'static,
     {
         let subscriber = {
             #[cfg(feature = "ansi")]
-            {
-                let f = Format::default().without_time().with_ansi(false);
-                Subscriber::builder()
-                    .event_format(f)
-                    .with_writer(make_writer)
-                    .finish()
-            }
+            let f = Format::default().without_time().with_ansi(false);
             #[cfg(not(feature = "ansi"))]
-            {
-                let f = Format::default().without_time();
-                Subscriber::builder()
-                    .event_format(f)
-                    .with_writer(make_writer)
-                    .finish()
-            }
+            let f = Format::default().without_time();
+            Subscriber::builder()
+                .event_format(f)
+                .with_writer(make_writer)
+                .finish()
         };
         let dispatch = Dispatch::from(subscriber);
 
@@ -1145,39 +1200,43 @@ mod test {
 
     #[test]
     fn custom_writer_closure() {
-        lazy_static! {
-            static ref BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-        }
-
-        let make_writer = || MockWriter::new(&BUF);
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let buf2 = buf.clone();
+        let make_writer = move || MockWriter::new(buf2.clone());
         let msg = "my custom writer closure error";
-        test_writer(make_writer, msg, &BUF);
+        test_writer(make_writer, msg, &buf);
     }
 
     #[test]
     fn custom_writer_struct() {
-        lazy_static! {
-            static ref BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-        }
-
-        let make_writer = MockMakeWriter::new(&BUF);
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let make_writer = MockMakeWriter::new(buf.clone());
         let msg = "my custom writer struct error";
-        test_writer(make_writer, msg, &BUF);
+        test_writer(make_writer, msg, &buf);
+    }
+
+    #[test]
+    fn custom_writer_mutex() {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let writer = MockWriter::new(buf.clone());
+        let make_writer = Mutex::new(writer);
+        let msg = "my mutex writer error";
+        test_writer(make_writer, msg, &buf);
     }
 
     #[test]
     fn combinators_level_filters() {
-        lazy_static! {
-            static ref INFO_BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-            static ref DEBUG_BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-            static ref WARN_BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-            static ref ERR_BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-        }
+        let info_buf = Arc::new(Mutex::new(Vec::new()));
+        let info = MockMakeWriter::new(info_buf.clone());
 
-        let info = MockMakeWriter::new(&INFO_BUF);
-        let debug = MockMakeWriter::new(&DEBUG_BUF);
-        let warn = MockMakeWriter::new(&WARN_BUF);
-        let err = MockMakeWriter::new(&ERR_BUF);
+        let debug_buf = Arc::new(Mutex::new(Vec::new()));
+        let debug = MockMakeWriter::new(debug_buf.clone());
+
+        let warn_buf = Arc::new(Mutex::new(Vec::new()));
+        let warn = MockMakeWriter::new(warn_buf.clone());
+
+        let err_buf = Arc::new(Mutex::new(Vec::new()));
+        let err = MockMakeWriter::new(err_buf.clone());
 
         let make_writer = info
             .with_max_level(Level::INFO)
@@ -1214,27 +1273,25 @@ mod test {
         ];
 
         println!("max level debug");
-        has_lines(&DEBUG_BUF, &all_lines[1..]);
+        has_lines(&debug_buf, &all_lines[1..]);
 
         println!("max level info");
-        has_lines(&INFO_BUF, &all_lines[2..]);
+        has_lines(&info_buf, &all_lines[2..]);
 
         println!("max level warn");
-        has_lines(&WARN_BUF, &all_lines[3..]);
+        has_lines(&warn_buf, &all_lines[3..]);
 
         println!("max level error");
-        has_lines(&ERR_BUF, &all_lines[4..]);
+        has_lines(&err_buf, &all_lines[4..]);
     }
 
     #[test]
     fn combinators_or_else() {
-        lazy_static! {
-            static ref SOME_BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-            static ref OR_ELSE_BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-        }
+        let some_buf = Arc::new(Mutex::new(Vec::new()));
+        let some = MockMakeWriter::new(some_buf.clone());
 
-        let some = MockMakeWriter::new(&SOME_BUF);
-        let or_else = MockMakeWriter::new(&OR_ELSE_BUF);
+        let or_else_buf = Arc::new(Mutex::new(Vec::new()));
+        let or_else = MockMakeWriter::new(or_else_buf.clone());
 
         let return_some = AtomicBool::new(true);
         let make_writer = move || {
@@ -1262,26 +1319,26 @@ mod test {
         info!("world");
         info!("goodbye");
 
-        has_lines(&SOME_BUF, &[(Level::INFO, "hello")]);
+        has_lines(&some_buf, &[(Level::INFO, "hello")]);
         has_lines(
-            &OR_ELSE_BUF,
+            &or_else_buf,
             &[(Level::INFO, "world"), (Level::INFO, "goodbye")],
         );
     }
 
     #[test]
     fn combinators_or_else_chain() {
-        lazy_static! {
-            static ref INFO_BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-            static ref DEBUG_BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-            static ref WARN_BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-            static ref ERR_BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-        }
+        let info_buf = Arc::new(Mutex::new(Vec::new()));
+        let info = MockMakeWriter::new(info_buf.clone());
 
-        let info = MockMakeWriter::new(&INFO_BUF);
-        let debug = MockMakeWriter::new(&DEBUG_BUF);
-        let warn = MockMakeWriter::new(&WARN_BUF);
-        let err = MockMakeWriter::new(&ERR_BUF);
+        let debug_buf = Arc::new(Mutex::new(Vec::new()));
+        let debug = MockMakeWriter::new(debug_buf.clone());
+
+        let warn_buf = Arc::new(Mutex::new(Vec::new()));
+        let warn = MockMakeWriter::new(warn_buf.clone());
+
+        let err_buf = Arc::new(Mutex::new(Vec::new()));
+        let err = MockMakeWriter::new(err_buf.clone());
 
         let make_writer = err.with_max_level(Level::ERROR).or_else(
             warn.with_max_level(Level::WARN).or_else(
@@ -1311,27 +1368,25 @@ mod test {
         error!("error");
 
         println!("max level debug");
-        has_lines(&DEBUG_BUF, &[(Level::DEBUG, "debug")]);
+        has_lines(&debug_buf, &[(Level::DEBUG, "debug")]);
 
         println!("max level info");
-        has_lines(&INFO_BUF, &[(Level::INFO, "info")]);
+        has_lines(&info_buf, &[(Level::INFO, "info")]);
 
         println!("max level warn");
-        has_lines(&WARN_BUF, &[(Level::WARN, "warn")]);
+        has_lines(&warn_buf, &[(Level::WARN, "warn")]);
 
         println!("max level error");
-        has_lines(&ERR_BUF, &[(Level::ERROR, "error")]);
+        has_lines(&err_buf, &[(Level::ERROR, "error")]);
     }
 
     #[test]
     fn combinators_and() {
-        lazy_static! {
-            static ref A_BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-            static ref B_BUF: Mutex<Vec<u8>> = Mutex::new(vec![]);
-        }
+        let a_buf = Arc::new(Mutex::new(Vec::new()));
+        let a = MockMakeWriter::new(a_buf.clone());
 
-        let a = MockMakeWriter::new(&A_BUF);
-        let b = MockMakeWriter::new(&B_BUF);
+        let b_buf = Arc::new(Mutex::new(Vec::new()));
+        let b = MockMakeWriter::new(b_buf.clone());
 
         let lines = &[(Level::INFO, "hello"), (Level::INFO, "world")];
 
@@ -1352,7 +1407,7 @@ mod test {
         info!("hello");
         info!("world");
 
-        has_lines(&A_BUF, &lines[..]);
-        has_lines(&B_BUF, &lines[..]);
+        has_lines(&a_buf, &lines[..]);
+        has_lines(&b_buf, &lines[..]);
     }
 }


### PR DESCRIPTION
This backports PR #781 from `master`.

## Motivation

Currently, the `tracing-subscriber` crate has the `MakeWriter` trait for
customizing the io writer used by `fmt`. This trait is necessary (rather
than simply using a `Write` instance) because the default implementation
performs the IO on the thread where an event was recorded, meaning that
a separate writer needs to be acquired by each thread (either by calling
a function like `io::stdout`, by locking a shared `Write` instance,
etc).

Right now there is a blanket impl for `Fn() -> T where T: Write`. This
works fine with functions like `io::stdout`. However, the _other_ common
case for this trait is locking a shared writer.

Therefore, it makes sense to see an implementation like this:

``` rust
impl<'a, W: io::Write> MakeWriter for Mutex<W>
where
    W: io::Write,
{
    type Writer = MutexWriter<'a, W>;
    fn make_writer(&self) -> Self::Writer {
        MutexWriter(self.lock().unwrap())
    }
}

pub struct MutexWriter<'a, W>(MutexGuard<'a, W>);

impl<W: io::Write> io::Write for MutexWriter<'_, W> {
    // write to the shared writer in the `MutexGuard`...
}
```

Unfortunately, it's impossible to write this. Since `MakeWriter` always
takes an `&self` parameter and returns `Self::Writer`, the generic
parameter is unbounded:
```
    Checking tracing-subscriber v0.2.4 (/home/eliza/code/tracing/tracing-subscriber)
error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
  --> tracing-subscriber/src/fmt/writer.rs:61:6
   |
61 | impl<'a, W: io::Write> MakeWriter for Mutex<W>
   |      ^^ unconstrained lifetime parameter

error: aborting due to previous error
```

This essentially precludes any `MakeWriter` impl where the writer is
borrowed from the type implementing `MakeWriter`. This is a significant
blow to the usefulness of the trait. For example, it prevented the use
of `MakeWriter` in `tracing-flame` as suggested in
https://github.com/tokio-rs/tracing/pull/631#discussion_r391138233.

## Proposal

This PR changes `MakeWriter` to be generic over a lifetime `'a`:

```rust
pub trait MakeWriter<'a> {
    type Writer: io::Write;

    fn make_writer(&'a self) -> Self::Writer;
}
```
The `self` parameter is now borrowed for the `&'a` lifetime, so it is
okay to return a writer borrowed from `self`, such as in the `Mutex`
case.

I've also added an impl of `MakeWriter` for `Mutex<T> where T: Writer`.

Unfortunately, this is a breaking change and will need to wait until we
release `tracing-subscriber` 0.3.

Fixes #675.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
