### PR TITLE
Use unconnected socket

### DIFF
--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -86,6 +86,9 @@ pub struct Subscriber {
     field_prefix: Option<String>,
 }
 
+#[cfg(unix)]
+const JOURNALD_PATH: &str = "/run/systemd/journal/socket";
+
 impl Subscriber {
     /// Construct a journald subscriber
     ///
@@ -95,11 +98,14 @@ impl Subscriber {
         #[cfg(unix)]
         {
             let socket = UnixDatagram::unbound()?;
-            socket.connect("/run/systemd/journal/socket")?;
-            Ok(Self {
+            let sub = Self {
                 socket,
                 field_prefix: Some("F".into()),
-            })
+            };
+            // Check that we can talk to journald, by sending empty payload which journald discards.
+            // However if the socket didn't exist or if none listened we'd get an error here.
+            sub.send_payload(&[])?;
+            Ok(sub)
         }
         #[cfg(not(unix))]
         Err(io::Error::new(
@@ -125,13 +131,15 @@ impl Subscriber {
 
     #[cfg(unix)]
     fn send_payload(&self, payload: &[u8]) -> io::Result<usize> {
-        self.socket.send(payload).or_else(|error| {
-            if Some(libc::EMSGSIZE) == error.raw_os_error() {
-                self.send_large_payload(payload)
-            } else {
-                Err(error)
-            }
-        })
+        self.socket
+            .send_to(payload, JOURNALD_PATH)
+            .or_else(|error| {
+                if Some(libc::EMSGSIZE) == error.raw_os_error() {
+                    self.send_large_payload(payload)
+                } else {
+                    Err(error)
+                }
+            })
     }
 
     #[cfg(all(unix, not(target_os = "linux")))]
@@ -154,7 +162,7 @@ impl Subscriber {
         // Fully seal the memfd to signal journald that its backing data won't resize anymore
         // and so is safe to mmap.
         memfd::seal_fully(mem.as_raw_fd())?;
-        socket::send_one_fd(&self.socket, mem.as_raw_fd())
+        socket::send_one_fd_to(&self.socket, mem.as_raw_fd(), JOURNALD_PATH)
     }
 }
 


### PR DESCRIPTION
Lets journald subscribers survive a journald restart.

Closes #1745

## Motivation

Currently the journald subscriber immediately connects to the journald socket.  As such I understand it'd not survive a full restart of journald.

## Solution

Do not connect the client socket immediately; instead pass the socket pathname every time we send a message.  This is also what upstream does.