### PR TITLE
implement `Targets::enabled_for`

### DIFF
--- a/tracing-subscriber/src/filter/targets.rs
+++ b/tracing-subscriber/src/filter/targets.rs
@@ -315,11 +315,11 @@ impl Targets {
     }
 
     /// Returns whether a [target]-[`Level`] pair would be enabled
-    /// for this `Targets`.
+    /// by this `Targets`.
     ///
-    /// You can use [`module_path!`] from `std` as the target
-    /// if you want to emulate the behavior of the
-    /// [`tracing::event!`] suite of macros.
+    /// This method can be used with [`module_path!`] from `std` as the target
+    /// in order to emulate the behavior of the [`tracing::event!`] and [`tracing::span!`]
+    /// macros.
     ///
     /// # Examples
     ///
@@ -331,17 +331,16 @@ impl Targets {
     ///     .with_target("my_crate", Level::INFO)
     ///     .with_target("my_crate::interesting_module", Level::DEBUG);
     ///
-    /// assert!(filter.enabled_for("my_crate", &Level::INFO));
-    /// assert!(!filter.enabled_for("my_crate::interesting_module", &Level::TRACE));
+    /// assert!(filter.would_enable("my_crate", &Level::INFO));
+    /// assert!(!filter.would_enable("my_crate::interesting_module", &Level::TRACE));
     /// ```
     ///
     /// [target]: tracing_core::Metadata::target
-    /// [`tracing::event!`]: tracing::event!
     /// [`module_path!`]: std::module_path!
-    pub fn enabled_for(&self, target: &'static str, level: &Level) -> bool {
+    pub fn would_enable(&self, target: &str, level: &Level) -> bool {
         // "Correct" to call because `Targets` only produces `StaticDirective`'s with NO
         // fields
-        self.0.enabled_for(target, level)
+        self.0.target_enabled(target, level)
     }
 }
 

--- a/tracing-subscriber/src/filter/targets.rs
+++ b/tracing-subscriber/src/filter/targets.rs
@@ -20,7 +20,7 @@ use core::{
     slice,
     str::FromStr,
 };
-use tracing_core::{Interest, Metadata, Subscriber};
+use tracing_core::{Interest, Level, Metadata, Subscriber};
 
 /// A filter that enables or disables spans and events based on their [target]
 /// and [level].
@@ -312,6 +312,36 @@ impl Targets {
         } else {
             Interest::never()
         }
+    }
+
+    /// Returns whether a [target]-[`Level`] pair would be enabled
+    /// for this `Targets`.
+    ///
+    /// You can use [`module_path!`] from `std` as the target
+    /// if you want to emulate the behavior of the
+    /// [`tracing::event!`] suite of macros.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tracing_subscriber::filter::{Targets, LevelFilter};
+    /// use tracing_core::Level;
+    ///
+    /// let filter = Targets::new()
+    ///     .with_target("my_crate", Level::INFO)
+    ///     .with_target("my_crate::interesting_module", Level::DEBUG);
+    ///
+    /// assert!(filter.enabled_for("my_crate", &Level::INFO));
+    /// assert!(!filter.enabled_for("my_crate::interesting_module", &Level::TRACE));
+    /// ```
+    ///
+    /// [target]: tracing_core::Metadata::target
+    /// [`tracing::event!`]: tracing::event!
+    /// [`module_path!`]: std::module_path!
+    pub fn enabled_for(&self, target: &'static str, level: &Level) -> bool {
+        // "Correct" to call because `Targets` only produces `StaticDirective`'s with NO
+        // fields
+        self.0.enabled_for(target, level)
     }
 }
 


### PR DESCRIPTION
## Motivation

As discussed on discord, this API + `Targets` being `: Clone` makes it easier to solve the original problem I had tried to solve in https://github.com/tokio-rs/tracing/pull/1889.

My plan on how to use this is in https://github.com/MaterializeInc/materialize/issues/10441 if you are interested!

## Solution

I considered doing some macro magic to create a `Metadata` with a callsite and empty fields and everything, to be able to called `DirectiveSet::enabled`, but it felt cleaner and easier to reason about the special-case-ness (`Targets` never having field filters) using a new set of methods that do a similar thing.

For testing I opted for just a doc-test, let me know if thats fine!
