### PR TITLE
Port layer mock from 0.1 to 0.2

### DIFF
--- a/tracing-mock/Cargo.toml
+++ b/tracing-mock/Cargo.toml
@@ -20,6 +20,7 @@ publish = false
 [dependencies]
 tracing = { path = "../tracing", version = "0.2", default-features = false }
 tracing-core = { path = "../tracing-core", version = "0.2", default-features = false }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, optional = true }
 tokio-test = { version = "0.2.0", optional = true }
 
 [package.metadata.docs.rs]

--- a/tracing-mock/src/event.rs
+++ b/tracing-mock/src/event.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-use super::{field, metadata, Parent};
+use super::{field, metadata, span, Parent};
 
 use std::fmt;
 
@@ -11,6 +11,7 @@ use std::fmt;
 pub struct MockEvent {
     pub fields: Option<field::Expect>,
     pub(crate) parent: Option<Parent>,
+    in_spans: Vec<span::MockSpan>,
     metadata: metadata::Expect,
 }
 
@@ -78,17 +79,42 @@ impl MockEvent {
         }
     }
 
-    pub(crate) fn check(&mut self, event: &tracing::Event<'_>) {
+    pub(crate) fn check(
+        &mut self,
+        event: &tracing::Event<'_>,
+        get_parent_name: impl FnOnce() -> Option<String>,
+        subscriber_name: &str,
+    ) {
         let meta = event.metadata();
         let name = meta.name();
         self.metadata
-            .check(meta, format_args!("event \"{}\"", name));
-        assert!(meta.is_event(), "expected {}, but got {:?}", self, event);
+            .check(meta, format_args!("event \"{}\"", name), subscriber_name);
+        assert!(
+            meta.is_event(),
+            "[{}] expected {}, but got {:?}",
+            subscriber_name,
+            self,
+            event
+        );
         if let Some(ref mut expected_fields) = self.fields {
             let mut checker = expected_fields.checker(name.to_string());
             event.record(&mut checker);
             checker.finish();
         }
+
+        if let Some(ref expected_parent) = self.parent {
+            let actual_parent = get_parent_name();
+            expected_parent.check_parent_name(
+                actual_parent.as_deref(),
+                event.parent().cloned(),
+                event.metadata().name(),
+                subscriber_name,
+            )
+        }
+    }
+
+    pub fn scope_mut(&mut self) -> &mut [span::MockSpan] {
+        &mut self.in_spans[..]
     }
 }
 

