### PR TITLE
docs: fix incorrect docs in `tracing_core::LevelFilter`

### DIFF
--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -225,8 +225,8 @@ pub struct Level(LevelInner);
 /// A filter comparable to a verbosity [`Level`].
 ///
 /// If a [`Level`] is considered less than a `LevelFilter`, it should be
-/// considered *possibly* enabled; if greater than or equal to the `LevelFilter`,
-/// that level is *definitely* disabled. See [`LevelFilter::current`] for more
+/// considered enabled; if greater than or equal to the `LevelFilter`,
+/// that level is disabled. See [`LevelFilter::current`] for more
 /// details.
 ///
 /// Note that this is essentially identical to the `Level` type, but with the


### PR DESCRIPTION
Resolves #1669. Namely, I:
- fixed the incorrect docs on `LevelFilter`.
- Removed a stray backtick on `LevelFilter::current`.
- Added a matching backtick in Level's documentation.

I did _not_ add example of comparing a level against a `LevelFilter`; I instead pointed readers to Level's documentation.
