### PR TITLE
Add feature to print line number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,9 @@ Cargo.lock
 !.vscode/launch.json
 !.vscode/extensions.json
 
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+.idea
+
 
 # End of https://www.gitignore.io/api/rust,macos,visualstudiocode

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -299,9 +299,9 @@ where
     }
 
     /// Sets whether or not line number is displayed.
-    pub fn with_line_numbers(self, display_line_number: bool) -> Subscriber<C, N, format::Format<L, T>, W> {
+    pub fn with_line_numbers(self, display_line_numbers: bool) -> Subscriber<C, N, format::Format<L, T>, W> {
         Subscriber {
-            fmt_event: self.fmt_event.with_line_number(display_line_number),
+            fmt_event: self.fmt_event.with_line_number(display_line_numbers),
             ..self
         }
     }

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -298,6 +298,14 @@ where
         }
     }
 
+    /// Sets whether or not line number is displayed.
+    pub fn with_line_numbers(self, display_line_number: bool) -> Subscriber<C, N, format::Format<L, T>, W> {
+        Subscriber {
+            fmt_event: self.fmt_event.with_line_number(display_line_number),
+            ..self
+        }
+    }
+
     /// Sets whether or not an event's level is displayed.
     pub fn with_level(self, display_level: bool) -> Subscriber<C, N, format::Format<L, T>, W> {
         Subscriber {

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1597,6 +1597,20 @@ pub(super) mod test {
     }
 
     #[test]
+    fn with_line_numbers() {
+        let make_writer = MockMakeWriter::default();
+        let subscriber = crate::fmt::Collector::builder()
+            .with_writer(make_writer.clone())
+            .with_ansi(false)
+            .with_line_numbers(true)
+            .with_timer(MockTime);
+        let expected =
+            "fake time  INFO tracing_subscriber::fmt::format::test:NUMERIC: hello\n";
+
+        assert_info_hello_ignore_numeric(subscriber, make_writer, expected);
+    }
+
+    #[test]
     fn pretty_default() {
         let make_writer = MockMakeWriter::default();
         let subscriber = crate::fmt::Collector::builder()

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -328,6 +328,7 @@ pub struct Format<F = Full, T = SystemTime> {
     pub(crate) display_level: bool,
     pub(crate) display_thread_id: bool,
     pub(crate) display_thread_name: bool,
+    pub(crate) display_line_number: bool,
 }
 
 // === impl Writer ===
@@ -504,6 +505,7 @@ impl Default for Format<Full, SystemTime> {
             display_level: true,
             display_thread_id: false,
             display_thread_name: false,
+            display_line_number: false,
         }
     }
 }
@@ -522,6 +524,7 @@ impl<F, T> Format<F, T> {
             display_level: self.display_level,
             display_thread_id: self.display_thread_id,
             display_thread_name: self.display_thread_name,
+            display_line_number: self.display_line_number,
         }
     }
 
@@ -559,6 +562,7 @@ impl<F, T> Format<F, T> {
             display_level: self.display_level,
             display_thread_id: self.display_thread_id,
             display_thread_name: self.display_thread_name,
+            display_line_number: self.display_line_number,
         }
     }
 
@@ -589,6 +593,7 @@ impl<F, T> Format<F, T> {
             display_level: self.display_level,
             display_thread_id: self.display_thread_id,
             display_thread_name: self.display_thread_name,
+            display_line_number: self.display_line_number
         }
     }
 
@@ -616,6 +621,7 @@ impl<F, T> Format<F, T> {
             display_level: self.display_level,
             display_thread_id: self.display_thread_id,
             display_thread_name: self.display_thread_name,
+            display_line_number: self.display_line_number
         }
     }
 
@@ -630,6 +636,7 @@ impl<F, T> Format<F, T> {
             display_level: self.display_level,
             display_thread_id: self.display_thread_id,
             display_thread_name: self.display_thread_name,
+            display_line_number: self.display_line_number
         }
     }
 
@@ -645,6 +652,14 @@ impl<F, T> Format<F, T> {
     pub fn with_target(self, display_target: bool) -> Format<F, T> {
         Format {
             display_target,
+            ..self
+        }
+    }
+
+    /// Sets whether or not an event's level is displayed.
+    pub fn with_line_number(self, display_line_number: bool) -> Format<F, T> {
+        Format {
+            display_line_number,
             ..self
         }
     }
@@ -854,12 +869,25 @@ where
         }
 
         if self.display_target {
-            write!(
-                writer,
-                "{}{} ",
-                dimmed.paint(meta.target()),
-                dimmed.paint(":")
-            )?;
+            match meta.line() {
+                Some(line) if self.display_line_number => {
+                    write!(
+                        writer,
+                        "{}:{}{} ",
+                        dimmed.paint(meta.target()),
+                        line,
+                        dimmed.paint(":"),
+                    )?;
+                },
+                _ => {
+                    write!(
+                        writer,
+                        "{}{} ",
+                        dimmed.paint(meta.target()),
+                        dimmed.paint(":")
+                    )?;
+                }
+            }
         }
 
         ctx.format_fields(writer.by_ref(), event)?;
