### PR TITLE
Log floats as number rather than string

### DIFF
--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -393,8 +393,9 @@ impl_values! {
     record_u64(usize, u32, u16, u8 as u64),
     record_i64(i64),
     record_i64(isize, i32, i16, i8 as i64),
-    record_bool(bool),
-    record_f64(f64, f32 as f64)
+    record_f64(f64),
+    record_f64(f32 as f64),
+    record_bool(bool)
 }
 
 impl<T: crate::sealed::Sealed> crate::sealed::Sealed for Wrapping<T> {}

--- a/tracing-subscriber/src/field/delimited.rs
+++ b/tracing-subscriber/src/field/delimited.rs
@@ -95,6 +95,11 @@ where
         self.inner.record_u64(field, value);
     }
 
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.delimit();
+        self.inner.record_f64(field, value);
+    }
+
     fn record_bool(&mut self, field: &Field, value: bool) {
         self.delimit();
         self.inner.record_bool(field, value);


### PR DESCRIPTION
PR to follow on from points raised in: 

https://github.com/tokio-rs/tracing/pull/1370 

Output now compared to example previously looks like: 

```Bash
{"timestamp":"2021-10-22T13:36:41.719430Z","level":"INFO","fields":{"message":"Float","float":0.24},"target":"trace_test"}
```
