### PR TITLE
Use more efficient `thread_local! { … = const { … } }`

### DIFF
--- a/examples/examples/sloggish/sloggish_collector.rs
+++ b/examples/examples/sloggish/sloggish_collector.rs
@@ -27,7 +27,7 @@ pub struct CurrentSpanPerThread {
 impl CurrentSpanPerThread {
     pub fn new() -> Self {
         thread_local! {
-            static CURRENT: RefCell<Vec<Id>> = RefCell::new(vec![]);
+            static CURRENT: RefCell<Vec<Id>> = const { RefCell::new(vec![]) };
         };
         Self { current: &CURRENT }
     }

--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -178,10 +178,10 @@ enum Kind<T> {
 
 #[cfg(feature = "std")]
 thread_local! {
-    static CURRENT_STATE: State = State {
+    static CURRENT_STATE: State = const { State {
         default: RefCell::new(None),
         can_enter: Cell::new(true),
-    };
+    } };
 }
 
 static EXISTS: AtomicBool = AtomicBool::new(false);

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -108,7 +108,7 @@ pub struct EnvFilter {
 }
 
 thread_local! {
-    static SCOPE: RefCell<Vec<LevelFilter>> = RefCell::new(Vec::new());
+    static SCOPE: RefCell<Vec<LevelFilter>> = const { RefCell::new(Vec::new()) };
 }
 
 type FieldMap<T> = HashMap<Field, T>;

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -727,7 +727,7 @@ where
 
     fn on_event(&self, event: &Event<'_>, ctx: Context<'_, C>) {
         thread_local! {
-            static BUF: RefCell<String> = RefCell::new(String::new());
+            static BUF: RefCell<String> = const { RefCell::new(String::new()) };
         }
 
         BUF.with(|buf| {

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -198,7 +198,7 @@ thread_local! {
     /// track how many subscribers have processed the close.
     /// For additional details, see [`CloseGuard`].
     ///
-    static CLOSE_COUNT: Cell<usize> = Cell::new(0);
+    static CLOSE_COUNT: Cell<usize> = const { Cell::new(0) };
 }
 
 impl Collect for Registry {


### PR DESCRIPTION
These don't require an initialization check on every access, which
should at least be useful for the `CURRENT_STATE` `thread_local!` in
`tracing-core`.

Probably can't be included any time soon, as this requires Rust 1.59:
https://github.com/rust-lang/rust/pull/91355#event-5716333914.