### PR TITLE
Implement compression in tracing-appender

### DIFF
--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -23,6 +23,7 @@ rust-version = "1.51.0"
 [dependencies]
 crossbeam-channel = "0.5.0"
 time = { version = "0.3", default-features = false, features = ["formatting"] }
+flate2 = { version = "1.0.22" }
 
 [dependencies.tracing-subscriber]
 path = "../tracing-subscriber"

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -161,6 +161,8 @@ pub mod rolling;
 
 mod worker;
 
+mod writer;
+
 /// Convenience function for creating a non-blocking, off-thread writer.
 ///
 /// See the [`non_blocking` module's docs][mod@non_blocking]'s for more details.

--- a/tracing-appender/src/writer.rs
+++ b/tracing-appender/src/writer.rs
@@ -1,0 +1,18 @@
+use std::io::{BufWriter, Write};
+use std::fs::File;
+use flate2::write::GzEncoder;
+
+#[derive(Debug)]
+pub enum WriterChannel {
+    File(BufWriter<File>),
+    CompressedFileGzip(BufWriter<GzEncoder<BufWriter<File>>>),
+}
+
+impl WriterChannel {
+    pub fn get_writer(&mut self) -> &mut dyn Write {
+        match self {
+            WriterChannel::File(x) => x,
+            WriterChannel::CompressedFileGzip(x) => x,
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

This PR implements compression mechanism for tracing-appender crate. In our project we use tracing for event logging and they tend to be very big and compress quite well. We wanted to have a pure Rust solution to handle compression.

## Solution

To overcome compatibility issues it looks at the file extension that is given by the user.

```rust
let appender = tracing_appender::rolling::minutely("/some/path", "rolling.log.gz")
```

will output compressed logs to `/some/path/rolling.log.yyyy-MM-dd-HH-mm.gz`

Note that I add non-optional dependency flate2 to Cargo.toml.

Let me know if this is ok so I can update the documentation.