### PR TITLE
Fix broken link in Targets rustdoc

### DIFF
--- a/tracing-subscriber/src/filter/targets.rs
+++ b/tracing-subscriber/src/filter/targets.rs
@@ -111,7 +111,7 @@ use tracing_core::{Interest, Level, Metadata, Subscriber};
 /// by the user at runtime.
 ///
 /// The `Targets` filter can be used as a [per-layer filter][plf] *and* as a
-/// [global filter]:
+/// [global filter][global]:
 ///
 /// ```rust
 /// use tracing_subscriber::{


### PR DESCRIPTION
The link `[global]` is defined at the bottom (and already used in line 32), so I used it here as well