### PR TITLE
tracing-journald: Write literal string values to journal

### DIFF
--- a/tracing-journald/tests/journal.rs
+++ b/tracing-journald/tests/journal.rs
@@ -88,8 +88,7 @@ fn read_from_journal(test_name: &str) -> Vec<HashMap<String, Field>> {
             .args(&["--user", "--output=json"])
             // Filter by the PID of the current test process
             .arg(format!("_PID={}", std::process::id()))
-            // tracing-journald logs strings in their debug representation
-            .arg(format!("TEST_NAME={:?}", test_name))
+            .arg(format!("TEST_NAME={}", test_name))
             .output()
             .unwrap()
             .stdout,


### PR DESCRIPTION
See #1710: Do not write strings in Debug representation.

## Motivation

As discussed in #1710 writing strings literally makes tracing-journald behave like other journal clients, and allows 3rd party journal readers to extract the original value from the journal without having to "un"-parse the Debug representation of Rust strings.