### PR TITLE
docs: don't state that `tracing-futures` is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,9 +209,6 @@ async fn write(stream: &mut TcpStream) -> io::Result<usize> {
 }
 ```
 
-The [`tracing-futures`] crate must be specified as a dependency to enable
-`async` support.
-
 Special handling is needed for the general case of code using
 [`std::future::Future`][std-future] or blocks with `async`/`await`, as the
 following example _will not_ work:
@@ -250,10 +247,9 @@ Under the hood, the [`#[instrument]`][instrument] macro performs same the explic
 attachment that `Future::instrument` does.
 
 [std-future]: https://doc.rust-lang.org/stable/std/future/trait.Future.html
-[`tracing-futures`]: https://docs.rs/tracing-futures
 [closing]: https://docs.rs/tracing/latest/tracing/span/index.html#closing-spans
 [`Future::instrument`]: https://docs.rs/tracing/latest/tracing/trait.Instrument.html#method.instrument
-[instrument]: https://docs.rs/tracing/0.1.11/tracing/attr.instrument.html
+[instrument]: https://docs.rs/tracing/latest/tracing/attr.instrument.html
 
 ## Supported Rust Versions
 

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -210,9 +210,8 @@ conflicts when executables try to set the default later.
 
 If you are instrumenting code that make use of
 [`std::future::Future`](https://doc.rust-lang.org/stable/std/future/trait.Future.html)
-or async/await, be sure to use the
-[`tracing-futures`](https://docs.rs/tracing-futures) crate. This is needed
-because the following example _will not_ work:
+or async/await, avoid using the `Span::enter` method. The following example
+_will not_ work:
 
 ```rust
 async {


### PR DESCRIPTION
Currently, the documentation states in a few places that the
`tracing-futures` crate is required for asynchronous code to use
`tracing`. This is no longer the case, as `tracing` provides the
`Instrument` combinator for futures; `tracing-futures` is only needed
for things defined in the `futures` crate, such as `Stream` and `Sink`.

This branch updates the documentation so that it doesn't incorrectly
state that `tracing-futures` is required.
