### PR TITLE
subscriber: add `EnvFilter::builder`, option to disable regex

### DIFF
--- a/tracing-subscriber/src/filter/env/builder.rs
+++ b/tracing-subscriber/src/filter/env/builder.rs
@@ -23,8 +23,8 @@ impl Builder {
     ///
     /// If this is `true`, field filter directives will be interpreted as
     /// regular expressions if they are not able to be interpreted as a `bool`,
-    /// `i64`, `u64`, `f64`, or `String` literal. If this is `false,` those
-    /// field values will be interpreted as literal `fmt::Debug` output instead.
+    /// `i64`, `u64`, or `f64` literal. If this is `false,` those field values
+    /// will be interpreted as literal [`std::fmt::Debug`] output instead.
     ///
     /// By default, regular expressions are enabled.
     ///

--- a/tracing-subscriber/src/filter/env/builder.rs
+++ b/tracing-subscriber/src/filter/env/builder.rs
@@ -1,0 +1,309 @@
+use super::{
+    directive::{self, Directive},
+    EnvFilter, FromEnvError,
+};
+use crate::sync::RwLock;
+use std::env;
+use thread_local::ThreadLocal;
+use tracing::level_filters::STATIC_MAX_LEVEL;
+
+/// A [builder] for constructing new [`EnvFilter`]s.
+///
+/// [builder]: https://rust-unofficial.github.io/patterns/patterns/creational/builder.html
+#[derive(Debug, Clone)]
+pub struct Builder {
+    regex: bool,
+    env: Option<String>,
+    default_directive: Option<Directive>,
+}
+
+impl Builder {
+    /// Sets whether or not span field values can be matched with regular
+    /// expressions.
+    ///
+    /// If this is `true`, field filter directives will be interpreted as
+    /// regular expressions if they are not able to be interpreted as a `bool`,
+    /// `i64`, `u64`, `f64`, or `String` literal. If this is `false,` those
+    /// field values will be interpreted as literal `fmt::Debug` output instead.
+    ///
+    /// By default, regular expressions are enabled.
+    ///
+    /// **Note**: when [`EnvFilter`]s are constructed from untrusted inputs,
+    /// disabling regular expressions is strongly encouraged.
+    pub fn with_regex(self, regex: bool) -> Self {
+        Self { regex, ..self }
+    }
+
+    /// Sets a [filtering directive] that will be added to the filter if
+    /// the parsed string or environment variable contains no filter directives.
+    ///
+    /// By default, there is no default directive.
+    ///
+    /// # Examples
+    ///
+    /// If [`parse_lossy`] or [`from_env_lossy`] is called with only invalid
+    /// filtering directives, the default directive is used instead:
+    ///
+    /// ```rust
+    /// use tracing_subscriber::EnvFilter;
+    ///
+    /// let filter = EnvFilter::builder()
+    ///     .default_directive(LevelFilter::INFO.into())
+    ///     .parse_lossy("some_target=fake level,foo::bar=lolwut");
+    ///
+    /// assert_eq!(format!("{}", filter), "info");
+    /// ```
+    ///
+    /// If [`parse`], [`parse_lossy`], [`from_env`], or [`from_env_lossy`] are
+    /// called with only invalid
+    /// filtering directives, the default directive is used instead:
+    ///
+    /// ```rust
+    /// use tracing_subscriber::EnvFilter;
+    ///
+    /// let filter = EnvFilter::builder()
+    ///     .default_directive(LevelFilter::INFO.into())
+    ///     .parse("");
+    ///
+    /// assert_eq!(format!("{}", filter), "info");
+    /// ```
+    ///
+    /// If the string or environment variable contains valid filtering
+    /// directives, the default directive is not used:
+    ///
+    /// ```rust
+    /// use tracing_subscriber::EnvFilter;
+    ///
+    /// let filter = EnvFilter::builder()
+    ///     .default_directive(LevelFilter::INFO.into())
+    ///     .parse_lossy("foo=trace");
+    ///
+    /// // The default directive is *not* used:
+    /// assert_eq!(format!("{}", filter), "foo=trace");
+    /// ```
+    ///
+    /// Parsing a more complex default directive from a string:
+    ///
+    /// ```rust
+    /// use tracing_subscriber::EnvFilter;
+    ///
+    /// let default = "myapp=debug".parse()
+    ///     .expect("hard-coded default directive should be valid");
+    ///
+    /// let filter = EnvFilter::builder()
+    ///     .default_directive(default)
+    ///     .parse("");
+    ///
+    /// assert_eq!(format!("{}", filter), "myapp=trace");
+    /// ```
+    ///
+    /// [`parse_lossy`]: Self::parse_lossy
+    /// [`from_env_lossy`]: Self::from_env_lossy
+    /// [`parse`]: Self::parse
+    /// [`from_env`]: Self::from_env
+    pub fn with_default_directive(self, default_directive: Directive) -> Self {
+        Self {
+            default_directive: Some(default_directive),
+            ..self
+        }
+    }
+
+    /// Sets the name of the environment variable used by the [`from_env`],
+    /// [`from_env_lossy`], and [`try_from_env`] methods.
+    ///
+    /// By default, this is the value of [`EnvFilter::DEFAULT_ENV`]
+    /// (`RUST_LOG`).
+    ///
+    /// [`from_env`]: Self::from_env
+    /// [`from_env_lossy`]: Self::from_env_lossy
+    /// [`try_from_env`]: Self::try_from_env
+    pub fn with_env_var(self, var: impl ToString) -> Self {
+        Self {
+            env: Some(var.to_string()),
+            ..self
+        }
+    }
+
+    /// Returns a new [`EnvFilter`] from the directives in the given string,
+    /// *ignoring* any that are invalid.
+    pub fn parse_lossy<S: AsRef<str>>(&self, dirs: S) -> EnvFilter {
+        let directives =
+            dirs.as_ref()
+                .split(',')
+                .filter_map(|s| match Directive::parse(s, self.regex) {
+                    Ok(d) => Some(d),
+                    Err(err) => {
+                        eprintln!("ignoring `{}`: {}", s, err);
+                        None
+                    }
+                });
+        self.from_directives(directives)
+    }
+
+    /// Returns a new [`EnvFilter`] from the directives in the given string,
+    /// or an error if any are invalid.
+    pub fn parse<S: AsRef<str>>(&self, dirs: S) -> Result<EnvFilter, directive::ParseError> {
+        let directives = dirs
+            .as_ref()
+            .split(',')
+            .map(|s| Directive::parse(s, self.regex))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(self.from_directives(directives))
+    }
+
+    /// Returns a new [`EnvFilter`] from the directives in the configured
+    /// environment variable, ignoring any directives that are invalid.
+    pub fn from_env_lossy(&self) -> EnvFilter {
+        let var = env::var(self.env_var_name()).unwrap_or_default();
+        self.parse_lossy(var)
+    }
+
+    /// Returns a new [`EnvFilter`] from the directives in the in the configured
+    /// environment variable, or an error if the environment variable is not set
+    /// or contains invalid directives.
+    pub fn from_env(&self) -> Result<EnvFilter, FromEnvError> {
+        let var = env::var(self.env_var_name()).unwrap_or_default();
+        self.parse(var).map_err(Into::into)
+    }
+
+    /// Returns a new [`EnvFilter`] from the directives in the in the configured
+    /// environment variable, or an error if the environment variable is not set
+    /// or contains invalid directives.
+    pub fn try_from_env(&self) -> Result<EnvFilter, FromEnvError> {
+        let var = env::var(self.env_var_name())?;
+        self.parse(var).map_err(Into::into)
+    }
+
+    // TODO(eliza): consider making this a public API?
+    pub(super) fn from_directives(
+        &self,
+        directives: impl IntoIterator<Item = Directive>,
+    ) -> EnvFilter {
+        use tracing::Level;
+
+        let mut directives: Vec<_> = directives.into_iter().collect();
+        let mut disabled = Vec::new();
+        for directive in &mut directives {
+            if directive.level > STATIC_MAX_LEVEL {
+                disabled.push(directive.clone());
+            }
+            if !self.regex {
+                directive.deregexify();
+            }
+        }
+
+        if !disabled.is_empty() {
+            #[cfg(feature = "ansi_term")]
+            use ansi_term::{Color, Style};
+            // NOTE: We can't use a configured `MakeWriter` because the EnvFilter
+            // has no knowledge of any underlying subscriber or collector, which
+            // may or may not use a `MakeWriter`.
+            let warn = |msg: &str| {
+                #[cfg(not(feature = "ansi_term"))]
+                let msg = format!("warning: {}", msg);
+                #[cfg(feature = "ansi_term")]
+                let msg = {
+                    let bold = Style::new().bold();
+                    let mut warning = Color::Yellow.paint("warning");
+                    warning.style_ref_mut().is_bold = true;
+                    format!("{}{} {}", warning, bold.paint(":"), bold.paint(msg))
+                };
+                eprintln!("{}", msg);
+            };
+            let ctx_prefixed = |prefix: &str, msg: &str| {
+                #[cfg(not(feature = "ansi_term"))]
+                let msg = format!("{} {}", prefix, msg);
+                #[cfg(feature = "ansi_term")]
+                let msg = {
+                    let mut equal = Color::Fixed(21).paint("="); // dark blue
+                    equal.style_ref_mut().is_bold = true;
+                    format!(" {} {} {}", equal, Style::new().bold().paint(prefix), msg)
+                };
+                eprintln!("{}", msg);
+            };
+            let ctx_help = |msg| ctx_prefixed("help:", msg);
+            let ctx_note = |msg| ctx_prefixed("note:", msg);
+            let ctx = |msg: &str| {
+                #[cfg(not(feature = "ansi_term"))]
+                let msg = format!("note: {}", msg);
+                #[cfg(feature = "ansi_term")]
+                let msg = {
+                    let mut pipe = Color::Fixed(21).paint("|");
+                    pipe.style_ref_mut().is_bold = true;
+                    format!(" {} {}", pipe, msg)
+                };
+                eprintln!("{}", msg);
+            };
+            warn("some trace filter directives would enable traces that are disabled statically");
+            for directive in disabled {
+                let target = if let Some(target) = &directive.target {
+                    format!("the `{}` target", target)
+                } else {
+                    "all targets".into()
+                };
+                let level = directive
+                    .level
+                    .into_level()
+                    .expect("=off would not have enabled any filters");
+                ctx(&format!(
+                    "`{}` would enable the {} level for {}",
+                    directive, level, target
+                ));
+            }
+            ctx_note(&format!("the static max level is `{}`", STATIC_MAX_LEVEL));
+            let help_msg = || {
+                let (feature, filter) = match STATIC_MAX_LEVEL.into_level() {
+                    Some(Level::TRACE) => unreachable!(
+                        "if the max level is trace, no static filtering features are enabled"
+                    ),
+                    Some(Level::DEBUG) => ("max_level_debug", Level::TRACE),
+                    Some(Level::INFO) => ("max_level_info", Level::DEBUG),
+                    Some(Level::WARN) => ("max_level_warn", Level::INFO),
+                    Some(Level::ERROR) => ("max_level_error", Level::WARN),
+                    None => return ("max_level_off", String::new()),
+                };
+                (feature, format!("{} ", filter))
+            };
+            let (feature, earlier_level) = help_msg();
+            ctx_help(&format!(
+                "to enable {}logging, remove the `{}` feature",
+                earlier_level, feature
+            ));
+        }
+
+        let (dynamics, statics) = Directive::make_tables(directives);
+        let has_dynamics = !dynamics.is_empty();
+
+        let mut filter = EnvFilter {
+            statics,
+            dynamics,
+            has_dynamics,
+            by_id: RwLock::new(Default::default()),
+            by_cs: RwLock::new(Default::default()),
+            scope: ThreadLocal::new(),
+            regex: self.regex,
+        };
+
+        if !has_dynamics && filter.statics.is_empty() {
+            if let Some(ref default) = self.default_directive {
+                filter = filter.add_directive(default.clone());
+            }
+        }
+
+        filter
+    }
+
+    fn env_var_name(&self) -> &str {
+        self.env.as_deref().unwrap_or(EnvFilter::DEFAULT_ENV)
+    }
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self {
+            regex: true,
+            env: None,
+            default_directive: None,
+        }
+    }
+}

