### PR TITLE
subscriber: fix broken docs links

### DIFF
--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -441,7 +441,7 @@ pub struct CollectorBuilder<
 /// ```
 ///
 /// [formatting collector]: Collector
-/// [`CollectorBuilder::default()`]: CollectorBuilder::default()
+/// [`CollectorBuilder::default()`]: struct.CollectorBuilder.html#method.default
 /// [`init`]: CollectorBuilder::init()
 /// [`try_init`]: CollectorBuilder::try_init()
 /// [`finish`]: CollectorBuilder::finish()
@@ -453,10 +453,11 @@ pub fn fmt() -> CollectorBuilder {
 /// Returns a new [formatting subscriber] that can be [composed] with other subscribers to
 /// construct a collector.
 ///
-/// This is a shorthand for the equivalent [`Subscriber::default`] function.
+/// This is a shorthand for the equivalent [`Subscriber::default()`] function.
 ///
 /// [formatting subscriber]: Subscriber
 /// [composed]: super::subscribe
+/// [`Subscriber::default()`]: struct.Subscriber.html#method.default
 #[cfg_attr(docsrs, doc(cfg(all(feature = "fmt", feature = "std"))))]
 pub fn subscriber<C>() -> Subscriber<C> {
     Subscriber::default()

--- a/tracing-subscriber/src/subscribe.rs
+++ b/tracing-subscriber/src/subscribe.rs
@@ -1055,7 +1055,7 @@ where
     ///
     /// [register]: tracing_core::collect::Collect::register_callsite()
     /// [`enabled`]: tracing_core::collect::Collect::enabled()
-    /// [`Context::enabled`]: Layered::enabled()
+    /// [`Context::enabled`]: <Layered as Subscribe>::enabled()
     #[inline]
     pub fn event(&self, event: &Event<'_>) {
         if let Some(collector) = self.collector {


### PR DESCRIPTION
Apparently the links to the `Default::default()` methods didn't actually
work! Or, maybe they did work, but they don't on the latest nightly?

Regardless, this fixes them (as well as the RustDoc errors).

Should fix CI.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>