### PR TITLE
chore: add a warning header to docs built from `master`

### DIFF
--- a/assets/noindex.html
+++ b/assets/noindex.html
@@ -1,0 +1,1 @@
+<meta name="robots" content="noindex">

--- a/assets/warning.css
+++ b/assets/warning.css
@@ -1,0 +1,25 @@
+#tracing-warning-header {
+    z-index: 400;
+    position: fixed;
+    background-color: orange;
+    left: 0;
+    top: 0;
+    right: 0;
+    height: 50px;
+    display: block;
+    color: black;
+    font-size-adjust: 0.55;
+    line-height: 0.6;
+    padding-top: 10px;
+    padding-left: 230px;
+}
+
+body {
+    /* add top padding to fit the warning header */
+    padding-top: 50px !important;
+}
+
+.sidebar {
+    /* add top padding to fit the warning header */
+    margin-top: 50px !important;
+}

--- a/assets/warning.html
+++ b/assets/warning.html
@@ -1,0 +1,9 @@
+<div id="tracing-warning-header">
+    <p>
+        <strong>&#x1F6C8; Note</strong>: This is <em>pre-release</em> documentation
+        for the upcoming <code>tracing</code> 0.2.0 ecosystem.
+    </p>
+    <p>
+        For the release documentation, please see <a href="https://docs.rs">docs.rs</a>, instead.
+    </p>
+</div>

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,8 +3,14 @@
     rustup install nightly --profile minimal \
       && cargo doc --no-deps
     """
-  environment = { RUSTDOCFLAGS= "--cfg docsrs" }
   publish = "target/doc"
+
+[build.environment]
+  RUSTDOCFLAGS="""
+    --cfg docsrs \
+    --html-before-content $(pwd)/assets/warning.html \
+    --extend-css $(pwd)/assets/warning.css
+    """
 
 [[redirects]]
   from = "/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,7 +10,7 @@
     --cfg docsrs \
     --html-before-content $(pwd)/assets/warning.html \
     --html-in-header $(pwd)/assets/noindex.html \
-    --extend-css $(pwd)/assets/warning.css
+    --extend-css $(pwd)/assets/warning.css \
     """
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,7 @@
   RUSTDOCFLAGS="""
     --cfg docsrs \
     --html-before-content $(pwd)/assets/warning.html \
+    --html-in-header $(pwd)/assets/noindex.html \
     --extend-css $(pwd)/assets/warning.css
     """
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,7 @@
   RUSTDOCFLAGS="""
     --cfg docsrs \
     --html-before-content /opt/build/repo/assets/warning.html \
-    --html-in-header /opt/build/repo/noindex.html \
+    --html-in-header /opt/build/repo/assets/noindex.html \
     --extend-css /opt/build/repo/assets/warning.css \
     """
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,9 +8,9 @@
 [build.environment]
   RUSTDOCFLAGS="""
     --cfg docsrs \
-    --html-before-content $(pwd)/assets/warning.html \
-    --html-in-header $(pwd)/assets/noindex.html \
-    --extend-css $(pwd)/assets/warning.css \
+    --html-before-content /opt/build/repo/assets/warning.html \
+    --html-in-header /opt/build/repo/noindex.html \
+    --extend-css /opt/build/repo/assets/warning.css \
     """
 
 [[redirects]]


### PR DESCRIPTION
This branch adds a warning header to documentation built from the
`master` branch, noting that this is _not_ documentation for the release
version, and suggesting that users refer to docs.rs for the release
documentation instead. Netlify is configured to include this header when
building documentation. This should make it clearer that documentation
built from `master` does _not_ document the currently documented release
versions on crates.io.

I'm very far from a web developer, so it's almost certainly possible
that the warning header could look nicer. I'll happily take suggestions
for improving the styling, but at least this gets the point across.

Additionally, I've added a [`noindex` meta tag][1] to the documentation's
HTML `<head>`. This should prevent it from showing up in search engines,
so that when people Google tracing APIs, they end up on the docs.rs
documentation, rather than the `master` branch dev docs.

Closes #1592

[1]: https://developers.google.com/search/docs/advanced/crawling/block-indexing