### PR TITLE
tracing: prepare to release v0.1.31

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,4 +1,32 @@
-# 0.1.30 (February 3rd, 2021)
+# 0.1.31 (February 17th, 2022)
+
+This release increases the minimum supported Rust version (MSRV) to 1.49.0. In
+addition, it fixes some relatively rare macro bugs.
+
+### Added
+
+- Added `tracing-forest` to the list of related crates ([#1935])
+
+### Changed
+
+- Updated minimum supported Rust version (MSRV) to 1.49.0 ([#1913])
+
+### Fixed
+
+- Fixed the `warn!` macro incorrectly generating an event with the `TRACE` level
+  ([#1930])
+- Fixed macro hygiene issues when used in a crate that defines its own `concat!`
+  macro, for real this time ([#1918])
+
+Thanks to @QnnOkabayashi, @nicolaasg, and @teohhanhui for contributing to this
+release!
+
+[#1935]: https://github.com/tokio-rs/tracing/pull/1935
+[#1913]: https://github.com/tokio-rs/tracing/pull/1913
+[#1930]: https://github.com/tokio-rs/tracing/pull/1930
+[#1918]: https://github.com/tokio-rs/tracing/pull/1918
+
+# 0.1.30 (February 3rd, 2022)
 
 This release adds *experimental* support for recording structured field
 values using the [`valuable`] crate. See [this blog post][post] for

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.30"
+version = "0.1.31"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -16,9 +16,9 @@ Application-level tracing for Rust.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.30
+[crates-url]: https://crates.io/crates/tracing/0.1.31
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.30
+[docs-url]: https://docs.rs/tracing/0.1.31
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -250,7 +250,7 @@ my_future
 is as long as the future's.
 
 The second, and preferred, option is through the
-[`#[instrument]`](https://docs.rs/tracing/0.1.30/tracing/attr.instrument.html)
+[`#[instrument]`](https://docs.rs/tracing/0.1.31/tracing/attr.instrument.html)
 attribute:
 
 ```rust
@@ -297,7 +297,7 @@ span.in_scope(|| {
 // Dropping the span will close it, indicating that it has ended.
 ```
 
-The [`#[instrument]`](https://docs.rs/tracing/0.1.30/tracing/attr.instrument.html) attribute macro
+The [`#[instrument]`](https://docs.rs/tracing/0.1.31/tracing/attr.instrument.html) attribute macro
 can reduce some of this boilerplate:
 
 ```rust

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -809,7 +809,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing = { version = "0.1.30", default-features = false }
+//!   tracing = { version = "0.1.31", default-features = false }
 //!   ```
 //!
 //! <pre class="ignore" style="white-space:normal;font:inherit;">
@@ -892,7 +892,7 @@
 //! [flags]: #crate-feature-flags
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.30")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.31")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.1.31 (February 17th, 2022)

This release increases the minimum supported Rust version (MSRV) to
1.49.0. In addition, it fixes some relatively rare macro bugs.

### Added

- Added `tracing-forest` to the list of related crates ([#1935])

### Changed

- Updated minimum supported Rust version (MSRV) to 1.49.0 ([#1913])

### Fixed

- Fixed the `warn!` macro incorrectly generating an event with the
  `TRACE` level ([#1930])
- Fixed macro hygiene issues when used in a crate that defines its own
  `concat!` macro, for real this time ([#1918])

Thanks to @QnnOkabayashi, @nicolaasg, and @teohhanhui for contributing
to this release!

[#1935]: https://github.com/tokio-rs/tracing/pull/1935
[#1913]: https://github.com/tokio-rs/tracing/pull/1913
[#1930]: https://github.com/tokio-rs/tracing/pull/1930
[#1918]: https://github.com/tokio-rs/tracing/pull/1918