### PR TITLE
Fix pretty formatter thread id double space

### DIFF
--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1468,6 +1468,8 @@ pub(super) mod test {
     use super::{FmtSpan, TimingDisplay, Writer};
     use std::fmt;
 
+    use regex::Regex;
+
     pub(crate) struct MockTime;
     impl FormatTime for MockTime {
         fn format_time(&self, w: &mut Writer<'_>) -> fmt::Result {
@@ -1488,21 +1490,31 @@ pub(super) mod test {
             .with_thread_names(false);
         #[cfg(feature = "ansi")]
         let subscriber = subscriber.with_ansi(false);
-        run_test(subscriber, make_writer, "hello\n")
+        assert_info_hello(subscriber, make_writer, "hello\n")
     }
 
     #[cfg(feature = "ansi")]
     #[test]
     fn with_ansi_true() {
         let expected = "\u{1b}[2mfake time\u{1b}[0m \u{1b}[32m INFO\u{1b}[0m \u{1b}[2mtracing_subscriber::fmt::format::test\u{1b}[0m\u{1b}[2m:\u{1b}[0m hello\n";
-        test_ansi(true, expected);
+        assert_info_hello_ansi(true, expected);
     }
 
     #[cfg(feature = "ansi")]
     #[test]
     fn with_ansi_false() {
         let expected = "fake time  INFO tracing_subscriber::fmt::format::test: hello\n";
-        test_ansi(false, expected);
+        assert_info_hello_ansi(false, expected);
+    }
+
+    #[cfg(feature = "ansi")]
+    fn assert_info_hello_ansi(is_ansi: bool, expected: &str) {
+        let make_writer = MockMakeWriter::default();
+        let subscriber = crate::fmt::Collector::builder()
+            .with_writer(make_writer.clone())
+            .with_ansi(is_ansi)
+            .with_timer(MockTime);
+        assert_info_hello(subscriber, make_writer, expected)
     }
 
     #[cfg(not(feature = "ansi"))]
@@ -1513,7 +1525,7 @@ pub(super) mod test {
         let subscriber = crate::fmt::Collector::builder()
             .with_writer(make_writer)
             .with_timer(MockTime);
-        run_test(subscriber, make_writer, expected);
+        assert_info_hello(subscriber, make_writer, expected);
     }
 
     #[test]
@@ -1526,23 +1538,65 @@ pub(super) mod test {
             .with_timer(MockTime);
         let expected = "fake time tracing_subscriber::fmt::format::test: hello\n";
 
-        run_test(subscriber, make_writer, expected);
+        assert_info_hello(subscriber, make_writer, expected);
     }
 
-    #[cfg(feature = "ansi")]
-    fn test_ansi(is_ansi: bool, expected: &str) {
+    #[test]
+    fn with_thread_ids() {
         let make_writer = MockMakeWriter::default();
         let subscriber = crate::fmt::Collector::builder()
             .with_writer(make_writer.clone())
-            .with_ansi(is_ansi)
+            .with_thread_ids(true)
+            .with_ansi(false)
             .with_timer(MockTime);
-        run_test(subscriber, make_writer, expected)
+        let expected =
+            "fake time  INFO ThreadId(NUMERIC) tracing_subscriber::fmt::format::test: hello\n";
+
+        assert_info_hello_ignore_numeric(subscriber, make_writer, expected);
     }
 
-    fn run_test(subscriber: impl Into<Dispatch>, buf: MockMakeWriter, expected: &str) {
+    #[test]
+    fn pretty_default() {
+        let make_writer = MockMakeWriter::default();
+        let subscriber = crate::fmt::Collector::builder()
+            .pretty()
+            .with_writer(make_writer.clone())
+            .with_ansi(false)
+            .with_timer(MockTime);
+        let expected = format!(
+            r#"  fake time  INFO tracing_subscriber::fmt::format::test: hello
+    at {}:NUMERIC
+
+"#,
+            file!()
+        );
+
+        assert_info_hello_ignore_numeric(subscriber, make_writer, &expected)
+    }
+
+    fn assert_info_hello(subscriber: impl Into<Dispatch>, buf: MockMakeWriter, expected: &str) {
         let _default = set_default(&subscriber.into());
         tracing::info!("hello");
-        assert_eq!(expected, buf.get_string())
+        let result = buf.get_string();
+
+        assert_eq!(expected, result)
+    }
+
+    // When numeric characters are used they often form a non-deterministic value as they usually represent things like a thread id or line number.
+    // This assert method should be used when non-deterministic numeric characters are present.
+    fn assert_info_hello_ignore_numeric(
+        subscriber: impl Into<Dispatch>,
+        buf: MockMakeWriter,
+        expected: &str,
+    ) {
+        let _default = set_default(&subscriber.into());
+        tracing::info!("hello");
+
+        let regex = Regex::new("[0-9]+").unwrap();
+        let result = buf.get_string();
+        let result_cleaned = regex.replace_all(&result, "NUMERIC");
+
+        assert_eq!(expected, result_cleaned)
     }
 
     #[test]

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -174,7 +174,7 @@ where
                 if let Some(name) = thread.name() {
                     write!(writer, "{}", name)?;
                     if self.display_thread_id {
-                        write!(writer, " ")?;
+                        writer.write_char(' ')?;
                     }
                 }
             }

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -174,13 +174,12 @@ where
                 if let Some(name) = thread.name() {
                     write!(writer, "{}", name)?;
                     if self.display_thread_id {
-                        write!(writer, " ({:?})", thread.id())?;
+                        write!(writer, " ")?;
                     }
-                } else if !self.display_thread_id {
-                    write!(writer, " {:?}", thread.id())?;
                 }
-            } else if self.display_thread_id {
-                write!(writer, " {:?}", thread.id())?;
+            }
+            if self.display_thread_id {
+                write!(writer, "{:?}", thread.id())?;
             }
             writer.write_char('\n')?;
         }


### PR DESCRIPTION
Before this PR there was one two many spaces between "on" and "ThreadId" when thread id formatting is enabled but thread name formatting is disabled.
There was no issue when both thread name and thread id were enabled.

Previous output:
```
  2021-12-15T00:44:05.596510Z ERROR shotover_proxy::transforms::redis::cache: failed to fetch from cache: system.local not a caching table
    at shotover-proxy/src/transforms/redis/cache.rs:366 on  ThreadId(5)
    in shotover_proxy::server::request with id=5 source="CassandraSource"
```

new output:
```
  2021-12-15T00:44:05.596510Z ERROR shotover_proxy::transforms::redis::cache: failed to fetch from cache: system.local not a caching table
    at shotover-proxy/src/transforms/redis/cache.rs:366 on ThreadId(5)
    in shotover_proxy::server::request with id=5 source="CassandraSource"
```

I spent a lot of time working on unittests, I managed to add tests for a lot of related cases but couldnt test the actual case here :/
When I write a test like:
```rust
    #[test]
    fn pretty_threads_ids() {
        let make_writer = MockMakeWriter::default();
        let subscriber = crate::fmt::Collector::builder()
            .pretty()
            .with_thread_ids(true)
            .with_writer(make_writer.clone())
            .with_ansi(false)
            .with_timer(MockTime);
        assert_info_hello_ignore_numeric(
            subscriber,
            make_writer,
            r#"  fake time  INFO tracing_subscriber::fmt::format::test: hello
    at tracing-subscriber/src/fmt/format/mod.rs:

"#,
        )
    }
```
Inexplicably the thread id is not displayed.

Hopefully you can accept the tests I did write as a compromise, the actual fix here is really simple.