### PR TITLE
subscriber: prepare to release 0.3.3

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.3.3 (Nov 29, 2021)
+
+This release fixes a pair of regressions in `tracing-subscriber`'s `fmt` module.
+
+### Fixed
+
+- **fmt**: Fixed missing event fields with `Compact` formatter ([#1755])
+- **fmt**: Fixed `PrettyFields` formatter (and thus `format::Pretty` event
+  formatter) ignoring the `fmt::Layer`'s ANSI color code configuration ([#1747])
+
+[#1755]: https://github.com/tokio-rs/tracing/pull/1755
+[#1747]: https://github.com/tokio-rs/tracing/pull/1747
+
 # 0.3.2 (Nov 19, 2021)
 
 ### Fixed

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.3.2"
+version = "0.3.3"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",


### PR DESCRIPTION
# 0.3.3 (Nov 29, 2021)

This release fixes a pair of regressions in `tracing-subscriber`'s `fmt`
module.

### Fixed

- **fmt**: Fixed missing event fields with `Compact` formatter ([#1755])
- **fmt**: Fixed `PrettyFields` formatter (and thus `format::Pretty`
  event formatter) ignoring the `fmt::Layer`'s ANSI color code
  configuration ([#1747])

[#1755]: https://github.com/tokio-rs/tracing/pull/1755
[#1747]: https://github.com/tokio-rs/tracing/pull/1747
