### PR TITLE
journald: fix memfd_create_syscall for 32 bit targets

### DIFF
--- a/tracing-journald/src/memfd.rs
+++ b/tracing-journald/src/memfd.rs
@@ -22,13 +22,13 @@ fn create(flags: c_uint) -> Result<File> {
 /// RHEL 7, etc.
 ///
 /// See: https://github.com/tokio-rs/tracing/issues/1879
-fn memfd_create_syscall(flags: c_uint) -> i64 {
+fn memfd_create_syscall(flags: c_uint) -> c_int {
     unsafe {
         syscall(
             SYS_memfd_create,
             "tracing-journald\0".as_ptr() as *const c_char,
             flags,
-        )
+        ) as c_int
     }
 }
 


### PR DESCRIPTION
## Motivation

I would like to use tracing-journald on a 32 bit target (armv7).

## Solution

On 32 bit targets (e.g. armv7) the syscall in memfd_create_syscall()
returns an i32, so this compilation error is printed:

```
| error[E0308]: mismatched types
|   --> .../tracing-journald-0.2.3/src/memfd.rs:27:9
|    |
| 25 |   fn memfd_create_syscall(flags: c_uint) -> i64 {
|    |                                             --- expected `i64`
|    |                                           because of return type
| 26 |       unsafe {
| 27 | /         syscall(
| 28 | |             SYS_memfd_create,
| 29 | |             "tracing-journald\0".as_ptr() as *const c_char,
| 30 | |             flags,
| 31 | |         )
|    | |_________^ expected `i64`, found `i32`
|    |
| help: you can convert an `i32` to an `i64`
|    |
| 31 |         ).into()
|    |          +++++++
|
| For more information about this error, try `rustc --explain E0308`.
| error: could not compile `tracing-journald` due to previous error
|
```