### PR TITLE
attributes: prepare to release v0.1.20

### DIFF
--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.1.20 (March 8, 2022)
+
+### Fixed
+
+- Compilation failure with `--minimal-versions` due to a too-permissive `syn`
+  dependency ([#1960])
+
+### Changed
+
+- Bumped minimum supported Rust version (MSRV) to 1.49.0 ([#1913])
+
+Thanks to new contributor @udoprog for contributing to this release!
+
+[#1960]: https://github.com/tokio-rs/tracing/pull/1960
+[#1913]: https://github.com/tokio-rs/tracing/pull/1913
+
 # 0.1.19 (February 3, 2022)
 
 This release introduces a new `#[instrument(ret)]` argument to emit an event

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-attributes"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.19"
+version = "0.1.20"
 authors = [
     "Tokio Contributors <team@tokio.rs>",
     "Eliza Weisman <eliza@buoyant.io>",

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -18,7 +18,7 @@ Macro attributes for application-level tracing.
 [crates-badge]: https://img.shields.io/crates/v/tracing-attributes.svg
 [crates-url]: https://crates.io/crates/tracing-attributes
 [docs-badge]: https://docs.rs/tracing-attributes/badge.svg
-[docs-url]: https://docs.rs/tracing-attributes/0.1.19
+[docs-url]: https://docs.rs/tracing-attributes/0.1.20
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_attributes
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -47,7 +47,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing-attributes = "0.1.19"
+tracing-attributes = "0.1.20"
 ```
 
 

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tracing-attributes = "0.1.19"
+//! tracing-attributes = "0.1.20"
 //! ```
 //!
 //! The [`#[instrument]`][instrument] attribute can now be added to a function
@@ -52,7 +52,7 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
-#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.19")]
+#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.20")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.1.20 (March 8, 2022)

### Fixed

- Compilation failure with `--minimal-versions` due to a too-permissive
  `syn` dependency ([#1960])

### Changed

- Bumped minimum supported Rust version (MSRV) to 1.49.0 ([#1913])

Thanks to new contributor @udoprog for contributing to this release!

[#1960]: https://github.com/tokio-rs/tracing/pull/1960
[#1913]: https://github.com/tokio-rs/tracing/pull/1913