### PR TITLE
subscriber: propagate ANSI config via `Writer`

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -499,6 +499,7 @@ where
 #[derive(Default)]
 pub struct FormattedFields<E: ?Sized> {
     _format_fields: PhantomData<fn(E)>,
+    was_ansi: bool,
     /// The formatted fields of a span.
     pub fields: String,
 }
@@ -508,6 +509,7 @@ impl<E: ?Sized> FormattedFields<E> {
     pub fn new(fields: String) -> Self {
         Self {
             fields,
+            was_ansi: false,
             _format_fields: PhantomData,
         }
     }
@@ -517,7 +519,7 @@ impl<E: ?Sized> FormattedFields<E> {
     /// The returned [`format::Writer`] can be used with the
     /// [`FormatFields::format_fields`] method.
     pub fn as_writer(&mut self) -> format::Writer<'_> {
-        format::Writer::new(&mut self.fields)
+        format::Writer::new(&mut self.fields).with_ansi(self.was_ansi)
     }
 }
 
@@ -526,6 +528,7 @@ impl<E: ?Sized> fmt::Debug for FormattedFields<E> {
         f.debug_struct("FormattedFields")
             .field("fields", &self.fields)
             .field("formatter", &format_args!("{}", std::any::type_name::<E>()))
+            .field("was_ansi", &self.was_ansi)
             .finish()
     }
 }
@@ -579,6 +582,7 @@ where
                 .format_fields(fields.as_writer().with_ansi(self.is_ansi), attrs)
                 .is_ok()
             {
+                fields.was_ansi = self.is_ansi;
                 extensions.insert(fields);
             }
         }
@@ -613,6 +617,7 @@ where
             .format_fields(fields.as_writer().with_ansi(self.is_ansi), values)
             .is_ok()
         {
+            fields.was_ansi = self.is_ansi;
             extensions.insert(fields);
         }
     }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -232,6 +232,7 @@ where
 pub struct Writer<'writer> {
     writer: &'writer mut dyn fmt::Write,
     // TODO(eliza): add ANSI support
+    is_ansi: bool,
 }
 
 /// A [`FormatFields`] implementation that formats fields by calling a function
@@ -289,7 +290,12 @@ impl<'writer> Writer<'writer> {
     pub(crate) fn new(writer: &'writer mut impl fmt::Write) -> Self {
         Self {
             writer: writer as &mut dyn fmt::Write,
+            is_ansi: false,
         }
+    }
+    // TODO(eliza): consider making this a public API?
+    pub(crate) fn with_ansi(self, is_ansi: bool) -> Self {
+        Self { is_ansi, ..self }
     }
 
     /// Return a new `Writer` that mutably borrows `self`.
@@ -298,7 +304,11 @@ impl<'writer> Writer<'writer> {
     /// to a function that takes a `Writer` by value, allowing the original writer
     /// to still be used once that function returns.
     pub fn by_ref(&mut self) -> Writer<'_> {
-        Writer::new(self)
+        let is_ansi = self.is_ansi;
+        Writer {
+            writer: self as &mut dyn fmt::Write,
+            is_ansi,
+        }
     }
 
     /// Writes a string slice into this `Writer`, returning whether the write succeeded.
@@ -344,7 +354,7 @@ impl<'writer> Writer<'writer> {
         self.writer.write_char(c)
     }
 
-    /// Glue for usage of the [`write!`] macro with `Wrriter`s.
+    /// Glue for usage of the [`write!`] macro with `Writer`s.
     ///
     /// This method should generally not be invoked manually, but rather through
     /// the [`write!`] macro itself.
@@ -358,6 +368,14 @@ impl<'writer> Writer<'writer> {
     /// [`write_fmt` method]: std::fmt::Write::write_fmt
     pub fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> fmt::Result {
         self.writer.write_fmt(args)
+    }
+
+    /// Returns `true` if ANSI escape codes may be used to add colors
+    /// and other formatting when writing to this `Writer`.
+    ///
+    /// If this returns `false`, formatters should not emit ANSI escape codes.
+    pub fn is_ansi(&self) -> bool {
+        self.is_ansi
     }
 }
 
@@ -571,7 +589,7 @@ impl<F, T> Format<F, T> {
         }
     }
 
