### PR TITLE
Add new filter methods

### DIFF
--- a/tracing-subscriber/src/filter/layer_filters/combinator.rs
+++ b/tracing-subscriber/src/filter/layer_filters/combinator.rs
@@ -132,6 +132,31 @@ where
         // If either hint is `None`, return `None`. Otherwise, return the most restrictive.
         cmp::min(self.a.max_level_hint(), self.b.max_level_hint())
     }
+
+    fn on_new_span(
+        &self,
+        attrs: &tracing_core::span::Attributes<'_>,
+        id: &tracing_core::span::Id,
+        ctx: Context<'_, S>,
+    ) {
+        self.a.on_new_span(attrs, id, ctx.clone());
+        self.b.on_new_span(attrs, id, ctx)
+    }
+
+    fn on_enter(&self, id: &tracing_core::span::Id, ctx: Context<'_, S>) {
+        self.a.on_enter(id, ctx.clone());
+        self.b.on_enter(id, ctx);
+    }
+
+    fn on_exit(&self, id: &tracing_core::span::Id, ctx: Context<'_, S>) {
+        self.a.on_exit(id, ctx.clone());
+        self.b.on_exit(id, ctx);
+    }
+
+    fn on_close(&self, id: tracing_core::span::Id, ctx: Context<'_, S>) {
+        self.a.on_close(id.clone(), ctx.clone());
+        self.b.on_close(id, ctx);
+    }
 }
 
 impl<A, B, S> Clone for And<A, B, S>
@@ -289,6 +314,31 @@ where
         // If either hint is `None`, return `None`. Otherwise, return the less restrictive.
         Some(cmp::max(self.a.max_level_hint()?, self.b.max_level_hint()?))
     }
+
+    fn on_new_span(
+        &self,
+        attrs: &tracing_core::span::Attributes<'_>,
+        id: &tracing_core::span::Id,
+        ctx: Context<'_, S>,
+    ) {
+        self.a.on_new_span(attrs, id, ctx.clone());
+        self.b.on_new_span(attrs, id, ctx)
+    }
+
+    fn on_enter(&self, id: &tracing_core::span::Id, ctx: Context<'_, S>) {
+        self.a.on_enter(id, ctx.clone());
+        self.b.on_enter(id, ctx);
+    }
+
+    fn on_exit(&self, id: &tracing_core::span::Id, ctx: Context<'_, S>) {
+        self.a.on_exit(id, ctx.clone());
+        self.b.on_exit(id, ctx);
+    }
+
+    fn on_close(&self, id: tracing_core::span::Id, ctx: Context<'_, S>) {
+        self.a.on_close(id.clone(), ctx.clone());
+        self.b.on_close(id, ctx);
+    }
 }
 
 impl<A, B, S> Clone for Or<A, B, S>
@@ -355,6 +405,27 @@ where
     fn max_level_hint(&self) -> Option<LevelFilter> {
         // TODO(eliza): figure this out???
         None
+    }
+
+    fn on_new_span(
+        &self,
+        attrs: &tracing_core::span::Attributes<'_>,
+        id: &tracing_core::span::Id,
+        ctx: Context<'_, S>,
+    ) {
+        self.a.on_new_span(attrs, id, ctx);
+    }
+
+    fn on_enter(&self, id: &tracing_core::span::Id, ctx: Context<'_, S>) {
+        self.a.on_enter(id, ctx);
+    }
+
+    fn on_exit(&self, id: &tracing_core::span::Id, ctx: Context<'_, S>) {
+        self.a.on_exit(id, ctx);
+    }
+
+    fn on_close(&self, id: tracing_core::span::Id, ctx: Context<'_, S>) {
+        self.a.on_close(id, ctx);
     }
 }
 

--- a/tracing-subscriber/src/filter/layer_filters/combinator.rs
+++ b/tracing-subscriber/src/filter/layer_filters/combinator.rs
@@ -414,6 +414,7 @@ where
         None
     }
 
+    #[inline]
     fn on_new_span(
         &self,
         attrs: &tracing_core::span::Attributes<'_>,
@@ -423,14 +424,17 @@ where
         self.a.on_new_span(attrs, id, ctx);
     }
 
+    #[inline]
     fn on_enter(&self, id: &tracing_core::span::Id, ctx: Context<'_, S>) {
         self.a.on_enter(id, ctx);
     }
 
+    #[inline]
     fn on_exit(&self, id: &tracing_core::span::Id, ctx: Context<'_, S>) {
         self.a.on_exit(id, ctx);
     }
 
