### PR TITLE
appender: bump MSRV to 1.53.0

### DIFF
--- a/.github/workflows/check_msrv.yml
+++ b/.github/workflows/check_msrv.yml
@@ -53,7 +53,7 @@ jobs:
     - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.51.0
+        toolchain: 1.53.0
         profile: minimal
         override: true
     - name: Check

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -18,7 +18,7 @@ categories = [
 ]
 keywords = ["logging", "tracing", "file-appender", "non-blocking-writer"]
 edition = "2018"
-rust-version = "1.51.0"
+rust-version = "1.53.0"
 
 [dependencies]
 crossbeam-channel = "0.5.0"

--- a/tracing-appender/README.md
+++ b/tracing-appender/README.md
@@ -36,7 +36,7 @@ allows events and spans to be recorded in a non-blocking manner through a
 dedicated logging thread. It also provides a [`RollingFileAppender`][file_appender] 
 that can be used with _or_ without the non-blocking writer.
 
-*Compiler support: [requires `rustc` 1.51+][msrv]*
+*Compiler support: [requires `rustc` 1.53+][msrv]*
 
 [msrv]: #supported-rust-versions
 
@@ -146,7 +146,7 @@ fn main() {
 ## Supported Rust Versions
 
 `tracing-appender` is built against the latest stable release. The minimum supported
-version is 1.51. The current `tracing-appender` version is not guaranteed to build on
+version is 1.53. The current `tracing-appender` version is not guaranteed to build on
 Rust versions earlier than the minimum supported version.
 
 Tracing follows the same compiler support policies as the rest of the Tokio


### PR DESCRIPTION
The `time` crate bumped its MSRV to 1.53.0 in v0.3.6:
https://github.com/time-rs/time/commit/2d37c01aff74bdccb8c537afa6bc7ce4f028048d

Since `tracing-appender` has a non-optional dependency on `time`, it's
necessary to increase its MSRV to track this.