### PR TITLE
Avoid wildcard imports

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -591,7 +591,7 @@ macro_rules! event {
         );
 
         if $crate::level_enabled!($lvl) {
-            use $crate::__macro_support::*;
+            use $crate::__macro_support::Callsite as _;
             static CALLSITE: $crate::__macro_support::MacroCallsite = $crate::callsite2! {
                 name: concat!(
                     "event ",
@@ -638,7 +638,7 @@ macro_rules! event {
             $($fields)*
         );
         if $crate::level_enabled!($lvl) {
-            use $crate::__macro_support::*;
+            use $crate::__macro_support::Callsite as _;
             static CALLSITE: $crate::__macro_support::MacroCallsite = $crate::callsite2! {
                 name: concat!(
                     "event ",


### PR DESCRIPTION
## Motivation

The current implementation triggers [`clippy::wildcard_imports`](https://rust-lang.github.io/rust-clippy/master/#wildcard_imports) warning.

## Solution

Import items explicitly instead of using `*`.