### PR TITLE
chore: prepare to release tracing-flame 0.2

### DIFF
--- a/tracing-flame/Cargo.toml
+++ b/tracing-flame/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-flame"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "Jane Lusby <jlusby@yaah.dev>",
     "Tokio Contributors <team@tokio.rs>"

--- a/tracing-opentelemetry/src/span_ext.rs
+++ b/tracing-opentelemetry/src/span_ext.rs
@@ -22,7 +22,7 @@ pub trait OpenTelemetrySpanExt {
     /// use std::collections::HashMap;
     /// use tracing::Span;
     ///
-    /// // Example carrier, could be a framework header map that impls otel's `Extract`.
+    /// // Example carrier, could be a framework header map that impls otel's `Extractor`.
     /// let mut carrier = HashMap::new();
     ///
     /// // Propagator can be swapped with b3 propagator, jaeger propagator, etc.
@@ -56,7 +56,7 @@ pub trait OpenTelemetrySpanExt {
     /// use std::collections::HashMap;
     /// use tracing::Span;
     ///
-    /// // Example carrier, could be a framework header map that impls otel's `Extract`.
+    /// // Example carrier, could be a framework header map that impls otel's `Extractor`.
     /// let mut carrier = HashMap::new();
     ///
     /// // Propagator can be swapped with b3 propagator, jaeger propagator, etc.


### PR DESCRIPTION
The current version of tracing-flame on crates.io relies on tracing-subscriber 0.2. This release fixes that.