### PR TITLE
docs: build Netlify docs with `--all-features`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   command = """
     rustup install nightly --profile minimal \
-      && cargo doc --no-deps
+      && cargo doc --no-deps --all-features
     """
   publish = "target/doc"
 


### PR DESCRIPTION
## Motivation

The docs.rs documentation is built with `--all-features` enabled.
However, the Netlify docs build does not enable default-off feature
flags. This means the docs may not match what's built on docs.rs, and in
some cases also results in docs build _failures_ when documentation
links to code that's behind an off-by-default feature flag.

## Solution

This commit changes the Netlify settings to enable all features.
