### PR TITLE
More layer modification

### DIFF
--- a/tracing-subscriber/src/filter/subscriber_filters/mod.rs
+++ b/tracing-subscriber/src/filter/subscriber_filters/mod.rs
@@ -473,8 +473,7 @@ impl<S, F, C> Filtered<S, F, C> {
 
     /// Mutably borrows the [`Filter`](crate::subscribe::Filter) used by this subscriber.
     ///
-    /// When this subscriber can be mutably borrowed, this may be used to mutate the filter.
-    /// Generally, this will primarily be used with the
+    /// This method is primarily expected to be used with the
     /// [`reload::Handle::modify`](crate::reload::Handle::modify) method.
     ///
     /// # Examples
@@ -498,6 +497,46 @@ impl<S, F, C> Filtered<S, F, C> {
     /// ```
     pub fn filter_mut(&mut self) -> &mut F {
         &mut self.filter
+    }
+
+    /// Borrows the inner [subscriber] wrapped by this `Filtered` subscriber.
+    ///
+    /// [subscriber]: Subscribe
+    pub fn inner(&self) -> &S {
+        &self.subscriber
+    }
+
+    /// Mutably borrows the inner [subscriber] wrapped by this `Filtered` subscriber.
+    ///
+    /// This method is primarily expected to be used with the
+    /// [`reload::Handle::modify`](crate::reload::Handle::modify) method.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tracing::info;
+    /// # use tracing_subscriber::{filter,fmt,reload,Registry,prelude::*};
+    /// # fn non_blocking<T: std::io::Write>(writer: T) -> (fn() -> std::io::Stdout) {
+    /// #   std::io::stdout
+    /// # }
+    /// # fn main() {
+    /// let filtered_subscriber = fmt::subscriber().with_writer(non_blocking(std::io::stderr())).with_filter(filter::LevelFilter::INFO);
+    /// let (filtered_subscriber, reload_handle) = reload::Subscriber::new(filtered_subscriber);
+    /// #
+    /// # // specifying the Registry type is required
+    /// # let _: &reload::Handle<filter::Filtered<fmt::Subscriber<Registry, _, _, fn() -> std::io::Stdout>,
+    /// # filter::LevelFilter, Registry>>
+    /// # = &reload_handle;
+    /// #
+    /// info!("This will be logged to stderr");
+    /// reload_handle.modify(|subscriber| *subscriber.inner_mut().writer_mut() = non_blocking(std::io::stdout()));
+    /// info!("This will be logged to stdout");
+    /// # }
+    /// ```
+    ///
+    /// [subscriber]: Subscribe
+    pub fn inner_mut(&mut self) -> &mut S {
+        &mut self.subscriber
     }
 }
 

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -157,6 +157,56 @@ impl<C, N, E, W> Subscriber<C, N, E, W> {
         }
     }
 
+    /// Borrows the [writer] for this subscriber.
+    ///
+    /// [writer]: MakeWriter
+    pub fn writer(&self) -> &W {
+        &self.make_writer
+    }
+
+    /// Mutably borrows the [writer] for this subscriber.
+    ///
+    /// This method is primarily expected to be used with the
+    /// [`reload::Handle::modify`](crate::reload::Handle::modify) method.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tracing::info;
+    /// # use tracing_subscriber::{fmt,reload,Registry,prelude::*};
+    /// # fn non_blocking<T: std::io::Write>(writer: T) -> (fn() -> std::io::Stdout) {
+    /// #   std::io::stdout
+    /// # }
+    /// # fn main() {
+    /// let subscriber = fmt::subscriber().with_writer(non_blocking(std::io::stderr()));
+    /// let (subscriber, reload_handle) = reload::Subscriber::new(subscriber);
+    /// #
+    /// # // specifying the Registry type is required
+    /// # let _: &reload::Handle<fmt::Subscriber<Registry, _, _, _>> = &reload_handle;
+    /// #
+    /// info!("This will be logged to stderr");
+    /// reload_handle.modify(|subscriber| *subscriber.writer_mut() = non_blocking(std::io::stdout()));
+    /// info!("This will be logged to stdout");
+    /// # }
+    /// ```
+    ///
+    /// [writer]: MakeWriter
+    pub fn writer_mut(&mut self) -> &mut W {
+        &mut self.make_writer
+    }
+
+    /// Sets whether this subscriber should use ANSI terminal formatting
+    /// escape codes (such as colors).
+    ///
+    /// This method is primarily expected to be used with the
+    /// [`reload::Handle::modify`](crate::reload::Handle::modify) method when changing
+    /// the writer.
+    #[cfg(feature = "ansi")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
+    pub fn set_ansi(&mut self, ansi: bool) {
+        self.is_ansi = ansi;
+    }
+
     /// Configures the subscriber to support [`libtest`'s output capturing][capturing] when used in
     /// unit tests.
     ///


### PR DESCRIPTION
This adds more modification methods for use with reloading. Replaces #2032.

Needs fixes in doc tests.

## Motivation

I have a Filtered layer that I'd like to modify with a reload handle. If I use `reload` then the filter doesn't work. If I use `modify` with `filter_mut` I can't update the writer. 

## Solution

Adds some additional accessor methods to allow the writer to be modified in `modify`.
