### PR TITLE
attributes: prepare to release 0.1.19

### DIFF
--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 0.1.19 (February 3, 2022)
+
+This release introduces a new `#[instrument(ret)]` argument to emit an event
+with the return value of an instrumented function.
+
+### Added
+
+- `#[instrument(ret)]` to record the return value of a function ([#1716])
+- added `err(Debug)` argument to cause `#[instrument(err)]` to record errors
+  with `Debug` rather than `Display ([#1631])
+
+### Fixed
+
+- incorrect code generation for functions returning async blocks ([#1866])
+- incorrect diagnostics when using `rust-analyzer` ([#1634])
+
+Thanks to @Swatinem, @hkmatsumoto, @cynecx, and @ciuncan for contributing to
+this release!
+
+[#1716]: https://github.com/tokio-rs/tracing/pull/1716
+[#1631]: https://github.com/tokio-rs/tracing/pull/1631
+[#1634]: https://github.com/tokio-rs/tracing/pull/1634
+[#1866]: https://github.com/tokio-rs/tracing/pull/1866
+
 # 0.1.18 (October 5, 2021)
 
 This release fixes issues introduced in v0.1.17.

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-attributes"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.18"
+version = "0.1.19"
 authors = [
     "Tokio Contributors <team@tokio.rs>",
     "Eliza Weisman <eliza@buoyant.io>",

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -18,7 +18,7 @@ Macro attributes for application-level tracing.
 [crates-badge]: https://img.shields.io/crates/v/tracing-attributes.svg
 [crates-url]: https://crates.io/crates/tracing-attributes
 [docs-badge]: https://docs.rs/tracing-attributes/badge.svg
-[docs-url]: https://docs.rs/tracing-attributes/0.1.18
+[docs-url]: https://docs.rs/tracing-attributes/0.1.19
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_attributes
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -47,7 +47,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing-attributes = "0.1.18"
+tracing-attributes = "0.1.19"
 ```
 
 

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tracing-attributes = "0.1.18"
+//! tracing-attributes = "0.1.19"
 //! ```
 //!
 //! The [`#[instrument]`][instrument] attribute can now be added to a function
@@ -52,7 +52,7 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
-#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.18")]
+#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.19")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -30,7 +30,7 @@ rust-version = "1.42.0"
 [dependencies]
 tracing-core = { path = "../tracing-core", version = "0.1.22", default-features = false }
 log = { version = "0.4", optional = true }
-tracing-attributes = { path = "../tracing-attributes", version = "0.1.18", optional = true }
+tracing-attributes = { path = "../tracing-attributes", version = "0.1.19", optional = true }
 cfg-if = "1.0.0"
 pin-project-lite = "0.2"
 


### PR DESCRIPTION
# 0.1.19 (February 3, 2022)

This release introduces a new `#[instrument(ret)]` argument to emit an
event with the return value of an instrumented function.

### Added

- `#[instrument(ret)]` to record the return value of a function
  ([#1716])
- added `err(Debug)` argument to cause `#[instrument(err)]` to record
  errors with `Debug` rather than `Display ([#1631])

### Fixed

- incorrect code generation for functions returning async blocks
  ([#1866])
- incorrect diagnostics when using `rust-analyzer` ([#1634])

Thanks to @Swatinem, @hkmatsumoto, @cynecx, and @ciuncan for
contributing to this release!

[#1716]: https://github.com/tokio-rs/tracing/pull/1716
[#1631]: https://github.com/tokio-rs/tracing/pull/1631
[#1634]: https://github.com/tokio-rs/tracing/pull/1634
[#1866]: https://github.com/tokio-rs/tracing/pull/1866