### PR TITLE
Create a symlink to latest log file

### DIFF
--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -24,6 +24,7 @@ rust-version = "1.53.0"
 crossbeam-channel = "0.5.0"
 time = { version = "0.3", default-features = false, features = ["formatting"] }
 parking_lot = { optional = true, version = "0.12.0" }
+symlink = "0.1.0"
 
 [dependencies.tracing-subscriber]
 path = "../tracing-subscriber"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

When monitoring logs of rotating files, it will be very helpful to create a symlink
to the latest log file when creating and rotating the log file.

Then you can `tail -F symlink_file` to keep watching the new created log file.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Create a symlink file when creating and rotating the log file.

Use a `symlink` crate to achieve a system compatible implementation.

It's necessary to remove the old symlink file before creating it, otherwise it may cause failure.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
