### PR TITLE
More layer modification

### DIFF
--- a/tracing-subscriber/src/filter/layer_filters/mod.rs
+++ b/tracing-subscriber/src/filter/layer_filters/mod.rs
@@ -504,6 +504,14 @@ impl<L, F, S> Filtered<L, F, S> {
     pub fn filter_mut(&mut self) -> &mut F {
         &mut self.filter
     }
+
+    pub fn wrapped(&self) -> &L {
+        &self.layer
+    }
+
+    pub fn wrapped_mut(&mut self) -> &mut L {
+        &mut self.layer
+    }
 }
 
 impl<S, L, F> Layer<S> for Filtered<L, F, S>

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -185,6 +185,18 @@ impl<S, N, E, W> Layer<S, N, E, W> {
         }
     }
 
+    pub fn writer(&self) -> &W {
+        &self.make_writer
+    }
+
+    pub fn writer_mut(&mut self) -> &mut W {
+        &mut self.make_writer
+    }
+
+    pub fn set_ansi(&mut self, ansi: bool) {
+        self.is_ansi = ansi;
+    }
+
     /// Configures the subscriber to support [`libtest`'s output capturing][capturing] when used in
     /// unit tests.
     ///


### PR DESCRIPTION
This adds more modification methods for use with reloading. I will add tests once the basic API has been approved.

## Motivation

I have a Filtered layer that I'd like to modify with a reload handle. If I use `reload` then the filter doesn't work. If I use `modify` with `filter_mut` I can't update the writer. 

## Solution

Adds some additional accessor methods to allow the writer to be modified in `modify`.