+    #[inline]
     fn on_close(&self, id: tracing_core::span::Id, ctx: Context<'_, S>) {
         self.a.on_close(id, ctx);
     }

--- a/tracing-subscriber/src/filter/layer_filters/combinator.rs
+++ b/tracing-subscriber/src/filter/layer_filters/combinator.rs
@@ -1,7 +1,11 @@
 //! Filter combinators
 use crate::layer::{Context, Filter};
 use std::{cmp, fmt, marker::PhantomData};
-use tracing_core::{subscriber::Interest, LevelFilter, Metadata};
+use tracing_core::{
+    span::{Attributes, Id},
+    subscriber::Interest,
+    LevelFilter, Metadata,
+};
 
 /// Combines two [`Filter`]s so that spans and events are enabled if and only if
 /// *both* filters return `true`.
@@ -134,30 +138,25 @@ where
     }
 
     #[inline]
-    fn on_new_span(
-        &self,
-        attrs: &tracing_core::span::Attributes<'_>,
-        id: &tracing_core::span::Id,
-        ctx: Context<'_, S>,
-    ) {
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         self.a.on_new_span(attrs, id, ctx.clone());
         self.b.on_new_span(attrs, id, ctx)
     }
 
     #[inline]
-    fn on_enter(&self, id: &tracing_core::span::Id, ctx: Context<'_, S>) {
+    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
         self.a.on_enter(id, ctx.clone());
         self.b.on_enter(id, ctx);
     }
 
     #[inline]
-    fn on_exit(&self, id: &tracing_core::span::Id, ctx: Context<'_, S>) {
+    fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
         self.a.on_exit(id, ctx.clone());
         self.b.on_exit(id, ctx);
     }
 
     #[inline]
-    fn on_close(&self, id: tracing_core::span::Id, ctx: Context<'_, S>) {
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
         self.a.on_close(id.clone(), ctx.clone());
         self.b.on_close(id, ctx);
     }
@@ -319,30 +318,25 @@ where
         Some(cmp::max(self.a.max_level_hint()?, self.b.max_level_hint()?))
     }
     #[inline]
-    fn on_new_span(
-        &self,
-        attrs: &tracing_core::span::Attributes<'_>,
-        id: &tracing_core::span::Id,
-        ctx: Context<'_, S>,
-    ) {
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         self.a.on_new_span(attrs, id, ctx.clone());
         self.b.on_new_span(attrs, id, ctx)
     }
 
     #[inline]
-    fn on_enter(&self, id: &tracing_core::span::Id, ctx: Context<'_, S>) {
+    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
         self.a.on_enter(id, ctx.clone());
         self.b.on_enter(id, ctx);
     }
 
     #[inline]
-    fn on_exit(&self, id: &tracing_core::span::Id, ctx: Context<'_, S>) {
+    fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
         self.a.on_exit(id, ctx.clone());
         self.b.on_exit(id, ctx);
     }
 
     #[inline]
-    fn on_close(&self, id: tracing_core::span::Id, ctx: Context<'_, S>) {
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
         self.a.on_close(id.clone(), ctx.clone());
         self.b.on_close(id, ctx);
     }
@@ -415,27 +409,22 @@ where
     }
 
     #[inline]
-    fn on_new_span(
-        &self,
-        attrs: &tracing_core::span::Attributes<'_>,
-        id: &tracing_core::span::Id,
-        ctx: Context<'_, S>,
-    ) {
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         self.a.on_new_span(attrs, id, ctx);
     }
 
     #[inline]
-    fn on_enter(&self, id: &tracing_core::span::Id, ctx: Context<'_, S>) {
+    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
         self.a.on_enter(id, ctx);
     }
 
     #[inline]
-    fn on_exit(&self, id: &tracing_core::span::Id, ctx: Context<'_, S>) {
+    fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
         self.a.on_exit(id, ctx);
     }
 
     #[inline]
-    fn on_close(&self, id: tracing_core::span::Id, ctx: Context<'_, S>) {
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
         self.a.on_close(id, ctx);
     }
 }

--- a/tracing-subscriber/src/filter/layer_filters/combinator.rs
+++ b/tracing-subscriber/src/filter/layer_filters/combinator.rs
@@ -318,7 +318,7 @@ where
         // If either hint is `None`, return `None`. Otherwise, return the less restrictive.
         Some(cmp::max(self.a.max_level_hint()?, self.b.max_level_hint()?))
     }
