### PR TITLE
appender: prepare to release 0.2.2

### DIFF
--- a/tracing-appender/CHANGELOG.md
+++ b/tracing-appender/CHANGELOG.md
@@ -4,6 +4,7 @@ This release fixes an incorrect `compare_exchange` in RollingFileAppender
 when rolling files over, causing a panic.
 
 ### Fixed
+
 - **rolling**: Fixed a panic that prohibited rolling files over. ([#1989])
 
 [#1989]: https://github.com/tokio-rs/tracing/pull/1989

--- a/tracing-appender/CHANGELOG.md
+++ b/tracing-appender/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.2.2 (March 17, 2022)
 
-This release fixes an incorrect `compare_exchange` in RollingFileAppender 
-when rolling files over, causing a panic.
+This release fixes a bug in `RollingFileAppender` that could result
+in a failure to rotate the log file, or in panics in debug mode.
 
 ### Fixed
 

--- a/tracing-appender/CHANGELOG.md
+++ b/tracing-appender/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.2.2 (March 17, 2022)
+
+This release fixes an incorrect `compare_exchange` in RollingFileAppender 
+when rolling files over, causing a panic.
+
+### Fixed
+- **rolling**: Fixed a panic that prohibited rolling files over. ([#1989])
+
+[#1989]: https://github.com/tokio-rs/tracing/pull/1989
+
 # 0.2.1 (February 28, 2022)
 
 This release adds an implementation of the `MakeWriter` trait for

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-appender"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
     "Zeki Sherif <zekshi@amazon.com>",
     "Tokio Contributors <team@tokio.rs>"

--- a/tracing-appender/README.md
+++ b/tracing-appender/README.md
@@ -16,9 +16,9 @@ Writers for logging events and spans
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-appender.svg
-[crates-url]: https://crates.io/crates/tracing-appender/0.2.1
+[crates-url]: https://crates.io/crates/tracing-appender/0.2.2
 [docs-badge]: https://docs.rs/tracing-appender/badge.svg
-[docs-url]: https://docs.rs/tracing-appender/0.2.1
+[docs-url]: https://docs.rs/tracing-appender/0.2.2
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing.rs/tracing-appender
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -122,7 +122,7 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
-#![doc(html_root_url = "https://docs.rs/tracing-appender/0.2.1")]
+#![doc(html_root_url = "https://docs.rs/tracing-appender/0.2.2")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.2.2 (March 17, 2022)

This release fixes an incorrect `compare_exchange` in RollingFileAppender 
when rolling files over, causing a panic.

### Fixed
- **rolling**: Fixed a panic that prohibited rolling files over. ([#1989])

[#1989]: https://github.com/tokio-rs/tracing/pull/1989