### PR TITLE
chore: fix Rust 1.60 warnings

### DIFF
--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -225,5 +225,8 @@ pub mod prelude {
     //! extension traits. These traits allow attaching `SpanTrace`s to errors and
     //! subsequently retrieving them from `dyn Error` trait objects.
 
+    // apparently `as _` reexpoorts now generate `unreachable_pub` linting? which
+    // seems wrong to me...
+    #![allow(unreachable_pub)]
     pub use crate::{ExtractSpanTrace as _, InstrumentError as _, InstrumentResult as _};
 }

--- a/tracing-subscriber/src/filter/env/builder.rs
+++ b/tracing-subscriber/src/filter/env/builder.rs
@@ -184,6 +184,10 @@ impl Builder {
     }
 
     // TODO(eliza): consider making this a public API?
+    // Clippy doesn't love this naming, because it suggests that `from_` methods
+    // should not take a `Self`...but in this case, it's the `EnvFilter` that is
+    // being constructed "from" the directives, rather than the builder itself.
+    #[allow(clippy::wrong_self_convention)]
     pub(super) fn from_directives(
         &self,
         directives: impl IntoIterator<Item = Directive>,

--- a/tracing-subscriber/src/prelude.rs
+++ b/tracing-subscriber/src/prelude.rs
@@ -3,6 +3,9 @@
 //! This brings into scope a number of extension traits that define methods on
 //! types defined here and in other crates.
 
+// apparently `as _` reexpoorts now generate `unreachable_pub` linting? which
+// seems wrong to me...
+#![allow(unreachable_pub)]
 pub use crate::field::{MakeExt as _, RecordFields as _};
 pub use crate::subscribe::{CollectExt as _, Subscribe as _};
 pub use crate::util::SubscriberInitExt as _;

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -373,7 +373,7 @@ impl<'a> LookupSpan<'a> for Registry {
 // === impl CloseGuard ===
 
 impl<'a> CloseGuard<'a> {
-    pub(crate) fn is_closing(&mut self) {
+    pub(crate) fn set_closing(&mut self) {
         self.is_closing = true;
     }
 }

--- a/tracing-subscriber/src/subscribe/layered.rs
+++ b/tracing-subscriber/src/subscribe/layered.rs
@@ -154,7 +154,7 @@ where
             #[cfg(all(feature = "registry", feature = "std"))]
             {
                 if let Some(g) = guard.as_mut() {
-                    g.is_closing()
+                    g.set_closing()
                 };
             }
 


### PR DESCRIPTION
## Motivation

The Rust 1.60 release introduced a few new lints that trigger on the
`tracing` codebase. In particular, `clippy` added some new lints for
method naming, and the `unreachable_pub` lint now seems to be triggered
incorrectly by `pub use foo as _` re-exports.

## Solution

This branch fixes the lints.