### PR TITLE
journald: prepare to release 0.2.4

### DIFF
--- a/tracing-journald/CHANGELOG.md
+++ b/tracing-journald/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.2.4 (March 17, 2022)
+
+### Fixed
+
+- Fixed compilation error in `memfd_create_syscall` on 32-bit targets ([#1982])
+
+Thanks to new contributor @chrta for contributing to this release!
+
+
+[#1982]: https://github.com/tokio-rs/tracing/pull/1982
+
 # 0.2.3 (February 7, 2022)
 
 ### Fixed

--- a/tracing-journald/Cargo.toml
+++ b/tracing-journald/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-journald"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/tracing-journald/README.md
+++ b/tracing-journald/README.md
@@ -27,7 +27,7 @@ scoped, structured, and async-aware diagnostics. `tracing-journald` provides a
 [`tracing-subscriber::Layer`][layer] implementation for logging `tracing` spans
 and events to [`systemd-journald`][journald], on Linux distributions that use
 `systemd`.
- 
+
 *Compiler support: [requires `rustc` 1.49+][msrv]*
 
 [msrv]: #supported-rust-versions


### PR DESCRIPTION
# 0.2.4 (March 17, 2022)

### Fixed

- Fixed compilation error in `memfd_create_syscall` on 32-bit targets
  ([#1982])

Thanks to new contributor @chrta for contributing to this release!

[#1982]: https://github.com/tokio-rs/tracing/pull/1982