### PR TITLE
core: inline `get_default` global fast path

### DIFF
--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -372,6 +372,7 @@ impl error::Error for SetGlobalDefaultError {}
 ///
 /// [dispatcher]: super::dispatch::Dispatch
 #[cfg(feature = "std")]
+#[inline(always)]
 pub fn get_default<T, F>(mut f: F) -> T
 where
     F: FnMut(&Dispatch) -> T,
@@ -382,6 +383,15 @@ where
         return f(get_global());
     }
 
+    get_default_slow(f)
+}
+
+#[cfg(feature = "std")]
+#[inline(never)]
+fn get_default_slow<T, F>(mut f: F) -> T
+where
+    F: FnMut(&Dispatch) -> T,
+{
     // While this guard is active, additional calls to collector functions on
     // the default dispatcher will not be able to access the dispatch context.
     // Dropping the guard will allow the dispatch context to be re-entered.


### PR DESCRIPTION
This branch makes a small optimization to
`tracing-core::dispatch::get_default` in the case where only the global
default is in use. By factoring out the slow path, where we actually
perform a thread-local access to get the global default, into a second
function, it's now okay to always inline the fast path, since it's very
small. If the fast path fails because there _are_ scoped defaults in
use, we fall back to the slow path, a separate function call. This
should improve fast path performance significantly.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>