### PR TITLE
subscriber: use ANSI formatting in field formatters

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -499,6 +499,7 @@ where
 #[derive(Default)]
 pub struct FormattedFields<E: ?Sized> {
     _format_fields: PhantomData<fn(E)>,
+    was_ansi: bool,
     /// The formatted fields of a span.
     pub fields: String,
 }
@@ -508,6 +509,7 @@ impl<E: ?Sized> FormattedFields<E> {
     pub fn new(fields: String) -> Self {
         Self {
             fields,
+            was_ansi: false,
             _format_fields: PhantomData,
         }
     }
@@ -517,7 +519,7 @@ impl<E: ?Sized> FormattedFields<E> {
     /// The returned [`format::Writer`] can be used with the
     /// [`FormatFields::format_fields`] method.
     pub fn as_writer(&mut self) -> format::Writer<'_> {
-        format::Writer::new(&mut self.fields)
+        format::Writer::new(&mut self.fields).with_ansi(self.was_ansi)
     }
 }
 
@@ -526,6 +528,7 @@ impl<E: ?Sized> fmt::Debug for FormattedFields<E> {
         f.debug_struct("FormattedFields")
             .field("fields", &self.fields)
             .field("formatter", &format_args!("{}", std::any::type_name::<E>()))
+            .field("was_ansi", &self.was_ansi)
             .finish()
     }
 }
@@ -579,6 +582,7 @@ where
                 .format_fields(fields.as_writer().with_ansi(self.is_ansi), attrs)
                 .is_ok()
             {
+                fields.was_ansi = self.is_ansi;
                 extensions.insert(fields);
             }
         }
@@ -613,6 +617,7 @@ where
             .format_fields(fields.as_writer().with_ansi(self.is_ansi), values)
             .is_ok()
         {
+            fields.was_ansi = self.is_ansi;
             extensions.insert(fields);
         }
     }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -378,6 +378,39 @@ impl<'writer> Writer<'writer> {
     pub fn has_ansi_escapes(&self) -> bool {
         self.is_ansi
     }
+
+    pub(in crate::fmt::format) fn bold(&self) -> Style {
+        #[cfg(feature = "ansi")]
+        {
+            if self.is_ansi {
+                return Style::new().bold();
+            }
+        }
+
+        Style::new()
+    }
+
+    pub(in crate::fmt::format) fn dimmed(&self) -> Style {
+        #[cfg(feature = "ansi")]
+        {
+            if self.is_ansi {
+                return Style::new().dimmed();
+            }
+        }
+
+        Style::new()
+    }
+
+    pub(in crate::fmt::format) fn italic(&self) -> Style {
+        #[cfg(feature = "ansi")]
+        {
+            if self.is_ansi {
+                return Style::new().italic();
+            }
+        }
+
+        Style::new()
+    }
 }
 
 impl fmt::Write for Writer<'_> {
@@ -963,9 +996,17 @@ impl<'a> field::Visit for DefaultVisitor<'a> {
 
     fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
         if let Some(source) = value.source() {
+            let italic = self.writer.italic();
             self.record_debug(
                 field,
-                &format_args!("{} {}.sources={}", value, field, ErrorSourceList(source)),
+                &format_args!(
+                    "{} {}{}{}{}",
+                    value,
+                    italic.paint(field.name()),
+                    italic.paint(".sources"),
+                    self.writer.dimmed().paint("="),
+                    ErrorSourceList(source)
+                ),
             )
         } else {
             self.record_debug(field, &format_args!("{}", value))
@@ -983,8 +1024,20 @@ impl<'a> field::Visit for DefaultVisitor<'a> {
             // Skip fields that are actually log metadata that have already been handled
             #[cfg(feature = "tracing-log")]
             name if name.starts_with("log.") => Ok(()),
-            name if name.starts_with("r#") => write!(self.writer, "{}={:?}", &name[2..], value),
-            name => write!(self.writer, "{}={:?}", name, value),
+            name if name.starts_with("r#") => write!(
+                self.writer,
+                "{}{}{:?}",
+                self.writer.italic().paint(&name[2..]),
+                self.writer.dimmed().paint("="),
+                value
+            ),
+            name => write!(
+                self.writer,
+                "{}{}{:?}",
+                self.writer.italic().paint(name),
+                self.writer.dimmed().paint("="),
+                value
+            ),
         };
     }
 }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -232,6 +232,7 @@ where
 pub struct Writer<'writer> {
     writer: &'writer mut dyn fmt::Write,
     // TODO(eliza): add ANSI support
