### PR TITLE
journald: remove span field prefixes; add separate fields for span data

### DIFF
--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -74,7 +74,10 @@ mod socket;
 /// The standard journald `CODE_LINE` and `CODE_FILE` fields are automatically emitted. A `TARGET`
 /// field is emitted containing the event's target. Enclosing spans are numbered counting up from
 /// the root, and their fields and metadata are included in fields prefixed by `Sn_` where `n` is
-/// that number. Prefixing user-defined span fields may be disabled.
+/// that number. The prefix for user-defined span fields may be changed or  disabled using the 
+/// [`with_span_field_prefix`] method.
+///
+/// [`with_span_field_prefix`]: Subscriber::with_span_field_prefix
 ///
 /// User-defined fields other than the event `message` field have a prefix applied by default to
 /// prevent collision with standard fields.
@@ -132,7 +135,9 @@ impl Subscriber {
     }
 
     /// Sets the prefix to apply to names of user-defined span fields.
-    /// Defaults to `Some("S")`.
+    ///
+    /// By default, this is `Some("S")`. Setting the span field prefix to
+    /// `None` will disable the prefix.
     pub fn with_span_field_prefix(mut self, x: Option<String>) -> Self {
         self.span_field_prefix = x;
         self

--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -73,7 +73,8 @@ mod socket;
 /// The standard journald `CODE_LINE` and `CODE_FILE` fields are automatically emitted. A `TARGET`
 /// field is emitted containing the event's target.
 ///
-/// For events recorded inside spans additional `SPAN_NAME` field is emitted.
+/// For events recorded inside spans, an additional `SPAN_NAME` field is emitted with the name of
+/// each of the event's parent spans.
 ///
 /// User-defined fields other than the event `message` field have a prefix applied by default to
 /// prevent collision with standard fields.

--- a/tracing-journald/tests/journal.rs
+++ b/tracing-journald/tests/journal.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 use std::time::Duration;
 
 use serde::Deserialize;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, info_span, warn};
 use tracing_journald::Subscriber;
 use tracing_subscriber::subscribe::CollectExt;
 use tracing_subscriber::Registry;
@@ -16,9 +16,13 @@ fn journalctl_version() -> std::io::Result<String> {
 }
 
 fn with_journald(f: impl FnOnce()) {
+    with_journald_subscriber(Subscriber::new().unwrap().with_field_prefix(None), f)
+}
+
+fn with_journald_subscriber(subscriber: Subscriber, f: impl FnOnce()) {
     match journalctl_version() {
         Ok(_) => {
-            let sub = Registry::default().with(Subscriber::new().unwrap().with_field_prefix(None));
+            let sub = Registry::default().with(subscriber);
             tracing::collect::with_default(sub, f);
         }
         Err(error) => eprintln!(
@@ -32,6 +36,7 @@ fn with_journald(f: impl FnOnce()) {
 #[serde(untagged)]
 enum Field {
     Text(String),
+    Array(Vec<String>),
     Binary(Vec<u8>),
 }
 
@@ -41,6 +46,7 @@ impl PartialEq<&str> for Field {
         match self {
             Field::Text(s) => s == other,
             Field::Binary(_) => false,
+            Field::Array(_) => false
         }
     }
 }
@@ -50,6 +56,17 @@ impl PartialEq<[u8]> for Field {
         match self {
             Field::Text(s) => s.as_bytes() == other,
             Field::Binary(data) => data == other,
+            Field::Array(_) => false
+        }
+    }
+}
+
+impl PartialEq<Vec<&str>> for Field {
+    fn eq(&self, other: &Vec<&str>) -> bool {
+        match self {
+            Field::Text(_) => false,
+            Field::Binary(_) => false,
+            Field::Array(data) => data == other
         }
     }
 }
@@ -180,5 +197,75 @@ fn large_message() {
             format!("Message: {}", large_string).as_str()
         );
         assert_eq!(message["PRIORITY"], "6");
+    });
+}
+
+#[test]
+fn span_metadata() {
+    with_journald(|| {
+        let s1 = info_span!("span1", span_field1 = "foo1");
+        let _g1 = s1.enter();
+        let s2 = info_span!("span2", span_field1 = "foo2");
+        let _g2 = s2.enter();
+
+        info!(test.name = "span_metadata", "Hello World");
+
+        let message = retry_read_one_line_from_journal("span_metadata");
+        assert_eq!(message["MESSAGE"], "Hello World");
+        assert_eq!(message["PRIORITY"], "5");
+
+        assert_eq!(message["S0_SPAN_FIELD1"], "foo1");
+        assert_eq!(message["S0_NAME"], "span1");
+        assert!(message.contains_key("S0_CODE_FILE"));
+        assert!(message.contains_key("S0_CODE_LINE"));
+
+        assert_eq!(message["S1_SPAN_FIELD1"], "foo2");
+        assert_eq!(message["S1_NAME"], "span2");
+        assert!(message.contains_key("S1_CODE_FILE"));
+        assert!(message.contains_key("S1_CODE_LINE"));
+    });
+}
+
+#[test]
+fn no_span_field_prefix() {
+    let sub = Subscriber::new().unwrap()
+        .with_field_prefix(None)
+        .with_span_field_prefix(None);
+    with_journald_subscriber(sub, || {
+        let s1 = info_span!("span1", span_field = "foo");
+        let _guard = s1.enter();
+        info!(test.name = "no_span_prefix", "Hello World");
+
+        let message = retry_read_one_line_from_journal("no_span_prefix");
+        assert_eq!(message["MESSAGE"], "Hello World");
+        assert_eq!(message["PRIORITY"], "5");
+
+        // standard fields still prefixed
+        assert_eq!(message["S0_NAME"], "span1");
+        assert!(message.contains_key("S0_CODE_FILE"));
+        assert!(message.contains_key("S0_CODE_LINE"));
+
+        assert_eq!(message["SPAN_FIELD"], "foo");
+    });
+}
+
+#[test]
+fn spans_field_collision() {
+    let sub = Subscriber::new().unwrap()
+        .with_field_prefix(None)
+        .with_span_field_prefix(None);
+    with_journald_subscriber(sub, || {
+        let s1 = info_span!("span1", span_field = "foo1");
+        let _g1 = s1.enter();
+        let s2 = info_span!("span2", span_field = "foo2");
+        let _g2 = s2.enter();
+
+        info!(test.name = "spans_field_collision", "Hello World");
+
+        let message = retry_read_one_line_from_journal("spans_field_collision");
+        assert_eq!(message["MESSAGE"], "Hello World");
+        assert_eq!(message["S0_NAME"], "span1");
+
+        assert_eq!(message["SPAN_FIELD"], vec!["foo1", "foo2"]);
     });
 }

