### PR TITLE
appender: prepare to release v0.2.1

### DIFF
--- a/tracing-appender/CHANGELOG.md
+++ b/tracing-appender/CHANGELOG.md
@@ -1,3 +1,31 @@
+# 0.2.1 (February 28, 2022)
+
+This release adds an implementation of the `MakeWriter` trait for
+`RollingFileAppender`, allowing it to be used without wrapping in a
+`NonBlocking` writer.
+
+This release increases the minimum supported Rust version to 1.53.0.
+
+### Added
+
+- **rolling**: Added `MakeWriter` implementation for `RollingFileAppender`
+  ([#1760])
+
+### Changed
+
+- Updated minimum supported Rust version (MSRV) to 1.53.0 ([#1851])
+- `parking_lot`: updated to v0.12 ([#1878])
+
+### Fixed
+
+- Fixed several documentation typos and issues ([#1780], [d868054], [#1943])
+
+[#1760]: https://github.com/tokio-rs/tracing/pull/1760
+[#1851]: https://github.com/tokio-rs/tracing/pull/1851
+[#1878]: https://github.com/tokio-rs/tracing/pull/1878
+[#1943]: https://github.com/tokio-rs/tracing/pull/1943
+[d868054]: https://github.com/tokio-rs/tracing/commit/d8680547b509978c7113c8f7e19e9b00c789c698
+
 # 0.2.0 (October 22, 2021)
 
 This breaking change release adds support for the new v0.3.x series of
@@ -10,9 +38,11 @@ This release increases the minimum supported Rust version to 1.51.0.
 - Updated `tracing-subscriber` to v0.3.x ([#1677])
 - Changed `NonBlocking::error_counter` to return an `ErrorCounter` type, rather
   than an `Arc<AtomicU64>` ([#1675])
+
 ### Changed
 
 - Updated `tracing-subscriber` to v0.3.x ([#1677])
+
 ### Fixed
 
 - **non-blocking**: Fixed compilation on 32-bit targets ([#1675])

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-appender"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     "Zeki Sherif <zekshi@amazon.com>",
     "Tokio Contributors <team@tokio.rs>"

--- a/tracing-appender/README.md
+++ b/tracing-appender/README.md
@@ -16,9 +16,9 @@ Writers for logging events and spans
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-appender.svg
-[crates-url]: https://crates.io/crates/tracing-appender/0.2.0
+[crates-url]: https://crates.io/crates/tracing-appender/0.2.1
 [docs-badge]: https://docs.rs/tracing-appender/badge.svg
-[docs-url]: https://docs.rs/tracing-appender/0.2.0
+[docs-url]: https://docs.rs/tracing-appender/0.2.1
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing.rs/tracing-appender
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -7,7 +7,7 @@
 //! a dedicated logging thread. It also provides a [`RollingFileAppender`][file_appender] that can
 //! be used with _or_ without the non-blocking writer.
 //!
-//! *Compiler support: [requires `rustc` 1.51+][msrv]*
+//! *Compiler support: [requires `rustc` 1.53+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
 //! [file_appender]: ./rolling/struct.RollingFileAppender.html
@@ -111,7 +111,7 @@
 //! ## Supported Rust Versions
 //!
 //! `tracing-appender` is built against the latest stable release. The minimum supported
-//! version is 1.51. The current `tracing-appender` version is not guaranteed to build on
+//! version is 1.53. The current `tracing-appender` version is not guaranteed to build on
 //! Rust versions earlier than the minimum supported version.
 //!
 //! Tracing follows the same compiler support policies as the rest of the Tokio
@@ -122,7 +122,7 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
-#![doc(html_root_url = "https://docs.rs/tracing-appender/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-appender/0.2.1")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.2.1 (February 28, 2022)

This release adds an implementation of the `MakeWriter` trait for
`RollingFileAppender`, allowing it to be used without wrapping in a
`NonBlocking` writer.

This release increases the minimum supported Rust version to 1.53.0.

### Added

- **rolling**: Added `MakeWriter` implementation for
  `RollingFileAppender` ([#1760])

### Changed

- Updated minimum supported Rust version (MSRV) to 1.53.0 ([#1851])
- `parking_lot`: updated to v0.12 ([#1878])

### Fixed

- Fixed several documentation typos and issues ([#1780], [d868054],
  [#1943])

[#1760]: https://github.com/tokio-rs/tracing/pull/1760
[#1851]: https://github.com/tokio-rs/tracing/pull/1851
[#1878]: https://github.com/tokio-rs/tracing/pull/1878
[#1943]: https://github.com/tokio-rs/tracing/pull/1943
[d868054]: https://github.com/tokio-rs/tracing/commit/d8680547b509978c7113c8f7e19e9b00c789c698