### PR TITLE
chore: add `cargo hack` check to `bin/publish`

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -31,6 +31,13 @@ verify() {
         exit 1
     fi
 
+    status "Checking" "if $CRATE builds without default features"
+    cargo check $VERBOSE --no-default-features
+    if [ "$?" -ne 0 ]; then
+        err "$CRATE did not build successfully with --no-default-features"
+        exit 1
+    fi
+
     if git tag -l | grep -Fxq "$TAG" ; then
         err "git tag \`$TAG\` already exists"
         exit 1

--- a/bin/publish
+++ b/bin/publish
@@ -31,10 +31,15 @@ verify() {
         exit 1
     fi
 
-    status "Checking" "if $CRATE builds without default features"
-    cargo check $VERBOSE --no-default-features
-    if [ "$?" -ne 0 ]; then
-        err "$CRATE did not build successfully with --no-default-features"
+    if ! cargo list | grep -q "hack"; then
+        status "Installing" "cargo-hack"
+        cargo install cargo-hack
+    fi
+
+    status "Checking" "if $CRATE builds across feature combinations"
+
+    if ! cargo hack check $VERBOSE --feature-powerset --no-dev-deps; then
+        err "$CRATE did not build with all feature combinations!"
         exit 1
     fi
 


### PR DESCRIPTION
This adds a check to the `bin/publish` script that the crate being
published builds successfully with all possible feature combinations,
using `cargo hack --feature-powerset`.

This would have prevented https://github.com/tokio-rs/tracing/issues/1944.

We test this on CI for most crates in the repo, but it's disabled for some
crates because the powerset is very large, making the check too slow
to run on CI. However, adding it to the publish script will ensure that it's
at least always run before publishing a crate.