### PR TITLE
subscriber: set smallvec minimum version to 1.2.0

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -43,7 +43,7 @@ tracing-core = { path = "../tracing-core", version = "0.1.20" }
 tracing = { optional = true, path = "../tracing", version = "0.1", default-features = false }
 matchers = { optional = true, version = "0.1.0" }
 regex = { optional = true, version = "1", default-features = false, features = ["std"] }
-smallvec = { optional = true, version = "1" }
+smallvec = { optional = true, version = "1.2.0" }
 lazy_static = { optional = true, version = "1" }
 
 # fmt


### PR DESCRIPTION
tracing-subscriber depends on smallvec version `1`. When using minimal versions this resolves to version `1.0.0`. However, tracing-subscriber does not compile with smallvec 1.0.0. Instead, the actual minimum working version is `1.2.0`.

You can verify this by creating an app with `cargo new` that depends on tracing-subscriber, then set the versions to the minimum versions with command `cargo +nightly update -Z minimal-versions`. The app fails to compile.

## Motivation

tracing-subscriber declares a dependency on smallvec version `1`, which is incorrect. The minimum version is `1.2.0` (or `1.2`).

Because of this, some apps depending on tracing-subscriber cannot be built or tested when using minimal dependency versions.

## Solution

Set smallvec dependency version to `1.2.0`.