### PR TITLE
tracing: prepare to release 0.1.32

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 0.1.32 (March 8th, 2022)
+
+This release reduces the overhead of creating and dropping disabled
+spans significantly, which should improve performance when no `tracing`
+subscriber is in use or when spans are disabled by a filter.
+
+### Fixed
+
+- **attributes**: Compilation failure with `--minimal-versions` due to a
+  too-permissive `syn` dependency ([#1960])
+
+### Changed
+
+- Reduced `Drop` overhead for disabled spans ([#1974])
+- `tracing-attributes`: updated to [0.1.20][attributes-0.1.20]
+
+[#1974]: https://github.com/tokio-rs/tracing/pull/1974
+[#1960]: https://github.com/tokio-rs/tracing/pull/1960
+[attributes-0.1.20]: https://github.com/tokio-rs/tracing/releases/tag/tracing-attributes-0.1.20
+
 # 0.1.31 (February 17th, 2022)
 
 This release increases the minimum supported Rust version (MSRV) to 1.49.0. In

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.31"
+version = "0.1.32"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
@@ -30,7 +30,7 @@ rust-version = "1.49.0"
 [dependencies]
 tracing-core = { path = "../tracing-core", version = "0.1.22", default-features = false }
 log = { version = "0.4", optional = true }
-tracing-attributes = { path = "../tracing-attributes", version = "0.1.19", optional = true }
+tracing-attributes = { path = "../tracing-attributes", version = "0.1.20", optional = true }
 cfg-if = "1.0.0"
 pin-project-lite = "0.2"
 

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -16,9 +16,9 @@ Application-level tracing for Rust.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.31
+[crates-url]: https://crates.io/crates/tracing/0.1.32
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.31
+[docs-url]: https://docs.rs/tracing/0.1.32
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -250,7 +250,7 @@ my_future
 is as long as the future's.
 
 The second, and preferred, option is through the
-[`#[instrument]`](https://docs.rs/tracing/0.1.31/tracing/attr.instrument.html)
+[`#[instrument]`](https://docs.rs/tracing/0.1.32/tracing/attr.instrument.html)
 attribute:
 
 ```rust
@@ -297,7 +297,7 @@ span.in_scope(|| {
 // Dropping the span will close it, indicating that it has ended.
 ```
 
-The [`#[instrument]`](https://docs.rs/tracing/0.1.31/tracing/attr.instrument.html) attribute macro
+The [`#[instrument]`](https://docs.rs/tracing/0.1.32/tracing/attr.instrument.html) attribute macro
 can reduce some of this boilerplate:
 
 ```rust

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -809,7 +809,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing = { version = "0.1.31", default-features = false }
+//!   tracing = { version = "0.1.32", default-features = false }
 //!   ```
 //!
 //! <pre class="ignore" style="white-space:normal;font:inherit;">
@@ -892,7 +892,7 @@
 //! [flags]: #crate-feature-flags
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.31")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.32")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.1.32 (March 8th, 2022)

This release reduces the overhead of creating and dropping disabled
spans significantly, which should improve performance when no `tracing`
subscriber is in use or when spans are disabled by a filter.

### Fixed

- **attributes**: Compilation failure with `--minimal-versions` due to a
  too-permissive `syn` dependency ([#1960])

### Changed

- Reduced `Drop` overhead for disabled spans ([#1974])
- `tracing-attributes`: updated to [0.1.20][attributes-0.1.20]

[#1974]: https://github.com/tokio-rs/tracing/pull/1974
[#1960]: https://github.com/tokio-rs/tracing/pull/1960
[attributes-0.1.20]: https://github.com/tokio-rs/tracing/releases/tag/tracing-attributes-0.1.20