+    is_ansi: bool,
 }
 
 /// A [`FormatFields`] implementation that formats fields by calling a function
@@ -289,7 +290,12 @@ impl<'writer> Writer<'writer> {
     pub(crate) fn new(writer: &'writer mut impl fmt::Write) -> Self {
         Self {
             writer: writer as &mut dyn fmt::Write,
+            is_ansi: false,
         }
+    }
+    // TODO(eliza): consider making this a public API?
+    pub(crate) fn with_ansi(self, is_ansi: bool) -> Self {
+        Self { is_ansi, ..self }
     }
 
     /// Return a new `Writer` that mutably borrows `self`.
@@ -298,7 +304,11 @@ impl<'writer> Writer<'writer> {
     /// to a function that takes a `Writer` by value, allowing the original writer
     /// to still be used once that function returns.
     pub fn by_ref(&mut self) -> Writer<'_> {
-        Writer::new(self)
+        let is_ansi = self.is_ansi;
+        Writer {
+            writer: self as &mut dyn fmt::Write,
+            is_ansi,
+        }
     }
 
     /// Writes a string slice into this `Writer`, returning whether the write succeeded.
@@ -344,7 +354,7 @@ impl<'writer> Writer<'writer> {
         self.writer.write_char(c)
     }
 
-    /// Glue for usage of the [`write!`] macro with `Wrriter`s.
+    /// Glue for usage of the [`write!`] macro with `Writer`s.
     ///
     /// This method should generally not be invoked manually, but rather through
     /// the [`write!`] macro itself.
@@ -358,6 +368,14 @@ impl<'writer> Writer<'writer> {
     /// [`write_fmt` method]: std::fmt::Write::write_fmt
     pub fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> fmt::Result {
         self.writer.write_fmt(args)
+    }
+
+    /// Returns `true` if ANSI escape codes may be used to add colors
+    /// and other formatting when writing to this `Writer`.
+    ///
+    /// If this returns `false`, formatters should not emit ANSI escape codes.
+    pub fn is_ansi(&self) -> bool {
+        self.is_ansi
     }
 }
 
@@ -571,7 +589,7 @@ impl<F, T> Format<F, T> {
         }
     }
 
