### PR TITLE
Check that cargo test builds for each package

### DIFF
--- a/.github/workflows/check_features.yml
+++ b/.github/workflows/check_features.yml
@@ -63,7 +63,7 @@ jobs:
       # cargo-hack --feature-powerset with all features in the powerset, so
       # exclude some
       run: |
-        CARGO_HACK=(cargo hack check --feature-powerset --no-dev-deps)
+        CARGO_HACK=(cargo hack check --lib --tests --feature-powerset --no-dev-deps)
         case "${{ matrix.subcrate }}" in
           tracing)
             EXCLUDE_FEATURES=(


### PR DESCRIPTION
## Motivation

`cargo test -p tracing-futures` fails to build because it's missing that it needs to enable a feature in `tracing-mock`.

## Solution

Add `check --tests` to the `cargo hack check`. `check --tests` just checks tests, so we also add `--lib` to continue checking the lib without `--test`.