### PR TITLE
journald: prepare to release 0.2.2

### DIFF
--- a/tracing-journald/CHANGELOG.md
+++ b/tracing-journald/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.2.2 (January 14, 2022)
+### Added
+
+- Include a syslog identifier in log messages ([#1822])
+- Added `Layer::with_syslog_identifier` method to override the syslog identifier
+  ([#1822])
+
+Thanks to @lunaryorn for contributing to this release!
+
+[#1822]: https://github.com/tokio-rs/tracing/pull/1822
+
 # 0.2.1 (December 29, 2021)
 
 This release improves how `tracing-journald` communicates with `journald`,

--- a/tracing-journald/Cargo.toml
+++ b/tracing-journald/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-journald"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -10,7 +10,7 @@
 //! [`tracing-subscriber::Layer`][layer] implementation for logging `tracing` spans
 //! and events to [`systemd-journald`][journald], on Linux distributions that
 //! use `systemd`.
-//!  
+//!
 //! *Compiler support: [requires `rustc` 1.42+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions


### PR DESCRIPTION
# 0.2.2 (January 14, 2022)

### Added

- Include a syslog identifier in log messages ([#1822])
- Added `Layer::with_syslog_identifier` method to override the syslog
  identifier ([#1822])

Thanks to @lunaryorn for contributing to this release!

[#1822]: https://github.com/tokio-rs/tracing/pull/1822