--- a/tracing-journald/tests/journal.rs
+++ b/tracing-journald/tests/journal.rs
@@ -52,7 +52,7 @@ impl Field {
         match self {
             Field::Text(v) => Some(v.as_str()),
             Field::Binary(_) => None,
-            Field::Array(v) => None,
+            Field::Array(_) => None,
         }
     }
 }

--- a/tracing-journald/tests/journal.rs
+++ b/tracing-journald/tests/journal.rs
@@ -46,7 +46,7 @@ impl PartialEq<&str> for Field {
         match self {
             Field::Text(s) => s == other,
             Field::Binary(_) => false,
-            Field::Array(_) => false
+            Field::Array(_) => false,
         }
     }
 }
@@ -56,7 +56,7 @@ impl PartialEq<[u8]> for Field {
         match self {
             Field::Text(s) => s.as_bytes() == other,
             Field::Binary(data) => data == other,
-            Field::Array(_) => false
+            Field::Array(_) => false,
         }
     }
 }
@@ -66,7 +66,7 @@ impl PartialEq<Vec<&str>> for Field {
         match self {
             Field::Text(_) => false,
             Field::Binary(_) => false,
-            Field::Array(data) => data == other
+            Field::Array(data) => data == other,
         }
     }
 }
@@ -228,7 +228,8 @@ fn span_metadata() {
 
 #[test]
 fn no_span_field_prefix() {
-    let sub = Subscriber::new().unwrap()
+    let sub = Subscriber::new()
+        .unwrap()
         .with_field_prefix(None)
         .with_span_field_prefix(None);
     with_journald_subscriber(sub, || {
@@ -251,7 +252,8 @@ fn no_span_field_prefix() {
 
 #[test]
 fn spans_field_collision() {
-    let sub = Subscriber::new().unwrap()
+    let sub = Subscriber::new()
+        .unwrap()
         .with_field_prefix(None)
         .with_span_field_prefix(None);
     with_journald_subscriber(sub, || {

--- a/tracing-journald/tests/journal.rs
+++ b/tracing-journald/tests/journal.rs
@@ -281,7 +281,7 @@ fn multiple_spans_metadata() {
         assert!(message["CODE_FILE"].as_text().is_some());
         assert!(message["CODE_LINE"].as_text().is_some());
 
-        assert!(message["SPAN_CODE_FILE"].as_text().is_some());
+        assert!(message.contains_key("SPAN_CODE_FILE"));
         assert_eq!(message["SPAN_CODE_LINE"].as_array().unwrap().len(), 2);
     });
 }

--- a/tracing-journald/tests/journal.rs
+++ b/tracing-journald/tests/journal.rs
@@ -41,15 +41,15 @@ enum Field {
 }
 
 impl Field {
-    pub fn as_array(&self) -> Option<&[String]> {
+    fn as_array(&self) -> Option<&[String]> {
         match self {
             Field::Text(_) => None,
             Field::Binary(_) => None,
             Field::Array(v) => Some(v),
         }
     }
-    
-    pub fn as_text(&self) -> Option<&str> {
+
+    fn as_text(&self) -> Option<&str> {
         match self {
             Field::Text(v) => Some(v.as_str()),
             Field::Binary(_) => None,

--- a/tracing-journald/tests/journal.rs
+++ b/tracing-journald/tests/journal.rs
@@ -48,6 +48,7 @@ impl Field {
             Field::Array(v) => Some(v),
         }
     }
+    
     pub fn as_text(&self) -> Option<&str> {
         match self {
             Field::Text(v) => Some(v.as_str()),


### PR DESCRIPTION
## Motivation
Currently, `tracing-journald` prefixes event fields with the number
of parent spans, if present, in order to namespace field values. This
turned out to be unnecessary as journald preserves values for duplicated
field names.

## Solution
This branch removes event field prefixes and emits parent span names
and their field/value pairs as additional key/value pairs.