### PR TITLE
opentelemetry: prepare to release v0.17.1

### DIFF
--- a/tracing-opentelemetry/CHANGELOG.md
+++ b/tracing-opentelemetry/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 0.17.1 (February 11, 2022)
+
+### Added
+
+- `OpenTelemetryLayer` can now add detailed location information to
+  forwarded events (defaults to on) ([#1911])
+- `OpenTelemetryLayer::with_event_location` to control whether source locations
+  are recorded ([#1911])
+### Changed
+
+- Avoid unnecessary allocations to improve performance when recording events
+  ([#1917])
+
+Thanks to @djc for contributing to this release!
+
+[#1917]: https://github.com/tokio-rs/tracing/pull/1917
+[#1911]: https://github.com/tokio-rs/tracing/pull/1911
+
 # 0.17.0 (February 3, 2022)
 
 ### Breaking Changes
@@ -6,7 +24,7 @@
   For list of breaking changes in OpenTelemetry, see the
   [v0.17.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/CHANGELOG.md#v0170).
 
-# 0.16.0 (October 23, 2021)
+# 0.17.1 (October 23, 2021)
 
 ### Breaking Changes
 
@@ -29,9 +47,9 @@ Thanks to @LehMaxence for contributing to this release!
 
 ### Breaking Changes
 
-- Upgrade to `v0.16.0` of `opentelemetry` (#1497)
+- Upgrade to `v0.17.1` of `opentelemetry` (#1497)
   For list of breaking changes in OpenTelemetry, see the
-  [v0.16.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/CHANGELOG.md#v0160).
+  [v0.17.1 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/CHANGELOG.md#v0160).
 
 # 0.14.0 (July 9, 2021)
 

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-opentelemetry"
-version = "0.17.0"
+version = "0.17.1"
 authors = [
     "Julian Tescher <julian@tescher.me>",
     "Tokio Contributors <team@tokio.rs>"

--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -17,9 +17,9 @@ Utilities for adding [OpenTelemetry] interoperability to [`tracing`].
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-opentelemetry.svg
-[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.16.0
+[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.17.1
 [docs-badge]: https://docs.rs/tracing-opentelemetry/badge.svg
-[docs-url]: https://docs.rs/tracing-opentelemetry/0.16.0/tracing_opentelemetry
+[docs-url]: https://docs.rs/tracing-opentelemetry/0.17.1/tracing_opentelemetry
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_opentelemetry
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -92,7 +92,7 @@
 //!
 #![deny(unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.16.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.17.1")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.17.1 (February 11, 2022)

### Added

- `OpenTelemetryLayer` can now add detailed location information to
  forwarded events (defaults to on) ([#1911])
- `OpenTelemetryLayer::with_event_location` to control whether source
  locations are recorded ([#1911])
### Changed

- Avoid unnecessary allocations to improve performance when recording
  events ([#1917])

Thanks to @djc for contributing to this release!

[#1917]: https://github.com/tokio-rs/tracing/pull/1917
[#1911]: https://github.com/tokio-rs/tracing/pull/1911

Closes #1919

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
