### PR TITLE
tracing: fix issues compiling for WASM/other <=32-bit platforms

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1005,7 +1005,7 @@ pub mod __macro_support {
         /// without warning.
         pub const fn new(meta: &'static Metadata<'static>) -> Self {
             Self {
-                interest: AtomicUsize::new(0xDEADFACED),
+                interest: AtomicUsize::new(0xDEAD),
                 meta,
                 registration: Once::new(),
             }

--- a/tracing/tests/macros_redefined_core.rs
+++ b/tracing/tests/macros_redefined_core.rs
@@ -2,19 +2,16 @@ extern crate self as core;
 
 use tracing::{enabled, event, span, Level};
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn span() {
     span!(Level::DEBUG, "foo");
 }
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn event() {
     event!(Level::DEBUG, "foo");
 }
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn enabled() {
     enabled!(Level::DEBUG);


### PR DESCRIPTION
This changes the "unregistered" interest state from `0xDEADFACED`
to`0xDEAD`, which should fit in a `usize` even on 16-bit platforms. The
actual value of this thing doesn't matter at all, it just has to be "not
0, 1, or 2", and it's good for it to be something weird to make it more
obvious in the event of stuff going wrong.

This should fix a warning being emitted when building for wasm (and
other <=32-bit platforms) because the previous literal would be
truncated.

Also, the `wasm_bindgen_test` macro apparently messes with the 
`macros_redefined_core` tests, so skip them on wasm.