### PR TITLE
serde: prepare to release 0.1.3

### DIFF
--- a/tracing-serde/CHANGELOG.md
+++ b/tracing-serde/CHANGELOG.md
@@ -1,3 +1,41 @@
+# 0.1.3 (February 4, 2022)
+
+This release adds *experimental* support for recording structured field
+values using the [`valuable`] crate. See [this blog post][post] for
+details on `valuable`.
+
+Note that `valuable` support currently requires `--cfg
+tracing_unstable`. See the documentation for details.
+
+### Added
+
+- **valuable**: Experimental support for serializing user-defined types using
+  [`valuable`] and [`valuable-serde`] ([#1862])
+- Support for serializing `f64` values ([#1507])
+
+### Fixed
+
+- Fixed incorrect size hint in `SerializeFieldSet` ([#1333])
+- A number of documentation fixes
+
+Thanks to @akinnane and @maxburke for contributing to this release!
+
+[`valuable`]: https://crates.io/crates/valuable
+[`valuable-serde`]: https://crates.io/crates/valuable-serde
+[post]: https://tokio.rs/blog/2021-05-valuable
+[#1862]: https://github.com/tokio-rs/tracing/pull/1862
+[#1507]: https://github.com/tokio-rs/tracing/pull/1507
+[#1333]: https://github.com/tokio-rs/tracing/pull/1333
+
+# 0.1.2 (September 11, 2020)
+
+### Added
+
+- `SerdeMapVisitor::finish` to complete serializing the visited objects
+  (#892)
+- `SerdeMapVisitor::take_serializer` to return the serializer wrapped by
+  a `SerdeMapVisitor` (#892)
+
 # 0.1.1 (February 27, 2020)
 
 ### Added

--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-serde"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 edition = "2018"

--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -23,7 +23,7 @@ valuable = ["valuable_crate", "valuable-serde", "tracing-core/valuable"]
 
 [dependencies]
 serde = "1"
-tracing-core = { path = "../tracing-core", version = "0.1.2"}
+tracing-core = { path = "../tracing-core", version = "0.1.22"}
 
 [dev-dependencies]
 serde_json = "1"

--- a/tracing-serde/README.md
+++ b/tracing-serde/README.md
@@ -18,7 +18,7 @@ An adapter for serializing [`tracing`] types using [`serde`].
 
 [`tracing`] is a framework for instrumenting Rust programs to collect
 scoped, structured, and async-aware diagnostics.`tracing-serde` enables
-serializing `tracing` types using [`serde`]. 
+serializing `tracing` types using [`serde`].
 
 Traditional logging is based on human-readable text messages.
 `tracing` gives us machine-readable structured diagnostic

--- a/tracing-serde/src/lib.rs
+++ b/tracing-serde/src/lib.rs
@@ -155,7 +155,7 @@
 //!
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [`serde`]: https://crates.io/crates/serde
-#![doc(html_root_url = "https://docs.rs/tracing-serde/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/tracing-serde/0.1.3")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -55,7 +55,7 @@ time = { version = "0.3", features = ["formatting"], optional = true }
 # only required by the json feature
 serde_json = { version = "1.0", optional = true }
 serde = { version = "1.0", optional = true }
-tracing-serde = { path = "../tracing-serde", version = "0.1.2", optional = true }
+tracing-serde = { path = "../tracing-serde", version = "0.1.3", optional = true }
 
 # opt-in deps
 parking_lot = { version = ">= 0.7, <= 0.11", optional = true }


### PR DESCRIPTION
# 0.1.3 (February 4, 2022)

This release adds *experimental* support for recording structured field
values using the [`valuable`] crate. See [this blog post][post] for
details on `valuable`.

Note that `valuable` support currently requires `--cfg
tracing_unstable`. See the documentation for details.

### Added

- **valuable**: Experimental support for serializing user-defined types
  using [`valuable`] and [`valuable-serde`] ([#1862])
- Support for serializing `f64` values ([#1507])

### Fixed

- Fixed incorrect size hint in `SerializeFieldSet` ([#1333])
- A number of documentation fixes

Thanks to @akinnane and @maxburke for contributing to this release!

[`valuable`]: https://crates.io/crates/valuable
[`valuable-serde`]: https://crates.io/crates/valuable-serde
[post]: https://tokio.rs/blog/2021-05-valuable
[#1862]: https://github.com/tokio-rs/tracing/pull/1862
[#1507]: https://github.com/tokio-rs/tracing/pull/1507
[#1333]: https://github.com/tokio-rs/tracing/pull/1333

(I also noticed there was a missing changelog entry for v0.1.2, so I
fixed that while I was here)