--- a/tracing-mock/src/layer.rs
+++ b/tracing-mock/src/layer.rs
@@ -1,0 +1,401 @@
+use crate::{
+    collector::{Expect, MockHandle},
+    event::MockEvent,
+    field,
+    span::{MockSpan, NewSpan},
+};
+use tracing_core::{
+    span::{Attributes, Id, Record},
+    Collect, Event,
+};
+use tracing_subscriber::{
+    registry::{LookupSpan, SpanRef},
+    subscribe::{Context, Subscribe},
+};
+
+use std::{
+    collections::VecDeque,
+    fmt,
+    sync::{Arc, Mutex},
+};
+
+pub fn mock() -> ExpectLayerBuilder {
+    ExpectLayerBuilder {
+        expected: Default::default(),
+        name: std::thread::current()
+            .name()
+            .map(String::from)
+            .unwrap_or_default(),
+    }
+}
+
+pub fn named(name: impl std::fmt::Display) -> ExpectLayerBuilder {
+    mock().named(name)
+}
+
+pub struct ExpectLayerBuilder {
+    expected: VecDeque<Expect>,
+    name: String,
+}
+
+pub struct ExpectLayer {
+    expected: Arc<Mutex<VecDeque<Expect>>>,
+    current: Mutex<Vec<Id>>,
+    name: String,
+}
+
+impl ExpectLayerBuilder {
+    /// Overrides the name printed by the mock subscriber's debugging output.
+    ///
+    /// The debugging output is displayed if the test panics, or if the test is
+    /// run with `--nocapture`.
+    ///
+    /// By default, the mock subscriber's name is the  name of the test
+    /// (*technically*, the name of the thread where it was created, which is
+    /// the name of the test unless tests are run with `--test-threads=1`).
+    /// When a test has only one mock subscriber, this is sufficient. However,
+    /// some tests may include multiple subscribers, in order to test
+    /// interactions between multiple subscribers. In that case, it can be
+    /// helpful to give each subscriber a separate name to distinguish where the
+    /// debugging output comes from.
+    pub fn named(mut self, name: impl fmt::Display) -> Self {
+        use std::fmt::Write;
+        if !self.name.is_empty() {
+            write!(&mut self.name, "::{}", name).unwrap();
+        } else {
+            self.name = name.to_string();
+        }
+        self
+    }
+
+    pub fn enter(mut self, span: MockSpan) -> Self {
+        self.expected.push_back(Expect::Enter(span));
+        self
+    }
+
+    pub fn event(mut self, event: MockEvent) -> Self {
+        self.expected.push_back(Expect::Event(event));
+        self
+    }
+
+    pub fn exit(mut self, span: MockSpan) -> Self {
+        self.expected.push_back(Expect::Exit(span));
+        self
+    }
+
+    pub fn done(mut self) -> Self {
+        self.expected.push_back(Expect::Nothing);
+        self
+    }
+
+    pub fn record<I>(mut self, span: MockSpan, fields: I) -> Self
+    where
+        I: Into<field::Expect>,
+    {
+        self.expected.push_back(Expect::Visit(span, fields.into()));
+        self
+    }
+
+    pub fn new_span<I>(mut self, new_span: I) -> Self
+    where
+        I: Into<NewSpan>,
+    {
+        self.expected.push_back(Expect::NewSpan(new_span.into()));
+        self
+    }
+
+    pub fn run(self) -> ExpectLayer {
+        ExpectLayer {
+            expected: Arc::new(Mutex::new(self.expected)),
+            name: self.name,
+            current: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn run_with_handle(self) -> (ExpectLayer, MockHandle) {
+        let expected = Arc::new(Mutex::new(self.expected));
+        let handle = MockHandle::new(expected.clone(), self.name.clone());
+        let layer = ExpectLayer {
+            expected,
+            name: self.name,
+            current: Mutex::new(Vec::new()),
+        };
+        (layer, handle)
+    }
+}
+
+impl ExpectLayer {
+    fn check_span_ref<'spans, S>(
+        &self,
+        expected: &MockSpan,
+        actual: &SpanRef<'spans, S>,
+        what_happened: impl fmt::Display,
+    ) where
+        S: LookupSpan<'spans>,
+    {
+        if let Some(exp_name) = expected.name() {
+            assert_eq!(
+                actual.name(),
+                exp_name,
+                "\n[{}] expected {} a span named {:?}\n\
+                 [{}] but it was named {:?} instead (span {} {:?})",
+                self.name,
+                what_happened,
+                exp_name,
+                self.name,
+                actual.name(),
+                actual.name(),
+                actual.id()
+            );
+        }
+
+        if let Some(exp_level) = expected.level() {
+            let actual_level = actual.metadata().level();
+            assert_eq!(
+                actual_level,
+                &exp_level,
+                "\n[{}] expected {} a span at {:?}\n\
+                 [{}] but it was at {:?} instead (span {} {:?})",
+                self.name,
+                what_happened,
+                exp_level,
+                self.name,
+                actual_level,
+                actual.name(),
+                actual.id(),
+            );
+        }
+
+        if let Some(exp_target) = expected.target() {
+            let actual_target = actual.metadata().target();
+            assert_eq!(
+                actual_target,
+                exp_target,
+                "\n[{}] expected {} a span with target {:?}\n\
+                 [{}] but it had the target {:?} instead (span {} {:?})",
+                self.name,
+                what_happened,
+                exp_target,
+                self.name,
+                actual_target,
+                actual.name(),
+                actual.id(),
+            );
+        }
+    }
+}
+
+impl<S> Subscribe<S> for ExpectLayer
+where
+    S: Collect + for<'a> LookupSpan<'a>,
+{
+    fn register_callsite(
+        &self,
+        metadata: &'static tracing::Metadata<'static>,
+    ) -> tracing_core::Interest {
+        println!("[{}] register_callsite {:#?}", self.name, metadata);
+        tracing_core::Interest::always()
+    }
+
+    fn on_record(&self, _: &Id, _: &Record<'_>, _: Context<'_, S>) {
+        unimplemented!(
+            "so far, we don't have any tests that need an `on_record` \
+            implementation.\nif you just wrote one that does, feel free to \
+            implement it!"
+        );
+    }
+
+    fn on_event(&self, event: &Event<'_>, cx: Context<'_, S>) {
+        let name = event.metadata().name();
+        println!(
+            "[{}] event: {}; level: {}; target: {}",
+            self.name,
+            name,
+            event.metadata().level(),
+            event.metadata().target(),
+        );
+        match self.expected.lock().unwrap().pop_front() {
+            None => {}
+            Some(Expect::Event(mut expected)) => {
+                let get_parent_name = || cx.event_span(event).map(|span| span.name().to_string());
+                expected.check(event, get_parent_name, &self.name);
+                let mut current_scope = cx.event_scope(event).into_iter().flatten();
+                let expected_scope = expected.scope_mut();
+                let mut i = 0;
+                for (expected, actual) in expected_scope.iter_mut().zip(&mut current_scope) {
+                    println!(
+                        "[{}] event_scope[{}] actual={} ({:?}); expected={}",
+                        self.name,
+                        i,
+                        actual.name(),
+                        actual.id(),
+                        expected
+                    );
+                    self.check_span_ref(
+                        expected,
+                        &actual,
+                        format_args!("the {}th span in the event's scope to be", i),
+                    );
+                    i += 1;
+                }
+                let remaining_expected = &expected_scope[i..];
+                assert!(
+                    remaining_expected.is_empty(),
+                    "\n[{}] did not observe all expected spans in event scope!\n[{}] missing: {:#?}",
+                    self.name,
+                    self.name,
+                    remaining_expected,
+                );
+                assert!(
+                    current_scope.next().is_none(),
+                    "\n[{}] did not expect all spans in the actual event scope!",
+                    self.name,
+                );
+            }
+            Some(ex) => ex.bad(&self.name, format_args!("observed event {:#?}", event)),
+        }
+    }
+
+    fn on_follows_from(&self, _span: &Id, _follows: &Id, _: Context<'_, S>) {
+        // TODO: it should be possible to expect spans to follow from other spans
+    }
+
+    fn on_new_span(&self, span: &Attributes<'_>, id: &Id, cx: Context<'_, S>) {
+        let meta = span.metadata();
+        println!(
+            "[{}] new_span: name={:?}; target={:?}; id={:?};",
+            self.name,
+            meta.name(),
+            meta.target(),
+            id
+        );
+        let mut expected = self.expected.lock().unwrap();
+        let was_expected = matches!(expected.front(), Some(Expect::NewSpan(_)));
+        if was_expected {
+            if let Expect::NewSpan(mut expected) = expected.pop_front().unwrap() {
+                let get_parent_name = || {
+                    span.parent()
+                        .and_then(|id| cx.span(id))
+                        .or_else(|| cx.lookup_current())
+                        .map(|span| span.name().to_string())
+                };
+                expected.check(span, get_parent_name, &self.name);
+            }
+        }
+    }
+
+    fn on_enter(&self, id: &Id, cx: Context<'_, S>) {
+        let span = cx
+            .span(id)
+            .unwrap_or_else(|| panic!("[{}] no span for ID {:?}", self.name, id));
+        println!("[{}] enter: {}; id={:?};", self.name, span.name(), id);
+        match self.expected.lock().unwrap().pop_front() {
+            None => {}
+            Some(Expect::Enter(ref expected_span)) => {
+                self.check_span_ref(expected_span, &span, "to enter");
+            }
+            Some(ex) => ex.bad(&self.name, format_args!("entered span {:?}", span.name())),
+        }
+        self.current.lock().unwrap().push(id.clone());
+    }
+
+    fn on_exit(&self, id: &Id, cx: Context<'_, S>) {
+        if std::thread::panicking() {
+            // `exit()` can be called in `drop` impls, so we must guard against
+            // double panics.
+            println!("[{}] exit {:?} while panicking", self.name, id);
+            return;
+        }
+        let span = cx
+            .span(id)
+            .unwrap_or_else(|| panic!("[{}] no span for ID {:?}", self.name, id));
+        println!("[{}] exit: {}; id={:?};", self.name, span.name(), id);
+        match self.expected.lock().unwrap().pop_front() {
+            None => {}
+            Some(Expect::Exit(ref expected_span)) => {
+                self.check_span_ref(expected_span, &span, "to exit");
+                let curr = self.current.lock().unwrap().pop();
+                assert_eq!(
+                    Some(id),
+                    curr.as_ref(),
+                    "[{}] exited span {:?}, but the current span was {:?}",
+                    self.name,
+                    span.name(),
+                    curr.as_ref().and_then(|id| cx.span(id)).map(|s| s.name())
+                );
+            }
+            Some(ex) => ex.bad(&self.name, format_args!("exited span {:?}", span.name())),
+        };
+    }
+
+    fn on_close(&self, id: Id, cx: Context<'_, S>) {
+        if std::thread::panicking() {
+            // `try_close` can be called in `drop` impls, so we must guard against
+            // double panics.
+            println!("[{}] close {:?} while panicking", self.name, id);
+            return;
+        }
+        let span = cx.span(&id);
+        let name = span.as_ref().map(|span| {
+            println!("[{}] close_span: {}; id={:?};", self.name, span.name(), id,);
+            span.name()
+        });
+        if name.is_none() {
+            println!("[{}] drop_span: id={:?}", self.name, id);
+        }
+        if let Ok(mut expected) = self.expected.try_lock() {
+            let was_expected = match expected.front() {
+                Some(Expect::DropSpan(ref expected_span)) => {
+                    // Don't assert if this function was called while panicking,
+                    // as failing the assertion can cause a double panic.
+                    if !::std::thread::panicking() {
+                        if let Some(ref span) = span {
+                            self.check_span_ref(expected_span, span, "to close");
+                        }
+                    }
+                    true
+                }
+                Some(Expect::Event(_)) => {
+                    if !::std::thread::panicking() {
+                        panic!(
+                            "[{}] expected an event, but dropped span {} (id={:?}) instead",
+                            self.name,
+                            name.unwrap_or("<unknown name>"),
+                            id
+                        );
+                    }
+                    true
+                }
+                _ => false,
+            };
+            if was_expected {
+                expected.pop_front();
+            }
+        }
+    }
+
+    fn on_id_change(&self, _old: &Id, _new: &Id, _ctx: Context<'_, S>) {
+        panic!("well-behaved subscribers should never do this to us, lol");
+    }
+}
+
+impl fmt::Debug for ExpectLayer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("ExpectLayer");
+        s.field("name", &self.name);
+
+        if let Ok(expected) = self.expected.try_lock() {
+            s.field("expected", &expected);
+        } else {
+            s.field("expected", &format_args!("<locked>"));
+        }
+
+        if let Ok(current) = self.current.try_lock() {
+            s.field("current", &format_args!("{:?}", &current));
+        } else {
+            s.field("current", &format_args!("<locked>"));
+        }
+
+        s.finish()
+    }
+}

