### PR TITLE
tracing: Fix wrong log level in warn macro  #1929

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -1695,7 +1695,7 @@ macro_rules! warn {
     (%$($k:ident).+ = $($field:tt)*) => (
         $crate::event!(
             target: module_path!(),
-            $crate::Level::TRACE,
+            $crate::Level::WARN,
             { %$($k).+ = $($field)*}
         )
     );


### PR DESCRIPTION
tracing:  Fix wrong log level in warn macro

Fixes: #1929
