### PR TITLE
tracing: prepare to release v0.1.33

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 0.1.33 (April 9, 2022)
+
+This release adds new `span_enabled!` and `event_enabled!` variants of the
+`enabled!` macro, for testing whether a subscriber would specifically enable a
+span or an event.
+
+### Added
+
+- `span_enabled!` and `event_enabled!` macros ([#1900])
+- Several documentation improvements ([#2010], [#2012])
+
+### Fixed
+
+- Compilation warning when compiling for <=32-bit targets (including `wasm32`)
+  ([#2060])
+
+Thanks to @guswynn, @arifd, @hrxi, @CAD97, and @name1e5s for contributing to
+this release!
+
+[#1900]: https://github.com/tokio-rs/tracing/pull/1900
+[#2010]: https://github.com/tokio-rs/tracing/pull/2010
+[#2012]: https://github.com/tokio-rs/tracing/pull/2012
+[#2060]: https://github.com/tokio-rs/tracing/pull/2060
+
 # 0.1.32 (March 8th, 2022)
 
 This release reduces the overhead of creating and dropping disabled

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.32"
+version = "0.1.33"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -16,9 +16,9 @@ Application-level tracing for Rust.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.32
+[crates-url]: https://crates.io/crates/tracing/0.1.33
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.32
+[docs-url]: https://docs.rs/tracing/0.1.33
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -250,7 +250,7 @@ my_future
 is as long as the future's.
 
 The second, and preferred, option is through the
-[`#[instrument]`](https://docs.rs/tracing/0.1.32/tracing/attr.instrument.html)
+[`#[instrument]`](https://docs.rs/tracing/0.1.33/tracing/attr.instrument.html)
 attribute:
 
 ```rust
@@ -297,7 +297,7 @@ span.in_scope(|| {
 // Dropping the span will close it, indicating that it has ended.
 ```
 
-The [`#[instrument]`](https://docs.rs/tracing/0.1.32/tracing/attr.instrument.html) attribute macro
+The [`#[instrument]`](https://docs.rs/tracing/0.1.33/tracing/attr.instrument.html) attribute macro
 can reduce some of this boilerplate:
 
 ```rust

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -812,7 +812,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing = { version = "0.1.32", default-features = false }
+//!   tracing = { version = "0.1.33", default-features = false }
 //!   ```
 //!
 //! <pre class="ignore" style="white-space:normal;font:inherit;">
@@ -895,7 +895,7 @@
 //! [flags]: #crate-feature-flags
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.32")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.33")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.1.33 (April 9, 2022)

This release adds new `span_enabled!` and `event_enabled!` variants of
the `enabled!` macro, for testing whether a subscriber would
specifically enable a span or an event.

### Added

- `span_enabled!` and `event_enabled!` macros ([#1900])
- Several documentation improvements ([#2010], [#2012])

### Fixed

- Compilation warning when compiling for <=32-bit targets (including
  `wasm32`) ([#2060])

Thanks to @guswynn, @arifd, @hrxi, @CAD97, and @name1e5s for
contributing to this release!

[#1900]: https://github.com/tokio-rs/tracing/pull/1900
[#2010]: https://github.com/tokio-rs/tracing/pull/2010
[#2012]: https://github.com/tokio-rs/tracing/pull/2012
[#2060]: https://github.com/tokio-rs/tracing/pull/2060