### PR TITLE
subscriber: fix `clippy::map_flatten` lint

### DIFF
--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1092,12 +1092,7 @@ where
 
         ctx.format_fields(writer.by_ref(), event)?;
 
-        for span in ctx
-            .event_scope()
-            .into_iter()
-            .map(Scope::from_root)
-            .flatten()
-        {
+        for span in ctx.event_scope().into_iter().flat_map(Scope::from_root) {
             let exts = span.extensions();
             if let Some(fields) = exts.get::<FormattedFields<N>>() {
                 if !fields.is_empty() {


### PR DESCRIPTION
Clippy now warns about code that calls `.map(...).flatten()` on an
iterator and suggests `.flat_map(...)` instead:
https://rust-lang.github.io/rust-clippy/master/index.html#map_flatten

This branch fixes one place where we do that. CI should be happy again.