### PR TITLE
Set minimal version of syn

### DIFF
--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -35,7 +35,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1"
-syn = { version = "1", default-features = false, features = ["full", "parsing", "printing", "visit", "visit-mut", "clone-impls", "extra-traits", "proc-macro"] }
+syn = { version = "1.0.43", default-features = false, features = ["full", "parsing", "printing", "visit", "visit-mut", "clone-impls", "extra-traits", "proc-macro"] }
 quote = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
This sets the minimal version of `syn` to `1.0.43` - the actual minimal version that is required to build `tracing-attributes`.

See this build failure in Tokio: https://github.com/tokio-rs/tokio/runs/5344598894?check_suite_focus=true

CC: tokio-rs/tokio#4513