### PR TITLE
chore: backport #1722

### DIFF
--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -255,11 +255,11 @@ pub fn set_default(dispatcher: &Dispatch) -> DefaultGuard {
 /// Can only be set once; subsequent attempts to set the global default will fail.
 /// Returns `Err` if the global default has already been set.
 ///
-/// <pre class="compile_fail" style="white-space:normal;font:inherit;">
+/// <div class="example-wrap" style="display:inline-block"><pre class="compile_fail" style="white-space:normal;font:inherit;">
 ///     <strong>Warning</strong>: In general, libraries should <em>not</em> call
 ///     <code>set_global_default()</code>! Doing so will cause conflicts when
 ///     executables that depend on the library try to set the default later.
-/// </pre>
+/// </pre></div>
 ///
 /// [span]: ../span/index.html
 /// [`Subscriber`]: ../subscriber/trait.Subscriber.html

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -51,13 +51,14 @@
 //! The [`span` module][span]'s documentation provides further details on how to
 //! use spans.
 //!
-//! <pre class="compile_fail" style="white-space:normal;font:inherit;">
-//!     <strong>Warning</strong>: In asynchronous code that uses async/await syntax,
-//!     <code>Span::enter</code> may produce incorrect traces if the returned drop
-//!     guard is held across an await point. See
-//!     <a href="span/struct.Span.html#in-asynchronous-code">the method documentation</a>
-//!     for details.
-//! </pre>
+//! <div class="example-wrap" style="display:inline-block"><pre class="compile_fail" style="white-space:normal;font:inherit;">
+//!
+//!  **Warning**: In asynchronous code that uses async/await syntax,
+//!  `Span::enter` may produce incorrect traces if the returned drop
+//!  guard is held across an await point. See
+//!  [the method documentation][Span#in-asynchronous-code] for details.
+//!
+//! </pre></div>
 //!
 //! ## Events
 //!

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -75,7 +75,7 @@
 //! // Dropping the `_enter` guard will exit the span.
 //!```
 //!
-//! </div><div class="example-wrap" style="display:inline-block"><pre class="compile_fail" style="white-space:normal;font:inherit;">
+//! <div class="example-wrap" style="display:inline-block"><pre class="compile_fail" style="white-space:normal;font:inherit;">
 //!     <strong>Warning</strong>: In asynchronous code that uses async/await syntax,
 //!     <code>Span::enter</code> may produce incorrect traces if the returned drop
 //!     guard is held across an await point. See


### PR DESCRIPTION
Backports #1722 to v0.1.x; will require a release of `tracing` and (optionally) tracing-core.