### PR TITLE
subscriber: prepare to release v0.3.1

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 0.3.1 (Oct 25, 2021)
+
+This release fixes a few issues related to feature flagging.
+
+### Fixed
+
+- **time**: Compilation error when enabling the "time" feature flag without also
+  enabling the "local-time" feature flag ([#1685])
+- **registry**: Unused method warnings when the "std" feature is enabled but the
+  "registry" feature is disabled ([#1686])
+
+[#1685]: https://github.com/tokio-rs/tracing/pull/1685
+[#1686]: https://github.com/tokio-rs/tracing/pull/1686
+
 # 0.3.0 (Oct 22, 2021)
 
 This is a breaking release of `tracing-subscriber`. The primary breaking change
@@ -24,6 +38,7 @@ deprecated APIs, and more.
   trait object ([#1661])
 - Changed the signature of the `MakeWriter` trait by adding a lifetime parameter
   ([#781])
+
 ### Changed
 
 - **layer**: Renamed `Layer::new_span` to `Layer::on_new_span` ([#1674])

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -21,7 +21,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.3.0
+[docs-url]: https://docs.rs/tracing-subscriber/0.3.1
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -126,7 +126,7 @@
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`time` crate]: https://crates.io/crates/time
 //! [`liballoc`]: https://doc.rust-lang.org/alloc/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.3.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.3.1")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.3.1 (Oct 25, 2021)

This release fixes a few issues related to feature flagging.

### Fixed

- **time**: Compilation error when enabling the "time" feature flag
  without also enabling the "local-time" feature flag ([#1685])
- **registry**: Unused method warnings when the "std" feature is enabled
  but the "registry" feature is disabled ([#1686])

[#1685]: https://github.com/tokio-rs/tracing/pull/1685
[#1686]: https://github.com/tokio-rs/tracing/pull/1686