### PR TITLE
subscriber: fix boxed subscriber not forwarding `max_level_hint`

### DIFF
--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -1447,6 +1447,11 @@ macro_rules! subscriber_impl_body {
             self.deref().on_id_change(old, new, ctx)
         }
 
+        #[inline]
+        fn max_level_hint(&self) -> Option<LevelFilter> {
+            self.deref().max_level_hint()
+        }
+
         #[doc(hidden)]
         #[inline]
         unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {


### PR DESCRIPTION
## Motivation

Currently, the implementation of `Subscribe` for
`Box<dyn Subscribe<C> + ...>` does not implement the `max_level_hint`
method. This means that if the boxed subscriber has a max level hint, it
will be lost when boxing a subscriber.

Found this while working on tests for #2027.

## Solution

This commit adds the missing method implementation.