### PR TITLE
subscriber: fix unused method warnings for `Extensions`

### DIFF
--- a/tracing-subscriber/src/registry/extensions.rs
+++ b/tracing-subscriber/src/registry/extensions.rs
@@ -41,6 +41,7 @@ pub struct Extensions<'a> {
 }
 
 impl<'a> Extensions<'a> {
+    #[cfg(feature = "registry")]
     pub(crate) fn new(inner: RwLockReadGuard<'a, ExtensionsInner>) -> Self {
         Self { inner }
     }
@@ -59,6 +60,7 @@ pub struct ExtensionsMut<'a> {
 }
 
 impl<'a> ExtensionsMut<'a> {
+    #[cfg(feature = "registry")]
     pub(crate) fn new(inner: RwLockWriteGuard<'a, ExtensionsInner>) -> Self {
         Self { inner }
     }
@@ -120,6 +122,7 @@ pub(crate) struct ExtensionsInner {
 
 impl ExtensionsInner {
     /// Create an empty `Extensions`.
+    #[cfg(any(test, feature = "registry"))]
     #[inline]
     pub(crate) fn new() -> ExtensionsInner {
         ExtensionsInner {
@@ -179,6 +182,7 @@ impl ExtensionsInner {
     ///
     /// This permits the hash map allocation to be pooled by the registry so
     /// that future spans will not need to allocate new hashmaps.
+    #[cfg(any(test, feature = "registry"))]
     pub(crate) fn clear(&mut self) {
         self.map.clear();
     }


### PR DESCRIPTION
## Motivation

Currently, there are some `pub(crate)` methods on the `Extensions`,
`ExtensionsMut`, and `ExtensionsInner` types that are only used when the
"registry" feature is enabled. However, the _types_ exist when the "std"
feature flag is enabled, so those methods produce unused method
warnings.

## Solution

This commit adds `#[cfg(feature = "registry")]` to those methods, fixing
the warning.