### PR TITLE
core: take `valuable` `Value`s by value

### DIFF
--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -189,7 +189,7 @@ pub trait Visit {
     /// [`valuable`]: https://docs.rs/valuable
     #[cfg(all(tracing_unstable, feature = "valuable"))]
     #[cfg_attr(docsrs, doc(cfg(all(tracing_unstable, feature = "valuable"))))]
-    fn record_value(&mut self, field: &Field, value: &valuable::Value<'_>) {
+    fn record_value(&mut self, field: &Field, value: valuable::Value<'_>) {
         self.record_debug(field, &value)
     }
 


### PR DESCRIPTION
In #1881, I accidentally had the `Visit` trait take a `&Value<'_>`. This
was probably wrong, since `Value` is `Copy` and should only be a couple
words, one of which might be a pointer...so it's probably better to just
pass the `pointer + enum descriminant` (or `integer + enum descriminant`)
instead of passing `pointer to (pointer + enum descriminant)`.

This probably also makes the API a little nicer.