### PR TITLE
subscriber: fix `Filtered::on_exit` calling `on_enter` by mistake

### DIFF
--- a/tracing-subscriber/src/filter/layer_filters/mod.rs
+++ b/tracing-subscriber/src/filter/layer_filters/mod.rs
@@ -619,7 +619,7 @@ where
 
     fn on_exit(&self, id: &span::Id, cx: Context<'_, S>) {
         if let Some(cx) = cx.if_enabled_for(id, self.id()) {
-            self.filter.on_enter(id, cx.clone());
+            self.filter.on_exit(id, cx.clone());
             self.layer.on_exit(id, cx);
         }
     }


### PR DESCRIPTION
## Motivation

Currently, the `Filtered` type's `Layer` impl accidentally calls the
inner `Filter`'s `on_enter` hook in the `on_exit` hook. This
is...obviously wrong, lol, and means that filters like `EnvFilter` will
never consider spans to have exited, breaking filtering behavior.

@tfreiberg-fastly originally noticed this bug (see
https://github.com/tokio-rs/tracing/pull/1983#issuecomment-1076174188),
but I wanted to make the change separately from PR #1983 so that we can
fix it on the main branch without waiting for #1983 to merge first.

## Solution

This branch, uh, you know... fixes that.