### PR TITLE
subscriber: fix broken docs links

### DIFF
--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -100,6 +100,7 @@ use tracing_core::{
 /// [`level`]: tracing_core::Level
 /// [`Metadata`]: tracing_core::Metadata
 /// [`Targets`]: crate::filter::Targets
+/// [`env_logger`]: https://crates.io/crates/env_logger
 #[cfg_attr(docsrs, doc(cfg(all(feature = "env-filter", feature = "std"))))]
 #[derive(Debug)]
 pub struct EnvFilter {

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -153,6 +153,7 @@ pub use pretty::*;
 /// DEBUG yak_shaving::shaver: some-span{field-on-span=foo}: started shaving yak
 /// ```
 ///
+/// [`layer::Context`]: crate::layer::Context
 /// [`fmt::Layer`]: super::Layer
 /// [`fmt::Subscriber`]: super::Subscriber
 /// [`Event`]: tracing::Event

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -63,6 +63,8 @@
 //! - `local-time`: Enables local time formatting when using the [`time`
 //!   crate]'s timestamp formatters with the `fmt` subscriber.
 //!
+//! [`registry`]: mod@registry
+//!
 //! ### Optional Dependencies
 //!
 //! - [`tracing-log`]: Enables better formatting for events emitted by `log`
@@ -80,7 +82,7 @@
 //! used without requiring the Rust standard library, although some features are
 //! disabled. Although most of the APIs provided by `tracing-subscriber`, such
 //! as [`fmt`] and [`EnvFilter`], require the standard library, some
-//! functionality, such as the [`Subscribe`] trait, can still be used in
+//! functionality, such as the [`Layer`] trait, can still be used in
 //! `no_std` environments.
 //!
 //! The dependency on the standard library is controlled by two crate feature
@@ -125,6 +127,7 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`time` crate]: https://crates.io/crates/time
+//! [`libstd`]: https://doc.rust-lang.org/std/index.html
 //! [`liballoc`]: https://doc.rust-lang.org/alloc/index.html
 #![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.3.7")]
 #![doc(


### PR DESCRIPTION
This branch fixes some broken documentation links and other docs issues
in `tracing-subscriber`.