### PR TITLE
flame: remove hard coded version on `docs-url`

### DIFF
--- a/tracing-flame/README.md
+++ b/tracing-flame/README.md
@@ -136,7 +136,7 @@ terms or conditions.
 [crates-badge]: https://img.shields.io/crates/v/tracing-flame.svg
 [crates-url]: https://crates.io/crates/tracing-flame
 [docs-badge]: https://docs.rs/tracing-flame/badge.svg
-[docs-url]: https://docs.rs/tracing-flame/0.2.6
+[docs-url]: https://docs.rs/tracing-flame
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_flame
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg


### PR DESCRIPTION
Remove hard coded version on `docs-url` as it isn't needed and is out of date.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

Currently clicking on the documentation link/badge 404s which is not ideal.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Remove the hard coded version from the URL as it is not required and will now resolve to the latest version's documentation.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
