### PR TITLE
chore: forwardport #1692 

### DIFF
--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -128,7 +128,7 @@ pub struct Kind(KindInner);
 /// verbosity. `Level`s can be compared against [`LevelFilter`]s, and
 /// [`LevelFilter`] has a variant for each `Level`, which compares analogously
 /// to that level. In addition, [`LevelFilter`] adds a [`LevelFilter::OFF`]
-/// variant, which is considered "less verbose" than every other `Level. This is
+/// variant, which is considered "less verbose" than every other `Level`. This is
 /// intended to allow filters to completely disable tracing in a particular context.
 ///
 /// For example:
@@ -227,14 +227,16 @@ pub struct Level(LevelInner);
 /// A filter comparable to a verbosity [`Level`].
 ///
 /// If a [`Level`] is considered less than a `LevelFilter`, it should be
-/// considered disabled; if greater than or equal to the `LevelFilter`, that
-/// level is enabled.
+/// considered enabled; if greater than or equal to the `LevelFilter`,
+/// that level is disabled. See [`LevelFilter::current`] for more
+/// details.
 ///
 /// Note that this is essentially identical to the `Level` type, but with the
 /// addition of an [`OFF`] level that completely disables all trace
 /// instrumentation.
 ///
-/// See the documentation for the [`Level`] type for more details.
+/// See the documentation for the [`Level`] type to see how `Level`s
+/// and `LevelFilter`s interact.
 ///
 /// [`OFF`]: LevelFilter::OFF
 #[repr(transparent)]
@@ -584,7 +586,7 @@ impl LevelFilter {
     /// Therefore, comparing a given span or event's level to the returned
     /// `LevelFilter` **can** be used for determining if something is
     /// *disabled*, but **should not** be used for determining if something is
-    /// *enabled*.`
+    /// *enabled*.
     ///
     /// [`Level`]: super::Level
     /// [collector]: super::Collect


### PR DESCRIPTION
A forward port of #1692.

Resolves #1669. Namely, I:
- fixed the incorrect docs on `LevelFilter`.
- Removed a stray backtick on `LevelFilter::current`.
- Added a matching backtick in Level's documentation.

I did _not_ add example of comparing a level against a `LevelFilter`; I
instead pointed readers to Level's documentation.