### PR TITLE
Expose tracing-log's metadata normalization system

### DIFF
--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -688,6 +688,14 @@ impl FieldSet {
     pub fn is_empty(&self) -> bool {
         self.names.is_empty()
     }
+
+    #[doc(hidden)]
+    pub fn slice(&self, range: core::ops::RangeFrom<usize>) -> FieldSet {
+        FieldSet {
+            names: &self.names[range],
+            callsite: self.callsite.clone(),
+        }
+    }
 }
 
 impl<'a> IntoIterator for &'a FieldSet {

--- a/tracing-opentelemetry/src/subscriber.rs
+++ b/tracing-opentelemetry/src/subscriber.rs
@@ -117,7 +117,7 @@ impl<'a> field::Visit for SpanEventVisitor<'a> {
             "message" => self.0.name = value.to_string().into(),
             // Skip fields that are actually log metadata that have already been handled
             #[cfg(feature = "tracing-log")]
-            name if name.starts_with("log.") => (),
+            name if name.starts_with(tracing_log::MAGIC_EVENT_NAME) => (),
             name => {
                 self.0.attributes.push(KeyValue::new(name, value));
             }
@@ -132,7 +132,7 @@ impl<'a> field::Visit for SpanEventVisitor<'a> {
             "message" => self.0.name = value.to_string().into(),
             // Skip fields that are actually log metadata that have already been handled
             #[cfg(feature = "tracing-log")]
-            name if name.starts_with("log.") => (),
+            name if name.starts_with(tracing_log::MAGIC_EVENT_NAME) => (),
             name => {
                 self.0.attributes.push(KeyValue::new(name, value));
             }
@@ -147,7 +147,7 @@ impl<'a> field::Visit for SpanEventVisitor<'a> {
             "message" => self.0.name = value.to_string().into(),
             // Skip fields that are actually log metadata that have already been handled
             #[cfg(feature = "tracing-log")]
-            name if name.starts_with("log.") => (),
+            name if name.starts_with(tracing_log::MAGIC_EVENT_NAME) => (),
             name => {
                 self.0.attributes.push(KeyValue::new(name, value));
             }
@@ -162,7 +162,7 @@ impl<'a> field::Visit for SpanEventVisitor<'a> {
             "message" => self.0.name = value.to_string().into(),
             // Skip fields that are actually log metadata that have already been handled
             #[cfg(feature = "tracing-log")]
-            name if name.starts_with("log.") => (),
+            name if name.starts_with(tracing_log::MAGIC_EVENT_NAME) => (),
             name => {
                 self.0
                     .attributes
@@ -180,7 +180,7 @@ impl<'a> field::Visit for SpanEventVisitor<'a> {
             "message" => self.0.name = format!("{:?}", value).into(),
             // Skip fields that are actually log metadata that have already been handled
             #[cfg(feature = "tracing-log")]
-            name if name.starts_with("log.") => (),
+            name if name.starts_with(tracing_log::MAGIC_EVENT_NAME) => (),
             name => {
                 self.0
                     .attributes

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -492,7 +492,7 @@ impl<'a> field::Visit for JsonVisitor<'a> {
         match field.name() {
             // Skip fields that are actually log metadata that have already been handled
             #[cfg(feature = "tracing-log")]
-            name if name.starts_with("log.") => (),
+            name if name.starts_with(tracing_log::MAGIC_EVENT_NAME) => (),
             name if name.starts_with("r#") => {
                 self.values
                     .insert(&name[2..], serde_json::Value::from(format!("{:?}", value)));

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1229,7 +1229,7 @@ impl<'a> field::Visit for DefaultVisitor<'a> {
             "message" => write!(self.writer, "{:?}", value),
             // Skip fields that are actually log metadata that have already been handled
             #[cfg(feature = "tracing-log")]
-            name if name.starts_with("log.") => Ok(()),
+            name if name.starts_with(tracing_log::MAGIC_EVENT_NAME) => Ok(()),
             name if name.starts_with("r#") => write!(
                 self.writer,
                 "{}{}{:?}",

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -466,7 +466,7 @@ impl<'a> field::Visit for PrettyVisitor<'a> {
             "message" => self.write_padded(&format_args!("{}{:?}", self.style.prefix(), value,)),
             // Skip fields that are actually log metadata that have already been handled
             #[cfg(feature = "tracing-log")]
-            name if name.starts_with("log.") => self.result = Ok(()),
+            name if name.starts_with(tracing_log::MAGIC_EVENT_NAME) => self.result = Ok(()),
             name if name.starts_with("r#") => self.write_padded(&format_args!(
                 "{}{}{}: {:?}",
                 bold.prefix(),


### PR DESCRIPTION
@hawkw, can I have little a code crimes, as a treat?

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

I'm piping a linked library's logging callbacks into tracing. The callbacks provide file/line/func/message, which maps nicely into the log crate's model of log events, and equally fine into tracing, but because I'm using tracing, I can't provide dynamic file/line/module into the events to be logged, so instead attach them as structured fields.

## Solution

Tracing-log already does this for `log` records, so this "just" exposes and slightly extends/generalizes the practice to support arbitrary user implementations of runtime-normalized metadata.

In short, this works by sniffing the metadata name, rather than identifing a specific known callsite just for tracing-log. After the magic metadata name is found, event fields are extracted based on more magic names to fill in the runtime metadata contents, and any remaining fields are passed along to the end consumer.