--- a/tracing-subscriber/src/filter/env/builder.rs
+++ b/tracing-subscriber/src/filter/env/builder.rs
@@ -18,8 +18,7 @@ pub struct Builder {
 }
 
 impl Builder {
-    /// Sets whether or not span field values can be matched with regular
-    /// expressions.
+    /// Sets whether span field values can be matched with regular expressions.
     ///
     /// If this is `true`, field filter directives will be interpreted as
     /// regular expressions if they are not able to be interpreted as a `bool`,
@@ -34,14 +33,14 @@ impl Builder {
         Self { regex, ..self }
     }
 
-    /// Sets a [filtering directive] that will be added to the filter if
+    /// Sets a default [filtering directive] that will be added to the filter if
     /// the parsed string or environment variable contains no filter directives.
     ///
     /// By default, there is no default directive.
     ///
     /// # Examples
     ///
-    /// If [`parse_lossy`] or [`from_env_lossy`] is called with only invalid
+    /// If [`parse_lossy`] or [`from_env_lossy`] is called with _only_ invalid
     /// filtering directives, the default directive is used instead:
     ///
     /// ```rust
@@ -55,8 +54,8 @@ impl Builder {
     /// ```
     ///
     /// If [`parse`], [`parse_lossy`], [`from_env`], or [`from_env_lossy`] are
-    /// called with only invalid
-    /// filtering directives, the default directive is used instead:
+    /// called with an empty string or environment variable, the default
+    /// directive is used instead:
     ///
     /// ```rust
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/tracing-subscriber/src/filter/env/builder.rs
+++ b/tracing-subscriber/src/filter/env/builder.rs
@@ -40,19 +40,6 @@ impl Builder {
     ///
     /// # Examples
     ///
-    /// If [`parse_lossy`] or [`from_env_lossy`] is called with _only_ invalid
-    /// filtering directives, the default directive is used instead:
-    ///
-    /// ```rust
-    /// use tracing_subscriber::filter::{EnvFilter, LevelFilter};
-    ///
-    /// let filter = EnvFilter::builder()
-    ///     .with_default_directive(LevelFilter::INFO.into())
-    ///     .parse_lossy("some_target=fake level,foo::bar=lolwut");
-    ///
-    /// assert_eq!(format!("{}", filter), "info");
-    /// ```
-    ///
     /// If [`parse`], [`parse_lossy`], [`from_env`], or [`from_env_lossy`] are
     /// called with an empty string or environment variable, the default
     /// directive is used instead:
@@ -68,6 +55,22 @@ impl Builder {
     /// assert_eq!(format!("{}", filter), "info");
     /// # Ok(()) }
     /// ```
+    ///
+    /// Note that the `lossy` variants ([`parse_lossy`] and [`from_env_lossy`])
+    /// will ignore any invalid directives. If all directives in a filter
+    /// string or environment variable are invalid, those methods will also use
+    /// the default directive:
+    ///
+    /// ```rust
+    /// use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+    ///
+    /// let filter = EnvFilter::builder()
+    ///     .with_default_directive(LevelFilter::INFO.into())
+    ///     .parse_lossy("some_target=fake level,foo::bar=lolwut");
+    ///
+    /// assert_eq!(format!("{}", filter), "info");
+    /// ```
+    ///
     ///
     /// If the string or environment variable contains valid filtering
     /// directives, the default directive is not used:

--- a/tracing-subscriber/src/filter/env/directive.rs
+++ b/tracing-subscriber/src/filter/env/directive.rs
@@ -230,9 +230,10 @@ impl Match for Directive {
         }
 
         // Does the metadata define all the fields that this directive cares about?
-        let fields = meta.fields();
-        for field in &self.fields {
-            if fields.field(&field.name).is_none() {
+        let actual_fields = meta.fields();
+        for expected_field in &self.fields {
+            // Does the actual field set (from the metadata) contain this field?
+            if actual_fields.field(&expected_field.name).is_none() {
                 return false;
             }
         }

--- a/tracing-subscriber/src/filter/env/directive.rs
+++ b/tracing-subscriber/src/filter/env/directive.rs
@@ -107,45 +107,19 @@ impl Directive {
             .collect();
         (Dynamics::from_iter(dyns), statics)
     }
-}
 
-impl Match for Directive {
-    fn cares_about(&self, meta: &Metadata<'_>) -> bool {
-        // Does this directive have a target filter, and does it match the
-        // metadata's target?
-        if let Some(ref target) = self.target {
-            if !meta.target().starts_with(&target[..]) {
-                return false;
+    pub(super) fn deregexify(&mut self) {
+        for field in &mut self.fields {
+            field.value = match field.value.take() {
+                Some(field::ValueMatch::Pat(pat)) => {
+                    Some(field::ValueMatch::Debug(pat.into_debug_match()))
+                }
+                x => x,
             }
         }
-
-        // Do we have a name filter, and does it match the metadata's name?
-        // TODO(eliza): put name globbing here?
-        if let Some(ref name) = self.in_span {
-            if name != meta.name() {
-                return false;
-            }
-        }
-
-        // Does the metadata define all the fields that this directive cares about?
-        let fields = meta.fields();
-        for field in &self.fields {
-            if fields.field(&field.name).is_none() {
-                return false;
-            }
-        }
-
-        true
     }
 
-    fn level(&self) -> &LevelFilter {
-        &self.level
-    }
-}
-
-impl FromStr for Directive {
-    type Err = ParseError;
-    fn from_str(from: &str) -> Result<Self, Self::Err> {
+    pub(super) fn parse(from: &str, regex: bool) -> Result<Self, ParseError> {
         lazy_static! {
             static ref DIRECTIVE_RE: Regex = Regex::new(
                 r"(?x)
@@ -214,7 +188,7 @@ impl FromStr for Directive {
                     .map(|c| {
                         FIELD_FILTER_RE
                             .find_iter(c.as_str())
-                            .map(|c| c.as_str().parse())
+                            .map(|c| field::Match::parse(c.as_str(), regex))
                             .collect::<Result<Vec<_>, _>>()
                     })
                     .unwrap_or_else(|| Ok(Vec::new()));
@@ -228,12 +202,53 @@ impl FromStr for Directive {
             // Setting the target without the level enables every level for that target
             .unwrap_or(LevelFilter::TRACE);
 
-        Ok(Directive {
+        Ok(Self {
             level,
             target,
             in_span,
             fields: fields?,
         })
+    }
+}
+
+impl Match for Directive {
+    fn cares_about(&self, meta: &Metadata<'_>) -> bool {
+        // Does this directive have a target filter, and does it match the
+        // metadata's target?
+        if let Some(ref target) = self.target {
+            if !meta.target().starts_with(&target[..]) {
+                return false;
+            }
+        }
+
+        // Do we have a name filter, and does it match the metadata's name?
+        // TODO(eliza): put name globbing here?
+        if let Some(ref name) = self.in_span {
+            if name != meta.name() {
+                return false;
+            }
+        }
+
+        // Does the metadata define all the fields that this directive cares about?
+        let fields = meta.fields();
+        for field in &self.fields {
+            if fields.field(&field.name).is_none() {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    fn level(&self) -> &LevelFilter {
+        &self.level
+    }
+}
+
+impl FromStr for Directive {
+    type Err = ParseError;
+    fn from_str(from: &str) -> Result<Self, Self::Err> {
+        Directive::parse(from, true)
     }
 }
 

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -4,7 +4,8 @@
 // these are publicly re-exported, but the compiler doesn't realize
 // that for some reason.
 #[allow(unreachable_pub)]
-pub use self::{directive::Directive, field::BadName as BadFieldName};
+pub use self::{builder::Builder, directive::Directive, field::BadName as BadFieldName};
+mod builder;
 mod directive;
 mod field;
 
@@ -62,9 +63,25 @@ use tracing_core::{
 ///    and will match on any [`Span`] or [`Event`] that has a field with that name.
 ///    For example: `[span{field=\"value\"}]=debug`, `[{field}]=trace`.
 /// - `value` matches on the value of a span's field. If a value is a numeric literal or a bool,
-///    it will match _only_ on that value. Otherwise, this filter acts as a regex on
-///    the `std::fmt::Debug` output from the value.
+///    it will match _only_ on that value. Otherwise, this filter matches the
+///    `std::fmt::Debug` output from the value.
 /// - `level` sets a maximum verbosity level accepted by this directive.
+///
+/// When a field value directive (`[{<FIELD NAME>=<FIELD_VALUE>}]=...`) matches a
+/// value's `fmt::Debug` output (i.e., the field value in the directive is not a
+/// `bool`, `i64`, `u64`, `f64`, or string literal), the matched pattern may be
+/// interpreted as either a regular expression or as the precise expected output
+/// of the field's `Debug` implementation. By default, these filters are
+/// interpreted as regular expressions, but this can be disabled using the
+/// [`Builder::with_regex`] builder method to use precise matching instead.
+///
+/// When field value filters are interpreted as regular expressions, the
+/// [`regex-automata` crate's regular expression syntax][re-syntax] is
+/// supported.
+///
+/// **Note**: When filters are constructed from potentially untrusted inputs,
+/// [disabling regular expression matching](Builder::with_regex) is strongly
+/// recommended.
 ///
 /// ## Usage Notes
 ///
@@ -147,6 +164,20 @@ use tracing_core::{
 ///     .with(unfiltered_subscriber)
 ///     .init();
 /// ```
+/// # Constructing `EnvFilter`s
+///
+/// An `EnvFilter` is be constructed by parsing a string containing one or more
+/// directives. The [`EnvFilter::new`] constructor parses an `EnvFilter` from a
+/// string, ignoring any invalid directives, while [`EnvFilter::try_new`]
+/// returns an error if invalid directives are encountered. Similarly, the
+/// [`EnvFilter::from_env`] and [`EnvFilter::try_from_env`] constructors parse
+/// an `EnvFilter` from the value of the provided environment variable, with
+/// lossy and strict validation, respectively.
+///
+/// A [builder](EnvFilter::builder) interface is available to set additional
+/// configuration options prior to parsing an `EnvFilter`. See the [`Builder`
+/// type's documentation](Builder) for details on the options that can be
+/// configured using the builder.
 ///
 /// [`Subscriber`]: Subscribe
 /// [`env_logger`]: https://docs.rs/env_logger/0.7.1/env_logger/#enabling-logging
@@ -169,6 +200,7 @@ pub struct EnvFilter {
     by_id: RwLock<HashMap<span::Id, directive::SpanMatcher>>,
     by_cs: RwLock<HashMap<callsite::Identifier, directive::CallsiteMatcher>>,
     scope: ThreadLocal<RefCell<Vec<LevelFilter>>>,
+    regex: bool,
 }
 
 type FieldMap<T> = HashMap<Field, T>;
@@ -193,54 +225,163 @@ impl EnvFilter {
     ///
     pub const DEFAULT_ENV: &'static str = "RUST_LOG";
 
+    /// Returns a [builder] that can be used to configure a new [`EnvFilter`]
+    /// instance.
+    ///
+    /// The [`Builder`] type is used to set additional configurations, such as
+    /// [whether regular expressions are enabled](Builder::with_regex) or [the
+    /// default directive](Builder::with_default_directive) before parsing an
+    /// [`EnvFilter`] from a string or environment variable.
+    ///
+    /// [builder]: https://rust-unofficial.github.io/patterns/patterns/creational/builder.html
+    pub fn builder() -> Builder {
+        Builder::default()
+    }
+
     /// Returns a new `EnvFilter` from the value of the `RUST_LOG` environment
     /// variable, ignoring any invalid filter directives.
+    ///
+    /// If the environment variable is empty or not set, or if it contains only
+    /// invalid directives, a default directive enabling the [`ERROR`] level is
+    /// added.
+    ///
+    /// To set additional configuration options prior to parsing the filter, use
+    /// the [`Builder`] type instead.
+    ///
+    /// This function is equivalent to the following:
+    ///
+    /// ```rust
+    /// use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+    //
+    /// EnvFilter::builder()
+    ///     .with_default_directive(LevelFilter::ERROR.into())
+    ///     .from_env_lossy()
+    /// ```
+    ///
+    /// [`ERROR`]: tracing::Level::ERROR
     pub fn from_default_env() -> Self {
-        Self::from_env(Self::DEFAULT_ENV)
+        Self::builder()
+            .with_default_directive(LevelFilter::ERROR.into())
+            .from_env_lossy()
     }
 
     /// Returns a new `EnvFilter` from the value of the given environment
     /// variable, ignoring any invalid filter directives.
+    ///
+    /// If the environment variable is empty or not set, or if it contains only
+    /// invalid directives, a default directive enabling the [`ERROR`] level is
+    /// added.
+    ///
+    /// To set additional configuration options prior to parsing the filter, use
+    /// the [`Builder`] type instead.
+    ///
+    /// This function is equivalent to the following:
+    ///
+    /// ```rust
+    /// use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+    ///
+    /// # let env = "";
+    /// EnvFilter::builder()
+    ///     .with_default_directive(LevelFilter::ERROR.into())
+    ///     .with_env_var(env)
+    ///     .from_env_lossy()
+    /// ```
+    ///
+    /// [`ERROR`]: tracing::Level::ERROR
     pub fn from_env<A: AsRef<str>>(env: A) -> Self {
-        env::var(env.as_ref()).map(Self::new).unwrap_or_default()
+        Self::builder()
+            .with_default_directive(LevelFilter::ERROR.into())
+            .with_env_var(env.as_ref())
+            .from_env_lossy()
     }
 
     /// Returns a new `EnvFilter` from the directives in the given string,
     /// ignoring any that are invalid.
-    pub fn new<S: AsRef<str>>(dirs: S) -> Self {
-        let directives = dirs.as_ref().split(',').filter_map(|s| match s.parse() {
-            Ok(d) => Some(d),
-            Err(err) => {
-                eprintln!("ignoring `{}`: {}", s, err);
-                None
-            }
-        });
-        Self::from_directives(directives)
+    ///
+    /// If the string is empty or contains only invalid directives, a default
+    /// directive enabling the [`ERROR`] level is added.
+    ///
+    /// To set additional configuration options prior to parsing the filter, use
+    /// the [`Builder`] type instead.
+    ///
+    /// This function is equivalent to the following:
+    ///
+    /// ```rust
+    /// use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+    ///
+    /// # let directives = "";
+    /// EnvFilter::builder()
+    ///     .with_default_directive(LevelFilter::ERROR.into())
+    ///     .parse_lossy(directives)
+    /// ```
+    ///
+    /// [`ERROR`]: tracing::Level::ERROR
+    pub fn new<S: AsRef<str>>(directives: S) -> Self {
+        Self::builder()
+            .with_default_directive(LevelFilter::ERROR.into())
+            .parse_lossy(directives)
     }
 
     /// Returns a new `EnvFilter` from the directives in the given string,
     /// or an error if any are invalid.
+    ///
+    /// If the string is empty, a default directive enabling the [`ERROR`] level
+    /// is added.
+    ///
+    /// To set additional configuration options prior to parsing the filter, use
+    /// the [`Builder`] type instead.
+    ///
+    /// This function is equivalent to the following:
+    ///
+    /// ```rust
+    /// use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+    ///
+    /// # let directives = "";
+    /// EnvFilter::builder()
+    ///     .with_default_directive(LevelFilter::ERROR.into())
+    ///     .parse(directives)
+    /// ```
+    ///
+    /// [`ERROR`]: tracing::Level::ERROR
     pub fn try_new<S: AsRef<str>>(dirs: S) -> Result<Self, directive::ParseError> {
-        let directives = dirs
-            .as_ref()
-            .split(',')
-            .map(|s| s.parse())
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(Self::from_directives(directives))
+        Self::builder().parse(dirs)
     }
 
     /// Returns a new `EnvFilter` from the value of the `RUST_LOG` environment
-    /// variable, or an error if the environment variable contains any invalid
-    /// filter directives.
+    /// variable, or an error if the environment variable is unset or contains
+    /// any invalid filter directives.
+    ///
+    /// To set additional configuration options prior to parsing the filter, use
+    /// the [`Builder`] type instead.
+    ///
+    /// This function is equivalent to the following:
+    ///
+    /// ```rust
+    /// use tracing_subscriber::EnvFilter;
+    ///
+    /// EnvFilter::builder().try_from_env()
+    /// ```
     pub fn try_from_default_env() -> Result<Self, FromEnvError> {
-        Self::try_from_env(Self::DEFAULT_ENV)
+        Self::builder().try_from_env()
     }
 
     /// Returns a new `EnvFilter` from the value of the given environment
     /// variable, or an error if the environment variable is unset or contains
     /// any invalid filter directives.
+    ///
+    /// To set additional configuration options prior to parsing the filter, use
+    /// the [`Builder`] type instead.
+    ///
+    /// This function is equivalent to the following:
+    ///
+    /// ```rust
+    /// use tracing_subscriber::EnvFilter;
+    ///
+    /// # let env = "";
+    /// EnvFilter::builder().with_env_var(env).try_from_env()
+    /// ```
     pub fn try_from_env<A: AsRef<str>>(env: A) -> Result<Self, FromEnvError> {
-        env::var(env.as_ref())?.parse().map_err(Into::into)
+        Self::builder().with_env_var(env.as_ref()).try_from_env()
     }
 
     /// Add a filtering directive to this `EnvFilter`.
@@ -290,7 +431,10 @@ impl EnvFilter {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn add_directive(mut self, directive: Directive) -> Self {
+    pub fn add_directive(mut self, mut directive: Directive) -> Self {
+        if !self.regex {
+            directive.deregexify();
+        }
         if let Some(stat) = directive.to_static() {
             self.statics.add(stat)
         } else {
@@ -298,116 +442,6 @@ impl EnvFilter {
             self.dynamics.add(directive);
         }
         self
-    }
-
-    fn from_directives(directives: impl IntoIterator<Item = Directive>) -> Self {
-        use tracing::level_filters::STATIC_MAX_LEVEL;
-        use tracing::Level;
-
-        let directives: Vec<_> = directives.into_iter().collect();
-
-        let disabled: Vec<_> = directives
-            .iter()
-            .filter(|directive| directive.level > STATIC_MAX_LEVEL)
-            .collect();
-
-        if !disabled.is_empty() {
-            #[cfg(feature = "ansi_term")]
-            use ansi_term::{Color, Style};
-            // NOTE: We can't use a configured `MakeWriter` because the EnvFilter
-            // has no knowledge of any underlying subscriber or collector, which
-            // may or may not use a `MakeWriter`.
-            let warn = |msg: &str| {
-                #[cfg(not(feature = "ansi_term"))]
-                let msg = format!("warning: {}", msg);
-                #[cfg(feature = "ansi_term")]
-                let msg = {
-                    let bold = Style::new().bold();
-                    let mut warning = Color::Yellow.paint("warning");
-                    warning.style_ref_mut().is_bold = true;
-                    format!("{}{} {}", warning, bold.paint(":"), bold.paint(msg))
-                };
-                eprintln!("{}", msg);
-            };
-            let ctx_prefixed = |prefix: &str, msg: &str| {
-                #[cfg(not(feature = "ansi_term"))]
-                let msg = format!("{} {}", prefix, msg);
-                #[cfg(feature = "ansi_term")]
-                let msg = {
-                    let mut equal = Color::Fixed(21).paint("="); // dark blue
-                    equal.style_ref_mut().is_bold = true;
-                    format!(" {} {} {}", equal, Style::new().bold().paint(prefix), msg)
-                };
-                eprintln!("{}", msg);
-            };
-            let ctx_help = |msg| ctx_prefixed("help:", msg);
-            let ctx_note = |msg| ctx_prefixed("note:", msg);
-            let ctx = |msg: &str| {
-                #[cfg(not(feature = "ansi_term"))]
-                let msg = format!("note: {}", msg);
-                #[cfg(feature = "ansi_term")]
-                let msg = {
-                    let mut pipe = Color::Fixed(21).paint("|");
-                    pipe.style_ref_mut().is_bold = true;
-                    format!(" {} {}", pipe, msg)
-                };
-                eprintln!("{}", msg);
-            };
-            warn("some trace filter directives would enable traces that are disabled statically");
-            for directive in disabled {
-                let target = if let Some(target) = &directive.target {
-                    format!("the `{}` target", target)
-                } else {
-                    "all targets".into()
-                };
-                let level = directive
-                    .level
-                    .into_level()
-                    .expect("=off would not have enabled any filters");
-                ctx(&format!(
-                    "`{}` would enable the {} level for {}",
-                    directive, level, target
-                ));
-            }
-            ctx_note(&format!("the static max level is `{}`", STATIC_MAX_LEVEL));
-            let help_msg = || {
-                let (feature, filter) = match STATIC_MAX_LEVEL.into_level() {
-                    Some(Level::TRACE) => unreachable!(
-                        "if the max level is trace, no static filtering features are enabled"
-                    ),
-                    Some(Level::DEBUG) => ("max_level_debug", Level::TRACE),
-                    Some(Level::INFO) => ("max_level_info", Level::DEBUG),
-                    Some(Level::WARN) => ("max_level_warn", Level::INFO),
-                    Some(Level::ERROR) => ("max_level_error", Level::WARN),
-                    None => return ("max_level_off", String::new()),
-                };
-                (feature, format!("{} ", filter))
-            };
-            let (feature, earlier_level) = help_msg();
-            ctx_help(&format!(
-                "to enable {}logging, remove the `{}` feature",
-                earlier_level, feature
-            ));
-        }
-
-        let (dynamics, mut statics) = Directive::make_tables(directives);
-        let has_dynamics = !dynamics.is_empty();
-
-        if statics.is_empty() && !has_dynamics {
-            statics.add(directive::StaticDirective::default());
-        }
-
-        Self {
-            statics,
-            dynamics,
-            has_dynamics,
-            by_id: RwLock::new(HashMap::new()),
-            by_cs: RwLock::new(HashMap::new()),
-            // TODO(eliza): maybe worth allocating capacity for `num_cpus`
-            // threads or something (assuming we're running in Tokio)? or
-            // `num_cpus * 2` or something?
-            scope: ThreadLocal::new(),
-        }
     }
 
     fn cares_about_span(&self, span: &span::Id) -> bool {
@@ -637,7 +671,7 @@ where
 
 impl Default for EnvFilter {
     fn default() -> Self {
-        Self::from_directives(std::iter::empty())
+        Builder::default().from_directives(std::iter::empty())
     }
 }
 

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -252,10 +252,12 @@ impl EnvFilter {
     ///
     /// ```rust
     /// use tracing_subscriber::filter::{EnvFilter, LevelFilter};
-    //
+    ///
+    /// # fn docs() -> EnvFilter {
     /// EnvFilter::builder()
     ///     .with_default_directive(LevelFilter::ERROR.into())
     ///     .from_env_lossy()
+    /// # }
     /// ```
     ///
     /// [`ERROR`]: tracing::Level::ERROR
@@ -280,11 +282,13 @@ impl EnvFilter {
     /// ```rust
     /// use tracing_subscriber::filter::{EnvFilter, LevelFilter};
     ///
+    /// # fn docs() -> EnvFilter {
     /// # let env = "";
     /// EnvFilter::builder()
     ///     .with_default_directive(LevelFilter::ERROR.into())
     ///     .with_env_var(env)
     ///     .from_env_lossy()
+    /// # }
     /// ```
     ///
     /// [`ERROR`]: tracing::Level::ERROR
@@ -309,10 +313,12 @@ impl EnvFilter {
     /// ```rust
     /// use tracing_subscriber::filter::{EnvFilter, LevelFilter};
     ///
+    /// # fn docs() -> EnvFilter {
     /// # let directives = "";
     /// EnvFilter::builder()
     ///     .with_default_directive(LevelFilter::ERROR.into())
     ///     .parse_lossy(directives)
+    /// # }
     /// ```
     ///
     /// [`ERROR`]: tracing::Level::ERROR
@@ -336,10 +342,12 @@ impl EnvFilter {
     /// ```rust
     /// use tracing_subscriber::filter::{EnvFilter, LevelFilter};
     ///
+    /// # fn docs() -> Result<EnvFilter, tracing_subscriber::filter::ParseError> {
     /// # let directives = "";
     /// EnvFilter::builder()
     ///     .with_default_directive(LevelFilter::ERROR.into())
     ///     .parse(directives)
+    /// # }
     /// ```
     ///
     /// [`ERROR`]: tracing::Level::ERROR
@@ -359,7 +367,9 @@ impl EnvFilter {
     /// ```rust
     /// use tracing_subscriber::EnvFilter;
     ///
+    /// # fn docs() -> Result<EnvFilter, tracing_subscriber::filter::FromEnvError> {
     /// EnvFilter::builder().try_from_env()
+    /// # }
     /// ```
     pub fn try_from_default_env() -> Result<Self, FromEnvError> {
         Self::builder().try_from_env()
@@ -377,8 +387,10 @@ impl EnvFilter {
     /// ```rust
     /// use tracing_subscriber::EnvFilter;
     ///
+    /// # fn docs() -> Result<EnvFilter, tracing_subscriber::filter::FromEnvError> {
     /// # let env = "";
     /// EnvFilter::builder().with_env_var(env).try_from_env()
+    /// # }
     /// ```
     pub fn try_from_env<A: AsRef<str>>(env: A) -> Result<Self, FromEnvError> {
         Self::builder().with_env_var(env.as_ref()).try_from_env()
@@ -403,7 +415,7 @@ impl EnvFilter {
     /// # Examples
     ///
     /// From [`LevelFilter`]:
-    ////
+    ///
     /// ```rust
     /// use tracing_subscriber::filter::{EnvFilter, LevelFilter};
     /// let mut filter = EnvFilter::from_default_env()
@@ -418,9 +430,9 @@ impl EnvFilter {
     /// let mut filter = EnvFilter::from_default_env()
     ///     .add_directive(Level::INFO.into());
     /// ```
-    ////
+    ///
     /// Parsed from a string:
-    ////
+    ///
     /// ```rust
     /// use tracing_subscriber::filter::{EnvFilter, Directive};
     ///

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -64,16 +64,17 @@ use tracing_core::{
 ///    For example: `[span{field=\"value\"}]=debug`, `[{field}]=trace`.
 /// - `value` matches on the value of a span's field. If a value is a numeric literal or a bool,
 ///    it will match _only_ on that value. Otherwise, this filter matches the
-///    `std::fmt::Debug` output from the value.
+///    [`std::fmt::Debug`] output from the value.
 /// - `level` sets a maximum verbosity level accepted by this directive.
 ///
 /// When a field value directive (`[{<FIELD NAME>=<FIELD_VALUE>}]=...`) matches a
-/// value's `fmt::Debug` output (i.e., the field value in the directive is not a
-/// `bool`, `i64`, `u64`, `f64`, or string literal), the matched pattern may be
-/// interpreted as either a regular expression or as the precise expected output
-/// of the field's `Debug` implementation. By default, these filters are
-/// interpreted as regular expressions, but this can be disabled using the
-/// [`Builder::with_regex`] builder method to use precise matching instead.
+/// value's [`std::fmt::Debug`] output (i.e., the field value in the directive
+/// is not a `bool`, `i64`, `u64`, or `f64` literal), the matched pattern may be
+/// interpreted as either a regular expression or as the precise expected
+/// output of the field's [`std::fmt::Debug`] implementation. By default, these
+/// filters are interpreted as regular expressions, but this can be disabled
+/// using the [`Builder::with_regex`] builder method to use precise matching
+/// instead.
 ///
 /// When field value filters are interpreted as regular expressions, the
 /// [`regex-automata` crate's regular expression syntax][re-syntax] is


### PR DESCRIPTION
## Motivation

Currently, `EnvFilter` will always interpret all field value filter
directives that are not numeric,or boolean literals as regular
expressions that are matched against a field's `fmt::Debug` output. In
many cases, it may not be desirable to use regular expressions in this
case, so users may prefer to perform literal matching of `fmt::Debug`
output against a string value instead. Currently, this is not possible.

## Solution

This branch introduces the ability to control whether an `EnvFilter`
interprets field value `fmt::Debug` match filters as regular expressions
or as literal strings. When matching literal `fmt::Debug` patterns, the
string is matched without requiring a temporary allocation for the
formatted representation by implementing `fmt::Write` for a matcher type
and "writing" the field's `Debug` output to it. This is similar to the
technique already used for matching regular expression patterns.

Since there is not currently a nice way to specify configurations prior
to parsing an `EnvFilter` from a string or environment variable, I've
also added a builder API. This allows setting things like whether field
value filters should use strict matching or regular expressions.

## Notes

Ideally, I think we would want the filter language to allow specifying
whether a field value filter should be interpreted as a regular
expression or as a literal string match. Instead of having a global
toggle between regular expressions and literal strings, we would
introduce new syntax for indicating that a value match pattern is a
regular expression. This way, a single filter can have both regular
expression and literal string value matchers. The `with_regex(false)`
configuration would just return an error any time the regex syntax was
used when parsing the filter string.

However, this would be a breaking change in behavior. Currently, field
value filters are interpreted as regex by default, so changing the
parser to only interpret a value filter as a regex if there's additional
syntax indicating it's a regex would break existing filter
configurations that rely on regex matching.

In `tracing-subscriber` 0.4, we should definitely consider introducing
new syntax to indicate a match pattern is a regex, and change the
`with_regex` method's behavior to disallow the use of that syntax. For
now, however, making it a global toggle at least allows users to control
whether or not we use regex matching, so this is a significant
improvement for v0.3.x.