-    fn format_level(&self, level: Level, writer: &mut dyn fmt::Write) -> fmt::Result
+    fn format_level(&self, level: Level, writer: &mut Writer<'_>) -> fmt::Result
     where
         F: LevelNames,
     {
@@ -579,7 +597,7 @@ impl<F, T> Format<F, T> {
             let fmt_level = {
                 #[cfg(feature = "ansi")]
                 {
-                    F::format_level(level, self.ansi)
+                    F::format_level(level, writer.is_ansi())
                 }
                 #[cfg(not(feature = "ansi"))]
                 {
@@ -606,7 +624,7 @@ impl<F, T> Format<F, T> {
         // colors.
         #[cfg(feature = "ansi")]
         {
-            if self.ansi {
+            if writer.is_ansi() {
                 let style = Style::new().dimmed();
                 write!(writer, "{}", style.prefix())?;
 
@@ -797,7 +815,7 @@ where
         if self.display_target {
             let target = meta.target();
             #[cfg(feature = "ansi")]
-            let target = if self.ansi {
+            let target = if writer.is_ansi() {
                 Style::new().bold().paint(target)
             } else {
                 Style::new().paint(target)
@@ -809,7 +827,7 @@ where
         ctx.format_fields(writer.by_ref(), event)?;
 
         #[cfg(feature = "ansi")]
-        let dimmed = if self.ansi {
+        let dimmed = if writer.is_ansi() {
             Style::new().dimmed()
         } else {
             Style::new()

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -107,7 +107,7 @@ where
 
         self.format_timestamp(&mut writer)?;
 
-        let style = if self.display_level && writer.is_ansi() {
+        let style = if self.display_level && writer.has_ansi_escapes() {
             Pretty::style_for(meta.level())
         } else {
             Style::new()
@@ -118,7 +118,7 @@ where
         }
 
         if self.display_target {
-            let target_style = if writer.is_ansi() {
+            let target_style = if writer.has_ansi_escapes() {
                 style.bold()
             } else {
                 style
@@ -136,7 +136,7 @@ where
         v.finish()?;
         writer.write_char('\n')?;
 
-        let dimmed = if writer.is_ansi() {
+        let dimmed = if writer.has_ansi_escapes() {
             Style::new().dimmed().italic()
         } else {
             Style::new()
@@ -175,7 +175,7 @@ where
             writer.write_char('\n')?;
         }
 
-        let bold = if writer.is_ansi() {
+        let bold = if writer.has_ansi_escapes() {
             Style::new().bold()
         } else {
             Style::new()
@@ -302,7 +302,7 @@ impl<'a> PrettyVisitor<'a> {
     }
 
     fn bold(&self) -> Style {
-        if self.writer.is_ansi() {
+        if self.writer.has_ansi_escapes() {
             self.style.bold()
         } else {
             Style::new()


### PR DESCRIPTION
## Motivation

Currently, whether `tracing-subscriber`'s `fmt` subscriber will ANSI
formatting escape codes use is configured on the `Format` type. This
means that the configuration is honored by the event formatters
implemented in `tracing-subscriber`, but is not easily exposed to those
in other crates. Additionally, it's not currently easy to expose the
configuration to the field formatter, so it's difficult to implement
field formatters that use ANSI escape codes conditionally.

Issue #1651 suggested a new API for this, where the writer that's passed
in to the event and field formatters provides a method for checking if
ANSI escape codes are supported.

## Solution

This branch adds a new method to the `Writer` type added in #1661. The
`FormatEvent` and `FormatFields` implementations can call
`Writer::has_ansi_escapes` to determine whether ANSI escape codes are
supported. This is also propagated to `FormattedFields`, so that it can
be determined when adding new fields to a preexisting set of formatted
fields.