### PR TITLE
Add sentry-tracing to README/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ are not maintained by the `tokio` project. These include:
   applications.
 - [`tracing-elastic-apm`] provides a layer for reporting traces to [Elastic APM].
 - [`tracing-etw`] provides a layer for emitting Windows [ETW] events.
+- [`sentry-tracing`] provides a layer for reporting events and traces to [Sentry].
 
 (if you're the maintainer of a `tracing` ecosystem crate not in this list,
 please let us know!)
@@ -432,6 +433,8 @@ please let us know!)
 [Elastic APM]: https://www.elastic.co/apm
 [`tracing-etw`]: https://github.com/microsoft/tracing-etw
 [ETW]: https://docs.microsoft.com/en-us/windows/win32/etw/about-event-tracing
+[`sentry-tracing`]: https://crates.io/crates/sentry-tracing
+[Sentry]: https://sentry.io/welcome/
 
 **Note:** that some of the ecosystem crates are currently unreleased and
 undergoing active development. They may be less stable than `tracing` and

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -375,6 +375,7 @@ maintained by the `tokio` project. These include:
 - [`tracing-etw`] provides a layer for emitting Windows [ETW] events.
 - [`tracing-fluent-assertions`] provides a fluent assertions-style testing
   framework for validating the behavior of `tracing` spans.
+- [`sentry-tracing`] provides a layer for reporting events and traces to [Sentry].
 
 If you're the maintainer of a `tracing` ecosystem crate not listed above,
 please let us know! We'd love to add your project to the list!
@@ -400,6 +401,8 @@ please let us know! We'd love to add your project to the list!
 [`tracing-etw`]: https://github.com/microsoft/tracing-etw
 [ETW]: https://docs.microsoft.com/en-us/windows/win32/etw/about-event-tracing
 [`tracing-fluent-assertions`]: https://crates.io/crates/tracing-fluent-assertions
+[`sentry-tracing`]: https://crates.io/crates/sentry-tracing
+[Sentry]: https://sentry.io/welcome/
 
 **Note:** that some of the ecosystem crates are currently unreleased and
 undergoing active development. They may be less stable than `tracing` and

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -802,6 +802,7 @@
 //!  - [`tracing-etw`] provides a layer for emitting Windows [ETW] events.
 //!  - [`tracing-fluent-assertions`] provides a fluent assertions-style testing
 //!    framework for validating the behavior of `tracing` spans.
+//!  - [`sentry-tracing`] provides a layer for reporting events and traces to [Sentry].
 //!
 //! If you're the maintainer of a `tracing` ecosystem crate not listed above,
 //! please let us know! We'd love to add your project to the list!
@@ -833,6 +834,8 @@
 //! [`tracing-etw`]: https://github.com/microsoft/tracing-etw
 //! [ETW]: https://docs.microsoft.com/en-us/windows/win32/etw/about-event-tracing
 //! [`tracing-fluent-assertions`]: https://crates.io/crates/tracing-fluent-assertions
+//! [`sentry-tracing`]: https://crates.io/crates/sentry-tracing
+//! [Sentry]: https://sentry.io/welcome/
 //!
 //! <div class="example-wrap" style="display:inline-block">
 //! <pre class="ignore" style="white-space:normal;font:inherit;">


### PR DESCRIPTION
## Motivation

We recently released a new version of the Rust SDK which has integration for `tracing`! 🎉