### PR TITLE
subscriber: fix clippy needless borrow warning

### DIFF
--- a/tracing-subscriber/src/field/mod.rs
+++ b/tracing-subscriber/src/field/mod.rs
@@ -341,7 +341,7 @@ pub(in crate::field) mod test_util {
 
     impl<'a> Visit for DebugVisitor<'a> {
         fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-            write!(&mut self.writer, "{}={:?}", field, value).unwrap();
+            write!(self.writer, "{}={:?}", field, value).unwrap();
         }
     }
 


### PR DESCRIPTION
This fixes CI on 1.57.0.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>