### PR TITLE
chore: add MSRV cargo metadata

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,6 +3,7 @@ name = "tracing-examples"
 version = "0.0.0"
 publish = false
 edition = "2018"
+rust = "1.42.0"
 
 [features]
 default = []

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -18,6 +18,7 @@ categories = [
 ]
 keywords = ["logging", "tracing", "file-appender", "non-blocking-writer"]
 edition = "2018"
+rust = "1.51.0"
 
 [dependencies]
 crossbeam-channel = "0.5.0"

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -28,6 +28,7 @@ keywords = ["logging", "tracing", "macro", "instrument", "log"]
 license = "MIT"
 readme = "README.md"
 edition = "2018"
+rust = "1.42.0"
 
 [lib]
 proc-macro = true

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -24,6 +24,7 @@ categories = [
 ]
 keywords = ["logging", "tracing", "profiling"]
 edition = "2018"
+rust = "1.42.0"
 
 [features]
 default = ["std"]

--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -32,6 +32,7 @@ keywords = [
     "backtrace"
 ]
 edition = "2018"
+rust = "1.42.0"
 
 [features]
 default = ["traced-error"]

--- a/tracing-flame/Cargo.toml
+++ b/tracing-flame/Cargo.toml
@@ -19,6 +19,7 @@ categories = [
     "asynchronous",
 ]
 keywords = ["tracing", "subscriber", "flamegraph", "profiling"]
+rust = "1.42.0"
 
 [features]
 default = ["smallvec"]

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -16,6 +16,7 @@ categories = [
 ]
 keywords = ["logging", "profiling", "tracing", "futures", "async"]
 license = "MIT"
+rust = "1.42.0"
 
 [features]
 default = ["std-future", "std"]

--- a/tracing-journald/Cargo.toml
+++ b/tracing-journald/Cargo.toml
@@ -13,6 +13,7 @@ categories = [
     "development-tools::profiling",
 ]
 keywords = ["tracing", "journald"]
+rust = "1.42.0"
 
 [dependencies]
 tracing-core = { path = "../tracing-core", version = "0.2" }

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -15,6 +15,7 @@ categories = [
 keywords = ["logging", "tracing", "log"]
 license = "MIT"
 readme = "README.md"
+rust = "1.42.0"
 
 [features]
 default = ["log-tracer", "std"]

--- a/tracing-macros/Cargo.toml
+++ b/tracing-macros/Cargo.toml
@@ -15,6 +15,7 @@ categories = [
 ]
 keywords = ["logging", "tracing"]
 license = "MIT"
+rust = "1.42.0"
 
 [dependencies]
 tracing = { path = "../tracing", version = "0.2", default-features = false, features = ["std"] }

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -17,6 +17,7 @@ categories = [
 keywords = ["tracing", "opentelemetry", "jaeger", "zipkin", "async"]
 license = "MIT"
 edition = "2018"
+rust = "1.42.0"
 
 [features]
 default = ["tracing-log"]

--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -16,6 +16,7 @@ categories = [
     "encoding",
 ]
 keywords = ["logging", "tracing", "serialization"]
+rust = "1.42.0"
 
 [features]
 default = ["std"]

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -20,6 +20,7 @@ categories = [
     "asynchronous",
 ]
 keywords = ["logging", "tracing", "metrics", "subscriber"]
+rust = "1.42.0"
 
 [features]
 

--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -15,6 +15,7 @@ categories = [
 ]
 keywords = ["logging", "tracing"]
 license = "MIT"
+rust = "1.42.0"
 
 [features]
 default = ["tower-layer", "tower-make"]

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -28,6 +28,7 @@ categories = [
 ]
 keywords = ["logging", "tracing", "metrics", "async"]
 edition = "2018"
+rust = "1.42.0"
 
 [dependencies]
 tracing-core = { path = "../tracing-core", version = "0.2", default-features = false }


### PR DESCRIPTION
This branch adds the `[package.rust]` metadata to `Cargo.toml` for all
crates. See https://rust-lang.github.io/rfcs/2495-min-rust-version.html
for details.