### PR TITLE
subscriber: fix missing `make_writer_for` in `BoxMakeWriter`

### DIFF
--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -757,10 +757,12 @@ impl fmt::Debug for BoxMakeWriter {
 impl<'a> MakeWriter<'a> for BoxMakeWriter {
     type Writer = Box<dyn Write + 'a>;
 
+    #[inline]
     fn make_writer(&'a self) -> Self::Writer {
         self.inner.make_writer()
     }
 
+    #[inline]
     fn make_writer_for(&'a self, meta: &Metadata<'_>) -> Self::Writer {
         self.inner.make_writer_for(meta)
     }
@@ -776,6 +778,11 @@ where
 
     fn make_writer(&'a self) -> Self::Writer {
         let w = self.0.make_writer();
+        Box::new(w)
+    }
+
+    fn make_writer_for(&'a self, meta: &Metadata<'_>) -> Self::Writer {
+        let w = self.0.make_writer_for(meta);
         Box::new(w)
     }
 }


### PR DESCRIPTION
## Motivation

In `tracing-subscriber` 0.3.x, `MakeWriter` filtering seems to have
stopped working when using the `BoxMakeWriter` wrapper to erase the type
of a `MakeWriter` implementation. It looks like what happened is that
commit 6cc6c47354ceeb47da7c95faa41c6d29b71b5f37, which backported the
change to add a lifetime parameter to `MakeWriter` (#781), I
accidentally clobbered the `make_writer_for` method on the inner `Boxed`
type, so that it only has `make_writer`:
https://github.com/tokio-rs/tracing/commit/6cc6c47354ceeb47da7c95faa41c6d29b71b5f37#diff-c5dc275b15a60c1a2d4694da3797f4247c4f2e1e0978fd210dd14452d6746283L737-L739

This meant that any filtering performed by the `MakeWriter` inside the
box is now ignored. My bad!

## Solution

This commit puts back the missing `make_writer_for` method. Whoops!

Fixes #1694