### PR TITLE
opentelemetry: prepare for 0.16.1 release

### DIFF
--- a/tracing-opentelemetry/CHANGELOG.md
+++ b/tracing-opentelemetry/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.16.1 (February 10, 2022)
+
+### Added
+
+- `OpenTelemetrySubscriber` can now add detailed location information to
+  forwarded events (defaults to on) (#1911)
+
+### Changed
+
+- Avoid allocations to improve performance (#1917)
+
 # 0.16.0 (January 30, 2022)
 
 ### Breaking Changes
@@ -5,6 +16,7 @@
 - Upgrade to `v0.17.0` of `opentelemetry` (#1853)
   For list of breaking changes in OpenTelemetry, see the
   [v0.17.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/CHANGELOG.md#v0170).
+
 # 0.15.0 (August 7, 2021)
 
 ### Breaking Changes

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-opentelemetry"
-version = "0.16.0"
+version = "0.16.1"
 authors = [
     "Julian Tescher <julian@tescher.me>",
     "Tokio Contributors <team@tokio.rs>"

--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -17,9 +17,9 @@ Utilities for adding [OpenTelemetry] interoperability to [`tracing`].
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-opentelemetry.svg
-[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.16.0
+[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.16.1
 [docs-badge]: https://docs.rs/tracing-opentelemetry/badge.svg
-[docs-url]: https://docs.rs/tracing-opentelemetry/0.16.0/tracing_opentelemetry
+[docs-url]: https://docs.rs/tracing-opentelemetry/0.16.1/tracing_opentelemetry
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_opentelemetry
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -33,9 +33,9 @@ Utilities for adding [OpenTelemetry] interoperability to [`tracing`].
 ## Overview
 
 [`tracing`] is a framework for instrumenting Rust programs to collect
-structured, event-based diagnostic information. This crate provides a 
-subscriber that connects spans from multiple systems into a trace and 
-emits them to [OpenTelemetry]-compatible distributed tracing systems 
+structured, event-based diagnostic information. This crate provides a
+subscriber that connects spans from multiple systems into a trace and
+emits them to [OpenTelemetry]-compatible distributed tracing systems
 for processing and visualization.
 
 The crate provides the following types:

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -92,7 +92,7 @@
 //!
 #![deny(unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.16.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.16.1")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     html_favicon_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/favicon.ico",


### PR DESCRIPTION
As discussed in #1911, prepares a point release for tracing-opentelemetry. This follows the changes made in #1877 for the 0.16.0 release.

(I'm confused by the backport/release strategy in this repo -- #1877 targeted the master branch, but a commit with a subset of those changes ended up in the 0.1.x branch, and the crates.io version was apparently published from v0.1.x. Definitely feels to me like life would be better if v0.1.x was the default branch for this repo -- I'm pretty sure merging forward is easier than merging backward, too.)