### PR TITLE
Add Subscribe::event_enabled to conditionally dis/enable events based on fields

### DIFF
--- a/tracing-core/src/collect.rs
+++ b/tracing-core/src/collect.rs
@@ -57,9 +57,9 @@ use core::ptr::NonNull;
 ///   See also the [documentation on the callsite registry][cs-reg] for details
 ///   on [`register_callsite`].
 ///
-/// - [`event_enabled`] is called once before every [`event`] is recorded. This
-///   can be used to implement filtering on events once their field values are
-///   known but before any processing is done in `event`.
+/// - [`event_enabled`] is called once before every call to the [`event`]
+///   method. This can be used to implement filtering on events once their field
+///   values are known, but before any processing is done in the `event` method.
 /// - [`clone_span`] is called every time a span ID is cloned, and [`try_close`]
 ///   is called when a span ID is dropped. By default, these functions do
 ///   nothing. However, they can be used to implement reference counting for

--- a/tracing-core/src/collect.rs
+++ b/tracing-core/src/collect.rs
@@ -702,6 +702,11 @@ impl Collect for alloc::boxed::Box<dyn Collect + Send + Sync + 'static> {
     }
 
     #[inline]
+    fn event_enabled(&self, event: &Event<'_>) -> bool {
+        self.as_ref().event_enabled(event)
+    }
+
+    #[inline]
     fn event(&self, event: &Event<'_>) {
         self.as_ref().event(event)
     }
@@ -770,6 +775,11 @@ impl Collect for alloc::sync::Arc<dyn Collect + Send + Sync + 'static> {
     #[inline]
     fn record_follows_from(&self, span: &span::Id, follows: &span::Id) {
         self.as_ref().record_follows_from(span, follows)
+    }
+
+    #[inline]
+    fn event_enabled(&self, event: &Event<'_>) -> bool {
+        self.as_ref().event_enabled(event)
     }
 
     #[inline]

--- a/tracing-core/src/collect.rs
+++ b/tracing-core/src/collect.rs
@@ -57,6 +57,9 @@ use core::ptr::NonNull;
 ///   See also the [documentation on the callsite registry][cs-reg] for details
 ///   on [`register_callsite`].
 ///
+/// - [`event_enabled`] is called once before every [`event`] is recorded. This
+///   can be used to implement filtering on events once their field values are
+///   known but before any processing is done in `event`.
 /// - [`clone_span`] is called every time a span ID is cloned, and [`try_close`]
 ///   is called when a span ID is dropped. By default, these functions do
 ///   nothing. However, they can be used to implement reference counting for
@@ -72,6 +75,8 @@ use core::ptr::NonNull;
 /// [`clone_span`]: Collect::clone_span
 /// [`try_close`]: Collect::try_close
 /// [cs-reg]: crate::callsite#registering-callsites
+/// [`event`]: Collect::event
+/// [`event_enabled`]: Collect::event_enabled
 pub trait Collect: 'static {
     // === Span registry methods ==============================================
 
@@ -287,6 +292,17 @@ pub trait Collect: 'static {
     /// (i.e., some span _a_ which proceeds some other span _b_ may not also
     /// follow from _b_), it may silently do nothing.
     fn record_follows_from(&self, span: &span::Id, follows: &span::Id);
+
+    /// Determine if an [`Event`] should be recorded.
+    ///
+    /// By default, this returns `true` and collectors can filter events in
+    /// [`event`][Self::event] without any penalty. However, when `event` is
+    /// more complicated, this can be used to determine if `event` should be
+    /// called at all, separating out the decision from the processing.
+    fn event_enabled(&self, event: &Event<'_>) -> bool {
+        let _ = event;
+        true
+    }
 
     /// Records that an [`Event`] has occurred.
     ///

--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -682,7 +682,10 @@ impl Dispatch {
     /// [`event`]: super::collect::Collect::event
     #[inline]
     pub fn event(&self, event: &Event<'_>) {
-        self.collector().event(event)
+        let collector = self.collector();
+        if collector.event_enabled(event) {
+            collector.event(event);
+        }
     }
 
     /// Records that a span has been can_enter.

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -394,6 +394,11 @@ where
     }
 
     #[inline]
+    fn event_enabled(&self, event: &Event<'_>) -> bool {
+        self.inner.event_enabled(event)
+    }
+
+    #[inline]
     fn event(&self, event: &Event<'_>) {
         self.inner.event(event);
     }

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -94,6 +94,11 @@ where
     }
 
     #[inline]
+    fn event_enabled(&self, event: &Event<'_>, ctx: subscribe::Context<'_, C>) -> bool {
+        try_lock!(self.inner.read(), else return false).event_enabled(event, ctx)
+    }
+
+    #[inline]
     fn on_event(&self, event: &Event<'_>, ctx: subscribe::Context<'_, C>) {
         try_lock!(self.inner.read()).on_event(event, ctx)
     }

