### PR TITLE
opentelemetry: prepare to release v0.16.0

### DIFF
--- a/tracing-opentelemetry/CHANGELOG.md
+++ b/tracing-opentelemetry/CHANGELOG.md
@@ -1,3 +1,22 @@
+# 0.16.0 (October 23, 2021)
+
+### Breaking Changes
+
+- Upgrade to `v0.3.0` of `tracing-subscriber` ([#1677])
+  For list of breaking changes in `tracing-subscriber`, see the
+  [v0.3.0 changelog].
+
+### Added
+
+- `OpenTelemetrySpanExt::add_link` method for adding a link between a `tracing`
+  span and a provided OpenTelemetry `Context` ([#1516])
+
+Thanks to @LehMaxence for contributing to this release!
+
+[v0.3.0 changelog]: https://github.com/tokio-rs/tracing/releases/tag/tracing-subscriber-0.3.0
+[#1516]: https://github.com/tokio-rs/tracing/pull/1516
+[#1677]: https://github.com/tokio-rs/tracing/pull/1677
+
 # 0.15.0 (August 7, 2021)
 
 ### Breaking Changes

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-opentelemetry"
-version = "0.15.0"
+version = "0.16.0"
 authors = [
     "Julian Tescher <julian@tescher.me>",
     "Tokio Contributors <team@tokio.rs>"

--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -17,9 +17,9 @@ Utilities for adding [OpenTelemetry] interoperability to [`tracing`].
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-opentelemetry.svg
-[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.15.0
+[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.16.0
 [docs-badge]: https://docs.rs/tracing-opentelemetry/badge.svg
-[docs-url]: https://docs.rs/tracing-opentelemetry/0.15.0/tracing_opentelemetry
+[docs-url]: https://docs.rs/tracing-opentelemetry/0.16.0/tracing_opentelemetry
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_opentelemetry
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -92,7 +92,7 @@
 //!
 #![deny(unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.15.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.16.0")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.16.0 (October 23, 2021)

### Breaking Changes

- Upgrade to `v0.3.0` of `tracing-subscriber` ([#1677]) For list of
  breaking changes in `tracing-subscriber`, see the [v0.3.0 changelog].

### Added

- `OpenTelemetrySpanExt::add_link` method for adding a link between a
  `tracing` span and a provided OpenTelemetry `Context` ([#1516])

Thanks to @LehMaxence for contributing to this release!

[v0.3.0 changelog]: https://github.com/tokio-rs/tracing/releases/tag/tracing-subscriber-0.3.0
[#1516]: https://github.com/tokio-rs/tracing/pull/1516
[#1677]: https://github.com/tokio-rs/tracing/pull/1677