### PR TITLE
subscriber: prepare to release 0.3.6

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,29 @@
+# 0.3.6 (Jan 14, 2022)
+
+This release adds configuration options to `tracing_subscriber::fmt` to log
+source code locations for events.
+### Added
+
+- **fmt**: Added `with_file` and `with_line_number`
+  configuration methods to `fmt::Format`, `fmt::SubscriberBuilder`, and
+  `fmt::Layer` ([#1773])
+
+### Fixed
+
+- **fmt**: Removed incorrect leading comma from span fields with the `Pretty`
+  formatter ([#1833])
+
+### Deprecated
+
+- **fmt**: Deprecated `Pretty::with_source_location`, as it can now be replaced
+  by the more general `Format`, `SubscriberBuilder`, and `Layer` methods
+  ([#1773])
+
+Thanks to new contributor @renecouto for contributing to this release!
+
+[#1773]: https://github.com/tokio-rs/tracing/pull/1773
+[#1833]: https://github.com/tokio-rs/tracing/pull/1833
+
 # 0.3.5 (Dec 29, 2021)
 
 This release re-enables `RUST_LOG` filtering in `tracing_subscriber::fmt`'s

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.3.5"
+version = "0.3.6"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -21,7 +21,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.3.5
+[docs-url]: https://docs.rs/tracing-subscriber/0.3.6
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -126,7 +126,7 @@
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`time` crate]: https://crates.io/crates/time
 //! [`liballoc`]: https://doc.rust-lang.org/alloc/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.3.5")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.3.6")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.3.6 (Jan 14, 2022)

This release adds configuration options to `tracing_subscriber::fmt` to
log source code locations for events.
### Added

- **fmt**: Added `with_file` and `with_line_number` configuration
  methods to `fmt::Format`, `fmt::SubscriberBuilder`, and `fmt::Layer`
  ([#1773])

### Fixed

- **fmt**: Removed incorrect leading comma from span fields with the
  `Pretty` formatter ([#1833])

### Deprecated

- **fmt**: Deprecated `Pretty::with_source_location`, as it can now be
  replaced by the more general `Format`, `SubscriberBuilder`, and
  `Layer` methods ([#1773])

Thanks to new contributor @renecouto for contributing to this release!

[#1773]: https://github.com/tokio-rs/tracing/pull/1773
[#1833]: https://github.com/tokio-rs/tracing/pull/1833