--- a/tracing-mock/src/lib.rs
+++ b/tracing-mock/src/lib.rs
@@ -6,6 +6,8 @@ use std::{
 pub mod collector;
 pub mod event;
 pub mod field;
+#[cfg(feature = "tracing-subscriber")]
+pub mod layer;
 mod metadata;
 pub mod span;
 
@@ -15,6 +17,76 @@ pub(crate) enum Parent {
     Contextual(String),
     ExplicitRoot,
     Explicit(String),
+}
+
+impl Parent {
+    pub(crate) fn check_parent_name(
+        &self,
+        parent_name: Option<&str>,
+        provided_parent: Option<tracing_core::span::Id>,
+        ctx: impl std::fmt::Display,
+        subscriber_name: &str,
+    ) {
+        match self {
+            Parent::ExplicitRoot => {
+                assert!(
+                    provided_parent.is_none(),
+                    "[{}] expected {} to be an explicit root, but its parent was actually {:?} (name: {:?})",
+                    subscriber_name,
+                    ctx,
+                    provided_parent,
+                    parent_name,
+                );
+            }
+            Parent::Explicit(expected_parent) => {
+                assert_eq!(
+                    Some(expected_parent.as_ref()),
+                    parent_name,
+                    "[{}] expected {} to have explicit parent {}, but its parent was actually {:?} (name: {:?})",
+                    subscriber_name,
+                    ctx,
+                    expected_parent,
+                    provided_parent,
+                    parent_name,
+                );
+            }
+            Parent::ContextualRoot => {
+                assert!(
+                    provided_parent.is_none(),
+                    "[{}] expected {} to have a contextual parent, but its parent was actually {:?} (name: {:?})",
+                    subscriber_name,
+                    ctx,
+                    provided_parent,
+                    parent_name,
+                );
+                assert!(
+                    parent_name.is_none(),
+                    "[{}] expected {} to be contextual a root, but we were inside span {:?}",
+                    subscriber_name,
+                    ctx,
+                    parent_name,
+                );
+            }
+            Parent::Contextual(expected_parent) => {
+                assert!(provided_parent.is_none(),
+                    "[{}] expected {} to have a contextual parent\nbut its parent was actually {:?} (name: {:?})",
+                    subscriber_name,
+                    ctx,
+                    provided_parent,
+                    parent_name,
+                );
+                assert_eq!(
+                    Some(expected_parent.as_ref()),
+                    parent_name,
+                    "[{}] expected {} to have contextual parent {:?}, but got {:?}",
+                    subscriber_name,
+                    ctx,
+                    expected_parent,
+                    parent_name,
+                );
+            }
+        }
+    }
 }
 
 pub struct PollN<T, E> {

--- a/tracing-mock/src/metadata.rs
+++ b/tracing-mock/src/metadata.rs
@@ -9,12 +9,18 @@ pub struct Expect {
 }
 
 impl Expect {
-    pub(crate) fn check(&self, actual: &Metadata<'_>, ctx: fmt::Arguments<'_>) {
+    pub(crate) fn check(
+        &self,
+        actual: &Metadata<'_>,
+        ctx: fmt::Arguments<'_>,
+        collector_name: &str,
+    ) {
         if let Some(ref expected_name) = self.name {
             let name = actual.name();
             assert!(
                 expected_name == name,
-                "expected {} to be named `{}`, but got one named `{}`",
+                "[{}] expected {} to be named `{}`, but got one named `{}`",
+                collector_name,
                 ctx,
                 expected_name,
                 name
@@ -25,7 +31,8 @@ impl Expect {
             let level = actual.level();
             assert!(
                 expected_level == level,
-                "expected {} to be at level `{:?}`, but it was at level `{:?}` instead",
+                "[{}] expected {} to be at level `{:?}`, but it was at level `{:?}` instead",
+                collector_name,
                 ctx,
                 expected_level,
                 level,
@@ -36,7 +43,8 @@ impl Expect {
             let target = actual.target();
             assert!(
                 expected_target == target,
-                "expected {} to have target `{}`, but it had target `{}` instead",
+                "[{}] expected {} to have target `{}`, but it had target `{}` instead",
+                collector_name,
                 ctx,
                 expected_target,
                 target,

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -65,7 +65,7 @@ thread_local = { version = "1.1.4", optional = true }
 
 [dev-dependencies]
 tracing = { path = "../tracing", version = "0.2" }
-tracing-mock = { path = "../tracing-mock" }
+tracing-mock = { path = "../tracing-mock", features = ["tracing-subscriber"] }
 log = "0.4"
 tracing-log = { path = "../tracing-log", version = "0.2" }
 criterion = { version = "0.3", default_features = false }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

This just does a naive forwardport(?) of the layer mock from the 0.1.x branch to the master branch. Probably shouldn't be merged as-is; more a proof of concept for testing² purposes.

(I _might_ end up taking a pass at rewriting tracing-mock with a more coherent/polished API after tracing-filter... absolutely _zero_ promises, though.)

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

I want to use this for testing tracing-filter, rather than _completely_ homebrewing something. Depending on whether this works for my test case, I may end up, anyway; we'll see once I try it out.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Experimentally forward-port the mock layer.