### PR TITLE
error: use intra-doc link

### DIFF
--- a/tracing-error/src/layer.rs
+++ b/tracing-error/src/layer.rs
@@ -16,7 +16,7 @@ use tracing_subscriber::{
 /// provided, the [default format] is used instead.
 ///
 /// [`Layer`]: https://docs.rs/tracing-subscriber/0.3/tracing_subscriber/layer/trait.Layer.html
-/// [`SpanTrace`]: ../struct.SpanTrace.html
+/// [`SpanTrace`]: super::SpanTrace
 /// [field formatter]: https://docs.rs/tracing-subscriber/0.3/tracing_subscriber/fmt/trait.FormatFields.html
 /// [default format]: https://docs.rs/tracing-subscriber/0.3/tracing_subscriber/fmt/format/struct.DefaultFields.html
 pub struct ErrorLayer<S, F = DefaultFields> {


### PR DESCRIPTION
## Motivation

`ErrorLayer`'s docs link to `SpanTrace` using a relative (`../`) path.
This works out wrong for the public re-export of `ErrorLayer` in the
crate root.

## Solution
    
Change to an intra-doc link which rustdoc knows to resolve whether
rendering the doc comment for the crate root or for the mod actually
defining `ErrorLayer`.
