### PR TITLE
Trial integrating spantrace extraction with tracing-subscriber via generic member access

### DIFF
--- a/examples/examples/fmt-error-chain.rs
+++ b/examples/examples/fmt-error-chain.rs
@@ -1,0 +1,133 @@
+//! This example demonstrates using the `tracing-error` crate's `SpanTrace` type
+//! to attach a trace context to a custom error type.
+#![deny(rust_2018_idioms)]
+#![feature(provide_any)]
+use std::any::Requisition;
+use std::fmt;
+use std::{error::Error, path::Path};
+use tracing::{error, info};
+use tracing_error::{ErrorSubscriber, SpanTrace};
+use tracing_subscriber::prelude::*;
+
+#[derive(Debug)]
+struct FileError {
+    context: SpanTrace,
+}
+
+impl FileError {
+    fn new() -> Self {
+        Self {
+            context: SpanTrace::capture(),
+        }
+    }
+}
+
+impl Error for FileError {
+    fn provide<'a>(&'a self, mut req: Requisition<'a, '_>) {
+        req.provide_ref(&self.context)
+           .provide_ref::<tracing::Span>(self.context.as_ref());
+    }
+}
+
+impl fmt::Display for FileError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("file does not exist")
+    }
+}
+
+#[tracing::instrument]
+fn read_file(path: &Path) -> Result<String, FileError> {
+    Err(FileError::new())
+}
+
+#[derive(Debug)]
+struct ConfigError {
+    source: FileError,
+}
+
+impl From<FileError> for ConfigError {
+    fn from(source: FileError) -> Self {
+        Self { source }
+    }
+}
+
+impl Error for ConfigError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("config file cannot be loaded")
+    }
+}
+
+#[tracing::instrument]
+fn load_config() -> Result<String, ConfigError> {
+    let path = Path::new("my_config");
+    let config = read_file(&path)?;
+    Ok(config)
+}
+
+struct App {
+    // Imagine this is actually something we deserialize with serde
+    config: String,
+}
+
+impl App {
+    fn run() -> Result<(), AppError> {
+        let this = Self::init()?;
+        this.start()
+    }
+
+    fn init() -> Result<Self, ConfigError> {
+        let config = load_config()?;
+        Ok(Self { config })
+    }
+
+    fn start(&self) -> Result<(), AppError> {
+        // Pretend our actual application logic all exists here
+        info!("Loaded config: {}", self.config);
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct AppError {
+    source: ConfigError,
+}
+
+impl From<ConfigError> for AppError {
+    fn from(source: ConfigError) -> Self {
+        Self { source }
+    }
+}
+
+impl Error for AppError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+impl fmt::Display for AppError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("config invalid")
+    }
+}
+
+#[tracing::instrument]
+fn main() {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::subscriber())
+        // The `ErrorSubscriber` subscriber layer enables the use of `SpanTrace`.
+        .with(ErrorSubscriber::default())
+        .init();
+
+    if let Err(e) = App::run() {
+        error!(
+            error = &e as &(dyn Error + 'static),
+            "App exited unsuccessfully"
+        );
+    }
+}

--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -147,6 +147,12 @@ impl SpanTrace {
     }
 }
 
+impl AsRef<Span> for SpanTrace {
+    fn as_ref(&self) -> &Span {
+        &self.span
+    }
+}
+
 /// The current status of a SpanTrace, indicating whether it was captured or
 /// whether it is empty for some other reason.
 #[derive(Debug, PartialEq, Eq)]

--- a/tracing-error/src/subscriber.rs
+++ b/tracing-error/src/subscriber.rs
@@ -58,16 +58,6 @@ where
             span.extensions_mut().insert(fields);
         }
     }
-
-    unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
-        match id {
-            id if id == TypeId::of::<Self>() => Some(NonNull::from(self).cast()),
-            id if id == TypeId::of::<WithContext>() => {
-                Some(NonNull::from(&self.get_context).cast())
-            }
-            _ => None,
-        }
-    }
 }
 
 impl<C, F> ErrorSubscriber<C, F>

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -138,6 +138,8 @@
 // "needless".
 #![allow(clippy::needless_update)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![feature(error_in_core)]
+#![feature(error_iter)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
## Motivation

I'd like to be able to log errors that have captured a `SpanTrace` to gather context on the state of the world when the error was constructed. Right now this is possible but the only way to get this spantrace info back into tracing logs is to either include the info in your error message's display output or separately extract and log the spantrace in the tracing event alongside the error. I feel that the first option ends up looking bad, and the second option is error prone / easy to forget. I'd like to make this automatic in a way that formats well.

## Solution

This PR uses generic member access to request an arbitrary type through a `&dyn Error` trait object. For now I'm only printing a `Span` because `SpanTrace` is defined in a downstream crate and would have to be moved into `tracing-subscriber` to name it directly since `tracing-error` depends on `tracing-subscriber`.

This PR only compiles when using a custom rustc toolchain based on https://github.com/rust-lang/rust/pull/90328