### PR TITLE
subscriber: rename `Subscribe::new_span` to `on_new_span`

### DIFF
--- a/tracing-error/src/subscriber.rs
+++ b/tracing-error/src/subscriber.rs
@@ -43,7 +43,7 @@ where
 {
     /// Notifies this subscriber that a new span was constructed with the given
     /// `Attributes` and `Id`.
-    fn new_span(
+    fn on_new_span(
         &self,
         attrs: &span::Attributes<'_>,
         id: &span::Id,

--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -122,7 +122,7 @@ impl<C> tracing_subscriber::Subscribe<C> for Subscriber
 where
     C: Collect + for<'span> LookupSpan<'span>,
 {
-    fn new_span(&self, attrs: &Attributes, id: &Id, ctx: Context<C>) {
+    fn on_new_span(&self, attrs: &Attributes, id: &Id, ctx: Context<C>) {
         let span = ctx.span(id).expect("unknown span");
         let mut buf = Vec::with_capacity(256);
 

--- a/tracing-opentelemetry/benches/trace.rs
+++ b/tracing-opentelemetry/benches/trace.rs
@@ -60,7 +60,7 @@ impl<C> tracing_subscriber::Subscribe<C> for RegistryAccessCollector
 where
     C: tracing_core::Collect + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
 {
-    fn new_span(
+    fn on_new_span(
         &self,
         _attrs: &tracing_core::span::Attributes<'_>,
         id: &tracing::span::Id,
@@ -87,7 +87,7 @@ impl<C> tracing_subscriber::Subscribe<C> for OtelDataCollector
 where
     C: tracing_core::Collect + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
 {
-    fn new_span(
+    fn on_new_span(
         &self,
         attrs: &tracing_core::span::Attributes<'_>,
         id: &tracing::span::Id,

--- a/tracing-opentelemetry/src/subscriber.rs
+++ b/tracing-opentelemetry/src/subscriber.rs
@@ -410,7 +410,7 @@ where
     ///
     /// [OpenTelemetry `Span`]: opentelemetry::trace::Span
     /// [tracing `Span`]: tracing::Span
-    fn new_span(&self, attrs: &Attributes<'_>, id: &span::Id, ctx: Context<'_, C>) {
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &span::Id, ctx: Context<'_, C>) {
         let span = ctx.span(id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
 

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -442,7 +442,7 @@ impl<C: Collect> Subscribe<C> for EnvFilter {
         false
     }
 
-    fn new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, _: Context<'_, C>) {
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, _: Context<'_, C>) {
         let by_cs = try_lock!(self.by_cs.read());
         if let Some(cs) = by_cs.get(&attrs.metadata().callsite()) {
             let span = cs.to_span_match(attrs);

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -556,7 +556,7 @@ where
     E: FormatEvent<C, N> + 'static,
     W: for<'writer> MakeWriter<'writer> + 'static,
 {
-    fn new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, C>) {
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, C>) {
         let span = ctx.span(id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
 

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -542,7 +542,7 @@ mod tests {
     where
         C: Collect + for<'a> LookupSpan<'a>,
     {
-        fn new_span(&self, _: &Attributes<'_>, id: &Id, ctx: Context<'_, C>) {
+        fn on_new_span(&self, _: &Attributes<'_>, id: &Id, ctx: Context<'_, C>) {
             let span = ctx.span(id).expect("Missing span; this is a bug");
             let mut lock = self.inner.lock().unwrap();
             let is_removed = Arc::new(());

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -69,13 +69,13 @@ where
     }
 
     #[inline]
-    fn new_span(
+    fn on_new_span(
         &self,
         attrs: &span::Attributes<'_>,
         id: &span::Id,
         ctx: subscribe::Context<'_, C>,
     ) {
-        try_lock!(self.inner.read()).new_span(attrs, id, ctx)
+        try_lock!(self.inner.read()).on_new_span(attrs, id, ctx)
     }
 
     #[inline]

--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -289,7 +289,7 @@ where
 
     /// Notifies this subscriber that a new span was constructed with the given
     /// `Attributes` and `Id`.
-    fn new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, C>) {
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, C>) {
         let _ = (attrs, id, ctx);
     }
 
@@ -616,7 +616,7 @@ where
 
     fn new_span(&self, span: &span::Attributes<'_>) -> span::Id {
         let id = self.inner.new_span(span);
-        self.subscriber.new_span(span, &id, self.ctx());
+        self.subscriber.on_new_span(span, &id, self.ctx());
         id
     }
 
@@ -737,9 +737,9 @@ where
     }
 
     #[inline]
-    fn new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, C>) {
-        self.inner.new_span(attrs, id, ctx.clone());
-        self.subscriber.new_span(attrs, id, ctx);
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, C>) {
+        self.inner.on_new_span(attrs, id, ctx.clone());
+        self.subscriber.on_new_span(attrs, id, ctx);
     }
 
     #[inline]
@@ -817,9 +817,9 @@ where
     }
 
     #[inline]
-    fn new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, C>) {
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, C>) {
         if let Some(ref inner) = self {
-            inner.new_span(attrs, id, ctx)
+            inner.on_new_span(attrs, id, ctx)
         }
     }
 
@@ -897,8 +897,8 @@ feature! {
     macro_rules! subscriber_impl_body {
         () => {
             #[inline]
-            fn new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, C>) {
-                self.deref().new_span(attrs, id, ctx)
+            fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, C>) {
+                self.deref().on_new_span(attrs, id, ctx)
             }
 
             #[inline]


### PR DESCRIPTION
While we're breaking things, we may as well do this as well.

Closes #630
Closes #662