### PR TITLE
attributes: implement `#[instrument(tracing)]`

### DIFF
--- a/tracing-attributes/src/attr.rs
+++ b/tracing-attributes/src/attr.rs
@@ -29,27 +29,28 @@ impl InstrumentArgs {
             }
         }
 
+        let tracing = self.tracing();
         match &self.level {
             Some(Level::Str(ref lit)) if lit.value().eq_ignore_ascii_case("trace") => {
-                quote!(tracing::Level::TRACE)
+                quote!(#tracing::Level::TRACE)
             }
             Some(Level::Str(ref lit)) if lit.value().eq_ignore_ascii_case("debug") => {
-                quote!(tracing::Level::DEBUG)
+                quote!(#tracing::Level::DEBUG)
             }
             Some(Level::Str(ref lit)) if lit.value().eq_ignore_ascii_case("info") => {
-                quote!(tracing::Level::INFO)
+                quote!(#tracing::Level::INFO)
             }
             Some(Level::Str(ref lit)) if lit.value().eq_ignore_ascii_case("warn") => {
-                quote!(tracing::Level::WARN)
+                quote!(#tracing::Level::WARN)
             }
             Some(Level::Str(ref lit)) if lit.value().eq_ignore_ascii_case("error") => {
-                quote!(tracing::Level::ERROR)
+                quote!(#tracing::Level::ERROR)
             }
-            Some(Level::Int(ref lit)) if is_level(lit, 1) => quote!(tracing::Level::TRACE),
-            Some(Level::Int(ref lit)) if is_level(lit, 2) => quote!(tracing::Level::DEBUG),
-            Some(Level::Int(ref lit)) if is_level(lit, 3) => quote!(tracing::Level::INFO),
-            Some(Level::Int(ref lit)) if is_level(lit, 4) => quote!(tracing::Level::WARN),
-            Some(Level::Int(ref lit)) if is_level(lit, 5) => quote!(tracing::Level::ERROR),
+            Some(Level::Int(ref lit)) if is_level(lit, 1) => quote!(#tracing::Level::TRACE),
+            Some(Level::Int(ref lit)) if is_level(lit, 2) => quote!(#tracing::Level::DEBUG),
+            Some(Level::Int(ref lit)) if is_level(lit, 3) => quote!(#tracing::Level::INFO),
+            Some(Level::Int(ref lit)) if is_level(lit, 4) => quote!(#tracing::Level::WARN),
+            Some(Level::Int(ref lit)) if is_level(lit, 5) => quote!(#tracing::Level::ERROR),
             Some(Level::Path(ref pat)) => quote!(#pat),
             Some(_) => quote! {
                 compile_error!(
@@ -57,7 +58,7 @@ impl InstrumentArgs {
                      \"debug\", \"info\", \"warn\", or \"error\", or a number 1-5"
                 )
             },
-            None => quote!(tracing::Level::INFO),
+            None => quote!(#tracing::Level::INFO),
         }
     }
 
@@ -333,7 +334,8 @@ impl ToTokens for Field {
             // `instrument` produce empty field values, so changing it now
             // is a breaking change. agh.
             let name = &self.name;
-            tokens.extend(quote!(#name = tracing::field::Empty))
+            let tracing = todo!();
+            tokens.extend(quote!(#name = #tracing::field::Empty))
         } else {
             self.kind.to_tokens(tokens);
             self.name.to_tokens(tokens);


### PR DESCRIPTION
This adds an optional `tracing = Expr` parameter to the `#[instrument]` attribute, which can be used to override where the generated code looks for the `tracing` crate. This defaults to just `quote!(tracing)`, as before.

Closes #1818.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Please see the linked issue for details.

In short, this change makes `#[instrument]` more useful in proc macros (①¹) where `tracing` is available as optional dependency of the proc macro's library's main crate (②). With the override, ② can re-export `tracing` for use in ①'s output, which means library crates using ① via ② don't have to include `tracing` as optional dependency/feature.

¹ Sorry if this is odd. English isn't my first language and it's sometimes hard to use it unambiguously.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I tried to stay close to the style of the existing code.

So far, I've

- added the new parameter,
- defaulted it like `target`,
- updated the quotes to replace `tracing` with `#tracing`
  (and added the required `let tracing = args.tracing();` lookup where possible).

To do:

- add the last `args.tracing()` lookup,
- write tests: (I think these cover all relevant code paths.)
  - plain,
  - async,
  - each level,
  - a quoted field through `tracing::field::debug`,
  - format modes (default, `Debug`, `Display`) and
  - a custom field without value
- write documentation.

- - -

It's getting late here and I have a question regarding an implementation detail (I'll comment about that in a moment), so I'm making a draft PR for now.