### PR TITLE
Add cargo metadata to msrv check due to valuable

### DIFF
--- a/.github/workflows/check_msrv.yml
+++ b/.github/workflows/check_msrv.yml
@@ -44,6 +44,11 @@ jobs:
       with:
         command: check
         args: --all --exclude=tracing-appender
+    - name: Metadata
+      uses: actions-rs/cargo@v1
+      with:
+        command: metadata
+        args: --all --exclude=tracing-appender
 
   # TODO: remove this once tracing's MSRV is bumped.
   check-msrv-appender:
@@ -60,4 +65,9 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: check
+        args: --lib=tracing-appender
+    - name: Metadata
+      uses: actions-rs/cargo@v1
+      with:
+        command: metadata
         args: --lib=tracing-appender


### PR DESCRIPTION
> :rotating_light:  note: CI fail is expected here!

## Motivation

Hello! I noticed my CI is failing when trying to include tracing on rust version `1.49.0`. This is the advertised MSRV but is breaking because `tarpaulin`, used for calculating coverage, fails when calling `cargo metadata`.

Even when the `valuable` is not enabled, it shows up in `Cargo.lock`. This is fine even on rust version `1.49.0` as it is ignored when running `cargo build`, but `cargo metadata` fails:

```shell
❯ cargo metadata  
warning: please specify `--format-version` flag explicitly to avoid compatibility problems
error: failed to download `valuable v0.1.0`

Caused by:
  unable to get packages from source

Caused by:
  failed to parse manifest at `/home/arlyon/.cargo/registry/src/github.com-1ecc6299db9ec823/valuable-0.1.0/Cargo.toml`

Caused by:
  feature `resolver` is required

  this Cargo does not support nightly features, but if you
  switch to nightly channel you can add
  `cargo-features = ["resolver"]` to enable this feature
```

Running the same command on rust version 1.51.0, `valuable`'s stated MSRV, works as expected.

## Solution

This PR is just to highlight the issue. The proposed solution is to consider `cargo metadata` as a command that should be supported by the MSRV, and then bump all the crates that depend on `valuable` to MSRV `1.51.0`.

In my case (arlyon/async-stripe#160), I will probably end up downgrading to the latest version without `valuable` for now, and keep a note if we decide to bump MSRV later down the line.

Thanks for all the work you do! :heart_eyes: 

Alex

More context here: https://github.com/tokio-rs/tracing/pull/1913#issuecomment-1035130109