--- a/tracing-subscriber/src/subscribe/layered.rs
+++ b/tracing-subscriber/src/subscribe/layered.rs
@@ -138,11 +138,19 @@ where
         self.subscriber.on_follows_from(span, follows, self.ctx());
     }
 
-    fn event(&self, event: &Event<'_>) {
+    fn event_enabled(&self, event: &Event<'_>) -> bool {
         if self.subscriber.event_enabled(event, self.ctx()) {
-            self.inner.event(event);
-            self.subscriber.on_event(event, self.ctx());
+            // if the outer subscriber enables the event, ask the inner collector.
+            self.inner.event_enabled(event)
+        } else {
+            // otherwise, the event is disabled by this subscriber
+            false
         }
+    }
+
+    fn event(&self, event: &Event<'_>) {
+        self.inner.event(event);
+        self.subscriber.on_event(event, self.ctx());
     }
 
     fn enter(&self, span: &span::Id) {
@@ -285,10 +293,10 @@ where
     #[inline]
     fn event_enabled(&self, event: &Event<'_>, ctx: Context<'_, C>) -> bool {
         if self.subscriber.event_enabled(event, ctx.clone()) {
-            // if the outer subscriber enables the event, ask the inner subscriber.
+            // if the outer subscriber enables the event, ask the inner collector.
             self.inner.event_enabled(event, ctx)
         } else {
-            // otherwise, the callsite is disabled by this subscriber
+            // otherwise, the event is disabled by this subscriber
             false
         }
     }

--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -1505,6 +1505,14 @@ where
     }
 
     #[inline]
+    fn event_enabled(&self, event: &Event<'_>, ctx: Context<'_, C>) -> bool {
+        match self {
+            Some(ref inner) => inner.event_enabled(event, ctx),
+            None => false,
+        }
+    }
+
+    #[inline]
     fn on_event(&self, event: &Event<'_>, ctx: Context<'_, C>) {
         if let Some(ref inner) = self {
             inner.on_event(event, ctx);
@@ -1581,6 +1589,11 @@ macro_rules! subscriber_impl_body {
         #[inline]
         fn on_follows_from(&self, span: &span::Id, follows: &span::Id, ctx: Context<'_, C>) {
             self.deref().on_follows_from(span, follows, ctx)
+        }
+
+        #[inline]
+        fn event_enabled(&self, event: &Event<'_>, ctx: Context<'_, C>) -> bool {
+            self.deref().event_enabled(event, ctx)
         }
 
         #[inline]

--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -827,6 +827,30 @@ where
     // seems like a good future-proofing measure as it may grow other methods later...
     fn on_follows_from(&self, _span: &span::Id, _follows: &span::Id, _ctx: Context<'_, C>) {}
 
+    /// Called before `on_event`, to determine if `on_event` should be called.
+    ///
+    /// <div class="example-wrap" style="display:inline-block">
+    /// <pre class="ignore" style="white-space:normal;font:inherit;">
+    ///
+    /// **Note**: This method determines whether an event is globally enabled,
+    /// *not* whether the individual subscriber will be notified about the
+    /// event. This is intended to be used by layers that implement filtering
+    /// for the entire stack. Layers which do not wish to be notified about
+    /// certain events but do not wish to globally disable them should ignore
+    /// those events in their [on_event][Self::on_event].
+    ///
+    /// </pre></div>
+    ///
+    /// See [the trait-level documentation] for more information on filtering
+    /// with `Subscriber`s.
+    ///
+    /// [`Interest`]: tracing_core::Interest
+    /// [the trait-level documentation]: #filtering-with-subscribers
+    #[inline] // collapse this to a constant please mrs optimizer
+    fn event_enabled(&self, _event: &Event<'_>, _ctx: Context<'_, C>) -> bool {
+        true
+    }
+
     /// Notifies this subscriber that an event has occurred.
     fn on_event(&self, _event: &Event<'_>, _ctx: Context<'_, C>) {}
 

--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -417,7 +417,7 @@
 //! [`Interest::never()`] from its [`register_callsite`] method, filter
 //! evaluation will short-circuit and the span or event will be disabled.
 //!
-//! ### Enabling interest
+//! ### Enabling Interest
 //!
 //! Whenever an tracing event (or span) is emitted, it goes through a number of
 //! steps to determine how and how much it should be processed. The earlier an

--- a/tracing-subscriber/tests/event_enabling.rs
+++ b/tracing-subscriber/tests/event_enabling.rs
@@ -1,0 +1,35 @@
+use std::sync::{Arc, Mutex};
+use tracing::{collect::with_default, Collect};
+use tracing_subscriber::{prelude::*, registry, Subscribe};
+
+struct TrackingLayer {
+    event_enabled_count: Arc<Mutex<usize>>,
+}
+
+impl<C> Subscribe<C> for TrackingLayer
+where
+    C: Collect + Send + Sync + 'static,
+{
+    fn event_enabled(
+        &self,
+        _event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::subscribe::Context<'_, C>,
+    ) -> bool {
+        *self.event_enabled_count.lock().unwrap() += 1;
+        true
+    }
+}
+
+#[test]
+fn event_enabled_is_only_called_once() {
+    let event_enabled_count = Arc::new(Mutex::default());
+    let count = event_enabled_count.clone();
+    let collector = registry().with(TrackingLayer {
+        event_enabled_count,
+    });
+    with_default(collector, || {
+        tracing::error!("hiya!");
+    });
+
+    assert_eq!(1, *count.lock().unwrap());
+}

--- a/tracing-subscriber/tests/event_enabling.rs
+++ b/tracing-subscriber/tests/event_enabling.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "registry")]
+
 use std::sync::{Arc, Mutex};
 use tracing::{collect::with_default, Collect};
 use tracing_subscriber::{prelude::*, registry, Subscribe};

--- a/tracing-subscriber/tests/event_enabling.rs
+++ b/tracing-subscriber/tests/event_enabling.rs
@@ -1,24 +1,31 @@
 #![cfg(feature = "registry")]
 
 use std::sync::{Arc, Mutex};
-use tracing::{collect::with_default, Collect};
-use tracing_subscriber::{prelude::*, registry, Subscribe};
+use tracing::{collect::with_default, Collect, Event, Metadata};
+use tracing_subscriber::{prelude::*, registry, subscribe::Context, Subscribe};
 
 struct TrackingLayer {
+    enabled: bool,
     event_enabled_count: Arc<Mutex<usize>>,
+    event_enabled: bool,
+    on_event_count: Arc<Mutex<usize>>,
 }
 
 impl<C> Subscribe<C> for TrackingLayer
 where
     C: Collect + Send + Sync + 'static,
 {
-    fn event_enabled(
-        &self,
-        _event: &tracing::Event<'_>,
-        _ctx: tracing_subscriber::subscribe::Context<'_, C>,
-    ) -> bool {
+    fn enabled(&self, _metadata: &Metadata<'_>, _ctx: Context<'_, C>) -> bool {
+        self.enabled
+    }
+
+    fn event_enabled(&self, _event: &Event<'_>, _ctx: Context<'_, C>) -> bool {
         *self.event_enabled_count.lock().unwrap() += 1;
-        true
+        self.event_enabled
+    }
+
+    fn on_event(&self, _event: &Event<'_>, _ctx: Context<'_, C>) {
+        *self.on_event_count.lock().unwrap() += 1;
     }
 }
 
@@ -27,11 +34,48 @@ fn event_enabled_is_only_called_once() {
     let event_enabled_count = Arc::new(Mutex::default());
     let count = event_enabled_count.clone();
     let collector = registry().with(TrackingLayer {
+        enabled: true,
         event_enabled_count,
+        event_enabled: true,
+        on_event_count: Arc::new(Mutex::default()),
     });
     with_default(collector, || {
         tracing::error!("hiya!");
     });
 
     assert_eq!(1, *count.lock().unwrap());
+}
+
+#[test]
+fn event_enabled_not_called_when_not_enabled() {
+    let event_enabled_count = Arc::new(Mutex::default());
+    let count = event_enabled_count.clone();
+    let collector = registry().with(TrackingLayer {
+        enabled: false,
+        event_enabled_count,
+        event_enabled: true,
+        on_event_count: Arc::new(Mutex::default()),
+    });
+    with_default(collector, || {
+        tracing::error!("hiya!");
+    });
+
+    assert_eq!(0, *count.lock().unwrap());
+}
+
+#[test]
+fn event_disabled_does_disable_event() {
+    let on_event_count = Arc::new(Mutex::default());
+    let count = on_event_count.clone();
+    let collector = registry().with(TrackingLayer {
+        enabled: true,
+        event_enabled_count: Arc::new(Mutex::default()),
+        event_enabled: false,
+        on_event_count,
+    });
+    with_default(collector, || {
+        tracing::error!("hiya!");
+    });
+
+    assert_eq!(0, *count.lock().unwrap());
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Allow filter layers to filter on the contents of events (closes #2007).

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add `Subscribe::event_enabled(&self, event: &Event<'_>, ctx: Context<'_, C>) -> bool;`. This is called before `Subscribe::on_event`, and if `event_enabled` returns `false`, `on_event` is not called (nor is `Collect::event`).

### Previously, this PR did

`Subscribe::on_event` returns `ControlFlow`, and the `Layered` subscriber only continues to call `on_event` on `ControlFlow::Continue`.

This PR exists mainly as a place for discussion of this potential solution. Looking at this diff, and given that *most* subscriber layers will want to continue and not break the layering, it might make sense to make this a new method which delegates to on_event by default. Since Layered is the primary way of layering two subscribers together, perhaps the footgun of *calling* `on_event` rather than "`filter_on_event`" would not be a big deal in practice?