### PR TITLE
opentelemetry: fix broken build with `default-features = false`

### DIFF
--- a/.github/workflows/check_features.yml
+++ b/.github/workflows/check_features.yml
@@ -44,6 +44,7 @@ jobs:
         - tracing-macros
         - tracing-serde
         - tracing-tower
+        - tracing-opentelemetry
         # tracing and tracing-subscriber have too many features to be checked by
         # cargo-hack --feature-powerset, combinatorics there is exploding.
         #- tracing

--- a/tracing-opentelemetry/src/subscriber.rs
+++ b/tracing-opentelemetry/src/subscriber.rs
@@ -3,8 +3,6 @@ use opentelemetry::{
     trace::{self as otel, noop, TraceContextExt},
     Context as OtelContext, Key, KeyValue, Value,
 };
-#[cfg(not(feature = "tracing-log"))]
-use std::borrow::Cow;
 use std::fmt;
 use std::marker;
 use std::time::{Instant, SystemTime};

--- a/tracing-opentelemetry/src/subscriber.rs
+++ b/tracing-opentelemetry/src/subscriber.rs
@@ -585,7 +585,7 @@ where
                     let builder_attrs = builder.attributes.get_or_insert(Vec::new());
 
                     #[cfg(not(feature = "tracing-log"))]
-                    let normalized_meta = None;
+                    let normalized_meta: Option<tracing_core::Metadata<'_>> = None;
                     let (file, module) = match &normalized_meta {
                         Some(meta) => (
                             meta.file().map(|s| Value::from(s.to_owned())),


### PR DESCRIPTION
## Motivation

Currently, `tracing-opentelemetry` v0.17.1 fails to compile with
`default-features = false`. This is because there's a `let` binding for
`normalized_metadata` with a `None` where the `Some` type can't be
inferred. This managed to slip past CI and get released because we were
never actually building the crate with its default features disabled, an
oversight in our CI configuration.

## Solution

This branch fixes the issue by adding an explicit type annotation to the
`let` binding, so the `Option`'s type is known and the type error no
longer occurs. I also removed a feature-flagged import that was not
actually used.

I also added `tracing-opentelemetry` to the `cargo hack` CI job. This
way, we will now ensure that all its feature combinations are built on
CI (including no features), which should prevent this kind of thing from
occurring in the future. Without the fix, we can confirm that this job does
fail: https://github.com/tokio-rs/tracing/runs/5279139893?check_suite_focus=true

Fixes  #1944