### PR TITLE
Fix typo in "ultimate question" example snippet

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -415,7 +415,7 @@
 //! ```
 //! # use tracing::{event, Level};
 //! # fn main() {
-//! let question = "the answer to the ultimate question of life, the universe, and everything";
+//! let question = "the ultimate question of life, the universe, and everything";
 //! let answer = 42;
 //! // records an event with the following fields:
 //! // - `question.answer` with the value 42,


### PR DESCRIPTION
Since the formatting string is `"the answer to {} is {}.", question, answer`,
the value of `question` should be `"the ultimate question"`, not `"the answer to..."`.