### PR TITLE
appender: fix WorkerGuard not waiting for writer destruction

### DIFF
--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -277,14 +277,13 @@ impl Drop for WorkerGuard {
                 // TODO: Make timeout configurable.
                 let timeout = Duration::from_millis(1000);
                 match self.shutdown.send_timeout((), timeout) {
-                    Err(SendTimeoutError::Disconnected(_)) => (),
                     Err(SendTimeoutError::Timeout(_)) => {
                         eprintln!(
                             "Shutting down logging worker timed out after {:?}.",
                             timeout
                         );
                     }
-                    Ok(_) => {
+                    _ => {
                         // At this point it is safe to wait for `Worker` destruction without blocking
                         self.handle.take().map(std::thread::JoinHandle::join);
                     }

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -285,7 +285,11 @@ impl Drop for WorkerGuard {
                     }
                     _ => {
                         // At this point it is safe to wait for `Worker` destruction without blocking
-                        self.handle.take().map(std::thread::JoinHandle::join);
+                        if let Some(handle) = self.handle.take() {
+                            if handle.join().is_err() {
+                                eprintln!("Logging worker thread panicked");
+                            }
+                        };
                     }
                 }
             }

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -277,10 +277,11 @@ impl Drop for WorkerGuard {
                 // when the `Worker` calls `recv()` on a zero-capacity channel. Use `send_timeout`
                 // so that drop is not blocked indefinitely.
                 // TODO: Make timeout configurable.
-                match self.shutdown.send_timeout((), Duration::from_millis(1000)) {
+                let timeout = Duration::from_millis(1000);
+                match self.shutdown.send_timeout((), timeout) {
                     Err(SendTimeoutError::Disconnected(_)) => (),
-                    Err(SendTimeoutError::Timeout(e)) => {
-                        println!("Failed to wait for logging worker shutdown. Error: {:?}", e);
+                    Err(SendTimeoutError::Timeout(_)) => {
+                        eprintln!("Shutting down logging worker timed out after {:?}.", timeout);
                     }
                     Ok(_) => {
                         // At this point it is safe to wait for `Worker` destruction without blocking

--- a/tracing-appender/src/worker.rs
+++ b/tracing-appender/src/worker.rs
@@ -74,15 +74,12 @@ impl<T: Write + Send + Sync + 'static> Worker<T> {
                     Ok(WorkerState::Continue) | Ok(WorkerState::Empty) => {}
                     Ok(WorkerState::Shutdown) | Ok(WorkerState::Disconnected) => {
                         let _ = self.shutdown.recv();
-                        break;
+                        return;
                     }
                     Err(_) => {
                         // TODO: Expose a metric for IO Errors, or print to stderr
                     }
                 }
-            }
-            if let Err(e) = self.writer.flush() {
-                eprintln!("Failed to flush. Error: {}", e);
             }
         })
     }

--- a/tracing-appender/src/worker.rs
+++ b/tracing-appender/src/worker.rs
@@ -73,6 +73,7 @@ impl<T: Write + Send + Sync + 'static> Worker<T> {
                 match self.work() {
                     Ok(WorkerState::Continue) | Ok(WorkerState::Empty) => {}
                     Ok(WorkerState::Shutdown) | Ok(WorkerState::Disconnected) => {
+                        drop(self.writer); // drop now in case it blocks
                         let _ = self.shutdown.recv();
                         return;
                     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

Can be though of as a continuation to #1120 and #1125.

Example with problematic racy behavior:
```
use std::io::Write;

struct TestDrop<T: Write>(T);

impl<T: Write> Drop for TestDrop<T> {
    fn drop(&mut self) {
        println!("Dropped");
    }
}

impl<T: Write> Write for TestDrop<T> {
    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
        self.0.write(buf)
    }
    fn flush(&mut self) -> std::io::Result<()> {
        self.0.flush()
    }
}

fn main() {
    let writer = TestDrop(std::io::stdout());
    let (non_blocking, _guard) = tracing_appender::non_blocking(writer);
    tracing_subscriber::fmt().with_writer(non_blocking).init();
}
```

Running this test case in a loop with `while ./test | grep Dropped; do done`, it can be seen that sometimes writer (`TestDrop`) is not dropped and the message is not printed.
I suppose that proper destruction of non-blocking writer should properly destroy underlying writer.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Solution involves joining `Worker` thread (that owns writer) after waiting for it to almost finish avoiding potential deadlock (see https://github.com/tokio-rs/tracing/issues/1120#issuecomment-733982304)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