-
+    #[inline]
     fn on_new_span(
         &self,
         attrs: &tracing_core::span::Attributes<'_>,
@@ -329,16 +329,19 @@ where
         self.b.on_new_span(attrs, id, ctx)
     }
 
+    #[inline]
     fn on_enter(&self, id: &tracing_core::span::Id, ctx: Context<'_, S>) {
         self.a.on_enter(id, ctx.clone());
         self.b.on_enter(id, ctx);
     }
 
+    #[inline]
     fn on_exit(&self, id: &tracing_core::span::Id, ctx: Context<'_, S>) {
         self.a.on_exit(id, ctx.clone());
         self.b.on_exit(id, ctx);
     }
 
+    #[inline]
     fn on_close(&self, id: tracing_core::span::Id, ctx: Context<'_, S>) {
         self.a.on_close(id.clone(), ctx.clone());
         self.b.on_close(id, ctx);

--- a/tracing-subscriber/src/filter/layer_filters/combinator.rs
+++ b/tracing-subscriber/src/filter/layer_filters/combinator.rs
@@ -317,6 +317,7 @@ where
         // If either hint is `None`, return `None`. Otherwise, return the less restrictive.
         Some(cmp::max(self.a.max_level_hint()?, self.b.max_level_hint()?))
     }
+    
     #[inline]
     fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         self.a.on_new_span(attrs, id, ctx.clone());

--- a/tracing-subscriber/src/filter/layer_filters/combinator.rs
+++ b/tracing-subscriber/src/filter/layer_filters/combinator.rs
@@ -133,6 +133,7 @@ where
         cmp::min(self.a.max_level_hint(), self.b.max_level_hint())
     }
 
+    #[inline]
     fn on_new_span(
         &self,
         attrs: &tracing_core::span::Attributes<'_>,
@@ -143,16 +144,19 @@ where
         self.b.on_new_span(attrs, id, ctx)
     }
 
+    #[inline]
     fn on_enter(&self, id: &tracing_core::span::Id, ctx: Context<'_, S>) {
         self.a.on_enter(id, ctx.clone());
         self.b.on_enter(id, ctx);
     }
 
+    #[inline]
     fn on_exit(&self, id: &tracing_core::span::Id, ctx: Context<'_, S>) {
         self.a.on_exit(id, ctx.clone());
         self.b.on_exit(id, ctx);
     }
 
+    #[inline]
     fn on_close(&self, id: tracing_core::span::Id, ctx: Context<'_, S>) {
         self.a.on_close(id.clone(), ctx.clone());
         self.b.on_close(id, ctx);

--- a/tracing-subscriber/src/filter/layer_filters/mod.rs
+++ b/tracing-subscriber/src/filter/layer_filters/mod.rs
@@ -579,7 +579,9 @@ where
 
     fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, cx: Context<'_, S>) {
         self.did_enable(|| {
-            self.layer.on_new_span(attrs, id, cx.with_filter(self.id()));
+            let cx = cx.with_filter(self.id());
+            self.filter.on_new_span(attrs, id, cx.clone());
+            self.layer.on_new_span(attrs, id, cx);
         })
     }
 
@@ -610,19 +612,22 @@ where
 
     fn on_enter(&self, id: &span::Id, cx: Context<'_, S>) {
         if let Some(cx) = cx.if_enabled_for(id, self.id()) {
-            self.layer.on_enter(id, cx)
+            self.filter.on_enter(id, cx.clone());
+            self.layer.on_enter(id, cx);
         }
     }
 
     fn on_exit(&self, id: &span::Id, cx: Context<'_, S>) {
         if let Some(cx) = cx.if_enabled_for(id, self.id()) {
-            self.layer.on_exit(id, cx)
+            self.filter.on_enter(id, cx.clone());
+            self.layer.on_exit(id, cx);
         }
     }
 
     fn on_close(&self, id: span::Id, cx: Context<'_, S>) {
         if let Some(cx) = cx.if_enabled_for(&id, self.id()) {
-            self.layer.on_close(id, cx)
+            self.filter.on_close(id.clone(), cx.clone());
+            self.layer.on_close(id, cx);
         }
     }
 

