### PR TITLE
Add example for reloading a global filtering layer

### DIFF
--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -44,7 +44,7 @@
 //! # filter::LevelFilter, Registry>,Registry>
 //! # = &reload_handle;
 //! #
-//! Registry::default()
+//! tracing_subscriber::registry()
 //!   .with(filtered_layer)
 //!   .init();
 //! info!("This will be ignored");

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -12,6 +12,7 @@
 //! # Examples
 //!
 //! Reloading a [global filtering](crate::layer#global-filtering) layer:
+//!
 //! ```rust
 //! # use tracing::info;
 //! # use tracing_subscriber::{filter,fmt,reload,Registry,prelude::*};

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -11,9 +11,29 @@
 //!
 //! # Examples
 //!
-//! Reloading a [`Filtered`](crate::filter::Filtered) layer to change the filter at runtime.
-//!
+//! Reloading a global filtering layer:
+//! ```rust
+//! # use tracing::info;
+//! # use tracing_subscriber::{filter,fmt,reload,Registry,prelude::*};
+//! # fn main() {
+//! let filter = filter::LevelFilter::WARN;
+//! let (filter, reload_handle) = reload::Layer::new(filter);
+//! Registry::default()
+//!   .with(filter)
+//!   .with(fmt::Layer::default())
+//!   .init();
+//! #
+//! # // specifying the Registry type is required
+//! # let _: &reload::Handle<filter::LevelFilter ,Registry> = &reload_handle;
+//! #
+//! info!("This will be ignored");
+//! reload_handle.modify(|filter| *filter = filter::LevelFilter::INFO);
+//! info!("This will be logged");
+//! # }
 //! ```
+//!
+//! Reloading a [`Filtered`](crate::filter::Filtered) layer:
+//! ```rust
 //! # use tracing::info;
 //! # use tracing_subscriber::{filter,fmt,reload,Registry,prelude::*};
 //! # fn main() {
@@ -25,6 +45,9 @@
 //! # filter::LevelFilter, Registry>,Registry>
 //! # = &reload_handle;
 //! #
+//! Registry::default()
+//!   .with(filtered_layer)
+//!   .init();
 //! info!("This will be ignored");
 //! reload_handle.modify(|layer| *layer.filter_mut() = filter::LevelFilter::INFO);
 //! info!("This will be logged");

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -16,7 +16,6 @@
 //! ```rust
 //! # use tracing::info;
 //! # use tracing_subscriber::{filter,fmt,reload,Registry,prelude::*};
-//! # fn main() {
 //! let filter = filter::LevelFilter::WARN;
 //! let (filter, reload_handle) = reload::Layer::new(filter);
 //! Registry::default()
@@ -30,14 +29,12 @@
 //! info!("This will be ignored");
 //! reload_handle.modify(|filter| *filter = filter::LevelFilter::INFO);
 //! info!("This will be logged");
-//! # }
 //! ```
 //!
 //! Reloading a [`Filtered`](crate::filter::Filtered) layer:
 //! ```rust
 //! # use tracing::info;
 //! # use tracing_subscriber::{filter,fmt,reload,Registry,prelude::*};
-//! # fn main() {
 //! let filtered_layer = fmt::Layer::default().with_filter(filter::LevelFilter::WARN);
 //! let (filtered_layer, reload_handle) = reload::Layer::new(filtered_layer);
 //! #
@@ -52,7 +49,6 @@
 //! info!("This will be ignored");
 //! reload_handle.modify(|layer| *layer.filter_mut() = filter::LevelFilter::INFO);
 //! info!("This will be logged");
-//! # }
 //! ```
 //!
 //! [`Layer` type]: struct.Layer.html

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -15,16 +15,16 @@
 //!
 //! ```rust
 //! # use tracing::info;
-//! use tracing_subscriber::{filter, fmt, reload, Registry, prelude::*};
+//! use tracing_subscriber::{filter, fmt, reload, prelude::*};
 //! let filter = filter::LevelFilter::WARN;
 //! let (filter, reload_handle) = reload::Layer::new(filter);
-//! Registry::default()
+//! tracing_subscriber::registry()
 //!   .with(filter)
 //!   .with(fmt::Layer::default())
 //!   .init();
 //! #
 //! # // specifying the Registry type is required
-//! # let _: &reload::Handle<filter::LevelFilter ,Registry> = &reload_handle;
+//! # let _: &reload::Handle<filter::LevelFilter, tracing_subscriber::Registry> = &reload_handle;
 //! #
 //! info!("This will be ignored");
 //! reload_handle.modify(|filter| *filter = filter::LevelFilter::INFO);
@@ -35,13 +35,13 @@
 //!
 //! ```rust
 //! # use tracing::info;
-//! # use tracing_subscriber::{filter,fmt,reload,Registry,prelude::*};
+//! use tracing_subscriber::{filter, fmt, reload, prelude::*};
 //! let filtered_layer = fmt::Layer::default().with_filter(filter::LevelFilter::WARN);
 //! let (filtered_layer, reload_handle) = reload::Layer::new(filtered_layer);
 //! #
 //! # // specifying the Registry type is required
-//! # let _: &reload::Handle<filter::Filtered<fmt::Layer<Registry>,
-//! # filter::LevelFilter, Registry>,Registry>
+//! # let _: &reload::Handle<filter::Filtered<fmt::Layer<tracing_subscriber::Registry>,
+//! # filter::LevelFilter, tracing_subscriber::Registry>,tracing_subscriber::Registry>
 //! # = &reload_handle;
 //! #
 //! tracing_subscriber::registry()

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -11,7 +11,7 @@
 //!
 //! # Examples
 //!
-//! Reloading a global filtering layer:
+//! Reloading a [global filtering](crate::layer#global-filtering) layer:
 //! ```rust
 //! # use tracing::info;
 //! # use tracing_subscriber::{filter,fmt,reload,Registry,prelude::*};

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -32,6 +32,7 @@
 //! ```
 //!
 //! Reloading a [`Filtered`](crate::filter::Filtered) layer:
+//!
 //! ```rust
 //! # use tracing::info;
 //! # use tracing_subscriber::{filter,fmt,reload,Registry,prelude::*};

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -15,7 +15,7 @@
 //!
 //! ```rust
 //! # use tracing::info;
-//! # use tracing_subscriber::{filter,fmt,reload,Registry,prelude::*};
+//! use tracing_subscriber::{filter, fmt, reload, Registry, prelude::*};
 //! let filter = filter::LevelFilter::WARN;
 //! let (filter, reload_handle) = reload::Layer::new(filter);
 //! Registry::default()


### PR DESCRIPTION
Missing example was noticed in https://github.com/tokio-rs/tracing/pull/1959#discussion_r816248186

Should the descriptions of the examples distinguish global filtering and per-layer filtering a bit more explicitly?