### PR TITLE
subscriber: fix missing `register_callsite` for `Box<dyn Subscribe>`

### DIFF
--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -1398,6 +1398,11 @@ macro_rules! subscriber_impl_body {
         }
 
         #[inline]
+        fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
+            self.deref().register_callsite(metadata)
+        }
+
+        #[inline]
         fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, C>) {
             self.deref().on_new_span(attrs, id, ctx)
         }


### PR DESCRIPTION
Turns out the `Subscribe` impl for `Box<dyn Subscribe<...> + ...>` never
called the subscriber trait object's `register_callsite` method. Whoops!

This commit adds the missing `register_callsite` hook.