### PR TITLE
subscriber: update thread_local to 1.1.4

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -61,7 +61,7 @@ parking_lot = { version = ">= 0.7, <= 0.12", optional = true }
 
 # registry
 sharded-slab = { version = "0.1.0", optional = true }
-thread_local = { version = "1.0.1", optional = true }
+thread_local = { version = "1.1.4", optional = true }
 
 [dev-dependencies]
 tracing = { path = "../tracing", version = "0.2" }


### PR DESCRIPTION
Fixes https://rustsec.org/advisories/RUSTSEC-2022-0006.

## Motivation

`cargo audit` prevents us using `tracing-subscriber` at the moment. Upgrading `thread_local` to 1.1.4 would fix that.

## Solution

Upgrade `thread_local`.
