### PR TITLE
docs: replace comments regarding otel's 'Extract' with 'Extractor'

### DIFF
--- a/tracing-opentelemetry/src/span_ext.rs
+++ b/tracing-opentelemetry/src/span_ext.rs
@@ -22,7 +22,7 @@ pub trait OpenTelemetrySpanExt {
     /// use std::collections::HashMap;
     /// use tracing::Span;
     ///
-    /// // Example carrier, could be a framework header map that impls otel's `Extract`.
+    /// // Example carrier, could be a framework header map that impls otel's `Extractor`.
     /// let mut carrier = HashMap::new();
     ///
     /// // Propagator can be swapped with b3 propagator, jaeger propagator, etc.
@@ -56,7 +56,7 @@ pub trait OpenTelemetrySpanExt {
     /// use std::collections::HashMap;
     /// use tracing::Span;
     ///
-    /// // Example carrier, could be a framework header map that impls otel's `Extract`.
+    /// // Example carrier, could be a framework header map that impls otel's `Extractor`.
     /// let mut carrier = HashMap::new();
     ///
     /// // Propagator can be swapped with b3 propagator, jaeger propagator, etc.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

I was a little confused not to find a trait called `Extract` in the opentelemetry crate. Following the `TextMapPropagator` trait's `extract` function though I found that a reference to a `propagation::Extractor` is required instead.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

I replaced `otel's 'Extract'` with `otel's Extractor`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
