### PR TITLE
subscriber: prepare to release v0.3.7

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 0.3.7 (Jan 25, 2022)
+
+This release adds combinators for combining filters.
+
+Additionally, this release also updates the `thread-local` crate to v1.1.4,
+fixing warnings for the security advisory [RUSTSEC-2022-0006]. Note that
+previous versions of `tracing-subscriber` did not use any of the `thread-local`
+crate's APIs effected by the vulnerability. However, updating the version fixes
+warnings emitted by `cargo audit` and similar tools.
+
+### Added
+
+- **filter**: Added combinators for combining filters ([#1578])
+
+### Fixed
+
+- **registry**: Updated `thread-local` to v1.1.4 ([#1858])
+
+Thanks to new contributor @matze for contributing to this release!
+
+[RUSTSEC-2022-0006]: https://rustsec.org/advisories/RUSTSEC-2022-0006
+[#1578]: https://github.com/tokio-rs/tracing/pull/1578
+[#1858]: https://github.com/tokio-rs/tracing/pull/1858
+
 # 0.3.6 (Jan 14, 2022)
 
 This release adds configuration options to `tracing_subscriber::fmt` to log

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.3.6"
+version = "0.3.7"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -21,7 +21,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.3.6
+[docs-url]: https://docs.rs/tracing-subscriber/0.3.7
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -126,7 +126,7 @@
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`time` crate]: https://crates.io/crates/time
 //! [`liballoc`]: https://doc.rust-lang.org/alloc/index.html
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.3.6")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.3.7")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.3.7 (Jan 25, 2022)

This release adds combinators for combining filters.

Additionally, this release also updates the `thread-local` crate to
v1.1.4, fixing warnings for the security advisory [RUSTSEC-2022-0006].
Note that previous versions of `tracing-subscriber` did not use any of
the `thread-local` crate's APIs effected by the vulnerability. However,
updating the version fixes warnings emitted by `cargo audit` and similar
tools.

### Added

- **filter**: Added combinators for combining filters ([#1578])

### Fixed

- **registry**: Updated `thread-local` to v1.1.4 ([#1858])

Thanks to new contributor @matze for contributing to this release!

[RUSTSEC-2022-0006]: https://rustsec.org/advisories/RUSTSEC-2022-0006
[#1578]: https://github.com/tokio-rs/tracing/pull/1578
[#1858]: https://github.com/tokio-rs/tracing/pull/1858