### PR TITLE
backport recent changes to v0.1.x

### DIFF
--- a/.github/workflows/check_features.yml
+++ b/.github/workflows/check_features.yml
@@ -45,10 +45,8 @@ jobs:
         - tracing-serde
         - tracing-tower
         - tracing-opentelemetry
-        # tracing and tracing-subscriber have too many features to be checked by
-        # cargo-hack --feature-powerset, combinatorics there is exploding.
-        #- tracing
-        #- tracing-subscriber
+        - tracing
+        - tracing-subscriber
     steps:
     - uses: actions/checkout@main
     - uses: actions-rs/toolchain@v1
@@ -61,53 +59,31 @@ jobs:
         curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
     - name: cargo hack check
       working-directory: ${{ matrix.subcrate }}
-      run: cargo hack check --feature-powerset --no-dev-deps
-
-  cargo-check-tracing:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        featureset:
-        - ""
-        - log-always
-        - std log-always
-        - std
-      fail-fast: false
-    steps:
-    - uses: actions/checkout@main
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
-    - name: cargo check
-      working-directory: tracing
-      run: cargo check --no-default-features --features "${{ matrix.featureset }}"
-
-  cargo-check-subscriber:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        featureset:
-        - ""
-        - fmt
-        - fmt ansi
-        - fmt json
-        - fmt json ansi
-        - fmt registry
-        - fmt env-filter
-        - registry
-        - env-filter
-    steps:
-    - uses: actions/checkout@main
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
-    - name: cargo check
-      working-directory: tracing-subscriber
-      run: cargo check --no-default-features --features "${{ matrix.featureset }}"
+      # tracing and tracing-subscriber have too many features to be checked by
+      # cargo-hack --feature-powerset with all features in the powerset, so
+      # exclude some
+      run: |
+        CARGO_HACK=(cargo hack check --feature-powerset --no-dev-deps)
+        case "${{ matrix.subcrate }}" in
+          tracing)
+            EXCLUDE_FEATURES=(
+              max_level_off max_level_error max_level_warn max_level_info
+              max_level_debug max_level_trace release_max_level_off
+              release_max_level_error release_max_level_warn
+              release_max_level_info release_max_level_debug
+              release_max_level_trace
+            )
+            ${CARGO_HACK[@]} --exclude-features "${EXCLUDE_FEATURES[*]}"
+            ;;
+          tracing-subscriber)
+            INCLUDE_FEATURES=(fmt ansi json registry env-filter)
+            ${CARGO_HACK[@]} --include-features "${INCLUDE_FEATURES[*]}"
+            ;;
+          *)
+            ${CARGO_HACK[@]}
+            ;;
+        esac
+      shell: bash
 
   features-stable:
     # Feature flag tests that run on stable Rust.

--- a/bin/publish
+++ b/bin/publish
@@ -38,10 +38,40 @@ verify() {
 
     status "Checking" "if $CRATE builds across feature combinations"
 
-    if ! cargo hack check $VERBOSE --feature-powerset --no-dev-deps; then
+    CARGO_HACK=(cargo hack check $VERBOSE --feature-powerset  --no-dev-deps)
+    case "$CRATE" in
+        tracing-subscriber)
+            # for tracing-subscriber, don't test a complete powerset because
+            # there are lots of feature flags
+            INCLUDE_FEATURES=(fmt ansi json registry env-filter)
+            ${CARGO_HACK[@]} --include-features "${INCLUDE_FEATURES[*]}"
+            CARGO_HACK_STATUS="$?"
+            ;;
+        tracing)
+            # checking the full feature powerset for `tracing` will take
+            # *forever* because of the `max_level_XXX` and
+            # `release_max_level_XXX` features
+            EXCLUDE_FEATURES=(
+                max_level_off max_level_error max_level_warn max_level_info
+                max_level_debug max_level_trace release_max_level_off
+                release_max_level_error release_max_level_warn
+                release_max_level_info release_max_level_debug
+                release_max_level_trace
+            )
+            ${CARGO_HACK[@]} --exclude-features "${EXCLUDE_FEATURES[*]}"
+            CARGO_HACK_STATUS="$?"
+            ;;
+        *)
+            ${CARGO_HACK[@]}
+            CARGO_HACK_STATUS="$?"
+            ;;
+    esac
+
+    if "$CARGO_HACK_STATUS" ; then
         err "$CRATE did not build with all feature combinations!"
         exit 1
     fi
+
 
     if git tag -l | grep -Fxq "$TAG" ; then
         err "git tag \`$TAG\` already exists"
@@ -68,7 +98,7 @@ do
 case "$1" in
     -v|--verbose)
     VERBOSE="--verbose"
-    set +x
+    set -x
     shift
     ;;
     -d|--dry-run)

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -301,7 +301,7 @@ pub trait Visit {
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
-        self.record_debug(field, &format_args!("{}", value))
+        self.record_debug(field, &DisplayValue(value))
     }
 
     /// Visit a value implementing `fmt::Debug`.
@@ -599,19 +599,19 @@ where
     T: fmt::Display,
 {
     fn record(&self, key: &Field, visitor: &mut dyn Visit) {
-        visitor.record_debug(key, &format_args!("{}", self.0))
+        visitor.record_debug(key, self)
     }
 }
 
 impl<T: fmt::Display> fmt::Debug for DisplayValue<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        fmt::Display::fmt(self, f)
     }
 }
 
 impl<T: fmt::Display> fmt::Display for DisplayValue<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.0, f)
+        self.0.fmt(f)
     }
 }
 
@@ -630,7 +630,7 @@ where
 
 impl<T: fmt::Debug> fmt::Debug for DebugValue<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.0)
+        self.0.fmt(f)
     }
 }
 

--- a/tracing/tests/no_subscriber.rs
+++ b/tracing/tests/no_subscriber.rs
@@ -1,0 +1,17 @@
+#![cfg(feature = "std")]
+
+use tracing::subscriber::{self, NoSubscriber};
+
+mod support;
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn no_subscriber_disables_global() {
+    // Reproduces https://github.com/tokio-rs/tracing/issues/1999
+    let (subscriber, handle) = support::subscriber::mock().done().run_with_handle();
+    subscriber::set_global_default(subscriber).expect("setting global default must succeed");
+    subscriber::with_default(NoSubscriber::default(), || {
+        tracing::info!("this should not be recorded");
+    });
+    handle.assert_finished();
+}


### PR DESCRIPTION
This branch backports the following changes:
* 35ab8c03 core: don't use NoSubscriber as local placeholder  (#2001)
* b817ca0c core: avoid unnecessary `format_args!` and `write!` macros (#1988)
* 74eaf1ee chore: avoid giant feature powersets using `cargo-hack` (#1984)