### PR TITLE
subscriber: re-export prelude traits `as _`

### DIFF
--- a/tracing-subscriber/src/prelude.rs
+++ b/tracing-subscriber/src/prelude.rs
@@ -3,14 +3,8 @@
 //! This brings into scope a number of extension traits that define methods on
 //! types defined here and in other crates.
 
-pub use crate::field::{
-    MakeExt as __tracing_subscriber_field_MakeExt,
-    RecordFields as __tracing_subscriber_field_RecordFields,
-};
-pub use crate::layer::{
-    Layer as __tracing_subscriber_Layer, SubscriberExt as __tracing_subscriber_SubscriberExt,
-};
-
+pub use crate::field::{MakeExt as _, RecordFields as _};
+pub use crate::layer::{Layer as _, SubscriberExt as _};
 pub use crate::util::SubscriberInitExt as _;
 
 feature! {


### PR DESCRIPTION
Currently, the `tracing-subscriber` prelude re-exports some traits as
`__tracing_subscriber_<TRAIT NAME>` to avoid namespace conflicts. This
is because those traits were added to the prelude before `use Trait as
_` was available in stable Rust. In some cases, this can apparently
result in weird error messages (see #1847).

This commit changes the prelude to re-export everything `as _`. In
theory, this is _technically_ a breaking change in case anyone is
actually referring to traits as the re-exported names in the prelude.
However, I don't think it's likely that anyone's actually doing this,
and they shouldn't be considered stable API, so I don't think this needs
to wait for a breaking release. If anyone disagrees, I'm open to being
convinced otherwise.

Fixes #1847