@@ -908,12 +936,25 @@ where
         }
 
         if self.display_target {
-            write!(
-                writer,
-                "{}{}",
-                writer.bold().paint(meta.target()),
-                writer.dimmed().paint(":")
-            )?;
+            match meta.line() {
+                Some(line) if self.display_line_number => {
+                    write!(
+                        writer,
+                        "{}:{}{} ",
+                        writer.bold().paint(meta.target()),
+                        line,
+                        writer.dimmed().paint(":")
+                    )?;
+                },
+                _ => {
+                    write!(
+                        writer,
+                        "{}{} ",
+                        writer.bold().paint(meta.target()),
+                        writer.dimmed().paint(":")
+                    )?;
+                }
+            }
         }
 
         ctx.format_fields(writer.by_ref(), event)?;

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -133,13 +133,27 @@ where
             } else {
                 style
             };
-            write!(
-                writer,
-                "{}{}{}: ",
-                target_style.prefix(),
-                meta.target(),
-                target_style.infix(style)
-            )?;
+            match meta.line() {
+                Some(line) if self.display_line_number => {
+                    write!(
+                        writer,
+                        "{}{}:{}{}: ",
+                        target_style.prefix(),
+                        meta.target(),
+                        line,
+                        target_style.infix(style)
+                    )?;
+                }
+                _ => {
+                    write!(
+                        writer,
+                        "{}{}{}: ",
+                        target_style.prefix(),
+                        meta.target(),
+                        target_style.infix(style)
+                    )?;
+                }
+            }
         }
         let mut v = PrettyVisitor::new(writer.by_ref(), true).with_style(style);
         event.record(&mut v);

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -765,6 +765,17 @@ where
         }
     }
 
+    /// Sets whether or not an event's level is displayed.
+    pub fn with_line_numbers(
+        self,
+        display_line_numbers: bool,
+    ) -> CollectorBuilder<N, format::Format<L, T>, F, W> {
+        CollectorBuilder {
+            inner: self.inner.with_line_numbers(display_line_numbers),
+            ..self
+        }
+    }
+
     /// Sets whether or not the [name] of the current thread is displayed
     /// when formatting events
     ///

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -768,10 +768,10 @@ where
     /// Sets whether or not an event's level is displayed.
     pub fn with_line_numbers(
         self,
-        display_line_numbers: bool,
+        display_line_number: bool,
     ) -> CollectorBuilder<N, format::Format<L, T>, F, W> {
         CollectorBuilder {
-            inner: self.inner.with_line_numbers(display_line_numbers),
+            inner: self.inner.with_line_numbers(display_line_number),
             ..self
         }
     }


### PR DESCRIPTION
## Motivation

We have been using `tracing` for logging. However, one if it's major drawbacks is inability to display line numbers.
When looking at logs I noticed that we spend a huge portion of log to display the target, but the line number is not included,
making the log somewhat useless.

I often use tracing for debugging, and I would prefer to have line numbers written. As a user of `log4j`. I know how important line numbers are while debugging issues. It allows to quickly jump to the right line number to see the code, which printed the error, rather than having to search for it. Sometimes, it's not possible to uniquely determine which line logged given message, unless the user specifies it.

## Solution

Add logging line numbers, for example:
```
2021-12-26T23:09:29.508100Z  INFO play_ground::anything:6: res=[1, 2, 4, 8, 16, 32]
2021-12-26T23:09:29.508135Z  INFO play_ground::anything:22: send=Err(Os { code: 89, kind: Uncategorized, message: "Destination address required" })
```

Previously, the message would be:
```
2021-12-26T23:09:29.508100Z  INFO play_ground::anything: res=[1, 2, 4, 8, 16, 32]
2021-12-26T23:09:29.508135Z  INFO play_ground::anything: send=Err(Os { code: 89, kind: Uncategorized, message: "Destination address required" })
```


Notes:
- `line_numbers` are only drawn when `display_target` is defined - can be extended to work without `display_target` - as a separate PR

Questions:
- added `with_line_numbers` test - what other tests do we need?
- should `pretty` still print `line_numbers` if this option is disabled?
