### PR TITLE
Implement Clone for Directive, Match

### DIFF
--- a/tracing-subscriber/src/filter/env/directive.rs
+++ b/tracing-subscriber/src/filter/env/directive.rs
@@ -7,7 +7,7 @@ use tracing_core::{span, Level, Metadata};
 
 /// A single filtering directive.
 // TODO(eliza): add a builder for programmatically constructing directives?
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(docsrs, doc(cfg(feature = "env-filter")))]
 pub struct Directive {
     in_span: Option<String>,

--- a/tracing-subscriber/src/filter/env/field.rs
+++ b/tracing-subscriber/src/filter/env/field.rs
@@ -13,7 +13,7 @@ use std::{
 use super::{FieldMap, LevelFilter};
 use tracing_core::field::{Field, Visit};
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub(crate) struct Match {
     pub(crate) name: String, // TODO: allow match patterns for names?
     pub(crate) value: Option<ValueMatch>,


### PR DESCRIPTION
Using a crate like Clap, it's possible to support directive validation:

```rust
#[derive(clap::Args, Debug)]
pub(crate) struct Intrumentation {
    // ...

    /// Tracing directives (see https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives)
    #[clap(long, global = true, group = "verbosity", multiple_occurrences = true)]
    pub(crate) log_level: Vec<Directive>,
}
```

Resulting in nice runtime validation errors:

```
$ cargo run -- --log-level h2=tra
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/refuge --log-level h2=tra`
error: Invalid value "h2=tra" for '--log-level <LOG_LEVEL>': invalid filter directive

For more information try --help
```

Then later, we can build up an `EnvFilter` with these directives:

```rust
let mut filter_layer = match EnvFilter::try_from_default_env() {
    Ok(layer) => layer,
    Err(_) => EnvFilter::try_new(&format!("{}={}", env!("CARGO_PKG_NAME"), self.log_level()))?,
};
for directive in &self.log_level {
    // 'clone' the directive.
    let directive_str = directive.to_string();
    let directive = Directive::from_str(&directive_str)?;
    filter_layer = filter_layer.add_directive(directive)
}
```

This change allows cloning the `Directive` instead of doing the `to_string()` then `from_str()` dance.

```rust
for directive in &self.log_level {
    filter_layer = filter_layer.add_directive(directive.clone())
}
```