--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -1064,7 +1064,10 @@ feature! {
         /// Notifies this filter that a span with the given ID was entered.
         fn on_enter(&self, _id: &span::Id, _ctx: Context<'_, S>) {}
 
-        /// Notifies this filter that the span with the given ID was exited.
+        /// Notifies this filter that a span with the given ID was exited.
+        ///
+        /// By default, this method does nothing. `Filter` implementations that
+        /// need to be notified when a span is exited can override this method.
         fn on_exit(&self, _id: &span::Id, _ctx: Context<'_, S>) {}
 
         /// Notifies this filter that a span with the given ID has been closed.

--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -1057,6 +1057,10 @@ feature! {
 
         /// Notifies this filter that a new span was constructed with the given
         /// `Attributes` and `Id`.
+        ///
+        /// By default, this method does nothing. `Filter` implementations that
+        /// need to be notified when new spans are created can override this
+        /// method.
         fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
             let _ = (attrs, id, ctx);
         }

--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -1067,7 +1067,10 @@ feature! {
         /// Notifies this filter that the span with the given ID was exited.
         fn on_exit(&self, _id: &span::Id, _ctx: Context<'_, S>) {}
 
-        /// Notifies this filter that the span with the given ID has been closed.
+        /// Notifies this filter that a span with the given ID has been closed.
+        ///
+        /// By default, this method does nothing. `Filter` implementations that
+        /// need to be notified when a span is closed can override this method.
         fn on_close(&self, _id: span::Id, _ctx: Context<'_, S>) {}
     }
 }

--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -1062,6 +1062,9 @@ feature! {
         }
 
         /// Notifies this filter that a span with the given ID was entered.
+        ///
+        /// By default, this method does nothing. `Filter` implementations that
+        /// need to be notified when a span is entered can override this method.
         fn on_enter(&self, _id: &span::Id, _ctx: Context<'_, S>) {}
 
         /// Notifies this filter that a span with the given ID was exited.

--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -457,7 +457,7 @@
 //!         .json()
 //!         .with_writer(Arc::new(file));
 //!     Some(json_log)
-//! } else {   
+//! } else {
 //!     None
 //! };
 //!
@@ -1054,6 +1054,21 @@ feature! {
         fn max_level_hint(&self) -> Option<LevelFilter> {
             None
         }
+
+        /// Notifies this filter that a new span was constructed with the given
+        /// `Attributes` and `Id`.
+        fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+            let _ = (attrs, id, ctx);
+        }
+
+        /// Notifies this filter that a span with the given ID was entered.
+        fn on_enter(&self, _id: &span::Id, _ctx: Context<'_, S>) {}
+
+        /// Notifies this filter that the span with the given ID was exited.
+        fn on_exit(&self, _id: &span::Id, _ctx: Context<'_, S>) {}
+
+        /// Notifies this filter that the span with the given ID has been closed.
+        fn on_close(&self, _id: span::Id, _ctx: Context<'_, S>) {}
     }
 }
 

--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -1069,19 +1069,25 @@ feature! {
         ///
         /// By default, this method does nothing. `Filter` implementations that
         /// need to be notified when a span is entered can override this method.
-        fn on_enter(&self, _id: &span::Id, _ctx: Context<'_, S>) {}
+        fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
+            let _ = (id, ctx);
+        }
 
         /// Notifies this filter that a span with the given ID was exited.
         ///
         /// By default, this method does nothing. `Filter` implementations that
         /// need to be notified when a span is exited can override this method.
-        fn on_exit(&self, _id: &span::Id, _ctx: Context<'_, S>) {}
+        fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
+            let _ = (id, ctx);
+        }
 
         /// Notifies this filter that a span with the given ID has been closed.
         ///
         /// By default, this method does nothing. `Filter` implementations that
         /// need to be notified when a span is closed can override this method.
-        fn on_close(&self, _id: span::Id, _ctx: Context<'_, S>) {}
+        fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
+            let _ = (id, ctx);
+        }
     }
 }
 


### PR DESCRIPTION
Related to https://github.com/tokio-rs/tracing/issues/1955

Call those methods in the Layer methods for Filtered and delegate them in the filter combinators

## Motivation

Currently, if a Filter is going to implement dynamic filtering, it must do this by querying the wrapped Subscriber for the current span context. Since Filter only has callsite_enabled and enabled methods, a Filter implementation cannot track the span context internally, the way a Layer can.

Unfortunately, this means that the current implementation of EnvFilter can only implement Layer (and provide global filtering). It cannot currently implement Filter, because it stores span context data internally. See https://github.com/tokio-rs/tracing/issues/1868 for details.

## Proposal

We should add on_new_span, on_enter, on_exit, and on_close methods to Filter. This would allow implementing Filters (such as EnvFilter) that internally track span states.