### PR TITLE
core: fix warnings when compiling without `std`

### DIFF
--- a/tracing-core/tests/dispatch.rs
+++ b/tracing-core/tests/dispatch.rs
@@ -1,9 +1,9 @@
+#![cfg(feature = "std")]
 mod common;
 
 use common::*;
 use tracing_core::dispatcher::*;
 
-#[cfg(feature = "std")]
 #[test]
 fn set_default_dispatch() {
     set_global_default(Dispatch::new(TestSubscriberA)).expect("global dispatch set failed");
@@ -28,7 +28,6 @@ fn set_default_dispatch() {
     });
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn nested_set_default() {
     let _guard = set_default(&Dispatch::new(TestSubscriberA));


### PR DESCRIPTION
## Motivation

Currently, compiling `tracing-core` with `default-features = false`
(i.e. for `no_std` targets) emits a few warnings. This is due to the
spinlock implementation's use of the deprecated `atomic::spin_loop_hint`
function (renamed to `hint::spin_loop`), and the use of deprecated
`compare_and_swap` instead of `compare_exchange` methods. Now that our
MSRV is 1.49 (the version in which `hint::spin_loop` was stabilized), we
can fix these warnings.

## Solution

This branch replaces the deprecated APIs. 

Also, I noticed that one of the tests emits unused-imports warnings with
`--no-default-features`. This is because the actual tests are feature
flagged to require `std`, but the module itself doesn't, so the imports
are just hanging out and not getting used for anything. I went ahead and
fixed that as well.