### PR TITLE
backport changes from `master`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -48,7 +48,7 @@ humantime = "2.0"
 log = "0.4"
 
 # inferno example
-inferno = "0.10.0"
+inferno = "0.11.0"
 tempfile = "3"
 
 # opentelemetry example

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -40,7 +40,7 @@ async-await = []
 
 [dependencies]
 proc-macro2 = "1"
-syn = { version = "1", default-features = false, features = ["full", "parsing", "printing", "visit", "visit-mut", "clone-impls", "extra-traits", "proc-macro"] }
+syn = { version = "1.0.43", default-features = false, features = ["full", "parsing", "printing", "visit", "visit-mut", "clone-impls", "extra-traits", "proc-macro"] }
 quote = "1"
 
 [dev-dependencies]

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -524,7 +524,6 @@ impl Dispatch {
     ///
     /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
     /// [`enter`]: ../subscriber/trait.Subscriber.html#method.enter
-    #[inline]
     pub fn enter(&self, span: &span::Id) {
         self.subscriber.enter(span);
     }
@@ -536,7 +535,6 @@ impl Dispatch {
     ///
     /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
     /// [`exit`]: ../subscriber/trait.Subscriber.html#method.exit
-    #[inline]
     pub fn exit(&self, span: &span::Id) {
         self.subscriber.exit(span);
     }
@@ -604,7 +602,6 @@ impl Dispatch {
     /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
     /// [`try_close`]: ../subscriber/trait.Subscriber.html#method.try_close
     /// [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
-    #[inline]
     pub fn try_close(&self, id: span::Id) -> bool {
         self.subscriber.try_close(id)
     }

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -768,10 +768,10 @@ impl Span {
     /// info!("i'm outside the span!")
     /// ```
     ///
-    /// [`Subscriber::enter`]: ../subscriber/trait.Subscriber.html#method.enter
-    /// [`Subscriber::exit`]: ../subscriber/trait.Subscriber.html#method.exit
-    /// [`Id`]: ../struct.Id.html
-    #[inline]
+    /// [`Subscriber::enter`]: super::subscriber::Subscriber::enter()
+    /// [`Subscriber::exit`]: super::subscriber::Subscriber::exit()
+    /// [`Id`]: super::Id
+    #[inline(always)]
     pub fn enter(&self) -> Entered<'_> {
         self.do_enter();
         Entered { span: self }
@@ -878,10 +878,11 @@ impl Span {
     /// span.record("some_field", &"hello world!");
     /// ```
     ///
-    /// [`Subscriber::enter`]: ../subscriber/trait.Subscriber.html#method.enter
-    /// [`Subscriber::exit`]: ../subscriber/trait.Subscriber.html#method.exit
-    /// [`Id`]: ../struct.Id.html
-    #[inline]
+
+    /// [`Subscriber::enter`]: super::subscriber::Subscriber::enter()
+    /// [`Subscriber::exit`]: super::subscriber::Subscriber::exit()
+    /// [`Id`]: super::Id
+    #[inline(always)]
     pub fn entered(self) -> EnteredSpan {
         self.do_enter();
         EnteredSpan {
@@ -1020,7 +1021,7 @@ impl Span {
         self
     }
 
-    #[inline]
+    #[inline(always)]
     fn do_enter(&self) {
         if let Some(inner) = self.inner.as_ref() {
             inner.subscriber.enter(&inner.id);
@@ -1037,7 +1038,7 @@ impl Span {
     //
     // Running this behaviour on drop rather than with an explicit function
     // call means that spans may still be exited when unwinding.
-    #[inline]
+    #[inline(always)]
     fn do_exit(&self) {
         if let Some(inner) = self.inner.as_ref() {
             inner.subscriber.exit(&inner.id);
@@ -1438,6 +1439,7 @@ impl<'a> From<&'a EnteredSpan> for Option<Id> {
 }
 
 impl Drop for Span {
+    #[inline(always)]
     fn drop(&mut self) {
         if let Some(Inner {
             ref id,
@@ -1447,15 +1449,15 @@ impl Drop for Span {
             subscriber.try_close(id.clone());
         }
 
-        if let Some(_meta) = self.meta {
-            if_log_enabled! { crate::Level::TRACE, {
+        if_log_enabled! { crate::Level::TRACE, {
+            if let Some(meta) = self.meta {
                 self.log(
                     LIFECYCLE_LOG_TARGET,
                     log::Level::Trace,
-                    format_args!("-- {}", _meta.name()),
+                    format_args!("-- {}", meta.name()),
                 );
-            }}
-        }
+            }
+        }}
     }
 }
 
@@ -1547,14 +1549,14 @@ impl Deref for EnteredSpan {
 }
 
 impl<'a> Drop for Entered<'a> {
-    #[inline]
+    #[inline(always)]
     fn drop(&mut self) {
         self.span.do_exit()
     }
 }
 
 impl Drop for EnteredSpan {
-    #[inline]
+    #[inline(always)]
     fn drop(&mut self) {
         self.span.do_exit()
     }


### PR DESCRIPTION
This backports a few changes from `master` to v0.1.x. The important one is PR #1974

* 7ce611ee tracing: reduce disabled span `Drop` overhead (#1974)
* 968f0762 build(deps): update inferno requirement from 0.10.0 to 0.11.0 (#1966)
* 5de7f643 attributes: use correct minimal version of `syn` (#1960)