### PR TITLE
subscriber: prepare to release v0.3.4

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,25 @@
+# 0.3.4 (Dec 23, 2021)
+
+This release contains bugfixes for the `fmt` module, as well as documentation
+improvements.
+
+### Fixed
+
+- **fmt**: Fixed `fmt` not emitting log lines when timestamp formatting fails
+  ([#1689])
+- **fmt**: Fixed double space before thread IDs with `Pretty` formatter
+  ([#1778])
+- Several documentation improvements ([#1608], [#1699], [#1701])
+
+[#1689]: https://github.com/tokio-rs/tracing/pull/1689
+[#1778]: https://github.com/tokio-rs/tracing/pull/1778
+[#1608]: https://github.com/tokio-rs/tracing/pull/1608
+[#1699]: https://github.com/tokio-rs/tracing/pull/1699
+[#1701]: https://github.com/tokio-rs/tracing/pull/1701
+
+Thanks to new contributors @Swatinem and @rukai for contributing to this
+release!
+
 # 0.3.3 (Nov 29, 2021)
 
 This release fixes a pair of regressions in `tracing-subscriber`'s `fmt` module.

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.3.3"
+version = "0.3.4"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -21,7 +21,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.3.1
+[docs-url]: https://docs.rs/tracing-subscriber/0.3.3
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -126,7 +126,7 @@
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`time` crate]: https://crates.io/crates/time
 //! [`liballoc`]: https://doc.rust-lang.org/alloc/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.3.1")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.3.3")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.3.4 (Dec 23, 2021)

This release contains bugfixes for the `fmt` module, as well as documentation
improvements.

### Fixed

- **fmt**: Fixed `fmt` not emitting log lines when timestamp formatting fails
  ([#1689])
- **fmt**: Fixed double space before thread IDs with `Pretty` formatter
  ([#1778])
- Several documentation improvements ([#1608], [#1699], [#1701])

[#1689]: https://github.com/tokio-rs/tracing/pull/1689
[#1778]: https://github.com/tokio-rs/tracing/pull/1778
[#1608]: https://github.com/tokio-rs/tracing/pull/1608
[#1699]: https://github.com/tokio-rs/tracing/pull/1699
[#1701]: https://github.com/tokio-rs/tracing/pull/1701

Thanks to new contributors @Swatinem and @rukai for contributing to this
release!