### PR TITLE
opentelemetry: prepare to release v0.17.2

### DIFF
--- a/tracing-opentelemetry/CHANGELOG.md
+++ b/tracing-opentelemetry/CHANGELOG.md
@@ -1,4 +1,16 @@
-# 0.17.1 (February 11, 2022)
+# 0.17.2 (February 21, 2022)
+
+This release fixes [an issue][#1944] introduced in v0.17.1 where
+`tracing-opentelemetry` could not be compiled with `default-features = false`.
+
+### Fixed
+
+- Compilation failure with `tracing-log` feature disabled ([#1949])
+
+[#1949]: https://github.com/tokio-rs/tracing/pull/1917
+[#1944]: https://github.com/tokio-rs/tracing/issues/1944
+
+# 0.17.1 (February 11, 2022) (YANKED)
 
 ### Added
 
@@ -24,7 +36,7 @@ Thanks to @djc for contributing to this release!
   For list of breaking changes in OpenTelemetry, see the
   [v0.17.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/CHANGELOG.md#v0170).
 
-# 0.17.1 (October 23, 2021)
+# 0.16.1 (October 23, 2021)
 
 ### Breaking Changes
 

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-opentelemetry"
-version = "0.17.1"
+version = "0.17.2"
 authors = [
     "Julian Tescher <julian@tescher.me>",
     "Tokio Contributors <team@tokio.rs>"

--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -17,9 +17,9 @@ Utilities for adding [OpenTelemetry] interoperability to [`tracing`].
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-opentelemetry.svg
-[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.17.1
+[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.17.2
 [docs-badge]: https://docs.rs/tracing-opentelemetry/badge.svg
-[docs-url]: https://docs.rs/tracing-opentelemetry/0.17.1/tracing_opentelemetry
+[docs-url]: https://docs.rs/tracing-opentelemetry/0.17.2/tracing_opentelemetry
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_opentelemetry
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -92,7 +92,7 @@
 //!
 #![deny(unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.17.1")]
+#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.17.2")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.17.2 (February 21, 2022)

This release fixes [an issue][#1944] introduced in v0.17.1 where
`tracing-opentelemetry` could not be compiled with
`default-features = false`.

### Fixed

- Compilation failure with `tracing-log` feature disabled ([#1949])

[#1949]: https://github.com/tokio-rs/tracing/pull/1917
[#1944]: https://github.com/tokio-rs/tracing/issues/1944
