### PR TITLE
build(deps): use nu-ansi-term to replace ansi_term

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -43,7 +43,7 @@ bytes = "1"
 argh = "0.1.5"
 
 # sloggish example
-ansi_term = "0.12"
+nu-ansi-term = "0.45"
 humantime = "2.0"
 log = "0.4"
 

--- a/examples/examples/sloggish/sloggish_collector.rs
+++ b/examples/examples/sloggish/sloggish_collector.rs
@@ -1,4 +1,4 @@
-use ansi_term::{Color, Style};
+use nu_ansi_term::{Color, Style};
 use tracing::{
     field::{Field, Visit},
     Collect, Id, Level, Metadata,
@@ -120,7 +120,7 @@ impl<'a> Visit for Event<'a> {
             write!(
                 &mut self.stderr,
                 "{}",
-                // Have to alloc here due to `ansi_term`'s API...
+                // Have to alloc here due to `nu-ansi-term`'s API...
                 Style::new().bold().paint(format!("{:?}", value))
             )
             .unwrap();

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -29,7 +29,7 @@ alloc = []
 std = ["alloc", "tracing-core/std"]
 env-filter = ["matchers", "regex", "lazy_static", "tracing", "std", "thread_local"]
 fmt = ["registry", "std"]
-ansi = ["fmt", "ansi_term"]
+ansi = ["fmt", "nu-ansi-term"]
 registry = ["sharded-slab", "thread_local", "std"]
 json = ["tracing-serde", "serde", "serde_json"]
 # Enables support for local time when using the `time` crate timestamp
@@ -48,7 +48,7 @@ lazy_static = { optional = true, version = "1" }
 
 # fmt
 tracing-log = { path = "../tracing-log", version = "0.2", optional = true, default-features = false, features = ["log-tracer", "std"] }
-ansi_term = { version = "0.12", optional = true }
+nu-ansi-term = { version = "0.45", optional = true }
 time = { version = "0.3", features = ["formatting"], optional = true }
 
 # only required by the json feature

--- a/tracing-subscriber/src/filter/env/builder.rs
+++ b/tracing-subscriber/src/filter/env/builder.rs
@@ -202,15 +202,15 @@ impl Builder {
         }
 
         if !disabled.is_empty() {
-            #[cfg(feature = "ansi_term")]
-            use ansi_term::{Color, Style};
+            #[cfg(feature = "nu-ansi-term")]
+            use nu_ansi_term::{Color, Style};
             // NOTE: We can't use a configured `MakeWriter` because the EnvFilter
             // has no knowledge of any underlying subscriber or collector, which
             // may or may not use a `MakeWriter`.
             let warn = |msg: &str| {
-                #[cfg(not(feature = "ansi_term"))]
+                #[cfg(not(feature = "nu-ansi-term"))]
                 let msg = format!("warning: {}", msg);
-                #[cfg(feature = "ansi_term")]
+                #[cfg(feature = "nu-ansi-term")]
                 let msg = {
                     let bold = Style::new().bold();
                     let mut warning = Color::Yellow.paint("warning");
@@ -220,9 +220,9 @@ impl Builder {
                 eprintln!("{}", msg);
             };
             let ctx_prefixed = |prefix: &str, msg: &str| {
-                #[cfg(not(feature = "ansi_term"))]
+                #[cfg(not(feature = "nu-ansi-term"))]
                 let msg = format!("{} {}", prefix, msg);
-                #[cfg(feature = "ansi_term")]
+                #[cfg(feature = "nu-ansi-term")]
                 let msg = {
                     let mut equal = Color::Fixed(21).paint("="); // dark blue
                     equal.style_ref_mut().is_bold = true;
@@ -233,9 +233,9 @@ impl Builder {
             let ctx_help = |msg| ctx_prefixed("help:", msg);
             let ctx_note = |msg| ctx_prefixed("note:", msg);
             let ctx = |msg: &str| {
-                #[cfg(not(feature = "ansi_term"))]
+                #[cfg(not(feature = "nu-ansi-term"))]
                 let msg = format!("note: {}", msg);
-                #[cfg(feature = "ansi_term")]
+                #[cfg(feature = "nu-ansi-term")]
                 let msg = {
                     let mut pipe = Color::Fixed(21).paint("|");
                     pipe.style_ref_mut().is_bold = true;

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -46,7 +46,7 @@ use tracing_core::{
 use tracing_log::NormalizeEvent;
 
 #[cfg(feature = "ansi")]
-use ansi_term::{Colour, Style};
+use nu_ansi_term::{Color, Style};
 
 #[cfg(feature = "json")]
 mod json;
@@ -103,7 +103,7 @@ use fmt::{Debug, Display};
 ///   does not support ANSI escape codes (such as a log file), and they should
 ///   not be emitted.
 ///
-///   Crates like [`ansi_term`] and [`owo-colors`] can be used to add ANSI
+///   Crates like [`nu-ansi-term`] and [`owo-colors`] can be used to add ANSI
 ///   escape codes to formatted output.
 ///
 /// * The actual [`Event`] to be formatted.
@@ -191,7 +191,7 @@ use fmt::{Debug, Display};
 /// [implements `FormatFields`]: super::FmtContext#impl-FormatFields<'writer>
 /// [ANSI terminal escape codes]: https://en.wikipedia.org/wiki/ANSI_escape_code
 /// [`Writer::has_ansi_escapes`]: Writer::has_ansi_escapes
-/// [`ansi_term`]: https://crates.io/crates/ansi_term
+/// [`nu-ansi-term`]: https://crates.io/crates/nu-ansi-term
 /// [`owo-colors`]: https://crates.io/crates/owo-colors
 /// [default formatter]: Full
 pub trait FormatEvent<C, N>
@@ -1402,11 +1402,11 @@ impl<'a, F: LevelNames> fmt::Display for FmtLevel<F> {
         {
             if self.ansi {
                 return match self.level {
-                    Level::TRACE => write!(f, "{}", Colour::Purple.paint(F::TRACE_STR)),
-                    Level::DEBUG => write!(f, "{}", Colour::Blue.paint(F::DEBUG_STR)),
-                    Level::INFO => write!(f, "{}", Colour::Green.paint(F::INFO_STR)),
-                    Level::WARN => write!(f, "{}", Colour::Yellow.paint(F::WARN_STR)),
-                    Level::ERROR => write!(f, "{}", Colour::Red.paint(F::ERROR_STR)),
+                    Level::TRACE => write!(f, "{}", Color::Purple.paint(F::TRACE_STR)),
+                    Level::DEBUG => write!(f, "{}", Color::Blue.paint(F::DEBUG_STR)),
+                    Level::INFO => write!(f, "{}", Color::Green.paint(F::INFO_STR)),
+                    Level::WARN => write!(f, "{}", Color::Yellow.paint(F::WARN_STR)),
+                    Level::ERROR => write!(f, "{}", Color::Red.paint(F::ERROR_STR)),
                 };
             }
         }

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -14,7 +14,7 @@ use tracing_core::{
 #[cfg(feature = "tracing-log")]
 use tracing_log::NormalizeEvent;
 
-use ansi_term::{Colour, Style};
+use nu_ansi_term::{Color, Style};
 
 /// An excessively pretty, human-readable event formatter.
 ///
@@ -143,11 +143,11 @@ impl Default for Pretty {
 impl Pretty {
     fn style_for(level: &Level) -> Style {
         match *level {
-            Level::TRACE => Style::new().fg(Colour::Purple),
-            Level::DEBUG => Style::new().fg(Colour::Blue),
-            Level::INFO => Style::new().fg(Colour::Green),
-            Level::WARN => Style::new().fg(Colour::Yellow),
-            Level::ERROR => Style::new().fg(Colour::Red),
+            Level::TRACE => Style::new().fg(Color::Purple),
+            Level::DEBUG => Style::new().fg(Color::Blue),
+            Level::INFO => Style::new().fg(Color::Green),
+            Level::WARN => Style::new().fg(Color::Yellow),
+            Level::ERROR => Style::new().fg(Color::Red),
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

[ansi_term](https://github.com/ogham/rust-ansi-term) last time update is over 2 years ago, use nutshell team forked [nu-ansi-term](https://github.com/nushell/nu-ansi-term) instead

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

use [nu-ansi-term](https://github.com/nushell/nu-ansi-term)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