-    fn format_level(&self, level: Level, writer: &mut dyn fmt::Write) -> fmt::Result
+    fn format_level(&self, level: Level, writer: &mut Writer<'_>) -> fmt::Result
     where
         F: LevelNames,
     {
@@ -579,7 +597,7 @@ impl<F, T> Format<F, T> {
             let fmt_level = {
                 #[cfg(feature = "ansi")]
                 {
-                    F::format_level(level, self.ansi)
+                    F::format_level(level, writer.is_ansi())
                 }
                 #[cfg(not(feature = "ansi"))]
                 {
@@ -606,7 +624,7 @@ impl<F, T> Format<F, T> {
         // colors.
         #[cfg(feature = "ansi")]
         {
-            if self.ansi {
+            if writer.is_ansi() {
                 let style = Style::new().dimmed();
                 write!(writer, "{}", style.prefix())?;
 
@@ -797,7 +815,7 @@ where
         if self.display_target {
             let target = meta.target();
             #[cfg(feature = "ansi")]
-            let target = if self.ansi {
+            let target = if writer.is_ansi() {
                 Style::new().bold().paint(target)
             } else {
                 Style::new().paint(target)
@@ -809,7 +827,7 @@ where
         ctx.format_fields(writer.by_ref(), event)?;
 
         #[cfg(feature = "ansi")]
-        let dimmed = if self.ansi {
+        let dimmed = if writer.is_ansi() {
             Style::new().dimmed()
         } else {
             Style::new()

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1445,7 +1445,7 @@ pub(super) mod test {
     #[cfg(feature = "ansi")]
     #[test]
     fn with_ansi_true() {
-        let expected = "\u{1b}[2mfake time\u{1b}[0m \u{1b}[32m INFO\u{1b}[0m tracing_subscriber::fmt::format::test: hello\n";
+        let expected = "\u{1b}[2mfake time\u{1b}[0m \u{1b}[32m INFO\u{1b}[0m \u{1b}[2mtracing_subscriber::fmt::format::test\u{1b}[0m\u{1b}[2m:\u{1b}[0m hello\n";
         test_ansi(true, expected);
     }
 

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -801,7 +801,12 @@ where
         }
 
         if self.display_target {
-            write!(writer, "{}{} ", meta.target(), dimmed.paint(":"))?;
+            write!(
+                writer,
+                "{}{} ",
+                dimmed.paint(meta.target()),
+                dimmed.paint(":")
+            )?;
         }
 
         ctx.format_fields(writer.by_ref(), event)?;

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -107,7 +107,7 @@ where
 
         self.format_timestamp(&mut writer)?;
 
-        let style = if self.display_level && writer.is_ansi() {
+        let style = if self.display_level && writer.has_ansi_escapes() {
             Pretty::style_for(meta.level())
         } else {
             Style::new()
@@ -118,7 +118,7 @@ where
         }
 
         if self.display_target {
-            let target_style = if writer.is_ansi() {
+            let target_style = if writer.has_ansi_escapes() {
                 style.bold()
             } else {
                 style
@@ -136,7 +136,7 @@ where
         v.finish()?;
         writer.write_char('\n')?;
 
-        let dimmed = if writer.is_ansi() {
+        let dimmed = if writer.has_ansi_escapes() {
             Style::new().dimmed().italic()
         } else {
             Style::new()
@@ -175,7 +175,7 @@ where
             writer.write_char('\n')?;
         }
 
-        let bold = if writer.is_ansi() {
+        let bold = if writer.has_ansi_escapes() {
             Style::new().bold()
         } else {
             Style::new()
@@ -302,7 +302,7 @@ impl<'a> PrettyVisitor<'a> {
     }
 
     fn bold(&self) -> Style {
-        if self.writer.is_ansi() {
+        if self.writer.has_ansi_escapes() {
             self.style.bold()
         } else {
             Style::new()

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -175,11 +175,7 @@ where
             writer.write_char('\n')?;
         }
 
-        let bold = if writer.has_ansi_escapes() {
-            Style::new().bold()
-        } else {
-            Style::new()
-        };
+        let bold = writer.bold();
         let span = event
             .parent()
             .and_then(|id| ctx.span(id))


### PR DESCRIPTION
Depends on #1696 

## Motivation

PR #1696 adds a new API for propagating whether or not ANSI formatting
escape codes are enabled to the event formatter and field formatter via
the `Writer` type. This means that it's now quite easy to make field
formatting also include ANSI formatting escape codes when ANSI
formatting is enabled. Currently, `tracing-subscriber`'s default field
formatter does not use ANSI formatting --- ANSI escape codes are
currently only used for parts of the event log line controlled by the
event formatter, not within fields. Adding ANSI colors and formatting in
the fields could make the formatted output nicer looking and easier to
read.

## Solution

This branch adds support for ANSI formatting escapes in the default
field formatter, when ANSI formatting is enabled. Now, field names will
be italicized, and the `=` delimiter is dimmed. This should make it a
little easier to visually scan the field lists, since the names and
values are more clearly separated and should be easier to distinguish.

Additionally, I cleaned up the code for conditionally using ANSI
formatting significantly. Now, the `Writer` type has (crate-private)
methods for returning `Style`s for bold, dimmed, and italicized text,
when ANSI escapes are enabled, or no-op `Style`s when they are not. This
is reused in all the formatter implementations, so it makes sense to
have it in one place. I also added dimmed formatting of delimiters in a
couple other places in the default event format, which I thought
improved readability a bit by bringing the actual *text* to the
forefront.

Example of the default format with ANSI escapes enabled:
![image](https://user-images.githubusercontent.com/2796466/140166750-aaf64bd8-b051-4985-9e7d-168fe8757b11.png)
