### PR TITLE
subscriber: fix `LocalTime` being re-exported by the `time` feature

### DIFF
--- a/tracing-subscriber/src/fmt/time/mod.rs
+++ b/tracing-subscriber/src/fmt/time/mod.rs
@@ -6,11 +6,14 @@ use std::time::Instant;
 mod datetime;
 
 #[cfg(feature = "time")]
-#[cfg_attr(docsrs, doc(cfg(feature = "time")))]
 mod time_crate;
 #[cfg(feature = "time")]
 #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
-pub use time_crate::{LocalTime, UtcTime};
+pub use time_crate::UtcTime;
+
+#[cfg(feature = "local-time")]
+#[cfg_attr(docsrs, doc(cfg(feature = "local-time")))]
+pub use time_crate::LocalTime;
 
 /// A type that can measure and format the current time.
 ///


### PR DESCRIPTION
## Motivation

Currently, the `pub use` re-export for the `LocalTime` struct is enabled
whenever the "time" feature flag is enabled. However, this type only
_exists_ when the "local-time" feature flag is enabled, so enabling only
the `time` feature results in a compilation error.

## Solution

This commit adds a separate `pub use` for `LocalTime` that's only
enabled when the "local-time" feature is enabled.

Fixes #1683