### PR TITLE
Let `EnvFilter`'s filter disabled help say "help" without ansi_term

### DIFF
--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -275,7 +275,7 @@ impl EnvFilter {
             };
             let ctx_prefixed = |prefix: &str, msg: &str| {
                 #[cfg(not(feature = "ansi_term"))]
-                let msg = format!("note: {}", msg);
+                let msg = format!("{} {}", prefix, msg);
                 #[cfg(feature = "ansi_term")]
                 let msg = {
                     let mut equal = Color::Fixed(21).paint("="); // dark blue


### PR DESCRIPTION
## Motivation

EnvFilter with ansi_term will say something like the following when statically disabled filters are present:

```
warning: some trace filter directives would enable traces ...
 = note: the static max level is `LEVEL`
 = help: to enable LEVEL logging, ...
```

Without the ansi_term feature, it instead says something like the following:

```
warning: some trace filter directives would enable traces ...
note: the static max level is `LEVEL`
note: to enable LEVEL logging, ...
```

This is due to a simple error in cfg'd code that ignores the requested prefix and always uses `note:` when `not(feature = "ansi_term")`.

## Solution

Use the unused `prefix` variable to do what it does when `feature = "ansi_term"`.

The output without ansi_term is now

```
warning: some trace filter directives would enable traces ...
note: the static max level is `LEVEL`
help: to enable LEVEL logging, ...
```