### PR TITLE
core: derive `Default` for `NoSubscriber`

### DIFF
--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -568,14 +568,8 @@ impl Interest {
 ///
 /// [`NoSubscriber`] implements the [`Subscriber`] trait by never being enabled,
 /// never being interested in any callsite, and dropping all spans and events.
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct NoSubscriber(());
-
-impl Default for NoSubscriber {
-    fn default() -> Self {
-        NoSubscriber(())
-    }
-}
 
 impl Subscriber for NoSubscriber {
     #[inline]

--- a/tracing-subscriber/src/field/mod.rs
+++ b/tracing-subscriber/src/field/mod.rs
@@ -341,7 +341,7 @@ pub(in crate::field) mod test_util {
 
     impl<'a> Visit for DebugVisitor<'a> {
         fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-            write!(&mut self.writer, "{}={:?}", field, value).unwrap();
+            write!(self.writer, "{}={:?}", field, value).unwrap();
         }
     }
 


### PR DESCRIPTION
This makes Clippy shut up.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>