### PR TITLE
backport #1982 to v0.1.x

### DIFF
--- a/tracing-journald/src/memfd.rs
+++ b/tracing-journald/src/memfd.rs
@@ -22,13 +22,13 @@ fn create(flags: c_uint) -> Result<File> {
 /// RHEL 7, etc.
 ///
 /// See: https://github.com/tokio-rs/tracing/issues/1879
-fn memfd_create_syscall(flags: c_uint) -> i64 {
+fn memfd_create_syscall(flags: c_uint) -> c_int {
     unsafe {
         syscall(
             SYS_memfd_create,
             "tracing-journald\0".as_ptr() as *const c_char,
             flags,
-        )
+        ) as c_int
     }
 }
 


### PR DESCRIPTION
This backports #1982 to `v0.1.x`.

On 32 bit targets (e.g. armv7) the syscall in memfd_create_syscall()
returns an i32, so this compilation error is printed:

| error[E0308]: mismatched types
|   --> .../tracing-journald-0.2.3/src/memfd.rs:27:9
|    |
| 25 |   fn memfd_create_syscall(flags: c_uint) -> i64 {
|    |                                             --- expected `i64`
|    |                                           because of return type
| 26 |       unsafe {
| 27 | /         syscall(
| 28 | |             SYS_memfd_create,
| 29 | |             "tracing-journald\0".as_ptr() as *const c_char,
| 30 | |             flags,
| 31 | |         )
|    | |_________^ expected `i64`, found `i32`
|    |
| help: you can convert an `i32` to an `i64`
|    |
| 31 |         ).into()
|    |          +++++++
|
| For more information about this error, try `rustc --explain E0308`.
| error: could not compile `tracing-journald` due to previous error
|

This commit fixes this issue.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
