### PR TITLE
subscriber: fix doc link for impl Layer for Vec

### DIFF
--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -268,7 +268,7 @@
 //! more convenient, but [`Box::new`] may be used as well.
 //!
 //! When the number of `Layer`s varies at runtime, note that a
-//! [`Vec<L> where L: `Layer`` also implements `Layer`][vec-impl]. This
+//! [`Vec<L> where L: Layer` also implements `Layer`][vec-impl]. This
 //! can be used to add a variable number of `Layer`s to a `Subscriber`:
 //!
 //! ```
@@ -370,6 +370,7 @@
 //!
 //! [option-impl]: Layer#impl-Layer<S>-for-Option<L>
 //! [box-impl]: Layer#impl-Layer%3CS%3E-for-Box%3Cdyn%20Layer%3CS%3E%20+%20Send%20+%20Sync%3E
+//! [vec-impl]: Layer#impl-Layer<S>-for-Vec<L>
 //! [prelude]: crate::prelude
 //!
 //! # Recording Traces


### PR DESCRIPTION
## Motivation

There's a broken link and broken formatting in the [mod-level docs] for
`tracing_subscriber::layer` referring to the `Layer` impl for `Vec`s of
`Layer`s. Looks like it got mangled by search+replace in #2038 so it's
not an issue in master.

[mod-level docs]: https://docs.rs/tracing-subscriber/0.3.11/tracing_subscriber/layer/index.html#runtime-configuration-with-layers

## Solution

I have stolen the correct markdown and link from master.