### PR TITLE
journald: Set syslog identifier

### DIFF
--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -84,6 +84,7 @@ pub struct Subscriber {
     #[cfg(unix)]
     socket: UnixDatagram,
     field_prefix: Option<String>,
+    syslog_identifier: String,
 }
 
 #[cfg(unix)]
@@ -101,6 +102,13 @@ impl Subscriber {
             let sub = Self {
                 socket,
                 field_prefix: Some("F".into()),
+                syslog_identifier: std::env::current_exe()
+                    .ok()
+                    .as_ref()
+                    .and_then(|p| p.file_name())
+                    .map(|n| n.to_string_lossy().into_owned())
+                    // If we fail to get the name of the current executable fall back to an empty string.
+                    .unwrap_or_else(String::new),
             };
             // Check that we can talk to journald, by sending empty payload which journald discards.
             // However if the socket didn't exist or if none listened we'd get an error here.
@@ -119,6 +127,32 @@ impl Subscriber {
     pub fn with_field_prefix(mut self, x: Option<String>) -> Self {
         self.field_prefix = x;
         self
+    }
+
+    /// Sets the syslog identifier for this logger.
+    ///
+    /// The syslog identifier comes from the classic syslog interface (`openlog()`
+    /// and `syslog()`) and tags log entries with a given identifier.
+    /// Systemd exposes it in the `SYSLOG_IDENTIFIER` journal field, and allows
+    /// filtering log messages by syslog identifier with `journalctl -t`.
+    /// Unlike the unit (`journalctl -u`) this field is not trusted, i.e. applications
+    /// can set it freely, and use it e.g. to further categorize log entries emitted under
+    /// the same systemd unit or in the same process.  It also allows to filter for log
+    /// entries of processes not started in their own unit.
+    ///
+    /// See [Journal Fields](https://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html)
+    /// and [journalctl](https://www.freedesktop.org/software/systemd/man/journalctl.html)
+    /// for more information.
+    ///
+    /// Defaults to the file name of the executable of the current process, if any.
+    pub fn with_syslog_identifier(mut self, identifier: String) -> Self {
+        self.syslog_identifier = identifier;
+        self
+    }
+
+    /// Get the syslog identifier in use.
+    pub fn syslog_identifier(&self) -> &str {
+        &self.syslog_identifier
     }
 
     #[cfg(not(unix))]
@@ -224,6 +258,10 @@ where
 
         // Record event fields
         put_metadata(&mut buf, event.metadata(), None);
+        put_field_length_encoded(&mut buf, "SYSLOG_IDENTIFIER", |buf| {
+            write!(buf, "{}", self.syslog_identifier).unwrap()
+        });
+
         event.record(&mut EventVisitor::new(
             &mut buf,
             self.field_prefix.as_ref().map(|x| &x[..]),

--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -150,7 +150,7 @@ impl Subscriber {
         self
     }
 
-    /// Get the syslog identifier in use.
+    /// Returns the syslog identifier in use.
     pub fn syslog_identifier(&self) -> &str {
         &self.syslog_identifier
     }


### PR DESCRIPTION
Set the `SYSLOG_IDENTIFIER` field on all events.  I noticed that the subscriber didn't do this so far.

## Motivation

The identifier is used with `journalctl -t`, and while it's normally better to filter by unit with `journalctl -u` the identifier is still nice for processes that are not started through systemd units.

Upstream does this as well, see [https://github.com/systemd/systemd/blob/81218ac1e14b4b50b4337938bcf55cacc76f0728/src/libsystemd/sd-journal/journal-send.c#L270]:

![grafik](https://user-images.githubusercontent.com/224922/148660479-9525b21e-547f-4787-9bb7-db933963041a.png)

`program_invocation_short_name` is a glibc variable which holds the file name of the current executable; I tried to replicate this behaviour in Rust.

## Solution

Add a syslog identifier field to the subscriber, defaulting to the filename of the current executable, and write this value as SYSLOG_IDENTIFIER with every event.  It's not written for spans, because it's a global value and inevitably the same for each span.