### PR TITLE
chore: avoid giant feature powersets using `cargo-hack`

### DIFF
--- a/.github/workflows/check_features.yml
+++ b/.github/workflows/check_features.yml
@@ -45,10 +45,8 @@ jobs:
         - tracing-serde
         - tracing-tower
         - tracing-opentelemetry
-        # tracing and tracing-subscriber have too many features to be checked by
-        # cargo-hack --feature-powerset, combinatorics there is exploding.
-        #- tracing
-        #- tracing-subscriber
+        - tracing
+        - tracing-subscriber
     steps:
     - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
@@ -61,53 +59,31 @@ jobs:
         curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
     - name: cargo hack check
       working-directory: ${{ matrix.subcrate }}
-      run: cargo hack check --feature-powerset --no-dev-deps
-
-  cargo-check-tracing:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        featureset:
-        - ""
-        - log-always
-        - std log-always
-        - std
-      fail-fast: false
-    steps:
-    - uses: actions/checkout@main
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
-    - name: cargo check
-      working-directory: tracing
-      run: cargo check --no-default-features --features "${{ matrix.featureset }}"
-
-  cargo-check-subscriber:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        featureset:
-        - ""
-        - fmt
-        - fmt ansi
-        - fmt json
-        - fmt json ansi
-        - fmt registry
-        - fmt env-filter
-        - registry
-        - env-filter
-    steps:
-    - uses: actions/checkout@main
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
-    - name: cargo check
-      working-directory: tracing-subscriber
-      run: cargo check --no-default-features --features "${{ matrix.featureset }}"
+      # tracing and tracing-subscriber have too many features to be checked by
+      # cargo-hack --feature-powerset with all features in the powerset, so
+      # exclude some
+      run: |
+        CARGO_HACK=(cargo hack check --feature-powerset --no-dev-deps)
+        case "${{ matrix.subcrate }}" of
+          tracing)
+            EXCLUDE_FEATURES=(
+              max_level_off max_level_error max_level_warn max_level_info
+              max_level_debug max_level_trace release_max_level_off
+              release_max_level_error release_max_level_warn
+              release_max_level_info release_max_level_debug
+              release_max_level_trace
+            )
+            ${CARGO_HACK[@]} --exclude-features "${EXCLUDE_FEATURES[*]}"
+            ;;
+          tracing-subscriber)
+            INCLUDE_FEATURES=(fmt ansi json registry env-filter)
+            ${CARGO_HACK[@]} --include-features "${INCLUDE_FEATURES[*]}"
+            ;;
+          *)
+            ${CARGO_HACK[@]}
+            ;;
+        esac
+      shell: bash
 
   features-stable:
     # Feature flag tests that run on stable Rust.

--- a/.github/workflows/check_features.yml
+++ b/.github/workflows/check_features.yml
@@ -64,7 +64,7 @@ jobs:
       # exclude some
       run: |
         CARGO_HACK=(cargo hack check --feature-powerset --no-dev-deps)
-        case "${{ matrix.subcrate }}" of
+        case "${{ matrix.subcrate }}" in
           tracing)
             EXCLUDE_FEATURES=(
               max_level_off max_level_error max_level_warn max_level_info

--- a/bin/publish
+++ b/bin/publish
@@ -38,10 +38,40 @@ verify() {
 
     status "Checking" "if $CRATE builds across feature combinations"
 
-    if ! cargo hack check $VERBOSE --feature-powerset --no-dev-deps; then
+    CARGO_HACK=(cargo hack check $VERBOSE --feature-powerset  --no-dev-deps)
+    case "$CRATE" in
+        tracing-subscriber)
+            # for tracing-subscriber, don't test a complete powerset because
+            # there are lots of feature flags
+            INCLUDE_FEATURES=(fmt ansi json registry env-filter)
+            ${CARGO_HACK[@]} --include-features "${INCLUDE_FEATURES[*]}"
+            CARGO_HACK_STATUS="$?"
+            ;;
+        tracing)
+            # checking the full feature powerset for `tracing` will take
+            # *forever* because of the `max_level_XXX` and
+            # `release_max_level_XXX` features
+            EXCLUDE_FEATURES=(
+                max_level_off max_level_error max_level_warn max_level_info
+                max_level_debug max_level_trace release_max_level_off
+                release_max_level_error release_max_level_warn
+                release_max_level_info release_max_level_debug
+                release_max_level_trace
+            )
+            ${CARGO_HACK[@]} --exclude-features "${EXCLUDE_FEATURES[*]}"
+            CARGO_HACK_STATUS="$?"
+            ;;
+        *)
+            ${CARGO_HACK[@]}
+            CARGO_HACK_STATUS="$?"
+            ;;
+    esac
+
+    if "$CARGO_HACK_STATUS" ; then
         err "$CRATE did not build with all feature combinations!"
         exit 1
     fi
+
 
     if git tag -l | grep -Fxq "$TAG" ; then
         err "git tag \`$TAG\` already exists"
@@ -68,7 +98,7 @@ do
 case "$1" in
     -v|--verbose)
     VERBOSE="--verbose"
-    set +x
+    set -x
     shift
     ;;
     -d|--dry-run)


### PR DESCRIPTION
## Motivation

The `tracing`' crate's feature powerset is kind of unmanageably huge due
to the large number of `max_level_XXX` and `release_max_level_XXX`
feature flags. This is why we currently _don't_ run a `cargo-hack`
feature powerset check for it on CI. However, I forgot about that when I
added feature powerset checks to the `bin/publish` script, so publishing
a `tracing` release results in a combinatorial explosion that takes a
*very* long time to complete.

## Solution

It turns out that `cargo-hack` actually has flags for controlling what
features are included in the powerset (`--include-features` and
`--exclude-features`). This branch modifies `bin/publish` to use those
flags when checking the `tracing` and `tracing-subscriber` crate.
Additionally, I've modified the CI `cargo-hack` job to use the same
flags, so that it can now check `tracing` and `tracing-subscriber`.

This allows us to remove the manual feature check jobs for those crates
from CI.