### PR TITLE
chore(CI): attempt to automate github releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "tracing[\-a-z]*-v[0-9]+.*"
+
+jobs:
+  create-release:
+    name: Create GitHub release
+    # only publish from the origin repository
+    if: github.repository_owner == 'tokio-rs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: taiki-e/create-gh-release-action@v1.3.0
+        with:
+          prefix: "tracing[\-a-z]*"
+          changelog: "$prefix/CHANGELOG.md"
+          title: "$prefix $version"
+          branch: v0.1.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Release
 on:
   push:
     tags:
-      - tracing[\-a-z]*-v[0-9]+.*
+      - tracing-[0-9]+.*
+      - tracing-[a-z]+-[0-9]+.*
 
 jobs:
   create-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "tracing[\-a-z]*-v[0-9]+.*"
+      - tracing[\-a-z]*-v[0-9]+.*
 
 jobs:
   create-release:
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: taiki-e/create-gh-release-action@v1.3.0
         with:
-          prefix: "tracing[\-a-z]*"
+          prefix: tracing[\-a-z]*
           changelog: "$prefix/CHANGELOG.md"
           title: "$prefix $version"
           branch: v0.1.x


### PR DESCRIPTION
Hopefully this should automatically publish a GitHub release with
each individual crate's changelog when an appropriate tag is pushed,
provided I haven't made a YAML mistake.