### PR TITLE
subscriber: add `Filter::on_record` callback

### DIFF
--- a/tracing-subscriber/src/filter/layer_filters/combinator.rs
+++ b/tracing-subscriber/src/filter/layer_filters/combinator.rs
@@ -2,7 +2,7 @@
 use crate::layer::{Context, Filter};
 use std::{cmp, fmt, marker::PhantomData};
 use tracing_core::{
-    span::{Attributes, Id},
+    span::{Attributes, Id, Record},
     subscriber::Interest,
     LevelFilter, Metadata,
 };
@@ -141,6 +141,12 @@ where
     fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         self.a.on_new_span(attrs, id, ctx.clone());
         self.b.on_new_span(attrs, id, ctx)
+    }
+
+    #[inline]
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        self.a.on_record(id, values, ctx.clone());
+        self.b.on_record(id, values, ctx);
     }
 
     #[inline]
@@ -317,11 +323,17 @@ where
         // If either hint is `None`, return `None`. Otherwise, return the less restrictive.
         Some(cmp::max(self.a.max_level_hint()?, self.b.max_level_hint()?))
     }
-    
+
     #[inline]
     fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         self.a.on_new_span(attrs, id, ctx.clone());
         self.b.on_new_span(attrs, id, ctx)
+    }
+
+    #[inline]
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        self.a.on_record(id, values, ctx.clone());
+        self.b.on_record(id, values, ctx);
     }
 
     #[inline]
@@ -412,6 +424,11 @@ where
     #[inline]
     fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         self.a.on_new_span(attrs, id, ctx);
+    }
+
+    #[inline]
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        self.a.on_record(id, values, ctx.clone());
     }
 
     #[inline]

--- a/tracing-subscriber/src/filter/layer_filters/mod.rs
+++ b/tracing-subscriber/src/filter/layer_filters/mod.rs
@@ -592,6 +592,7 @@ where
 
     fn on_record(&self, span: &span::Id, values: &span::Record<'_>, cx: Context<'_, S>) {
         if let Some(cx) = cx.if_enabled_for(span, self.id()) {
+            self.filter.on_record(span, values, cx.clone());
             self.layer.on_record(span, values, cx)
         }
     }

--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -1065,6 +1065,17 @@ feature! {
             let _ = (attrs, id, ctx);
         }
 
+
+        /// Notifies this filter that a span with the given `Id` recorded the given
+        /// `values`.
+        ///
+        /// By default, this method does nothing. `Filter` implementations that
+        /// need to be notified when new spans are created can override this
+        /// method.
+        fn on_record(&self, id: &span::Id, values: &span::Record<'_>, ctx: Context<'_, S>) {
+            let _ = (id, values, ctx);
+        }
+
         /// Notifies this filter that a span with the given ID was entered.
         ///
         /// By default, this method does nothing. `Filter` implementations that


### PR DESCRIPTION
## Motivation

Currently, `Filter` only has the `on_new_span`, `on_enter`, `on_exit`,
and `on_close` callbacks. This means it won't handle cases where a
span records a new field value that changes its filter state.

## Solution

This branch adds the missing `on_record` callback.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>