### PR TITLE
ci: add `tracing_unstable` to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -253,6 +253,26 @@ jobs:
         command: test
         args: --all
 
+  test-unstable:
+    # Test the `tracing-unstable` cfg flags
+    env:
+      RUSTFLAGS: "--cfg tracing_unstable"
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@main
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+    - name: Run tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --all --all-features
+
+
   features-stable:
     # Feature flag tests that run on stable Rust.
     # TODO(david): once tracing's MSRV goes up to Rust 1.51, we should be able to switch to 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -274,13 +274,6 @@ jobs:
     # Test the `tracing-unstable` cfg flags
     env:
       RUSTFLAGS: "--cfg tracing_unstable"
-    strategy:
-      matrix:
-        subcrate:
-        - tracing-core
-        - tracing
-        - tracing-serde
-        - tracing-subscriber
     needs: check
     runs-on: ubuntu-latest
     steps:
@@ -294,7 +287,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: -p ${{ matrix.subcrate }} --features "valuable"
+        args: --all --features "valuable"
 
 
   features-stable:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -274,6 +274,13 @@ jobs:
     # Test the `tracing-unstable` cfg flags
     env:
       RUSTFLAGS: "--cfg tracing_unstable"
+    strategy:
+      matrix:
+        subcrate:
+        - tracing-core
+        - tracing
+        - tracing-serde
+        - tracing-subscriber
     needs: check
     runs-on: ubuntu-latest
     steps:
@@ -287,7 +294,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --all --all-features
+        args: -p ${{ matrix.subcrate }} --features "valuable"
 
 
   features-stable:

--- a/examples/examples/valuable_instrument.rs
+++ b/examples/examples/valuable_instrument.rs
@@ -2,7 +2,7 @@
 mod app {
     use std::collections::HashMap;
     use tracing::field::valuable;
-    use tracing::{info, info_span, instrument};
+    use tracing::{info, instrument};
     use valuable::Valuable;
 
     #[derive(Valuable)]

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -643,7 +643,7 @@ impl crate::sealed::Sealed for valuable::Value<'_> {}
 #[cfg_attr(docsrs, doc(cfg(all(tracing_unstable, feature = "valuable"))))]
 impl Value for valuable::Value<'_> {
     fn record(&self, key: &Field, visitor: &mut dyn Visit) {
-        visitor.record_value(key, self)
+        visitor.record_value(key, *self)
     }
 }
 
@@ -654,7 +654,7 @@ impl crate::sealed::Sealed for &'_ dyn valuable::Valuable {}
 #[cfg_attr(docsrs, doc(cfg(all(tracing_unstable, feature = "valuable"))))]
 impl Value for &'_ dyn valuable::Valuable {
     fn record(&self, key: &Field, visitor: &mut dyn Visit) {
-        visitor.record_value(key, &self.as_value())
+        visitor.record_value(key, self.as_value())
     }
 }
 


### PR DESCRIPTION
Currently, the `valuable` support requires the `tracing_unstable` cfg to
be set. Because none of our current CI jobs set this, we aren't
currently testing that code, and have no way of even ensuring that it
compiles. This is Bad.

This PR adds a CI job to run tests with the unstable cfg enabled.