### PR TITLE
fix README.md typo in example #1468

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ fn main() {
         // build but do not install the subscriber.
         .finish();
 
-    tracing::collector::with_default(collector, || {
+    tracing::collect::with_default(collector, || {
         info!("This will be logged to stdout");
     });
     info!("This will _not_ be logged to stdout");


### PR DESCRIPTION
## Motivation

As a new user, I stumbled over a broken link and thought I'd fix it. Also noticed an unrelated open issue while searching for one about the broken link, and thought I'd fix that too.

## Solution

Fix the typos.
