### PR TITLE
subscriber/fmt: address UX issues in defaults

### DIFF
--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -250,9 +250,7 @@ impl EnvFilter {
         use tracing::level_filters::STATIC_MAX_LEVEL;
         use tracing::Level;
 
-        let fallback_level = Directive::from(crate::fmt::Subscriber::DEFAULT_MAX_LEVEL);
-
-        let directives: Vec<_> = std::iter::once(fallback_level).chain(directives.into_iter()).collect();
+        let directives: Vec<_> = directives.into_iter().collect();
 
         let disabled: Vec<_> = directives
             .iter()

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -250,7 +250,9 @@ impl EnvFilter {
         use tracing::level_filters::STATIC_MAX_LEVEL;
         use tracing::Level;
 
-        let directives: Vec<_> = directives.into_iter().collect();
+        let fallback_level = Directive::from(crate::fmt::Subscriber::DEFAULT_MAX_LEVEL);
+
+        let directives: Vec<_> = std::iter::once(fallback_level).chain(directives.into_iter()).collect();
 
         let disabled: Vec<_> = directives
             .iter()

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -1132,6 +1132,14 @@ pub fn try_init() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     #[cfg(feature = "env-filter")]
     let builder = builder.with_env_filter(crate::EnvFilter::from_default_env());
 
+    // If `env-filter` is disabled, remove the default max level filter from the
+    // subscriber; it will be added to the `Targets` filter instead if no filter
+    // is set in `RUST_LOG`.
+    // Replacing the default `LevelFilter` with an `EnvFilter` would imply this,
+    // but we can't replace the builder's filter with a `Targets` filter yet.
+    #[cfg(not(feature = "env-filter"))]
+    let builder = builder.with_max_level(LevelFilter::TRACE);
+
     let subscriber = builder.finish();
     #[cfg(not(feature = "env-filter"))]
     let subscriber = {


### PR DESCRIPTION
The removal of env-filter from the default features in 0.3.0 has caused a lot of developer frustration.

This PR addresses all of the issue I'm aware of, except #1329, in individual commits.

See the commit message for notes on the implementation and the related issues.