### PR TITLE
subscriber: fix leading comma with `Pretty` formatter

### DIFF
--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -227,7 +227,7 @@ where
 
 impl<'writer> FormatFields<'writer> for Pretty {
     fn format_fields<R: RecordFields>(&self, writer: Writer<'writer>, fields: R) -> fmt::Result {
-        let mut v = PrettyVisitor::new(writer, false);
+        let mut v = PrettyVisitor::new(writer, true);
         fields.record(&mut v);
         v.finish()
     }


### PR DESCRIPTION
## Motivation

PR #1661 introduced a regression with the `Pretty` formatter: the
`PrettyVisitor` type was [accidentally changed][1] from being
constructed with `is_empty: true` to being constructed with 
`is_empty: false` This means that when visiting a set of span fields,
we emit a leading `, ` _before_ the first field, which looks quite bad.

## Solution

This branch changes it back, and now the output looks nice again. :)

### Before

```
  2022-01-13T17:09:04.772411Z TRACE fmt_pretty::yak_shave: hello! I'm gonna shave a yak, excitement: "yay!"
    at examples/examples/fmt/yak_shave.rs:16 on main
    in fmt_pretty::yak_shave::shave with , yak: 2
    in fmt_pretty::yak_shave::shaving_yaks with , yaks: 3
```

### After

```
  2022-01-13T17:10:28.472525Z TRACE fmt_pretty::yak_shave: hello! I'm gonna shave a yak, excitement: "yay!"
    at examples/examples/fmt/yak_shave.rs:16 on main
    in fmt_pretty::yak_shave::shave with yak: 1
    in fmt_pretty::yak_shave::shaving_yaks with yaks: 3,
```

Fixes: #1832

[1]: https://github.com/tokio-rs/tracing/commit/937c5d7cf08f5829651e3e9f99227c92e159fa82#diff-a27a4c3564a0c2f1b7af32be0f9eec25ddfbe8b4c2be8d74e84d874b919b393bR227