### PR TITLE
intra doc links instead of relative file paths

### DIFF
--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -88,7 +88,7 @@
 //!
 //! The [`non_blocking` module][non_blocking]'s documentation provides more detail on how to use `non_blocking`.
 //!
-//! [non_blocking]: self::non_blocking
+//! [non_blocking]: mod@self::non_blocking
 //! [write]: https://doc.rust-lang.org/std/io/trait.Write.html
 //! [guard]: self::non_blocking::WorkerGuard
 //! [rolling]: self::rolling
@@ -166,7 +166,7 @@ pub(crate) mod sync;
 ///
 /// See the [`non_blocking` module's docs][non_blocking]'s for more details.
 ///
-/// [non_blocking]: self::non_blocking
+/// [non_blocking]: mod@self::non_blocking
 ///
 /// # Examples
 ///

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -10,7 +10,7 @@
 //! *Compiler support: [requires `rustc` 1.53+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
-//! [file_appender]: ./rolling/struct.RollingFileAppender.html
+//! [file_appender]: self::rolling::RollingFileAppender
 //! [tracing]: https://docs.rs/tracing/
 //!
 //! # Usage
@@ -88,12 +88,12 @@
 //!
 //! The [`non_blocking` module][non_blocking]'s documentation provides more detail on how to use `non_blocking`.
 //!
-//! [non_blocking]: ./non_blocking/index.html
+//! [non_blocking]: self::non_blocking
 //! [write]: https://doc.rust-lang.org/std/io/trait.Write.html
-//! [guard]: ./non_blocking/struct.WorkerGuard.html
-//! [rolling]: ./rolling/index.html
+//! [guard]: self::non_blocking::WorkerGuard
+//! [rolling]: self::rolling
 //! [make_writer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/trait.MakeWriter.html
-//! [rolling_struct]: ./rolling/struct.RollingFileAppender.html
+//! [rolling_struct]: self::rolling::RollingFileAppender
 //! [fmt_subscriber]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Subscriber.html
 //!
 //! ## Non-Blocking Rolling File Appender
@@ -166,7 +166,7 @@ pub(crate) mod sync;
 ///
 /// See the [`non_blocking` module's docs][non_blocking]'s for more details.
 ///
-/// [non_blocking]: ./non_blocking/index.html
+/// [non_blocking]: self::non_blocking
 ///
 /// # Examples
 ///

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -10,7 +10,7 @@
 //! *Compiler support: [requires `rustc` 1.53+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
-//! [file_appender]: self::rolling::RollingFileAppender
+//! [file_appender]: rolling::RollingFileAppender
 //! [tracing]: https://docs.rs/tracing/
 //!
 //! # Usage
@@ -88,12 +88,12 @@
 //!
 //! The [`non_blocking` module][non_blocking]'s documentation provides more detail on how to use `non_blocking`.
 //!
-//! [non_blocking]: mod@self::non_blocking
+//! [non_blocking]: mod@non_blocking
 //! [write]: https://doc.rust-lang.org/std/io/trait.Write.html
-//! [guard]: self::non_blocking::WorkerGuard
-//! [rolling]: self::rolling
+//! [guard]: non_blocking::WorkerGuard
+//! [rolling]: rolling
 //! [make_writer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/trait.MakeWriter.html
-//! [rolling_struct]: self::rolling::RollingFileAppender
+//! [rolling_struct]: rolling::RollingFileAppender
 //! [fmt_subscriber]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Subscriber.html
 //!
 //! ## Non-Blocking Rolling File Appender
@@ -166,7 +166,7 @@ pub(crate) mod sync;
 ///
 /// See the [`non_blocking` module's docs][non_blocking]'s for more details.
 ///
-/// [non_blocking]: mod@self::non_blocking
+/// [non_blocking]: mod@non_blocking
 ///
 /// # Examples
 ///

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -19,7 +19,7 @@
 //! tracing_appender::non_blocking(std::io::stdout())
 //! # }
 //! ```
-//! [builder]: ./struct.NonBlockingBuilder.html#method.default
+//! [builder]: self::NonBlockingBuilder::default
 //!
 //! <br/> This function returns a tuple of `NonBlocking` and `WorkerGuard`.
 //! `NonBlocking` implements [`MakeWriter`] which integrates with `tracing_subscriber`.
@@ -33,7 +33,7 @@
 //!
 //! See [`WorkerGuard`][worker_guard] for examples of using the guard.
 //!
-//! [worker_guard]: ./struct.WorkerGuard.html
+//! [worker_guard]: self::WorkerGuard
 //!
 //! # Examples
 //!
@@ -65,7 +65,7 @@ use tracing_subscriber::fmt::MakeWriter;
 /// backpressure will be exerted on senders, causing them to block their
 /// respective threads until there is available capacity.
 ///
-/// [non-blocking]: ./struct.NonBlocking.html
+/// [non-blocking]: self::NonBlocking
 /// Recommended to be a power of 2.
 pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 
@@ -78,7 +78,7 @@ pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 /// terminates abruptly (such as through an uncaught `panic` or a `std::process::exit`), some spans
 /// or events may not be written.
 ///
-/// [`NonBlocking`]: ./struct.NonBlocking.html
+/// [`NonBlocking`]: self::NonBlocking
 /// Since spans/events and events recorded near a crash are often necessary for diagnosing the failure,
 /// `WorkerGuard` provides a mechanism to ensure that _all_ buffered logs are flushed to their output.
 /// `WorkerGuard` should be assigned in the `main` function or whatever the entrypoint of the program is.
@@ -145,8 +145,8 @@ impl NonBlocking {
     /// The returned `NonBlocking` writer will have the [default configuration][default] values.
     /// Other configurations can be specified using the [builder] interface.
     ///
-    /// [default]: ./struct.NonBlockingBuilder.html#method.default
-    /// [builder]: ./struct.NonBlockingBuilder.html
+    /// [default]: self::NonBlockingBuilder::default
+    /// [builder]: self::NonBlockingBuilder
     pub fn new<T: Write + Send + Sync + 'static>(writer: T) -> (NonBlocking, WorkerGuard) {
         NonBlockingBuilder::default().finish(writer)
     }
@@ -183,7 +183,7 @@ impl NonBlocking {
 
 /// A builder for [`NonBlocking`][non-blocking].
 ///
-/// [non-blocking]: ./struct.NonBlocking.html
+/// [non-blocking]: self::NonBlocking
 #[derive(Debug)]
 pub struct NonBlockingBuilder {
     buffered_lines_limit: usize,

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -19,7 +19,7 @@
 //! tracing_appender::non_blocking(std::io::stdout())
 //! # }
 //! ```
-//! [builder]: self::NonBlockingBuilder::default
+//! [builder]: NonBlockingBuilder::default
 //!
 //! <br/> This function returns a tuple of `NonBlocking` and `WorkerGuard`.
 //! `NonBlocking` implements [`MakeWriter`] which integrates with `tracing_subscriber`.
@@ -33,7 +33,7 @@
 //!
 //! See [`WorkerGuard`][worker_guard] for examples of using the guard.
 //!
-//! [worker_guard]: self::WorkerGuard
+//! [worker_guard]: WorkerGuard
 //!
 //! # Examples
 //!
@@ -65,7 +65,7 @@ use tracing_subscriber::fmt::MakeWriter;
 /// backpressure will be exerted on senders, causing them to block their
 /// respective threads until there is available capacity.
 ///
-/// [non-blocking]: self::NonBlocking
+/// [non-blocking]: NonBlocking
 /// Recommended to be a power of 2.
 pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 
@@ -78,7 +78,7 @@ pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 /// terminates abruptly (such as through an uncaught `panic` or a `std::process::exit`), some spans
 /// or events may not be written.
 ///
-/// [`NonBlocking`]: self::NonBlocking
+/// [`NonBlocking`]: NonBlocking
 /// Since spans/events and events recorded near a crash are often necessary for diagnosing the failure,
 /// `WorkerGuard` provides a mechanism to ensure that _all_ buffered logs are flushed to their output.
 /// `WorkerGuard` should be assigned in the `main` function or whatever the entrypoint of the program is.
@@ -145,8 +145,8 @@ impl NonBlocking {
     /// The returned `NonBlocking` writer will have the [default configuration][default] values.
     /// Other configurations can be specified using the [builder] interface.
     ///
-    /// [default]: self::NonBlockingBuilder::default
-    /// [builder]: self::NonBlockingBuilder
+    /// [default]: NonBlockingBuilder::default
+    /// [builder]: NonBlockingBuilder
     pub fn new<T: Write + Send + Sync + 'static>(writer: T) -> (NonBlocking, WorkerGuard) {
         NonBlockingBuilder::default().finish(writer)
     }
@@ -183,7 +183,7 @@ impl NonBlocking {
 
 /// A builder for [`NonBlocking`][non-blocking].
 ///
-/// [non-blocking]: self::NonBlocking
+/// [non-blocking]: NonBlocking
 #[derive(Debug)]
 pub struct NonBlockingBuilder {
     buffered_lines_limit: usize,

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -17,10 +17,10 @@
 //! will be created daily
 //! - [`Rotation::never()`][never()]: This will result in log file located at `some_directory/log_file_name`
 //!
-//! [minutely]: fn.minutely.html
-//! [hourly]: fn.hourly.html
-//! [daily]: fn.daily.html
-//! [never]: fn.never.html
+//! [minutely]: self::minutely
+//! [hourly]: self::hourly
+//! [daily]: self::daily
+//! [never]: self::never
 //!
 //! # Examples
 //!
@@ -126,10 +126,10 @@ impl RollingFileAppender {
     /// - [`Rotation::daily()`][daily],
     /// - [`Rotation::never()`][never()]
     ///
-    /// [minutely]: fn.minutely.html
-    /// [hourly]: fn.hourly.html
-    /// [daily]: fn.daily.html
-    /// [never]: fn.never.html
+    /// [minutely]: self::minutely
+    /// [hourly]: self::hourly
+    /// [daily]: self::daily
+    /// [never]: self::never
     ///
     /// # Examples
     /// ```rust

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -1,6 +1,6 @@
 //! A rolling file appender.
 //!
-//! Creates a new log file at a fixed frequency as defined by [`Rotation`](struct.Rotation.html).
+//! Creates a new log file at a fixed frequency as defined by [`Rotation`][self::Rotation].
 //! Logs will be written to this file for the duration of the period and will automatically roll over
 //! to the newly created log file once the time period has elapsed.
 //!
@@ -114,7 +114,7 @@ impl RollingFileAppender {
     /// Creates a new `RollingFileAppender`.
     ///
     /// A `RollingFileAppender` will have a fixed rotation whose frequency is
-    /// defined by [`Rotation`](struct.Rotation.html). The `directory` and
+    /// defined by [`Rotation`][self::Rotation]. The `directory` and
     /// `file_name_prefix` arguments determine the location and file name's _prefix_
     /// of the log file. `RollingFileAppender` will automatically append the current date
     /// and hour (UTC format) to the file name.
@@ -284,7 +284,7 @@ pub fn hourly(
 /// a non-blocking, daily file appender.
 ///
 /// A `RollingFileAppender` has a fixed rotation whose frequency is
-/// defined by [`Rotation`](struct.Rotation.html). The `directory` and
+/// defined by [`Rotation`][self::Rotation]. The `directory` and
 /// `file_name_prefix` arguments determine the location and file name's _prefix_
 /// of the log file. `RollingFileAppender` automatically appends the current date in UTC.
 ///

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -17,10 +17,10 @@
 //! will be created daily
 //! - [`Rotation::never()`][never()]: This will result in log file located at `some_directory/log_file_name`
 //!
-//! [minutely]: self::minutely
-//! [hourly]: self::hourly
-//! [daily]: self::daily
-//! [never]: self::never
+//! [minutely]: minutely
+//! [hourly]: hourly
+//! [daily]: daily
+//! [never]: never
 //!
 //! # Examples
 //!
@@ -126,10 +126,10 @@ impl RollingFileAppender {
     /// - [`Rotation::daily()`][daily],
     /// - [`Rotation::never()`][never()]
     ///
-    /// [minutely]: self::minutely
-    /// [hourly]: self::hourly
-    /// [daily]: self::daily
-    /// [never]: self::never
+    /// [minutely]: minutely
+    /// [hourly]: hourly
+    /// [daily]: daily
+    /// [never]: never
     ///
     /// # Examples
     /// ```rust

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
-//! [instrument]: self::instrument
+//! [instrument]: macro@self::instrument
 //!
 //! ## Supported Rust Versions
 //!

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
-//! [instrument]: attr.instrument.html
+//! [instrument]: self::instrument
 //!
 //! ## Supported Rust Versions
 //!

--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -98,9 +98,8 @@ pub struct Identifier(
     /// fn`s are available on stable Rust, this will no longer be necessary.
     /// Thus, these fields are *not* considered stable public API, and they may
     /// change warning. Do not rely on any fields on `Identifier`. When
-    /// constructing new `Identifier`s, use the `identify_callsite!` macro or
-    /// the `Callsite::id` function instead.
-    // TODO: When `Callsite::id` is a const fn, this need no longer be `pub`.
+    /// constructing new `Identifier`s, use the `identify_callsite!` macro
+    /// instead.
     #[doc(hidden)]
     pub &'static dyn Callsite,
 );

--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -77,12 +77,12 @@ impl Registry {
 pub trait Callsite: Sync {
     /// Sets the [`Interest`] for this callsite.
     ///
-    /// [`Interest`]: ../subscriber/struct.Interest.html
+    /// [`Interest`]: super::subscriber::Interest
     fn set_interest(&self, interest: Interest);
 
     /// Returns the [metadata] associated with the callsite.
     ///
-    /// [metadata]: ../metadata/struct.Metadata.html
+    /// [metadata]: super::metadata::Metadata
     fn metadata(&self) -> &Metadata<'_>;
 }
 
@@ -90,7 +90,7 @@ pub trait Callsite: Sync {
 ///
 /// Two `Identifier`s are equal if they both refer to the same callsite.
 ///
-/// [`Callsite`]: ../callsite/trait.Callsite.html
+/// [`Callsite`]: super::callsite::Callsite
 #[derive(Clone)]
 pub struct Identifier(
     /// **Warning**: The fields on this type are currently `pub` because it must
@@ -119,11 +119,11 @@ pub struct Identifier(
 /// implementation at runtime, then it **must** call this function after that
 /// value changes, in order for the change to be reflected.
 ///
-/// [`max_level_hint`]: ../subscriber/trait.Subscriber.html#method.max_level_hint
-/// [`Callsite`]: ../callsite/trait.Callsite.html
-/// [`enabled`]: ../subscriber/trait.Subscriber.html#tymethod.enabled
-/// [`Interest::sometimes()`]: ../subscriber/struct.Interest.html#method.sometimes
-/// [`Subscriber`]: ../subscriber/trait.Subscriber.html
+/// [`max_level_hint`]: super::subscriber::Subscriber::max_level_hint
+/// [`Callsite`]: super::callsite::Callsite
+/// [`enabled`]: super::subscriber::Subscriber#tymethod.enabled
+/// [`Interest::sometimes()`]: super::subscriber::Interest::sometimes
+/// [`Subscriber`]: super::subscriber::Subscriber
 pub fn rebuild_interest_cache() {
     let mut registry = REGISTRY.lock().unwrap();
     registry.rebuild_interest();

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -611,7 +611,7 @@ impl Dispatch {
     /// This calls the [`current`] function on the `Subscriber` that this
     /// `Dispatch` forwards to.
     ///
-    /// [`current`]: super::subscriber::Subscriber::current
+    /// [`current`]: super::subscriber::Subscriber::current_span
     #[inline]
     pub fn current_span(&self) -> span::Current {
         self.subscriber.current_span()

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -123,11 +123,11 @@
 //! currently default `Dispatch`. This is used primarily by `tracing`
 //! instrumentation.
 //!
-//! [`Subscriber`]: struct.Subscriber.html
-//! [`with_default`]: fn.with_default.html
-//! [`set_global_default`]: fn.set_global_default.html
-//! [`get_default`]: fn.get_default.html
-//! [`Dispatch`]: struct.Dispatch.html
+//! [`Subscriber`]: self::Subscriber
+//! [`with_default`]: self::with_default
+//! [`set_global_default`]: self::set_global_default
+//! [`get_default`]: self::get_default
+//! [`Dispatch`]: self::Dispatch
 use crate::{
     callsite, span,
     subscriber::{self, NoSubscriber, Subscriber},
@@ -151,7 +151,7 @@ use crate::stdlib::{
 
 /// `Dispatch` trace data to a [`Subscriber`].
 ///
-/// [`Subscriber`]: trait.Subscriber.html
+/// [`Subscriber`]: self::Subscriber
 #[derive(Clone)]
 pub struct Dispatch {
     subscriber: Arc<dyn Subscriber + Send + Sync>,
@@ -213,10 +213,10 @@ pub struct DefaultGuard(Option<Dispatch>);
 ///     <code>set_global_default</code></a> instead.
 /// </pre>
 ///
-/// [span]: ../span/index.html
-/// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-/// [`Event`]: ../event/struct.Event.html
-/// [`set_global_default`]: ../fn.set_global_default.html
+/// [span]: super::span
+/// [`Subscriber`]: super::subscriber::Subscriber
+/// [`Event`]: super::event::Event
+/// [`set_global_default`]: super::set_global_default
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn with_default<T>(dispatcher: &Dispatch, f: impl FnOnce() -> T) -> T {
@@ -237,7 +237,7 @@ pub fn with_default<T>(dispatcher: &Dispatch, f: impl FnOnce() -> T) -> T {
 ///     <code>set_global_default</code></a> instead.
 /// </pre>
 ///
-/// [`set_global_default`]: ../fn.set_global_default.html
+/// [`set_global_default`]: super::set_global_default
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[must_use = "Dropping the guard unregisters the dispatcher."]
@@ -261,9 +261,9 @@ pub fn set_default(dispatcher: &Dispatch) -> DefaultGuard {
 ///     executables that depend on the library try to set the default later.
 /// </pre></div>
 ///
-/// [span]: ../span/index.html
-/// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-/// [`Event`]: ../event/struct.Event.html
+/// [span]: super::span
+/// [`Subscriber`]: super::subscriber::Subscriber
+/// [`Event`]: super::event::Event
 pub fn set_global_default(dispatcher: Dispatch) -> Result<(), SetGlobalDefaultError> {
     // if `compare_exchange` returns Result::Ok(_), then `new` has been set and
     // `current`—now the prior value—has been returned in the `Ok()` branch.
@@ -319,7 +319,7 @@ impl error::Error for SetGlobalDefaultError {}
 /// called while inside of another `get_default`, that closure will be provided
 /// with `Dispatch::none` rather than the previously set dispatcher.
 ///
-/// [dispatcher]: ../dispatcher/struct.Dispatch.html
+/// [dispatcher]: super::dispatcher::Dispatch
 #[cfg(feature = "std")]
 pub fn get_default<T, F>(mut f: F) -> T
 where
@@ -342,7 +342,7 @@ where
 /// called while inside of another `get_default`, that closure will be provided
 /// with `Dispatch::none` rather than the previously set dispatcher.
 ///
-/// [dispatcher]: ../dispatcher/struct.Dispatch.html
+/// [dispatcher]: super::dispatcher::Dispatch
 #[cfg(feature = "std")]
 #[doc(hidden)]
 #[inline(never)]
@@ -357,7 +357,7 @@ pub fn get_current<T>(f: impl FnOnce(&Dispatch) -> T) -> Option<T> {
 
 /// Executes a closure with a reference to the current [dispatcher].
 ///
-/// [dispatcher]: ../dispatcher/struct.Dispatch.html
+/// [dispatcher]: super::dispatcher::Dispatch
 #[cfg(not(feature = "std"))]
 #[doc(hidden)]
 pub fn get_current<T>(f: impl FnOnce(&Dispatch) -> T) -> Option<T> {
@@ -367,7 +367,7 @@ pub fn get_current<T>(f: impl FnOnce(&Dispatch) -> T) -> Option<T> {
 
 /// Executes a closure with a reference to the current [dispatcher].
 ///
-/// [dispatcher]: ../dispatcher/struct.Dispatch.html
+/// [dispatcher]: super::dispatcher::Dispatch
 #[cfg(not(feature = "std"))]
 pub fn get_default<T, F>(mut f: F) -> T
 where
@@ -406,7 +406,7 @@ impl Dispatch {
 
     /// Returns a `Dispatch` that forwards to the given [`Subscriber`].
     ///
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
+    /// [`Subscriber`]: super::subscriber::Subscriber
     pub fn new<S>(subscriber: S) -> Self
     where
         S: Subscriber + Send + Sync + 'static,
@@ -428,8 +428,8 @@ impl Dispatch {
     /// This calls the [`register_callsite`] function on the [`Subscriber`]
     /// that this `Dispatch` forwards to.
     ///
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`register_callsite`]: ../subscriber/trait.Subscriber.html#method.register_callsite
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`register_callsite`]: super::subscriber::Subscriber::register_callsite
     #[inline]
     pub fn register_callsite(&self, metadata: &'static Metadata<'static>) -> subscriber::Interest {
         self.subscriber.register_callsite(metadata)
@@ -442,9 +442,9 @@ impl Dispatch {
     /// This calls the [`max_level_hint`] function on the [`Subscriber`]
     /// that this `Dispatch` forwards to.
     ///
-    /// [level]: ../struct.Level.html
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`register_callsite`]: ../subscriber/trait.Subscriber.html#method.max_level_hint
+    /// [level]: super::Level
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`register_callsite`]: super::subscriber::Subscriber::max_level_hint
     // TODO(eliza): consider making this a public API?
     #[inline]
     pub(crate) fn max_level_hint(&self) -> Option<LevelFilter> {
@@ -457,9 +457,9 @@ impl Dispatch {
     /// This calls the [`new_span`] function on the [`Subscriber`] that this
     /// `Dispatch` forwards to.
     ///
-    /// [ID]: ../span/struct.Id.html
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
+    /// [ID]: super::span::Id
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`new_span`]: super::subscriber::Subscriber::new_span
     #[inline]
     pub fn new_span(&self, span: &span::Attributes<'_>) -> span::Id {
         self.subscriber.new_span(span)
@@ -470,8 +470,8 @@ impl Dispatch {
     /// This calls the [`record`] function on the [`Subscriber`] that this
     /// `Dispatch` forwards to.
     ///
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`record`]: ../subscriber/trait.Subscriber.html#method.record
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`record`]: super::subscriber::Subscriber::record
     #[inline]
     pub fn record(&self, span: &span::Id, values: &span::Record<'_>) {
         self.subscriber.record(span, values)
@@ -483,8 +483,8 @@ impl Dispatch {
     /// This calls the [`record_follows_from`] function on the [`Subscriber`]
     /// that this `Dispatch` forwards to.
     ///
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`record_follows_from`]: ../subscriber/trait.Subscriber.html#method.record_follows_from
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`record_follows_from`]: super::subscriber::Subscriber::record_follows_from
     #[inline]
     pub fn record_follows_from(&self, span: &span::Id, follows: &span::Id) {
         self.subscriber.record_follows_from(span, follows)
@@ -496,9 +496,9 @@ impl Dispatch {
     /// This calls the [`enabled`] function on the [`Subscriber`] that this
     /// `Dispatch` forwards to.
     ///
-    /// [metadata]: ../metadata/struct.Metadata.html
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`enabled`]: ../subscriber/trait.Subscriber.html#method.enabled
+    /// [metadata]: super::metadata::Metadata
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`enabled`]: super::subscriber::Subscriber::enabled
     #[inline]
     pub fn enabled(&self, metadata: &Metadata<'_>) -> bool {
         self.subscriber.enabled(metadata)
@@ -509,9 +509,9 @@ impl Dispatch {
     /// This calls the [`event`] function on the [`Subscriber`] that this
     /// `Dispatch` forwards to.
     ///
-    /// [`Event`]: ../event/struct.Event.html
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`event`]: ../subscriber/trait.Subscriber.html#method.event
+    /// [`Event`]: super::event::Event
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`event`]: super::subscriber::Subscriber::event
     #[inline]
     pub fn event(&self, event: &Event<'_>) {
         self.subscriber.event(event)
@@ -522,8 +522,8 @@ impl Dispatch {
     /// This calls the [`enter`] function on the [`Subscriber`] that this
     /// `Dispatch` forwards to.
     ///
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`enter`]: ../subscriber/trait.Subscriber.html#method.enter
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`enter`]: super::subscriber::Subscriber::enter
     pub fn enter(&self, span: &span::Id) {
         self.subscriber.enter(span);
     }
@@ -533,8 +533,8 @@ impl Dispatch {
     /// This calls the [`exit`] function on the [`Subscriber`] that this
     /// `Dispatch` forwards to.
     ///
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`exit`]: ../subscriber/trait.Subscriber.html#method.exit
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`exit`]: super::subscriber::Subscriber::exit
     pub fn exit(&self, span: &span::Id) {
         self.subscriber.exit(span);
     }
@@ -549,10 +549,10 @@ impl Dispatch {
     /// This calls the [`clone_span`] function on the `Subscriber` that this
     /// `Dispatch` forwards to.
     ///
-    /// [span ID]: ../span/struct.Id.html
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`clone_span`]: ../subscriber/trait.Subscriber.html#method.clone_span
-    /// [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
+    /// [span ID]: super::span::Id
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`clone_span`]: super::subscriber::Subscriber::clone_span
+    /// [`new_span`]: super::subscriber::Subscriber::new_span
     #[inline]
     pub fn clone_span(&self, id: &span::Id) -> span::Id {
         self.subscriber.clone_span(id)
@@ -575,10 +575,10 @@ impl Dispatch {
     ///     instead of this method.
     /// </pre>
     ///
-    /// [span ID]: ../span/struct.Id.html
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`drop_span`]: ../subscriber/trait.Subscriber.html#method.drop_span
-    /// [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
+    /// [span ID]: super::span::Id
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`drop_span`]: super::subscriber::Subscriber::drop_span
+    /// [`new_span`]: super::subscriber::Subscriber::new_span
     /// [`try_close`]: #method.try_close
     #[inline]
     #[deprecated(since = "0.1.2", note = "use `Dispatch::try_close` instead")]
@@ -598,10 +598,10 @@ impl Dispatch {
     /// This calls the [`try_close`] function on the [`Subscriber`] that this
     ///  `Dispatch` forwards to.
     ///
-    /// [span ID]: ../span/struct.Id.html
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [`try_close`]: ../subscriber/trait.Subscriber.html#method.try_close
-    /// [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
+    /// [span ID]: super::span::Id
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [`try_close`]: super::subscriber::Subscriber::try_close
+    /// [`new_span`]: super::subscriber::Subscriber::new_span
     pub fn try_close(&self, id: span::Id) -> bool {
         self.subscriber.try_close(id)
     }
@@ -611,7 +611,7 @@ impl Dispatch {
     /// This calls the [`current`] function on the `Subscriber` that this
     /// `Dispatch` forwards to.
     ///
-    /// [`current`]: ../subscriber/trait.Subscriber.html#method.current
+    /// [`current`]: super::subscriber::Subscriber::current
     #[inline]
     pub fn current_span(&self) -> span::Current {
         self.subscriber.current_span()

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -123,11 +123,11 @@
 //! currently default `Dispatch`. This is used primarily by `tracing`
 //! instrumentation.
 //!
-//! [`Subscriber`]: self::Subscriber
-//! [`with_default`]: self::with_default
-//! [`set_global_default`]: self::set_global_default
-//! [`get_default`]: self::get_default
-//! [`Dispatch`]: self::Dispatch
+//! [`Subscriber`]: Subscriber
+//! [`with_default`]: with_default
+//! [`set_global_default`]: set_global_default
+//! [`get_default`]: get_default
+//! [`Dispatch`]: Dispatch
 use crate::{
     callsite, span,
     subscriber::{self, NoSubscriber, Subscriber},
@@ -151,7 +151,7 @@ use crate::stdlib::{
 
 /// `Dispatch` trace data to a [`Subscriber`].
 ///
-/// [`Subscriber`]: self::Subscriber
+/// [`Subscriber`]: Subscriber
 #[derive(Clone)]
 pub struct Dispatch {
     subscriber: Arc<dyn Subscriber + Send + Sync>,

--- a/tracing-core/src/event.rs
+++ b/tracing-core/src/event.rs
@@ -17,8 +17,8 @@ use crate::{field, Metadata};
 ///   associated with an event should be in the event's fields rather than in
 ///   the textual message, as the fields are more structured.
 ///
-/// [span]: ../span
-/// [fields]: ../field
+/// [span]: super::span
+/// [fields]: super::field
 #[derive(Debug)]
 pub struct Event<'a> {
     fields: &'a field::ValueSet<'a>,
@@ -81,7 +81,7 @@ impl<'a> Event<'a> {
 
     /// Visits all the fields on this `Event` with the specified [visitor].
     ///
-    /// [visitor]: ../field/trait.Visit.html
+    /// [visitor]: super::field::Visit
     #[inline]
     pub fn record(&self, visitor: &mut dyn field::Visit) {
         self.fields.record(visitor);
@@ -94,7 +94,7 @@ impl<'a> Event<'a> {
 
     /// Returns [metadata] describing this `Event`.
     ///
-    /// [metadata]: ../struct.Metadata.html
+    /// [metadata]: super::Metadata
     pub fn metadata(&self) -> &'static Metadata<'static> {
         self.metadata
     }

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -100,17 +100,17 @@
 //! [`record_value`]: Visit::record_value
 //! [`record_debug`]: Visit::record_debug
 //!
-//! [`Value`]: trait.Value.html
-//! [span]: ../span/
-//! [`Event`]: ../event/struct.Event.html
-//! [`Metadata`]: ../metadata/struct.Metadata.html
-//! [`Attributes`]:  ../span/struct.Attributes.html
-//! [`Record`]: ../span/struct.Record.html
-//! [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
-//! [`record`]: ../subscriber/trait.Subscriber.html#method.record
-//! [`event`]:  ../subscriber/trait.Subscriber.html#method.event
-//! [`Value::record`]: trait.Value.html#method.record
-//! [`Visit`]: trait.Visit.html
+//! [`Value`]: self::Value
+//! [span]: super::span
+//! [`Event`]: super::event::Event
+//! [`Metadata`]: super::metadata::Metadata
+//! [`Attributes`]:  super::span::Attributes
+//! [`Record`]: super::span::Record
+//! [`new_span`]: super::subscriber::Subscriber::new_span
+//! [`record`]: super::subscriber::Subscriber::record
+//! [`event`]:  super::subscriber::Subscriber::event
+//! [`Value::record`]: self::Value::record
+//! [`Visit`]: self::Visit
 use crate::callsite;
 use crate::stdlib::{
     borrow::Borrow,
@@ -249,13 +249,13 @@ pub struct Iter {
 /// <code>std::error::Error</code> trait.
 /// </pre></div>
 ///
-/// [`Value`]: trait.Value.html
-/// [recorded]: trait.Value.html#method.record
-/// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-/// [records an `Event`]: ../subscriber/trait.Subscriber.html#method.event
-/// [set of `Value`s added to a `Span`]: ../subscriber/trait.Subscriber.html#method.record
-/// [`Event`]: ../event/struct.Event.html
-/// [`ValueSet`]: struct.ValueSet.html
+/// [`Value`]: self::Value
+/// [recorded]: self::Value::record
+/// [`Subscriber`]: super::subscriber::Subscriber
+/// [records an `Event`]: super::subscriber::Subscriber::event
+/// [set of `Value`s added to a `Span`]: super::subscriber::Subscriber::record
+/// [`Event`]: super::event::Event
+/// [`ValueSet`]: self::ValueSet
 pub trait Visit {
     /// Visits an arbitrary type implementing the [`valuable`] crate's `Valuable` trait.
     ///
@@ -314,7 +314,7 @@ pub trait Visit {
 /// the [visitor] passed to their `record` method in order to indicate how
 /// their data should be recorded.
 ///
-/// [visitor]: trait.Visit.html
+/// [visitor]: self::Visit
 pub trait Value: crate::sealed::Sealed {
     /// Visits this value with the given `Visitor`.
     fn record(&self, key: &Field, visitor: &mut dyn Visit);
@@ -680,8 +680,8 @@ impl Field {
     /// Returns an [`Identifier`] that uniquely identifies the [`Callsite`]
     /// which defines this field.
     ///
-    /// [`Identifier`]: ../callsite/struct.Identifier.html
-    /// [`Callsite`]: ../callsite/trait.Callsite.html
+    /// [`Identifier`]: super::callsite::Identifier
+    /// [`Callsite`]: super::callsite::Callsite
     #[inline]
     pub fn callsite(&self) -> callsite::Identifier {
         self.fields.callsite()
@@ -746,15 +746,15 @@ impl FieldSet {
     /// Returns an [`Identifier`] that uniquely identifies the [`Callsite`]
     /// which defines this set of fields..
     ///
-    /// [`Identifier`]: ../callsite/struct.Identifier.html
-    /// [`Callsite`]: ../callsite/trait.Callsite.html
+    /// [`Identifier`]: super::callsite::Identifier
+    /// [`Callsite`]: super::callsite::Callsite
     pub(crate) fn callsite(&self) -> callsite::Identifier {
         callsite::Identifier(self.callsite.0)
     }
 
     /// Returns the [`Field`] named `name`, or `None` if no such field exists.
     ///
-    /// [`Field`]: ../struct.Field.html
+    /// [`Field`]: super::Field
     pub fn field<Q: ?Sized>(&self, name: &Q) -> Option<Field>
     where
         Q: Borrow<str>,
@@ -872,8 +872,8 @@ impl<'a> ValueSet<'a> {
     /// Returns an [`Identifier`] that uniquely identifies the [`Callsite`]
     /// defining the fields this `ValueSet` refers to.
     ///
-    /// [`Identifier`]: ../callsite/struct.Identifier.html
-    /// [`Callsite`]: ../callsite/trait.Callsite.html
+    /// [`Identifier`]: super::callsite::Identifier
+    /// [`Callsite`]: super::callsite::Callsite
     #[inline]
     pub fn callsite(&self) -> callsite::Identifier {
         self.fields.callsite()
@@ -881,7 +881,7 @@ impl<'a> ValueSet<'a> {
 
     /// Visits all the fields in this `ValueSet` with the provided [visitor].
     ///
-    /// [visitor]: Visit
+    /// [visitor]: self::Visit
     pub fn record(&self, visitor: &mut dyn Visit) {
         let my_callsite = self.callsite();
         for (field, value) in self.values {

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -100,7 +100,7 @@
 //! [`record_value`]: Visit::record_value
 //! [`record_debug`]: Visit::record_debug
 //!
-//! [`Value`]: self::Value
+//! [`Value`]: Value
 //! [span]: super::span
 //! [`Event`]: super::event::Event
 //! [`Metadata`]: super::metadata::Metadata
@@ -109,8 +109,8 @@
 //! [`new_span`]: super::subscriber::Subscriber::new_span
 //! [`record`]: super::subscriber::Subscriber::record
 //! [`event`]:  super::subscriber::Subscriber::event
-//! [`Value::record`]: self::Value::record
-//! [`Visit`]: self::Visit
+//! [`Value::record`]: Value::record
+//! [`Visit`]: Visit
 use crate::callsite;
 use crate::stdlib::{
     borrow::Borrow,
@@ -249,13 +249,13 @@ pub struct Iter {
 /// <code>std::error::Error</code> trait.
 /// </pre></div>
 ///
-/// [`Value`]: self::Value
-/// [recorded]: self::Value::record
+/// [`Value`]: Value
+/// [recorded]: Value::record
 /// [`Subscriber`]: super::subscriber::Subscriber
 /// [records an `Event`]: super::subscriber::Subscriber::event
 /// [set of `Value`s added to a `Span`]: super::subscriber::Subscriber::record
 /// [`Event`]: super::event::Event
-/// [`ValueSet`]: self::ValueSet
+/// [`ValueSet`]: ValueSet
 pub trait Visit {
     /// Visits an arbitrary type implementing the [`valuable`] crate's `Valuable` trait.
     ///
@@ -314,7 +314,7 @@ pub trait Visit {
 /// the [visitor] passed to their `record` method in order to indicate how
 /// their data should be recorded.
 ///
-/// [visitor]: self::Visit
+/// [visitor]: Visit
 pub trait Value: crate::sealed::Sealed {
     /// Visits this value with the given `Visitor`.
     fn record(&self, key: &Field, visitor: &mut dyn Visit);
@@ -881,7 +881,7 @@ impl<'a> ValueSet<'a> {
 
     /// Visits all the fields in this `ValueSet` with the provided [visitor].
     ///
-    /// [visitor]: self::Visit
+    /// [visitor]: Visit
     pub fn record(&self, visitor: &mut dyn Visit) {
         let my_callsite = self.callsite();
         for (field, value) in self.values {

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -104,16 +104,16 @@
 //! long as doing so complies with this policy.
 //!
 //!
-//! [`span::Id`]: span/struct.Id.html
-//! [`Event`]: event/struct.Event.html
-//! [`Subscriber`]: subscriber/trait.Subscriber.html
-//! [`Metadata`]: metadata/struct.Metadata.html
-//! [`Callsite`]: callsite/trait.Callsite.html
-//! [`Field`]: field/struct.Field.html
-//! [`FieldSet`]: field/struct.FieldSet.html
-//! [`Value`]: field/trait.Value.html
-//! [`ValueSet`]: field/struct.ValueSet.html
-//! [`Dispatch`]: dispatcher/struct.Dispatch.html
+//! [`span::Id`]: self::span::Id
+//! [`Event`]: self::event::Event
+//! [`Subscriber`]: self::subscriber::Subscriber
+//! [`Metadata`]: self::metadata::Metadata
+//! [`Callsite`]: self::callsite::Callsite
+//! [`Field`]: self::field::Field
+//! [`FieldSet`]: self::field::FieldSet
+//! [`Value`]: self::field::Value
+//! [`ValueSet`]: self::field::ValueSet
+//! [`Dispatch`]: self::dispatcher::Dispatch
 //! [`tokio-rs/tracing`]: https://github.com/tokio-rs/tracing
 //! [`tracing`]: https://crates.io/crates/tracing
 #![doc(html_root_url = "https://docs.rs/tracing-core/0.1.22")]
@@ -175,9 +175,9 @@ extern crate alloc;
 /// # }
 /// ```
 ///
-/// [`Identifier`]: callsite/struct.Identifier.html
-/// [`Callsite`]: callsite/trait.Callsite.html
-/// [`Callsite::id`]: callsite/trait.Callsite.html#method.id
+/// [`Identifier`]: self::callsite::Identifier
+/// [`Callsite`]: self::callsite::Callsite
+/// [`Callsite::id`]: self::callsite::Callsite::id
 #[macro_export]
 macro_rules! identify_callsite {
     ($callsite:expr) => {
@@ -214,8 +214,8 @@ macro_rules! identify_callsite {
 /// # }
 /// ```
 ///
-/// [metadata]: metadata/struct.Metadata.html
-/// [`Metadata::new`]: metadata/struct.Metadata.html#method.new
+/// [metadata]: self::metadata::Metadata
+/// [`Metadata::new`]: self::metadata::Metadata::new
 #[macro_export]
 macro_rules! metadata {
     (

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -150,8 +150,7 @@ extern crate alloc;
 
 /// Statically constructs an [`Identifier`] for the provided [`Callsite`].
 ///
-/// This may be used in contexts, such as static initializers, where the
-/// [`Callsite::id`] function is not currently usable.
+/// This may be used in contexts such as static initializers.
 ///
 /// For example:
 /// ```rust
@@ -177,7 +176,6 @@ extern crate alloc;
 ///
 /// [`Identifier`]: self::callsite::Identifier
 /// [`Callsite`]: self::callsite::Callsite
-/// [`Callsite::id`]: self::callsite::Callsite::id
 #[macro_export]
 macro_rules! identify_callsite {
     ($callsite:expr) => {

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -104,16 +104,16 @@
 //! long as doing so complies with this policy.
 //!
 //!
-//! [`span::Id`]: self::span::Id
-//! [`Event`]: self::event::Event
-//! [`Subscriber`]: self::subscriber::Subscriber
-//! [`Metadata`]: self::metadata::Metadata
-//! [`Callsite`]: self::callsite::Callsite
-//! [`Field`]: self::field::Field
-//! [`FieldSet`]: self::field::FieldSet
-//! [`Value`]: self::field::Value
-//! [`ValueSet`]: self::field::ValueSet
-//! [`Dispatch`]: self::dispatcher::Dispatch
+//! [`span::Id`]: span::Id
+//! [`Event`]: event::Event
+//! [`Subscriber`]: subscriber::Subscriber
+//! [`Metadata`]: metadata::Metadata
+//! [`Callsite`]: callsite::Callsite
+//! [`Field`]: field::Field
+//! [`FieldSet`]: field::FieldSet
+//! [`Value`]: field::Value
+//! [`ValueSet`]: field::ValueSet
+//! [`Dispatch`]: dispatcher::Dispatch
 //! [`tokio-rs/tracing`]: https://github.com/tokio-rs/tracing
 //! [`tracing`]: https://crates.io/crates/tracing
 #![doc(html_root_url = "https://docs.rs/tracing-core/0.1.22")]
@@ -174,8 +174,8 @@ extern crate alloc;
 /// # }
 /// ```
 ///
-/// [`Identifier`]: self::callsite::Identifier
-/// [`Callsite`]: self::callsite::Callsite
+/// [`Identifier`]: callsite::Identifier
+/// [`Callsite`]: callsite::Callsite
 #[macro_export]
 macro_rules! identify_callsite {
     ($callsite:expr) => {
@@ -212,8 +212,8 @@ macro_rules! identify_callsite {
 /// # }
 /// ```
 ///
-/// [metadata]: self::metadata::Metadata
-/// [`Metadata::new`]: self::metadata::Metadata::new
+/// [metadata]: metadata::Metadata
+/// [`Metadata::new`]: metadata::Metadata::new
 #[macro_export]
 macro_rules! metadata {
     (

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -45,8 +45,8 @@ use crate::stdlib::{
 ///     correspond to the same callsite.
 /// </pre>
 ///
-/// [span]: ../span/index.html
-/// [event]: ../event/index.html
+/// [span]: super::span
+/// [event]: super::event
 /// [name]: #method.name
 /// [target]: #method.target
 /// [fields]: #method.fields
@@ -54,9 +54,9 @@ use crate::stdlib::{
 /// [file name]: #method.file
 /// [line number]: #method.line
 /// [module path]: #method.module
-/// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-/// [`id`]: struct.Metadata.html#method.id
-/// [callsite identifier]: ../callsite/struct.Identifier.html
+/// [`Subscriber`]: super::subscriber::Subscriber
+/// [`id`]: self::Metadata::id
+/// [callsite identifier]: super::callsite::Identifier
 pub struct Metadata<'a> {
     /// The name of the span described by this metadata.
     name: &'static str,
@@ -604,7 +604,7 @@ impl LevelFilter {
     /// Returns the most verbose [`Level`] that this filter accepts, or `None`
     /// if it is [`OFF`].
     ///
-    /// [`Level`]: ../struct.Level.html
+    /// [`Level`]: super::Level
     /// [`OFF`]: #associatedconstant.OFF
     pub const fn into_level(self) -> Option<Level> {
         self.0
@@ -638,8 +638,8 @@ impl LevelFilter {
     /// *disabled*, but **should not** be used for determining if something is
     /// *enabled*.
     ///
-    /// [`Level`]: ../struct.Level.html
-    /// [`Subscriber`]: ../../trait.Subscriber.html
+    /// [`Level`]: super::Level
+    /// [`Subscriber`]: super::super::Subscriber
     #[inline(always)]
     pub fn current() -> Self {
         match MAX_LEVEL.load(Ordering::Relaxed) {

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -55,7 +55,7 @@ use crate::stdlib::{
 /// [line number]: #method.line
 /// [module path]: #method.module
 /// [`Subscriber`]: super::subscriber::Subscriber
-/// [`id`]: self::Metadata::id
+/// [`id`]: Metadata::id
 /// [callsite identifier]: super::callsite::Identifier
 pub struct Metadata<'a> {
     /// The name of the span described by this metadata.

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -639,7 +639,7 @@ impl LevelFilter {
     /// *enabled*.
     ///
     /// [`Level`]: super::Level
-    /// [`Subscriber`]: super::super::Subscriber
+    /// [`Subscriber`]: super::Subscriber
     #[inline(always)]
     pub fn current() -> Self {
         match MAX_LEVEL.load(Ordering::Relaxed) {

--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -10,8 +10,8 @@ use crate::{field, Metadata};
 /// the [`new_span`] trait method. See the documentation for that method for
 /// more information on span ID generation.
 ///
-/// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-/// [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
+/// [`Subscriber`]: super::subscriber::Subscriber
+/// [`new_span`]: super::subscriber::Subscriber::new_span
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Id(NonZeroU64);
 
@@ -38,9 +38,9 @@ pub struct Record<'a> {
 /// - "none", indicating that the current context is known to not be in a span,
 /// - "some", with the current span's [`Id`] and [`Metadata`].
 ///
-/// [the `Subscriber` considers]: ../subscriber/trait.Subscriber.html#method.current_span
-/// [`Id`]: struct.Id.html
-/// [`Metadata`]: ../metadata/struct.Metadata.html
+/// [the `Subscriber` considers]: super::subscriber::Subscriber::current_span
+/// [`Id`]: self::Id
+/// [`Metadata`]: super::metadata::Metadata
 #[derive(Debug)]
 pub struct Current {
     inner: CurrentInner,
@@ -179,7 +179,7 @@ impl<'a> Attributes<'a> {
     /// Records all the fields in this set of `Attributes` with the provided
     /// [Visitor].
     ///
-    /// [visitor]: ../field/trait.Visit.html
+    /// [visitor]: super::field::Visit
     pub fn record(&self, visitor: &mut dyn field::Visit) {
         self.values.record(visitor)
     }
@@ -221,7 +221,7 @@ impl<'a> Record<'a> {
 
     /// Records all the fields in this `Record` with the provided [Visitor].
     ///
-    /// [visitor]: ../field/trait.Visit.html
+    /// [visitor]: super::field::Visit
     pub fn record(&self, visitor: &mut dyn field::Visit) {
         self.values.record(visitor)
     }

--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -39,7 +39,7 @@ pub struct Record<'a> {
 /// - "some", with the current span's [`Id`] and [`Metadata`].
 ///
 /// [the `Subscriber` considers]: super::subscriber::Subscriber::current_span
-/// [`Id`]: self::Id
+/// [`Id`]: Id
 /// [`Metadata`]: super::metadata::Metadata
 #[derive(Debug)]
 pub struct Current {

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -65,12 +65,12 @@ use crate::stdlib::{
 ///   should override these functions together.
 ///
 /// [ID]: super::span::Id
-/// [`new_span`]: self::Subscriber::new_span
-/// [`register_callsite`]: self::Subscriber::register_callsite
-/// [`Interest`]: self::Interest
-/// [`enabled`]: self::Subscriber::enabled
-/// [`clone_span`]: self::Subscriber::clone_span
-/// [`try_close`]: self::Subscriber::try_close
+/// [`new_span`]: Subscriber::new_span
+/// [`register_callsite`]: Subscriber::register_callsite
+/// [`Interest`]: Interest
+/// [`enabled`]: Subscriber::enabled
+/// [`clone_span`]: Subscriber::clone_span
+/// [`try_close`]: Subscriber::try_close
 pub trait Subscriber: 'static {
     // === Span registry methods ==============================================
 
@@ -138,7 +138,7 @@ pub trait Subscriber: 'static {
     ///
     /// [filter]: #method.enabled
     /// [metadata]: super::metadata::Metadata
-    /// [`Interest`]: self::Interest
+    /// [`Interest`]: Interest
     /// [`enabled`]: #method.enabled
     /// [`rebuild_interest_cache`]: super::callsite::rebuild_interest_cache
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
@@ -166,8 +166,8 @@ pub trait Subscriber: 'static {
     /// time that span or event occurs.
     ///
     /// [metadata]: super::metadata::Metadata
-    /// [interested]: self::Interest
-    /// [`Interest::sometimes`]: self::Interest::sometimes
+    /// [interested]: Interest
+    /// [`Interest::sometimes`]: Interest::sometimes
     /// [`register_callsite`]: #method.register_callsite
     fn enabled(&self, metadata: &Metadata<'_>) -> bool;
 
@@ -192,7 +192,7 @@ pub trait Subscriber: 'static {
     /// level changes.
     ///
     /// [level]: super::Level
-    /// [`Interest`]: self::Interest
+    /// [`Interest`]: Interest
     /// [rebuild]: super::callsite::rebuild_interest_cache
     fn max_level_hint(&self) -> Option<LevelFilter> {
         None
@@ -345,7 +345,7 @@ pub trait Subscriber: 'static {
     /// what that means for the specified pointer.
     ///
     /// [span ID]: super::span::Id
-    /// [`try_close`]: self::Subscriber::try_close
+    /// [`try_close`]: Subscriber::try_close
     fn clone_span(&self, id: &span::Id) -> span::Id {
         id.clone()
     }
@@ -358,7 +358,7 @@ pub trait Subscriber: 'static {
     ///
     /// The default implementation of this function does nothing.
     ///
-    /// [`try_close`]: self::Subscriber::try_close
+    /// [`try_close`]: Subscriber::try_close
     #[deprecated(since = "0.1.2", note = "use `Subscriber::try_close` instead")]
     fn drop_span(&self, _id: span::Id) {}
 
@@ -396,8 +396,8 @@ pub trait Subscriber: 'static {
     /// was dropped due to a thread unwinding.
     ///
     /// [span ID]: super::span::Id
-    /// [`clone_span`]: self::Subscriber::clone_span
-    /// [`drop_span`]: self::Subscriber::drop_span
+    /// [`clone_span`]: Subscriber::clone_span
+    /// [`drop_span`]: Subscriber::drop_span
     fn try_close(&self, id: span::Id) -> bool {
         #[allow(deprecated)]
         self.drop_span(id);

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -64,13 +64,13 @@ use crate::stdlib::{
 ///   Subscribers which store per-span data or which need to track span closures
 ///   should override these functions together.
 ///
-/// [ID]: ../span/struct.Id.html
-/// [`new_span`]: trait.Subscriber.html#method.new_span
-/// [`register_callsite`]: trait.Subscriber.html#method.register_callsite
-/// [`Interest`]: struct.Interest.html
-/// [`enabled`]: trait.Subscriber.html#method.enabled
-/// [`clone_span`]: trait.Subscriber.html#method.clone_span
-/// [`try_close`]: trait.Subscriber.html#method.try_close
+/// [ID]: super::span::Id
+/// [`new_span`]: self::Subscriber::new_span
+/// [`register_callsite`]: self::Subscriber::register_callsite
+/// [`Interest`]: self::Interest
+/// [`enabled`]: self::Subscriber::enabled
+/// [`clone_span`]: self::Subscriber::clone_span
+/// [`try_close`]: self::Subscriber::try_close
 pub trait Subscriber: 'static {
     // === Span registry methods ==============================================
 
@@ -137,10 +137,10 @@ pub trait Subscriber: 'static {
     /// another subscriber expressed interest in it.
     ///
     /// [filter]: #method.enabled
-    /// [metadata]: ../metadata/struct.Metadata.html
-    /// [`Interest`]: struct.Interest.html
+    /// [metadata]: super::metadata::Metadata
+    /// [`Interest`]: self::Interest
     /// [`enabled`]: #method.enabled
-    /// [`rebuild_interest_cache`]: ../callsite/fn.rebuild_interest_cache.html
+    /// [`rebuild_interest_cache`]: super::callsite::rebuild_interest_cache
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         if self.enabled(metadata) {
             Interest::always()
@@ -165,9 +165,9 @@ pub trait Subscriber: 'static {
     /// [`Interest::sometimes`]. In that case, this function will be called every
     /// time that span or event occurs.
     ///
-    /// [metadata]: ../metadata/struct.Metadata.html
-    /// [interested]: struct.Interest.html
-    /// [`Interest::sometimes`]: struct.Interest.html#method.sometimes
+    /// [metadata]: super::metadata::Metadata
+    /// [interested]: self::Interest
+    /// [`Interest::sometimes`]: self::Interest::sometimes
     /// [`register_callsite`]: #method.register_callsite
     fn enabled(&self, metadata: &Metadata<'_>) -> bool;
 
@@ -191,9 +191,9 @@ pub trait Subscriber: 'static {
     /// [`rebuild_interest_cache`][rebuild] is called after the value of the max
     /// level changes.
     ///
-    /// [level]: ../struct.Level.html
-    /// [`Interest`]: struct.Interest.html
-    /// [rebuild]: ../callsite/fn.rebuild_interest_cache.html
+    /// [level]: super::Level
+    /// [`Interest`]: self::Interest
+    /// [rebuild]: super::callsite::rebuild_interest_cache
     fn max_level_hint(&self) -> Option<LevelFilter> {
         None
     }
@@ -218,10 +218,10 @@ pub trait Subscriber: 'static {
     /// scheme it sees fit. Any guarantees about uniqueness, ordering, or ID
     /// reuse are left up to the subscriber implementation to determine.
     ///
-    /// [span ID]: ../span/struct.Id.html
-    /// [`Attributes`]: ../span/struct.Attributes.html
-    /// [visitor]: ../field/trait.Visit.html
-    /// [`record` method]: ../span/struct.Attributes.html#method.record
+    /// [span ID]: super::span::Id
+    /// [`Attributes`]: super::span::Attributes
+    /// [visitor]: super::field::Visit
+    /// [`record` method]: super::span::Attributes::record
     fn new_span(&self, span: &span::Attributes<'_>) -> span::Id;
 
     // === Notification methods ===============================================
@@ -259,9 +259,9 @@ pub trait Subscriber: 'static {
     /// span.record("baz", &"a string");
     /// ```
     ///
-    /// [visitor]: ../field/trait.Visit.html
-    /// [`record`]: ../span/struct.Attributes.html#method.record
-    /// [`record` method]: ../span/struct.Record.html#method.record
+    /// [visitor]: super::field::Visit
+    /// [`record`]: super::span::Attributes::record
+    /// [`record` method]: super::span::Record::record
     fn record(&self, span: &span::Id, values: &span::Record<'_>);
 
     /// Adds an indication that `span` follows from the span with the id
@@ -298,10 +298,10 @@ pub trait Subscriber: 'static {
     /// event. The subscriber may pass a [visitor] to the `Event`'s
     /// [`record` method] to record these values.
     ///
-    /// [`Event`]: ../event/struct.Event.html
-    /// [visitor]: ../field/trait.Visit.html
-    /// [`record` method]: ../event/struct.Event.html#method.record
-    /// [`dispatch` method]: ../event/struct.Event.html#method.dispatch
+    /// [`Event`]: super::event::Event
+    /// [visitor]: super::field::Visit
+    /// [`record` method]: super::event::Event::record
+    /// [`dispatch` method]: super::event::Event::dispatch
     fn event(&self, event: &Event<'_>);
 
     /// Records that a span has been entered.
@@ -311,7 +311,7 @@ pub trait Subscriber: 'static {
     /// [span ID] of the entered span, and should update any internal state
     /// tracking the current span accordingly.
     ///
-    /// [span ID]: ../span/struct.Id.html
+    /// [span ID]: super::span::Id
     fn enter(&self, span: &span::Id);
 
     /// Records that a span has been exited.
@@ -323,7 +323,7 @@ pub trait Subscriber: 'static {
     ///
     /// Exiting a span does not imply that the span will not be re-entered.
     ///
-    /// [span ID]: ../span/struct.Id.html
+    /// [span ID]: super::span::Id
     fn exit(&self, span: &span::Id);
 
     /// Notifies the subscriber that a [span ID] has been cloned.
@@ -344,8 +344,8 @@ pub trait Subscriber: 'static {
     /// kind this can be used as a hook to "clone" the pointer, depending on
     /// what that means for the specified pointer.
     ///
-    /// [span ID]: ../span/struct.Id.html
-    /// [`try_close`]: trait.Subscriber.html#method.try_close
+    /// [span ID]: super::span::Id
+    /// [`try_close`]: self::Subscriber::try_close
     fn clone_span(&self, id: &span::Id) -> span::Id {
         id.clone()
     }
@@ -358,7 +358,7 @@ pub trait Subscriber: 'static {
     ///
     /// The default implementation of this function does nothing.
     ///
-    /// [`try_close`]: trait.Subscriber.html#method.try_close
+    /// [`try_close`]: self::Subscriber::try_close
     #[deprecated(since = "0.1.2", note = "use `Subscriber::try_close` instead")]
     fn drop_span(&self, _id: span::Id) {}
 
@@ -395,9 +395,9 @@ pub trait Subscriber: 'static {
     /// inside of a `try_close` function may cause a double panic, if the span
     /// was dropped due to a thread unwinding.
     ///
-    /// [span ID]: ../span/struct.Id.html
-    /// [`clone_span`]: trait.Subscriber.html#method.clone_span
-    /// [`drop_span`]: trait.Subscriber.html#method.drop_span
+    /// [span ID]: super::span::Id
+    /// [`clone_span`]: self::Subscriber::clone_span
+    /// [`drop_span`]: self::Subscriber::drop_span
     fn try_close(&self, id: span::Id) -> bool {
         #[allow(deprecated)]
         self.drop_span(id);
@@ -415,8 +415,8 @@ pub trait Subscriber: 'static {
     /// does **not** track what span is current. If the subscriber does not
     /// implement a current span, it should not override this method.
     ///
-    /// [`Current::new`]: ../span/struct.Current.html#tymethod.new
-    /// [`Current::none`]: ../span/struct.Current.html#tymethod.none
+    /// [`Current::new`]: super::span::Current#tymethod.new
+    /// [`Current::none`]: super::span::Current#tymethod.none
     fn current_span(&self) -> span::Current {
         span::Current::unknown()
     }
@@ -482,8 +482,8 @@ impl dyn Subscriber {
 /// `Subscriber`s return an `Interest` from their [`register_callsite`] methods
 /// in order to determine whether that span should be enabled or disabled.
 ///
-/// [`Subscriber`]: ../trait.Subscriber.html
-/// [`register_callsite`]: ../trait.Subscriber.html#method.register_callsite
+/// [`Subscriber`]: super::Subscriber
+/// [`register_callsite`]: super::Subscriber::register_callsite
 #[derive(Clone, Debug)]
 pub struct Interest(InterestKind);
 

--- a/tracing-error/src/layer.rs
+++ b/tracing-error/src/layer.rs
@@ -16,7 +16,7 @@ use tracing_subscriber::{
 /// provided, the [default format] is used instead.
 ///
 /// [`Layer`]: https://docs.rs/tracing-subscriber/0.3/tracing_subscriber/layer/trait.Layer.html
-/// [`SpanTrace`]: ../struct.SpanTrace.html
+/// [`SpanTrace`]: super::SpanTrace
 /// [field formatter]: https://docs.rs/tracing-subscriber/0.3/tracing_subscriber/fmt/trait.FormatFields.html
 /// [default format]: https://docs.rs/tracing-subscriber/0.3/tracing_subscriber/fmt/format/struct.DefaultFields.html
 pub struct ErrorLayer<S, F = DefaultFields> {

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -157,13 +157,13 @@
 //! }
 //! ```
 //!
-//! [`SpanTrace`]: self::SpanTrace
-//! [`ErrorLayer`]: self::ErrorLayer
-//! [`TracedError`]: self::TracedError
-//! [`InstrumentResult`]: self::InstrumentResult
-//! [`InstrumentError`]: self::InstrumentError
-//! [`ExtractSpanTrace`]: self::ExtractSpanTrace
-//! [`in_current_span()`]: self::InstrumentResult#tymethod.in_current_span
+//! [`SpanTrace`]: SpanTrace
+//! [`ErrorLayer`]: ErrorLayer
+//! [`TracedError`]: TracedError
+//! [`InstrumentResult`]: InstrumentResult
+//! [`InstrumentError`]: InstrumentError
+//! [`ExtractSpanTrace`]: ExtractSpanTrace
+//! [`in_current_span()`]: InstrumentResult#tymethod.in_current_span
 //! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 //! [events]: https://docs.rs/tracing/latest/tracing/struct.Event.html
 //! [`Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -157,13 +157,13 @@
 //! }
 //! ```
 //!
-//! [`SpanTrace`]: struct.SpanTrace.html
-//! [`ErrorLayer`]: struct.ErrorLayer.html
-//! [`TracedError`]: struct.TracedError.html
-//! [`InstrumentResult`]: trait.InstrumentResult.html
-//! [`InstrumentError`]: trait.InstrumentError.html
-//! [`ExtractSpanTrace`]: trait.ExtractSpanTrace.html
-//! [`in_current_span()`]: trait.InstrumentResult.html#tymethod.in_current_span
+//! [`SpanTrace`]: self::SpanTrace
+//! [`ErrorLayer`]: self::ErrorLayer
+//! [`TracedError`]: self::TracedError
+//! [`InstrumentResult`]: self::InstrumentResult
+//! [`InstrumentError`]: self::InstrumentError
+//! [`ExtractSpanTrace`]: self::ExtractSpanTrace
+//! [`in_current_span()`]: self::InstrumentResult#tymethod.in_current_span
 //! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 //! [events]: https://docs.rs/tracing/latest/tracing/struct.Event.html
 //! [`Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html

--- a/tracing-flame/src/lib.rs
+++ b/tracing-flame/src/lib.rs
@@ -91,8 +91,8 @@
 //!
 //! [`tracing`]: https://docs.rs/tracing
 //! [`inferno`]: https://docs.rs/inferno
-//! [`FlameLayer`]: self::FlameLayer
-//! [`FlushGuard`]: self::FlushGuard
+//! [`FlameLayer`]: FlameLayer
+//! [`FlushGuard`]: FlushGuard
 //! [`inferno-flamegraph`]: https://docs.rs/inferno/0.9.5/inferno/index.html#producing-a-flame-graph
 //!
 //! ## Supported Rust Versions
@@ -211,8 +211,8 @@ thread_local! {
 /// will flush the writer when it is dropped. If necessary, it can also be used to manually
 /// flush the writer.
 ///
-/// [`flush_on_drop`]: self::FlameLayer::flush_on_drop
-/// [`FlushGuard`]: self::FlushGuard
+/// [`flush_on_drop`]: FlameLayer::flush_on_drop
+/// [`FlushGuard`]: FlushGuard
 #[derive(Debug)]
 pub struct FlameLayer<S, W> {
     out: Arc<Mutex<W>>,

--- a/tracing-flame/src/lib.rs
+++ b/tracing-flame/src/lib.rs
@@ -91,8 +91,8 @@
 //!
 //! [`tracing`]: https://docs.rs/tracing
 //! [`inferno`]: https://docs.rs/inferno
-//! [`FlameLayer`]: struct.FlameLayer.html
-//! [`FlushGuard`]: struct.FlushGuard.html
+//! [`FlameLayer`]: self::FlameLayer
+//! [`FlushGuard`]: self::FlushGuard
 //! [`inferno-flamegraph`]: https://docs.rs/inferno/0.9.5/inferno/index.html#producing-a-flame-graph
 //!
 //! ## Supported Rust Versions
@@ -211,8 +211,8 @@ thread_local! {
 /// will flush the writer when it is dropped. If necessary, it can also be used to manually
 /// flush the writer.
 ///
-/// [`flush_on_drop`]: struct.FlameLayer.html#method.flush_on_drop
-/// [`FlushGuard`]: struct.FlushGuard.html
+/// [`flush_on_drop`]: self::FlameLayer::flush_on_drop
+/// [`FlushGuard`]: self::FlushGuard
 #[derive(Debug)]
 pub struct FlameLayer<S, W> {
     out: Arc<Mutex<W>>,

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -55,8 +55,8 @@
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 //! [`Subscriber`]: https://docs.rs/tracing/latest/tracing/subscriber/index.html
-//! [`Instrument`]: self::Instrument
-//! [`WithSubscriber`]: self::WithSubscriber
+//! [`Instrument`]: Instrument
+//! [`WithSubscriber`]: WithSubscriber
 //! [`futures`]: https://crates.io/crates/futures
 //!
 //! ## Supported Rust Versions

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -55,8 +55,8 @@
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 //! [`Subscriber`]: https://docs.rs/tracing/latest/tracing/subscriber/index.html
-//! [`Instrument`]: trait.Instrument.html
-//! [`WithSubscriber`]: trait.WithSubscriber.html
+//! [`Instrument`]: self::Instrument
+//! [`WithSubscriber`]: self::WithSubscriber
 //! [`futures`]: https://crates.io/crates/futures
 //!
 //! ## Supported Rust Versions

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -91,13 +91,13 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
-//! [`init`]: self::LogTracer::init
-//! [`init_with_filter`]: self::LogTracer::init_with_filter
-//! [`AsTrace`]: self::AsTrace
-//! [`AsLog`]: self::AsLog
-//! [`LogTracer`]: self::LogTracer
-//! [`TraceLogger`]: self::TraceLogger
-//! [`env_logger`]: self::env_logger
+//! [`init`]: LogTracer::init
+//! [`init_with_filter`]: LogTracer::init_with_filter
+//! [`AsTrace`]: AsTrace
+//! [`AsLog`]: AsLog
+//! [`LogTracer`]: LogTracer
+//! [`TraceLogger`]: TraceLogger
+//! [`env_logger`]: env_logger
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [`log`]: https://crates.io/crates/log
 //! [`env_logger` crate]: https://crates.io/crates/env-logger
@@ -487,8 +487,8 @@ impl AsLog for tracing_core::LevelFilter {
 /// to allow accessing its complete metadata in a consistent way,
 /// regardless of the source of its source.
 ///
-/// [`normalized_metadata`]: self::NormalizeEvent#normalized_metadata
-/// [`AsTrace`]: self::AsTrace
+/// [`normalized_metadata`]: NormalizeEvent#normalized_metadata
+/// [`AsTrace`]: AsTrace
 /// [`log::Record`]: https://docs.rs/log/0.4.7/log/struct.Record.html
 pub trait NormalizeEvent<'a>: crate::sealed::Sealed {
     /// If this `Event` comes from a `log`, this method provides a new

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -91,13 +91,13 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
-//! [`init`]: struct.LogTracer.html#method.init
-//! [`init_with_filter`]: struct.LogTracer.html#method.init_with_filter
-//! [`AsTrace`]: trait.AsTrace.html
-//! [`AsLog`]: trait.AsLog.html
-//! [`LogTracer`]: struct.LogTracer.html
-//! [`TraceLogger`]: struct.TraceLogger.html
-//! [`env_logger`]: env_logger/index.html
+//! [`init`]: self::LogTracer::init
+//! [`init_with_filter`]: self::LogTracer::init_with_filter
+//! [`AsTrace`]: self::AsTrace
+//! [`AsLog`]: self::AsLog
+//! [`LogTracer`]: self::LogTracer
+//! [`TraceLogger`]: self::TraceLogger
+//! [`env_logger`]: self::env_logger
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [`log`]: https://crates.io/crates/log
 //! [`env_logger` crate]: https://crates.io/crates/env-logger
@@ -487,8 +487,8 @@ impl AsLog for tracing_core::LevelFilter {
 /// to allow accessing its complete metadata in a consistent way,
 /// regardless of the source of its source.
 ///
-/// [`normalized_metadata`]: trait.NormalizeEvent.html#normalized_metadata
-/// [`AsTrace`]: trait.AsTrace.html
+/// [`normalized_metadata`]: self::NormalizeEvent#normalized_metadata
+/// [`AsTrace`]: self::AsTrace
 /// [`log::Record`]: https://docs.rs/log/0.4.7/log/struct.Record.html
 pub trait NormalizeEvent<'a>: crate::sealed::Sealed {
     /// If this `Event` comes from a `log`, this method provides a new

--- a/tracing-log/src/log_tracer.rs
+++ b/tracing-log/src/log_tracer.rs
@@ -208,7 +208,7 @@ impl log::Log for LogTracer {
 impl Builder {
     /// Returns a new `Builder` to construct a [`LogTracer`].
     ///
-    /// [`LogTracer`]: self::LogTracer
+    /// [`LogTracer`]: LogTracer
     pub fn new() -> Self {
         Self::default()
     }

--- a/tracing-log/src/log_tracer.rs
+++ b/tracing-log/src/log_tracer.rs
@@ -208,7 +208,7 @@ impl log::Log for LogTracer {
 impl Builder {
     /// Returns a new `Builder` to construct a [`LogTracer`].
     ///
-    /// [`LogTracer`]: struct.LogTracer.html
+    /// [`LogTracer`]: self::LogTracer
     pub fn new() -> Self {
         Self::default()
     }

--- a/tracing-log/src/trace_logger.rs
+++ b/tracing-log/src/trace_logger.rs
@@ -10,7 +10,7 @@
 //!
 //! [`log`]: https://docs.rs/log/0.4.8/log/index.html
 //! [`Subscriber`]: https://docs.rs/tracing/0.1.7/tracing/subscriber/trait.Subscriber.html
-//! [`TraceLogger`]: self::TraceLogger
+//! [`TraceLogger`]: TraceLogger
 //! [`log::Record`]: https://docs.rs/log/0.4.8/log/struct.Record.html
 //! [flags]: https://docs.rs/tracing/latest/tracing/#crate-feature-flags
 #![deprecated(
@@ -53,7 +53,7 @@ thread_local! {
 }
 /// Configures and constructs a [`TraceLogger`].
 ///
-/// [`TraceLogger`]: self::TraceLogger
+/// [`TraceLogger`]: TraceLogger
 #[derive(Debug)]
 pub struct Builder {
     log_span_closes: bool,
@@ -95,7 +95,7 @@ impl Builder {
     /// Configures whether or not the [`TraceLogger`] being constructed will log
     /// when a span closes.
     ///
-    /// [`TraceLogger`]: self::TraceLogger
+    /// [`TraceLogger`]: TraceLogger
     pub fn with_span_closes(self, log_span_closes: bool) -> Self {
         Self {
             log_span_closes,
@@ -106,7 +106,7 @@ impl Builder {
     /// Configures whether or not the [`TraceLogger`] being constructed will
     /// include the fields of parent spans when formatting events.
     ///
-    /// [`TraceLogger`]: self::TraceLogger
+    /// [`TraceLogger`]: TraceLogger
     pub fn with_parent_fields(self, parent_fields: bool) -> Self {
         Self {
             parent_fields,
@@ -120,7 +120,7 @@ impl Builder {
     /// If this is set to false, fields from the current span will still be
     /// recorded as context, but the actual entry will not create a log record.
     ///
-    /// [`TraceLogger`]: self::TraceLogger
+    /// [`TraceLogger`]: TraceLogger
     pub fn with_span_entry(self, log_enters: bool) -> Self {
         Self { log_enters, ..self }
     }
@@ -128,7 +128,7 @@ impl Builder {
     /// Configures whether or not the [`TraceLogger`] being constructed will log
     /// when a span is exited.
     ///
-    /// [`TraceLogger`]: self::TraceLogger
+    /// [`TraceLogger`]: TraceLogger
     pub fn with_span_exits(self, log_exits: bool) -> Self {
         Self { log_exits, ..self }
     }
@@ -136,7 +136,7 @@ impl Builder {
     /// Configures whether or not the [`TraceLogger`] being constructed will
     /// include span IDs when formatting log output.
     ///
-    /// [`TraceLogger`]: self::TraceLogger
+    /// [`TraceLogger`]: TraceLogger
     pub fn with_ids(self, log_ids: bool) -> Self {
         Self { log_ids, ..self }
     }
@@ -144,14 +144,14 @@ impl Builder {
     /// Configures whether or not the [`TraceLogger`] being constructed will
     /// include the names of parent spans as context when formatting events.
     ///
-    /// [`TraceLogger`]: self::TraceLogger
+    /// [`TraceLogger`]: TraceLogger
     pub fn with_parent_names(self, log_parent: bool) -> Self {
         Self { log_parent, ..self }
     }
 
     /// Complete the builder, returning a configured [`TraceLogger`].
     ///
-    /// [`TraceLogger`]: self::TraceLogger
+    /// [`TraceLogger`]: TraceLogger
     pub fn finish(self) -> TraceLogger {
         TraceLogger::from_builder(self)
     }

--- a/tracing-log/src/trace_logger.rs
+++ b/tracing-log/src/trace_logger.rs
@@ -10,7 +10,7 @@
 //!
 //! [`log`]: https://docs.rs/log/0.4.8/log/index.html
 //! [`Subscriber`]: https://docs.rs/tracing/0.1.7/tracing/subscriber/trait.Subscriber.html
-//! [`TraceLogger`]: struct.TraceLogger.html
+//! [`TraceLogger`]: self::TraceLogger
 //! [`log::Record`]: https://docs.rs/log/0.4.8/log/struct.Record.html
 //! [flags]: https://docs.rs/tracing/latest/tracing/#crate-feature-flags
 #![deprecated(
@@ -53,7 +53,7 @@ thread_local! {
 }
 /// Configures and constructs a [`TraceLogger`].
 ///
-/// [`TraceLogger`]: struct.TraceLogger.html
+/// [`TraceLogger`]: self::TraceLogger
 #[derive(Debug)]
 pub struct Builder {
     log_span_closes: bool,
@@ -95,7 +95,7 @@ impl Builder {
     /// Configures whether or not the [`TraceLogger`] being constructed will log
     /// when a span closes.
     ///
-    /// [`TraceLogger`]: struct.TraceLogger.html
+    /// [`TraceLogger`]: self::TraceLogger
     pub fn with_span_closes(self, log_span_closes: bool) -> Self {
         Self {
             log_span_closes,
@@ -106,7 +106,7 @@ impl Builder {
     /// Configures whether or not the [`TraceLogger`] being constructed will
     /// include the fields of parent spans when formatting events.
     ///
-    /// [`TraceLogger`]: struct.TraceLogger.html
+    /// [`TraceLogger`]: self::TraceLogger
     pub fn with_parent_fields(self, parent_fields: bool) -> Self {
         Self {
             parent_fields,
@@ -120,7 +120,7 @@ impl Builder {
     /// If this is set to false, fields from the current span will still be
     /// recorded as context, but the actual entry will not create a log record.
     ///
-    /// [`TraceLogger`]: struct.TraceLogger.html
+    /// [`TraceLogger`]: self::TraceLogger
     pub fn with_span_entry(self, log_enters: bool) -> Self {
         Self { log_enters, ..self }
     }
@@ -128,7 +128,7 @@ impl Builder {
     /// Configures whether or not the [`TraceLogger`] being constructed will log
     /// when a span is exited.
     ///
-    /// [`TraceLogger`]: struct.TraceLogger.html
+    /// [`TraceLogger`]: self::TraceLogger
     pub fn with_span_exits(self, log_exits: bool) -> Self {
         Self { log_exits, ..self }
     }
@@ -136,7 +136,7 @@ impl Builder {
     /// Configures whether or not the [`TraceLogger`] being constructed will
     /// include span IDs when formatting log output.
     ///
-    /// [`TraceLogger`]: struct.TraceLogger.html
+    /// [`TraceLogger`]: self::TraceLogger
     pub fn with_ids(self, log_ids: bool) -> Self {
         Self { log_ids, ..self }
     }
@@ -144,14 +144,14 @@ impl Builder {
     /// Configures whether or not the [`TraceLogger`] being constructed will
     /// include the names of parent spans as context when formatting events.
     ///
-    /// [`TraceLogger`]: struct.TraceLogger.html
+    /// [`TraceLogger`]: self::TraceLogger
     pub fn with_parent_names(self, log_parent: bool) -> Self {
         Self { log_parent, ..self }
     }
 
     /// Complete the builder, returning a configured [`TraceLogger`].
     ///
-    /// [`TraceLogger`]: struct.TraceLogger.html
+    /// [`TraceLogger`]: self::TraceLogger
     pub fn finish(self) -> TraceLogger {
         TraceLogger::from_builder(self)
     }

--- a/tracing-subscriber/src/field/delimited.rs
+++ b/tracing-subscriber/src/field/delimited.rs
@@ -41,7 +41,7 @@ impl<D, V> Delimited<D, V> {
     /// Returns a new [`MakeVisitor`] implementation that wraps `inner` so that
     /// it will format each visited field separated by the provided `delimiter`.
     ///
-    /// [`MakeVisitor`]: ../trait.MakeVisitor.html
+    /// [`MakeVisitor`]: super::MakeVisitor
     pub fn new(delimiter: D, inner: V) -> Self {
         Self { delimiter, inner }
     }

--- a/tracing-subscriber/src/field/display.rs
+++ b/tracing-subscriber/src/field/display.rs
@@ -18,7 +18,7 @@ impl<V> Messages<V> {
     /// Returns a new [`MakeVisitor`] implementation that will wrap `inner` so
     /// that any strings named `message` are formatted using `fmt::Display`.
     ///
-    /// [`MakeVisitor`]: ../trait.MakeVisitor.html
+    /// [`MakeVisitor`]: super::MakeVisitor
     pub fn new(inner: V) -> Self {
         Messages(inner)
     }

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -415,7 +415,7 @@ impl EnvFilter {
     /// and events as a previous filter, but sets a different level for those
     /// spans and events, the previous directive is overwritten.
     ///
-    /// [`LevelFilter`]: super::filter::LevelFilter
+    /// [`LevelFilter`]: super::LevelFilter
     /// [`Level`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Level.html
     ///
     /// # Examples

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -415,7 +415,7 @@ impl EnvFilter {
     /// and events as a previous filter, but sets a different level for those
     /// spans and events, the previous directive is overwritten.
     ///
-    /// [`LevelFilter`]: ../filter/struct.LevelFilter.html
+    /// [`LevelFilter`]: super::filter::LevelFilter
     /// [`Level`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Level.html
     ///
     /// # Examples

--- a/tracing-subscriber/src/filter/layer_filters/mod.rs
+++ b/tracing-subscriber/src/filter/layer_filters/mod.rs
@@ -538,7 +538,7 @@ impl<L, F, S> Filtered<L, F, S> {
     /// # }
     /// ```
     ///
-    /// [subscriber]: self::Subscribe
+    /// [subscriber]: Subscribe
     pub fn inner_mut(&mut self) -> &mut L {
         &mut self.layer
     }

--- a/tracing-subscriber/src/filter/layer_filters/mod.rs
+++ b/tracing-subscriber/src/filter/layer_filters/mod.rs
@@ -538,7 +538,7 @@ impl<L, F, S> Filtered<L, F, S> {
     /// # }
     /// ```
     ///
-    /// [subscriber]: Subscribe
+    /// [subscriber]: self::Subscribe
     pub fn inner_mut(&mut self) -> &mut L {
         &mut self.layer
     }

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -187,7 +187,7 @@ impl<S, N, E, W> Layer<S, N, E, W> {
 
     /// Borrows the [writer] for this [`Layer`].
     ///
-    /// [writer]: self::MakeWriter
+    /// [writer]: MakeWriter
     pub fn writer(&self) -> &W {
         &self.make_writer
     }
@@ -218,7 +218,7 @@ impl<S, N, E, W> Layer<S, N, E, W> {
     /// # }
     /// ```
     ///
-    /// [writer]: self::MakeWriter
+    /// [writer]: MakeWriter
     pub fn writer_mut(&mut self) -> &mut W {
         &mut self.make_writer
     }
@@ -1028,7 +1028,7 @@ where
     /// the event has an explicit parent span, this will return that span. If
     /// the event does not have a parent span, this will return `None`.
     ///
-    /// [stored data]: self::SpanRef
+    /// [stored data]: SpanRef
     pub fn parent_span(&self) -> Option<SpanRef<'_, S>> {
         self.ctx.event_span(self.event)
     }
@@ -1103,7 +1103,7 @@ where
     /// The event formatter may use the returned field formatter to format the
     /// fields of any events it records.
     ///
-    /// [field formatter]: self::FormatFields
+    /// [field formatter]: FormatFields
     pub fn field_format(&self) -> &N {
         self.fmt_fields
     }

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -74,7 +74,7 @@ pub struct Layer<
 }
 
 impl<S> Layer<S> {
-    /// Returns a new [`Layer`](struct.Layer.html) with the default configuration.
+    /// Returns a new [`Layer`][self::Layer] with the default configuration.
     pub fn new() -> Self {
         Self::default()
     }
@@ -466,7 +466,7 @@ where
         }
     }
 
-    /// Sets the layer being built to use a [less verbose formatter](../fmt/format/struct.Compact.html).
+    /// Sets the layer being built to use a [less verbose formatter][super::format::Compact].
     pub fn compact(self) -> Layer<S, N, format::Format<format::Compact, T>, W>
     where
         N: for<'writer> FormatFields<'writer> + 'static,
@@ -495,7 +495,7 @@ where
         }
     }
 
-    /// Sets the layer being built to use a [JSON formatter](../fmt/format/struct.Json.html).
+    /// Sets the layer being built to use a [JSON formatter][super::format::Json].
     ///
     /// The full format includes fields from all entered spans.
     ///
@@ -531,7 +531,7 @@ where
 impl<S, T, W> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
     /// Sets the JSON layer being built to flatten event metadata.
     ///
-    /// See [`format::Json`](../fmt/format/struct.Json.html)
+    /// See [`format::Json`][super::format::Json]
     pub fn flatten_event(
         self,
         flatten_event: bool,
@@ -546,7 +546,7 @@ impl<S, T, W> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
     /// Sets whether or not the formatter will include the current span in
     /// formatted events.
     ///
-    /// See [`format::Json`](../fmt/format/struct.Json.html)
+    /// See [`format::Json`][super::format::Json]
     pub fn with_current_span(
         self,
         display_current_span: bool,
@@ -561,7 +561,7 @@ impl<S, T, W> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
     /// Sets whether or not the formatter will include a list (from root to leaf)
     /// of all currently entered spans in formatted events.
     ///
-    /// See [`format::Json`](../fmt/format/struct.Json.html)
+    /// See [`format::Json`][super::format::Json]
     pub fn with_span_list(
         self,
         display_span_list: bool,

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -56,7 +56,7 @@ use tracing_core::{
 /// # tracing::subscriber::set_global_default(subscriber).unwrap();
 /// ```
 ///
-/// [`Layer`]: ../layer/trait.Layer.html
+/// [`Layer`]: super::layer::Layer
 #[cfg_attr(docsrs, doc(cfg(all(feature = "fmt", feature = "std"))))]
 #[derive(Debug)]
 pub struct Layer<
@@ -187,7 +187,7 @@ impl<S, N, E, W> Layer<S, N, E, W> {
 
     /// Borrows the [writer] for this [`Layer`].
     ///
-    /// [writer]: MakeWriter
+    /// [writer]: self::MakeWriter
     pub fn writer(&self) -> &W {
         &self.make_writer
     }
@@ -218,7 +218,7 @@ impl<S, N, E, W> Layer<S, N, E, W> {
     /// # }
     /// ```
     ///
-    /// [writer]: MakeWriter
+    /// [writer]: self::MakeWriter
     pub fn writer_mut(&mut self) -> &mut W {
         &mut self.make_writer
     }
@@ -256,7 +256,7 @@ impl<S, N, E, W> Layer<S, N, E, W> {
     /// ```
     /// [capturing]:
     /// https://doc.rust-lang.org/book/ch11-02-running-tests.html#showing-function-output
-    /// [`TestWriter`]: writer/struct.TestWriter.html
+    /// [`TestWriter`]: self::writer::TestWriter
     pub fn with_test_writer(self) -> Layer<S, N, E, TestWriter> {
         Layer {
             fmt_fields: self.fmt_fields,
@@ -660,7 +660,7 @@ where
 /// formatters are in use, each can store its own formatted representation
 /// without conflicting.
 ///
-/// [extensions]: ../registry/struct.Extensions.html
+/// [extensions]: super::registry::Extensions
 #[derive(Default)]
 pub struct FormattedFields<E: ?Sized> {
     _format_fields: PhantomData<fn(E)>,
@@ -984,7 +984,7 @@ where
     /// If this returns `None`, then no span exists for that ID (either it has
     /// closed or the ID is invalid).
     ///
-    /// [stored data]: ../registry/struct.SpanRef.html
+    /// [stored data]: super::registry::SpanRef
     #[inline]
     pub fn span(&self, id: &Id) -> Option<SpanRef<'_, S>>
     where
@@ -1007,7 +1007,7 @@ where
     ///
     /// If this returns `None`, then we are not currently within a span.
     ///
-    /// [stored data]: ../registry/struct.SpanRef.html
+    /// [stored data]: super::registry::SpanRef
     #[inline]
     pub fn lookup_current(&self) -> Option<SpanRef<'_, S>>
     where
@@ -1028,7 +1028,7 @@ where
     /// the event has an explicit parent span, this will return that span. If
     /// the event does not have a parent span, this will return `None`.
     ///
-    /// [stored data]: SpanRef
+    /// [stored data]: self::SpanRef
     pub fn parent_span(&self) -> Option<SpanRef<'_, S>> {
         self.ctx.event_span(self.event)
     }
@@ -1103,7 +1103,7 @@ where
     /// The event formatter may use the returned field formatter to format the
     /// fields of any events it records.
     ///
-    /// [field formatter]: FormatFields
+    /// [field formatter]: self::FormatFields
     pub fn field_format(&self) -> &N {
         self.fmt_fields
     }

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -256,7 +256,7 @@ impl<S, N, E, W> Layer<S, N, E, W> {
     /// ```
     /// [capturing]:
     /// https://doc.rust-lang.org/book/ch11-02-running-tests.html#showing-function-output
-    /// [`TestWriter`]: self::writer::TestWriter
+    /// [`TestWriter`]: super::writer::TestWriter
     pub fn with_test_writer(self) -> Layer<S, N, E, TestWriter> {
         Layer {
             fmt_fields: self.fmt_fields,
@@ -660,7 +660,7 @@ where
 /// formatters are in use, each can store its own formatted representation
 /// without conflicting.
 ///
-/// [extensions]: super::registry::Extensions
+/// [extensions]: crate::registry::Extensions
 #[derive(Default)]
 pub struct FormattedFields<E: ?Sized> {
     _format_fields: PhantomData<fn(E)>,
@@ -984,7 +984,7 @@ where
     /// If this returns `None`, then no span exists for that ID (either it has
     /// closed or the ID is invalid).
     ///
-    /// [stored data]: super::registry::SpanRef
+    /// [stored data]: crate::registry::SpanRef
     #[inline]
     pub fn span(&self, id: &Id) -> Option<SpanRef<'_, S>>
     where
@@ -1007,7 +1007,7 @@ where
     ///
     /// If this returns `None`, then we are not currently within a span.
     ///
-    /// [stored data]: super::registry::SpanRef
+    /// [stored data]: crate::registry::SpanRef
     #[inline]
     pub fn lookup_current(&self) -> Option<SpanRef<'_, S>>
     where

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -421,9 +421,9 @@ impl<'a> FormatFields<'a> for JsonFields {
 
 /// The [visitor] produced by [`JsonFields`]'s [`MakeVisitor`] implementation.
 ///
-/// [visitor]: super::super::field::Visit
+/// [visitor]: crate::field::Visit
 /// [`JsonFields`]: self::JsonFields
-/// [`MakeVisitor`]: super::super::field::MakeVisitor
+/// [`MakeVisitor`]: crate::field::MakeVisitor
 pub struct JsonVisitor<'a> {
     values: BTreeMap<&'a str, serde_json::Value>,
     writer: &'a mut dyn Write,

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -341,7 +341,7 @@ impl Default for Json {
 
 /// The JSON [`FormatFields`] implementation.
 ///
-/// [`FormatFields`]: self::FormatFields
+/// [`FormatFields`]: FormatFields
 #[derive(Debug)]
 pub struct JsonFields {
     // reserve the ability to add fields to this without causing a breaking
@@ -352,7 +352,7 @@ pub struct JsonFields {
 impl JsonFields {
     /// Returns a new JSON [`FormatFields`] implementation.
     ///
-    /// [`FormatFields`]: self::FormatFields
+    /// [`FormatFields`]: FormatFields
     pub fn new() -> Self {
         Self { _private: () }
     }
@@ -422,7 +422,7 @@ impl<'a> FormatFields<'a> for JsonFields {
 /// The [visitor] produced by [`JsonFields`]'s [`MakeVisitor`] implementation.
 ///
 /// [visitor]: crate::field::Visit
-/// [`JsonFields`]: self::JsonFields
+/// [`JsonFields`]: JsonFields
 /// [`MakeVisitor`]: crate::field::MakeVisitor
 pub struct JsonVisitor<'a> {
     values: BTreeMap<&'a str, serde_json::Value>,

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -341,7 +341,7 @@ impl Default for Json {
 
 /// The JSON [`FormatFields`] implementation.
 ///
-/// [`FormatFields`]: trait.FormatFields.html
+/// [`FormatFields`]: self::FormatFields
 #[derive(Debug)]
 pub struct JsonFields {
     // reserve the ability to add fields to this without causing a breaking
@@ -352,7 +352,7 @@ pub struct JsonFields {
 impl JsonFields {
     /// Returns a new JSON [`FormatFields`] implementation.
     ///
-    /// [`FormatFields`]: trait.FormatFields.html
+    /// [`FormatFields`]: self::FormatFields
     pub fn new() -> Self {
         Self { _private: () }
     }
@@ -421,9 +421,9 @@ impl<'a> FormatFields<'a> for JsonFields {
 
 /// The [visitor] produced by [`JsonFields`]'s [`MakeVisitor`] implementation.
 ///
-/// [visitor]: ../../field/trait.Visit.html
-/// [`JsonFields`]: struct.JsonFields.html
-/// [`MakeVisitor`]: ../../field/trait.MakeVisitor.html
+/// [visitor]: super::super::field::Visit
+/// [`JsonFields`]: self::JsonFields
+/// [`MakeVisitor`]: super::super::field::MakeVisitor
 pub struct JsonVisitor<'a> {
     values: BTreeMap<&'a str, serde_json::Value>,
     writer: &'a mut dyn Write,

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -227,8 +227,8 @@ where
 /// time a span or event with fields is recorded, the subscriber will format
 /// those fields with its associated `FormatFields` implementation.
 ///
-/// [set of fields]: super::field::RecordFields
-/// [`FmtSubscriber`]: super::fmt::Subscriber
+/// [set of fields]: crate::field::RecordFields
+/// [`FmtSubscriber`]: super::Subscriber
 pub trait FormatFields<'writer> {
     /// Format the provided `fields` to the provided [`Writer`], returning a result.
     fn format_fields<R: RecordFields>(&self, writer: Writer<'writer>, fields: R) -> fmt::Result;

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -855,7 +855,7 @@ impl<T> Format<Json, T> {
     /// ```ignore,json
     /// {"timestamp":"Feb 20 11:28:15.096","level":"INFO","target":"mycrate", "message":"some message", "key": "value"}
     /// ```
-    /// See [`Json`](../format/struct.Json.html).
+    /// See [`Json`][super::format::Json].
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub fn flatten_event(mut self, flatten_event: bool) -> Format<Json, T> {
@@ -866,7 +866,7 @@ impl<T> Format<Json, T> {
     /// Sets whether or not the formatter will include the current span in
     /// formatted events.
     ///
-    /// See [`format::Json`](../fmt/format/struct.Json.html)
+    /// See [`format::Json`][Json]
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub fn with_current_span(mut self, display_current_span: bool) -> Format<Json, T> {
@@ -877,7 +877,7 @@ impl<T> Format<Json, T> {
     /// Sets whether or not the formatter will include a list (from root to
     /// leaf) of all currently entered spans in formatted events.
     ///
-    /// See [`format::Json`](../fmt/format/struct.Json.html)
+    /// See [`format::Json`][Json]
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub fn with_span_list(mut self, display_span_list: bool) -> Format<Json, T> {
@@ -1569,7 +1569,7 @@ impl<'a, F> fmt::Debug for FieldFnVisitor<'a, F> {
 
 /// Configures what points in the span lifecycle are logged as events.
 ///
-/// See also [`with_span_events`](../struct.SubscriberBuilder.html#method.with_span_events).
+/// See also [`with_span_events`](super::SubscriberBuilder.html::with_span_events).
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct FmtSpan(u8);
 

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -191,7 +191,7 @@ pub use pretty::*;
 /// [`Writer::has_ansi_escapes`]: Writer::has_ansi_escapes
 /// [`ansi_term`]: https://crates.io/crates/ansi_term
 /// [`owo-colors`]: https://crates.io/crates/owo-colors
-/// [default formatter]: self::Full
+/// [default formatter]: Full
 pub trait FormatEvent<S, N>
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
@@ -281,7 +281,7 @@ pub fn json() -> Format<Json> {
 /// Returns a [`FormatFields`] implementation that formats fields using the
 /// provided function or closure.
 ///
-/// [`FormatFields`]: self::FormatFields
+/// [`FormatFields`]: FormatFields
 pub fn debug_fn<F>(f: F) -> FieldFn<F>
 where
     F: Fn(&mut Writer<'_>, &Field, &dyn fmt::Debug) -> fmt::Result + Clone,
@@ -313,13 +313,13 @@ pub struct Writer<'writer> {
 /// A [`FormatFields`] implementation that formats fields by calling a function
 /// or closure.
 ///
-/// [`FormatFields`]: self::FormatFields
+/// [`FormatFields`]: FormatFields
 #[derive(Debug, Clone)]
 pub struct FieldFn<F>(F);
 /// The [visitor] produced by [`FieldFn`]'s [`MakeVisitor`] implementation.
 ///
 /// [visitor]: super::super::field::Visit
-/// [`FieldFn`]: self::FieldFn
+/// [`FieldFn`]: FieldFn
 /// [`MakeVisitor`]: super::super::field::MakeVisitor
 pub struct FieldFnVisitor<'a, F> {
     f: F,
@@ -1157,7 +1157,7 @@ where
 
 /// The default [`FormatFields`] implementation.
 ///
-/// [`FormatFields`]: self::FormatFields
+/// [`FormatFields`]: FormatFields
 #[derive(Debug)]
 pub struct DefaultFields {
     // reserve the ability to add fields to this without causing a breaking
@@ -1179,7 +1179,7 @@ pub struct DefaultVisitor<'a> {
 impl DefaultFields {
     /// Returns a new default [`FormatFields`] implementation.
     ///
-    /// [`FormatFields`]: self::FormatFields
+    /// [`FormatFields`]: FormatFields
     pub fn new() -> Self {
         Self { _private: () }
     }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -191,7 +191,7 @@ pub use pretty::*;
 /// [`Writer::has_ansi_escapes`]: Writer::has_ansi_escapes
 /// [`ansi_term`]: https://crates.io/crates/ansi_term
 /// [`owo-colors`]: https://crates.io/crates/owo-colors
-/// [default formatter]: Full
+/// [default formatter]: self::Full
 pub trait FormatEvent<S, N>
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
@@ -227,8 +227,8 @@ where
 /// time a span or event with fields is recorded, the subscriber will format
 /// those fields with its associated `FormatFields` implementation.
 ///
-/// [set of fields]: ../field/trait.RecordFields.html
-/// [`FmtSubscriber`]: ../fmt/struct.Subscriber.html
+/// [set of fields]: super::field::RecordFields
+/// [`FmtSubscriber`]: super::fmt::Subscriber
 pub trait FormatFields<'writer> {
     /// Format the provided `fields` to the provided [`Writer`], returning a result.
     fn format_fields<R: RecordFields>(&self, writer: Writer<'writer>, fields: R) -> fmt::Result;
@@ -281,7 +281,7 @@ pub fn json() -> Format<Json> {
 /// Returns a [`FormatFields`] implementation that formats fields using the
 /// provided function or closure.
 ///
-/// [`FormatFields`]: trait.FormatFields.html
+/// [`FormatFields`]: self::FormatFields
 pub fn debug_fn<F>(f: F) -> FieldFn<F>
 where
     F: Fn(&mut Writer<'_>, &Field, &dyn fmt::Debug) -> fmt::Result + Clone,
@@ -313,14 +313,14 @@ pub struct Writer<'writer> {
 /// A [`FormatFields`] implementation that formats fields by calling a function
 /// or closure.
 ///
-/// [`FormatFields`]: trait.FormatFields.html
+/// [`FormatFields`]: self::FormatFields
 #[derive(Debug, Clone)]
 pub struct FieldFn<F>(F);
 /// The [visitor] produced by [`FieldFn`]'s [`MakeVisitor`] implementation.
 ///
-/// [visitor]: ../../field/trait.Visit.html
-/// [`FieldFn`]: struct.FieldFn.html
-/// [`MakeVisitor`]: ../../field/trait.MakeVisitor.html
+/// [visitor]: super::super::field::Visit
+/// [`FieldFn`]: self::FieldFn
+/// [`MakeVisitor`]: super::super::field::MakeVisitor
 pub struct FieldFnVisitor<'a, F> {
     f: F,
     writer: Writer<'a>,
@@ -1157,7 +1157,7 @@ where
 
 /// The default [`FormatFields`] implementation.
 ///
-/// [`FormatFields`]: trait.FormatFields.html
+/// [`FormatFields`]: self::FormatFields
 #[derive(Debug)]
 pub struct DefaultFields {
     // reserve the ability to add fields to this without causing a breaking
@@ -1179,7 +1179,7 @@ pub struct DefaultVisitor<'a> {
 impl DefaultFields {
     /// Returns a new default [`FormatFields`] implementation.
     ///
-    /// [`FormatFields`]: trait.FormatFields.html
+    /// [`FormatFields`]: self::FormatFields
     pub fn new() -> Self {
         Self { _private: () }
     }

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -1138,8 +1138,7 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
 ///
 /// [`LogTracer`]:
 ///     https://docs.rs/tracing-log/0.1.0/tracing_log/struct.LogTracer.html
-/// [`RUST_LOG` environment variable]:
-///     ../filter/struct.EnvFilter.html#associatedconstant.DEFAULT_ENV
+/// [`RUST_LOG` environment variable]: crate::filter::EnvFilter::DEFAULT_ENV
 pub fn try_init() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let builder = Subscriber::builder();
 
@@ -1195,8 +1194,7 @@ pub fn try_init() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 /// Panics if the initialization was unsuccessful, likely because a
 /// global subscriber was already installed by another call to `try_init`.
 ///
-/// [`RUST_LOG` environment variable]:
-///     ../filter/struct.EnvFilter.html#associatedconstant.DEFAULT_ENV
+/// [`RUST_LOG` environment variable]: crate::filter::EnvFilter::DEFAULT_ENV
 pub fn init() {
     try_init().expect("Unable to install global subscriber")
 }

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -18,7 +18,7 @@
 //!
 //! *Compiler support: [requires `rustc` 1.49+][msrv]*
 //!
-//! [msrv]: ../index.html#supported-rust-versions
+//! [msrv]: super#supported-rust-versions
 //!
 //! Add the following to your executable to initialize the default subscriber:
 //! ```rust
@@ -181,11 +181,11 @@
 //!     .init();
 //! ```
 //!
-//! [`EnvFilter`]: ../filter/struct.EnvFilter.html
+//! [`EnvFilter`]: super::filter::EnvFilter
 //! [`env_logger`]: https://docs.rs/env_logger/
-//! [`filter`]: ../filter/index.html
-//! [`SubscriberBuilder`]: ./struct.SubscriberBuilder.html
-//! [`FmtSubscriber`]: ./struct.Subscriber.html
+//! [`filter`]: super::filter
+//! [`SubscriberBuilder`]: self::SubscriberBuilder
+//! [`FmtSubscriber`]: self::Subscriber
 //! [`Subscriber`]:
 //!     https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
 //! [`tracing`]: https://crates.io/crates/tracing
@@ -312,8 +312,8 @@ pub struct SubscriberBuilder<
 /// })
 /// ```
 ///
-/// [formatting subscriber]: Subscriber
-/// [`SubscriberBuilder::default()`]: struct.SubscriberBuilder.html#method.default
+/// [formatting subscriber]: self::Subscriber
+/// [`SubscriberBuilder::default()`]: self::SubscriberBuilder::default
 /// [`init`]: SubscriberBuilder::init()
 /// [`try_init`]: SubscriberBuilder::try_init()
 /// [`finish`]: SubscriberBuilder::finish()
@@ -327,9 +327,9 @@ pub fn fmt() -> SubscriberBuilder {
 ///
 /// This is a shorthand for the equivalent [`Layer::default()`] function.
 ///
-/// [formatting layer]: Layer
+/// [formatting layer]: self::Layer
 /// [composed]: crate::layer
-/// [`Layer::default()`]: struct.Layer.html#method.default
+/// [`Layer::default()`]: self::Layer::default
 #[cfg_attr(docsrs, doc(cfg(all(feature = "fmt", feature = "std"))))]
 pub fn layer<S>() -> Layer<S> {
     Layer::default()
@@ -342,7 +342,7 @@ impl Subscriber {
     /// This can be overridden with the [`SubscriberBuilder::with_max_level`] method.
     ///
     /// [verbosity level]: https://docs.rs/tracing-core/0.1.5/tracing_core/struct.Level.html
-    /// [`SubscriberBuilder::with_max_level`]: struct.SubscriberBuilder.html#method.with_max_level
+    /// [`SubscriberBuilder::with_max_level`]: self::SubscriberBuilder::with_max_level
     pub const DEFAULT_MAX_LEVEL: LevelFilter = LevelFilter::INFO;
 
     /// Returns a new `SubscriberBuilder` for configuring a format subscriber.
@@ -892,7 +892,7 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
     ///     .try_init()?;
     /// # Ok(())}
     /// ```
-    /// [`EnvFilter`]: ../filter/struct.EnvFilter.html
+    /// [`EnvFilter`]: super::filter::EnvFilter
     /// [`with_max_level`]: #method.with_max_level
     #[cfg(feature = "env-filter")]
     #[cfg_attr(docsrs, doc(cfg(feature = "env-filter")))]
@@ -1029,7 +1029,7 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
     ///
     /// [capturing]:
     /// https://doc.rust-lang.org/book/ch11-02-running-tests.html#showing-function-output
-    /// [`TestWriter`]: writer/struct.TestWriter.html
+    /// [`TestWriter`]: self::writer::TestWriter
     pub fn with_test_writer(self) -> SubscriberBuilder<N, E, F, TestWriter> {
         SubscriberBuilder {
             filter: self.filter,

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -163,7 +163,7 @@
 //!
 //! ### Composing Layers
 //!
-//! Composing an [`EnvFilter`] `Layer` and a [format `Layer`](../fmt/struct.Layer.html):
+//! Composing an [`EnvFilter`] `Layer` and a [format `Layer`][super::fmt::Layer]:
 //!
 //! ```rust
 //! use tracing_subscriber::{fmt, EnvFilter};
@@ -721,7 +721,7 @@ where
 
     /// Sets the subscriber being built to use a JSON formatter.
     ///
-    /// See [`format::Json`](../fmt/format/struct.Json.html)
+    /// See [`format::Json`][super::fmt::format::Json]
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub fn json(
@@ -742,7 +742,7 @@ where
 impl<T, F, W> SubscriberBuilder<format::JsonFields, format::Format<format::Json, T>, F, W> {
     /// Sets the json subscriber being built to flatten event metadata.
     ///
-    /// See [`format::Json`](../fmt/format/struct.Json.html)
+    /// See [`format::Json`][super::fmt::format::Json]
     pub fn flatten_event(
         self,
         flatten_event: bool,
@@ -756,7 +756,7 @@ impl<T, F, W> SubscriberBuilder<format::JsonFields, format::Format<format::Json,
     /// Sets whether or not the JSON subscriber being built will include the current span
     /// in formatted events.
     ///
-    /// See [`format::Json`](../fmt/format/struct.Json.html)
+    /// See [`format::Json`][super::fmt::format::Json]
     pub fn with_current_span(
         self,
         display_current_span: bool,
@@ -770,7 +770,7 @@ impl<T, F, W> SubscriberBuilder<format::JsonFields, format::Format<format::Json,
     /// Sets whether or not the JSON subscriber being built will include a list (from
     /// root to leaf) of all currently entered spans in formatted events.
     ///
-    /// See [`format::Json`](../fmt/format/struct.Json.html)
+    /// See [`format::Json`][super::fmt::format::Json]
     pub fn with_span_list(
         self,
         display_span_list: bool,

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -184,8 +184,8 @@
 //! [`EnvFilter`]: super::filter::EnvFilter
 //! [`env_logger`]: https://docs.rs/env_logger/
 //! [`filter`]: super::filter
-//! [`SubscriberBuilder`]: self::SubscriberBuilder
-//! [`FmtSubscriber`]: self::Subscriber
+//! [`SubscriberBuilder`]: SubscriberBuilder
+//! [`FmtSubscriber`]: Subscriber
 //! [`Subscriber`]:
 //!     https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
 //! [`tracing`]: https://crates.io/crates/tracing
@@ -312,8 +312,8 @@ pub struct SubscriberBuilder<
 /// })
 /// ```
 ///
-/// [formatting subscriber]: self::Subscriber
-/// [`SubscriberBuilder::default()`]: self::SubscriberBuilder::default
+/// [formatting subscriber]: Subscriber
+/// [`SubscriberBuilder::default()`]: SubscriberBuilder::default
 /// [`init`]: SubscriberBuilder::init()
 /// [`try_init`]: SubscriberBuilder::try_init()
 /// [`finish`]: SubscriberBuilder::finish()
@@ -327,9 +327,9 @@ pub fn fmt() -> SubscriberBuilder {
 ///
 /// This is a shorthand for the equivalent [`Layer::default()`] function.
 ///
-/// [formatting layer]: self::Layer
+/// [formatting layer]: Layer
 /// [composed]: crate::layer
-/// [`Layer::default()`]: self::Layer::default
+/// [`Layer::default()`]: Layer::default
 #[cfg_attr(docsrs, doc(cfg(all(feature = "fmt", feature = "std"))))]
 pub fn layer<S>() -> Layer<S> {
     Layer::default()
@@ -342,7 +342,7 @@ impl Subscriber {
     /// This can be overridden with the [`SubscriberBuilder::with_max_level`] method.
     ///
     /// [verbosity level]: https://docs.rs/tracing-core/0.1.5/tracing_core/struct.Level.html
-    /// [`SubscriberBuilder::with_max_level`]: self::SubscriberBuilder::with_max_level
+    /// [`SubscriberBuilder::with_max_level`]: SubscriberBuilder::with_max_level
     pub const DEFAULT_MAX_LEVEL: LevelFilter = LevelFilter::INFO;
 
     /// Returns a new `SubscriberBuilder` for configuring a format subscriber.
@@ -1029,7 +1029,7 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
     ///
     /// [capturing]:
     /// https://doc.rust-lang.org/book/ch11-02-running-tests.html#showing-function-output
-    /// [`TestWriter`]: self::writer::TestWriter
+    /// [`TestWriter`]: writer::TestWriter
     pub fn with_test_writer(self) -> SubscriberBuilder<N, E, F, TestWriter> {
         SubscriberBuilder {
             filter: self.filter,

--- a/tracing-subscriber/src/fmt/time/mod.rs
+++ b/tracing-subscriber/src/fmt/time/mod.rs
@@ -30,7 +30,7 @@ pub use time_crate::OffsetTime;
 ///
 /// The full list of provided implementations can be found in [`time`].
 ///
-/// [`time`]: self::self
+/// [`time`]: self
 pub trait FormatTime {
     /// Measure and write out the current time.
     ///

--- a/tracing-subscriber/src/fmt/time/mod.rs
+++ b/tracing-subscriber/src/fmt/time/mod.rs
@@ -30,7 +30,7 @@ pub use time_crate::OffsetTime;
 ///
 /// The full list of provided implementations can be found in [`time`].
 ///
-/// [`time`]: ./index.html
+/// [`time`]: self::self
 pub trait FormatTime {
     /// Measure and write out the current time.
     ///

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -649,7 +649,7 @@ pub struct Tee<A, B> {
 /// [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 /// [`MutexGuard`]: https://doc.rust-lang.org/std/sync/struct.MutexGuard.html
 /// [`Mutex`]: https://doc.rust-lang.org/std/sync/struct.Mutex.html
-/// [`MakeWriter`]: self::MakeWriter
+/// [`MakeWriter`]: MakeWriter
 #[derive(Debug)]
 pub struct MutexGuardWriter<'a, W>(MutexGuard<'a, W>);
 
@@ -734,7 +734,7 @@ impl<'a> MakeWriter<'a> for TestWriter {
 impl BoxMakeWriter {
     /// Constructs a `BoxMakeWriter` wrapping a type implementing [`MakeWriter`].
     ///
-    /// [`MakeWriter`]: self::MakeWriter
+    /// [`MakeWriter`]: MakeWriter
     pub fn new<M>(make_writer: M) -> Self
     where
         M: for<'a> MakeWriter<'a> + Send + Sync + 'static,

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -501,8 +501,8 @@ pub trait MakeWriterExt<'a>: MakeWriter<'a> {
 /// Writing to [`io::stdout`] and [`io::stderr`] produces the same results as using
 /// [`libtest`'s `--nocapture` option][nocapture] which may make the results look unreadable.
 ///
-/// [`fmt::Subscriber`]: ../struct.Subscriber.html
-/// [`fmt::Layer`]: ../struct.Layer.html
+/// [`fmt::Subscriber`]: super::Subscriber
+/// [`fmt::Layer`]: super::Layer
 /// [capturing]: https://doc.rust-lang.org/book/ch11-02-running-tests.html#showing-function-output
 /// [nocapture]: https://doc.rust-lang.org/cargo/commands/cargo-test.html
 /// [`io::stdout`]: https://doc.rust-lang.org/std/io/fn.stdout.html
@@ -649,7 +649,7 @@ pub struct Tee<A, B> {
 /// [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 /// [`MutexGuard`]: https://doc.rust-lang.org/std/sync/struct.MutexGuard.html
 /// [`Mutex`]: https://doc.rust-lang.org/std/sync/struct.Mutex.html
-/// [`MakeWriter`]: trait.MakeWriter.html
+/// [`MakeWriter`]: self::MakeWriter
 #[derive(Debug)]
 pub struct MutexGuardWriter<'a, W>(MutexGuard<'a, W>);
 
@@ -734,7 +734,7 @@ impl<'a> MakeWriter<'a> for TestWriter {
 impl BoxMakeWriter {
     /// Constructs a `BoxMakeWriter` wrapping a type implementing [`MakeWriter`].
     ///
-    /// [`MakeWriter`]: trait.MakeWriter.html
+    /// [`MakeWriter`]: self::MakeWriter
     pub fn new<M>(make_writer: M) -> Self
     where
         M: for<'a> MakeWriter<'a> + Send + Sync + 'static,

--- a/tracing-subscriber/src/layer/context.rs
+++ b/tracing-subscriber/src/layer/context.rs
@@ -25,10 +25,10 @@ use crate::{filter::FilterId, registry::Registry};
 /// }
 /// ```
 ///
-/// [`Layer`]: super::layer::Layer
+/// [`Layer`]: super::Layer
 /// [`Subscriber`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html
-/// [stored data]: super::registry::SpanRef
-/// [`LookupSpan`]: super::registry::LookupSpan
+/// [stored data]: crate::registry::SpanRef
+/// [`LookupSpan`]: crate::registry::LookupSpan
 #[derive(Debug)]
 pub struct Context<'a, S> {
     subscriber: Option<&'a S>,
@@ -206,7 +206,7 @@ where
     ///     declaration</a> for details.
     /// </pre>
     ///
-    /// [stored data]: super::registry::SpanRef
+    /// [stored data]: crate::registry::SpanRef
     #[inline]
     pub fn span(&self, id: &span::Id) -> Option<registry::SpanRef<'_, S>>
     where
@@ -251,7 +251,7 @@ where
     ///     declaration</a> for details.
     /// </pre>
     ///
-    /// [stored data]: super::registry::SpanRef
+    /// [stored data]: crate::registry::SpanRef
     #[inline]
     pub fn lookup_current(&self) -> Option<registry::SpanRef<'_, S>>
     where
@@ -333,7 +333,7 @@ where
     ///     declaration</a> for details.
     /// </pre>
     ///
-    /// [stored data]: super::registry::SpanRef
+    /// [stored data]: crate::registry::SpanRef
     pub fn span_scope(&self, id: &span::Id) -> Option<registry::Scope<'_, S>>
     where
         S: for<'lookup> LookupSpan<'lookup>,
@@ -360,7 +360,7 @@ where
     ///     declaration</a> for details.
     /// </pre>
     ///
-    /// [stored data]: super::registry::SpanRef
+    /// [stored data]: crate::registry::SpanRef
     pub fn event_scope(&self, event: &Event<'_>) -> Option<registry::Scope<'_, S>>
     where
         S: for<'lookup> LookupSpan<'lookup>,

--- a/tracing-subscriber/src/layer/context.rs
+++ b/tracing-subscriber/src/layer/context.rs
@@ -25,10 +25,10 @@ use crate::{filter::FilterId, registry::Registry};
 /// }
 /// ```
 ///
-/// [`Layer`]: ../layer/trait.Layer.html
+/// [`Layer`]: super::layer::Layer
 /// [`Subscriber`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html
-/// [stored data]: ../registry/struct.SpanRef.html
-/// [`LookupSpan`]: "../registry/trait.LookupSpan.html
+/// [stored data]: super::registry::SpanRef
+/// [`LookupSpan`]: super::registry::LookupSpan
 #[derive(Debug)]
 pub struct Context<'a, S> {
     subscriber: Option<&'a S>,
@@ -206,7 +206,7 @@ where
     ///     declaration</a> for details.
     /// </pre>
     ///
-    /// [stored data]: ../registry/struct.SpanRef.html
+    /// [stored data]: super::registry::SpanRef
     #[inline]
     pub fn span(&self, id: &span::Id) -> Option<registry::SpanRef<'_, S>>
     where
@@ -251,7 +251,7 @@ where
     ///     declaration</a> for details.
     /// </pre>
     ///
-    /// [stored data]: ../registry/struct.SpanRef.html
+    /// [stored data]: super::registry::SpanRef
     #[inline]
     pub fn lookup_current(&self) -> Option<registry::SpanRef<'_, S>>
     where
@@ -333,7 +333,7 @@ where
     ///     declaration</a> for details.
     /// </pre>
     ///
-    /// [stored data]: ../registry/struct.SpanRef.html
+    /// [stored data]: super::registry::SpanRef
     pub fn span_scope(&self, id: &span::Id) -> Option<registry::Scope<'_, S>>
     where
         S: for<'lookup> LookupSpan<'lookup>,
@@ -360,7 +360,7 @@ where
     ///     declaration</a> for details.
     /// </pre>
     ///
-    /// [stored data]: ../registry/struct.SpanRef.html
+    /// [stored data]: super::registry::SpanRef
     pub fn event_scope(&self, event: &Event<'_>) -> Option<registry::Scope<'_, S>>
     where
         S: for<'lookup> LookupSpan<'lookup>,

--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -793,7 +793,7 @@ where
     /// with `Layer`s.
     ///
     /// [`Interest`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Interest.html
-    /// [`Context`]: ../struct.Context.html
+    /// [`Context`]: super::Context
     /// [`Subscriber::enabled`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html#method.enabled
     /// [`Layer::register_callsite`]: #method.register_callsite
     /// [`on_event`]: #method.on_event

--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -793,7 +793,7 @@ where
     /// with `Layer`s.
     ///
     /// [`Interest`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Interest.html
-    /// [`Context`]: super::Context
+    /// [`Context`]: Context
     /// [`Subscriber::enabled`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html#method.enabled
     /// [`Layer::register_callsite`]: #method.register_callsite
     /// [`on_event`]: #method.on_event

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -152,7 +152,7 @@
 //! [`tracing`]: https://docs.rs/tracing/latest/tracing/
 //! [`Subscriber`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/trait.Subscriber.html
 //! [`EnvFilter`]: self::filter::EnvFilter
-//! [`fmt`]: self::fmt
+//! [`fmt`]: mod@fmt
 //! [`tracing-log`]: https://crates.io/crates/tracing-log
 //! [`smallvec`]: https://crates.io/crates/smallvec
 //! [`env_logger` crate]: https://crates.io/crates/env_logger

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -151,8 +151,8 @@
 //!
 //! [`tracing`]: https://docs.rs/tracing/latest/tracing/
 //! [`Subscriber`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/trait.Subscriber.html
-//! [`EnvFilter`]: filter/struct.EnvFilter.html
-//! [`fmt`]: fmt/index.html
+//! [`EnvFilter`]: self::filter::EnvFilter
+//! [`fmt`]: self::fmt
 //! [`tracing-log`]: https://crates.io/crates/tracing-log
 //! [`smallvec`]: https://crates.io/crates/smallvec
 //! [`env_logger` crate]: https://crates.io/crates/env_logger

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -151,7 +151,7 @@
 //!
 //! [`tracing`]: https://docs.rs/tracing/latest/tracing/
 //! [`Subscriber`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/trait.Subscriber.html
-//! [`EnvFilter`]: self::filter::EnvFilter
+//! [`EnvFilter`]: filter::EnvFilter
 //! [`fmt`]: mod@fmt
 //! [`tracing-log`]: https://crates.io/crates/tracing-log
 //! [`smallvec`]: https://crates.io/crates/smallvec

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -104,7 +104,7 @@ pub trait LookupSpan<'a> {
     /// capable of performing more sophisiticated queries.
     /// </pre>
     ///
-    /// [`SpanData`]: self::SpanData
+    /// [`SpanData`]: SpanData
     fn span_data(&'a self, id: &Id) -> Option<Self::Data>;
 
     /// Returns a [`SpanRef`] for the span with the given `Id`, if it exists.
@@ -116,8 +116,8 @@ pub trait LookupSpan<'a> {
     /// rather than the [`span_data`] method; while _implementors_ of this trait
     /// should only implement `span_data`.
     ///
-    /// [`SpanRef`]: self::SpanRef
-    /// [`SpanData`]: self::SpanData
+    /// [`SpanRef`]: SpanRef
+    /// [`SpanData`]: SpanData
     /// [`span_data`]: #method.span_data
     fn span(&'a self, id: &Id) -> Option<SpanRef<'_, Self>>
     where
@@ -208,8 +208,8 @@ pub trait SpanData<'a> {
 /// provides additional methods for querying the registry based on values from
 /// the span.
 ///
-/// [span data]: self::SpanData
-/// [registry]: self::LookupSpan
+/// [span data]: SpanData
+/// [registry]: LookupSpan
 #[derive(Debug)]
 pub struct SpanRef<'a, R: LookupSpan<'a>> {
     registry: &'a R,

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -87,9 +87,9 @@ feature! {
 /// implement this trait; if they do, any [`Layer`]s wrapping them can look up
 /// metadata via the [`Context`] type's [`span()`] method.
 ///
-/// [`Layer`]: ../layer/trait.Layer.html
-/// [`Context`]: ../layer/struct.Context.html
-/// [`span()`]: ../layer/struct.Context.html#method.span
+/// [`Layer`]: super::layer::Layer
+/// [`Context`]: super::layer::Context
+/// [`span()`]: super::layer::Context::span
 pub trait LookupSpan<'a> {
     /// The type of span data stored in this registry.
     type Data: SpanData<'a>;
@@ -104,7 +104,7 @@ pub trait LookupSpan<'a> {
     /// capable of performing more sophisiticated queries.
     /// </pre>
     ///
-    /// [`SpanData`]: trait.SpanData.html
+    /// [`SpanData`]: self::SpanData
     fn span_data(&'a self, id: &Id) -> Option<Self::Data>;
 
     /// Returns a [`SpanRef`] for the span with the given `Id`, if it exists.
@@ -116,8 +116,8 @@ pub trait LookupSpan<'a> {
     /// rather than the [`span_data`] method; while _implementors_ of this trait
     /// should only implement `span_data`.
     ///
-    /// [`SpanRef`]: struct.SpanRef.html
-    /// [`SpanData`]: trait.SpanData.html
+    /// [`SpanRef`]: self::SpanRef
+    /// [`SpanData`]: self::SpanData
     /// [`span_data`]: #method.span_data
     fn span(&'a self, id: &Id) -> Option<SpanRef<'_, Self>>
     where
@@ -208,8 +208,8 @@ pub trait SpanData<'a> {
 /// provides additional methods for querying the registry based on values from
 /// the span.
 ///
-/// [span data]: trait.SpanData.html
-/// [registry]: trait.LookupSpan.html
+/// [span data]: self::SpanData
+/// [registry]: self::LookupSpan
 #[derive(Debug)]
 pub struct SpanRef<'a, R: LookupSpan<'a>> {
     registry: &'a R,

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -102,9 +102,9 @@ pub struct Registry {
 /// [`Layer`s], such as formatted fields, metrics, or distributed traces should
 /// be stored in the [extensions] typemap.
 ///
-/// [`Registry`]: self::Registry
+/// [`Registry`]: Registry
 /// [`Layer`s]: crate::layer::Layer
-/// [extensions]: self::Extensions
+/// [extensions]: Extensions
 #[cfg(feature = "registry")]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "registry", feature = "std"))))]
 #[derive(Debug)]
@@ -173,7 +173,7 @@ fn id_to_idx(id: &Id) -> usize {
 ///    greater than 0, `CloseGuard` decrements the counter by one and
 ///    _does not_ remove the span from the [`Registry`].
 ///
-/// [`Registry`]: self::Registry
+/// [`Registry`]: Registry
 pub(crate) struct CloseGuard<'a> {
     id: Id,
     registry: &'a Registry,
@@ -189,7 +189,7 @@ impl Registry {
     /// processed an `on_close` notification via the `CLOSE_COUNT` thread-local.
     /// For additional details, see [`CloseGuard`].
     ///
-    /// [`CloseGuard`]: self::CloseGuard
+    /// [`CloseGuard`]: CloseGuard
     pub(crate) fn start_close(&self, id: Id) -> CloseGuard<'_> {
         CLOSE_COUNT.with(|count| {
             let c = count.get();
@@ -216,7 +216,7 @@ thread_local! {
     /// track how many layers have processed the close.
     /// For additional details, see [`CloseGuard`].
     ///
-    /// [`CloseGuard`]: self::CloseGuard
+    /// [`CloseGuard`]: CloseGuard
     static CLOSE_COUNT: Cell<usize> = Cell::new(0);
 }
 

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -103,7 +103,7 @@ pub struct Registry {
 /// be stored in the [extensions] typemap.
 ///
 /// [`Registry`]: self::Registry
-/// [`Layer`s]: super::layer::Layer
+/// [`Layer`s]: crate::layer::Layer
 /// [extensions]: self::Extensions
 #[cfg(feature = "registry")]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "registry", feature = "std"))))]

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -102,9 +102,9 @@ pub struct Registry {
 /// [`Layer`s], such as formatted fields, metrics, or distributed traces should
 /// be stored in the [extensions] typemap.
 ///
-/// [`Registry`]: struct.Registry.html
-/// [`Layer`s]: ../layer/trait.Layer.html
-/// [extensions]: struct.Extensions.html
+/// [`Registry`]: self::Registry
+/// [`Layer`s]: super::layer::Layer
+/// [extensions]: self::Extensions
 #[cfg(feature = "registry")]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "registry", feature = "std"))))]
 #[derive(Debug)]
@@ -173,7 +173,7 @@ fn id_to_idx(id: &Id) -> usize {
 ///    greater than 0, `CloseGuard` decrements the counter by one and
 ///    _does not_ remove the span from the [`Registry`].
 ///
-/// [`Registry`]: ./struct.Registry.html
+/// [`Registry`]: self::Registry
 pub(crate) struct CloseGuard<'a> {
     id: Id,
     registry: &'a Registry,
@@ -189,7 +189,7 @@ impl Registry {
     /// processed an `on_close` notification via the `CLOSE_COUNT` thread-local.
     /// For additional details, see [`CloseGuard`].
     ///
-    /// [`CloseGuard`]: ./struct.CloseGuard.html
+    /// [`CloseGuard`]: self::CloseGuard
     pub(crate) fn start_close(&self, id: Id) -> CloseGuard<'_> {
         CLOSE_COUNT.with(|count| {
             let c = count.get();
@@ -216,7 +216,7 @@ thread_local! {
     /// track how many layers have processed the close.
     /// For additional details, see [`CloseGuard`].
     ///
-    /// [`CloseGuard`]: ./struct.CloseGuard.html
+    /// [`CloseGuard`]: self::CloseGuard
     static CLOSE_COUNT: Cell<usize> = Cell::new(0);
 }
 

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -52,7 +52,7 @@
 //! info!("This will be logged");
 //! ```
 //!
-//! [`Layer` type]: self::Layer
+//! [`Layer` type]: Layer
 //! [`Layer` trait]: super::layer::Layer
 use crate::layer;
 use crate::sync::RwLock;

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -52,8 +52,8 @@
 //! info!("This will be logged");
 //! ```
 //!
-//! [`Layer` type]: struct.Layer.html
-//! [`Layer` trait]: ../layer/trait.Layer.html
+//! [`Layer` type]: self::Layer
+//! [`Layer` trait]: super::layer::Layer
 use crate::layer;
 use crate::sync::RwLock;
 

--- a/tracing/src/dispatcher.rs
+++ b/tracing/src/dispatcher.rs
@@ -123,10 +123,10 @@
 //! instrumentation.
 //!
 //! [`Subscriber`]: crate::Subscriber
-//! [`with_default`]: self::with_default
-//! [`set_global_default`]: self::set_global_default
-//! [`get_default`]: self::get_default
-//! [`Dispatch`]: self::Dispatch
+//! [`with_default`]: with_default
+//! [`set_global_default`]: set_global_default
+//! [`get_default`]: get_default
+//! [`Dispatch`]: Dispatch
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use tracing_core::dispatcher::set_default;

--- a/tracing/src/dispatcher.rs
+++ b/tracing/src/dispatcher.rs
@@ -122,7 +122,7 @@
 //! currently default `Dispatch`. This is used primarily by `tracing`
 //! instrumentation.
 //!
-//! [`Subscriber`]: self::Subscriber
+//! [`Subscriber`]: crate::Subscriber
 //! [`with_default`]: self::with_default
 //! [`set_global_default`]: self::set_global_default
 //! [`get_default`]: self::get_default

--- a/tracing/src/dispatcher.rs
+++ b/tracing/src/dispatcher.rs
@@ -122,11 +122,11 @@
 //! currently default `Dispatch`. This is used primarily by `tracing`
 //! instrumentation.
 //!
-//! [`Subscriber`]: trait.Subscriber.html
-//! [`with_default`]: fn.with_default.html
-//! [`set_global_default`]: fn.set_global_default.html
-//! [`get_default`]: fn.get_default.html
-//! [`Dispatch`]: struct.Dispatch.html
+//! [`Subscriber`]: self::Subscriber
+//! [`with_default`]: self::with_default
+//! [`set_global_default`]: self::set_global_default
+//! [`get_default`]: self::get_default
+//! [`Dispatch`]: self::Dispatch
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use tracing_core::dispatcher::set_default;

--- a/tracing/src/level_filters.rs
+++ b/tracing/src/level_filters.rs
@@ -62,7 +62,7 @@ pub use tracing_core::{metadata::ParseLevelFilterError, LevelFilter};
 /// `Span` constructors should compare the level against this value to
 /// determine if those spans or events are enabled.
 ///
-/// [module-level documentation]: ../index.html#compile-time-filters
+/// [module-level documentation]: super#compile-time-filters
 pub const STATIC_MAX_LEVEL: LevelFilter = MAX_LEVEL;
 
 cfg_if::cfg_if! {

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -434,13 +434,13 @@
 //! Specifying a formatted message in this manner does not allocate by default.
 //!
 //! [struct initializers]: https://doc.rust-lang.org/book/ch05-01-defining-structs.html#using-the-field-init-shorthand-when-variables-and-fields-have-the-same-name
-//! [target]: struct.Metadata.html#method.target
-//! [parent span]: span/struct.Attributes.html#method.parent
-//! [determined contextually]: span/struct.Attributes.html#method.is_contextual
+//! [target]: self::Metadata::target
+//! [parent span]: self::span::Attributes::parent
+//! [determined contextually]: self::span::Attributes::is_contextual
 //! [`fmt::Debug`]: https://doc.rust-lang.org/std/fmt/trait.Debug.html
 //! [`fmt::Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
 //! [fmt]: https://doc.rust-lang.org/std/fmt/#usage
-//! [`Empty`]: field/struct.Empty.html
+//! [`Empty`]: self::field::Empty
 //!
 //! ### Shorthand Macros
 //!
@@ -454,19 +454,19 @@
 //! These are intended both as a shorthand, and for compatibility with the [`log`]
 //! crate (see the next section).
 //!
-//! [`span!`]: macro.span.html
-//! [`event!`]: macro.event.html
-//! [`trace!`]: macro.trace.html
-//! [`debug!`]: macro.debug.html
-//! [`info!`]: macro.info.html
-//! [`warn!`]: macro.warn.html
-//! [`error!`]: macro.error.html
-//! [`trace_span!`]: macro.trace_span.html
-//! [`debug_span!`]: macro.debug_span.html
-//! [`info_span!`]: macro.info_span.html
-//! [`warn_span!`]: macro.warn_span.html
-//! [`error_span!`]: macro.error_span.html
-//! [`Level`]: struct.Level.html
+//! [`span!`]: self::span
+//! [`event!`]: self::event
+//! [`trace!`]: self::trace
+//! [`debug!`]: self::debug
+//! [`info!`]: self::info
+//! [`warn!`]: self::warn
+//! [`error!`]: self::error
+//! [`trace_span!`]: self::trace_span
+//! [`debug_span!`]: self::debug_span
+//! [`info_span!`]: self::info_span
+//! [`warn_span!`]: self::warn_span
+//! [`error_span!`]: self::error_span
+//! [`Level`]: self::Level
 //!
 //! ### For `log` Users
 //!
@@ -870,14 +870,14 @@
 //! [spans]: mod@span
 //! [`Span`]: span::Span
 //! [`in_scope`]: span::Span::in_scope
-//! [event]: Event
-//! [events]: Event
+//! [event]: self::Event
+//! [events]: self::Event
 //! [`Subscriber`]: subscriber::Subscriber
 //! [Subscriber::event]: subscriber::Subscriber::event
 //! [`enter`]: subscriber::Subscriber::enter
 //! [`exit`]: subscriber::Subscriber::exit
 //! [`enabled`]: subscriber::Subscriber::enabled
-//! [metadata]: Metadata
+//! [metadata]: self::Metadata
 //! [`field::display`]: field::display
 //! [`field::debug`]: field::debug
 //! [`set_global_default`]: subscriber::set_global_default
@@ -890,7 +890,7 @@
 //! [`tracing-appender`]: https://crates.io/crates/tracing-appender
 //! [`env_logger`]: https://crates.io/crates/env_logger
 //! [`FmtSubscriber`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Subscriber.html
-//! [static verbosity level]: level_filters/index.html#compile-time-filters
+//! [static verbosity level]: self::level_filters#compile-time-filters
 //! [instrument]: https://docs.rs/tracing-attributes/latest/tracing_attributes/attr.instrument.html
 //! [flags]: #crate-feature-flags
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -454,18 +454,18 @@
 //! These are intended both as a shorthand, and for compatibility with the [`log`]
 //! crate (see the next section).
 //!
-//! [`span!`]: self::span
-//! [`event!`]: self::event
-//! [`trace!`]: self::trace
-//! [`debug!`]: self::debug
-//! [`info!`]: self::info
-//! [`warn!`]: self::warn
-//! [`error!`]: self::error
-//! [`trace_span!`]: self::trace_span
-//! [`debug_span!`]: self::debug_span
-//! [`info_span!`]: self::info_span
-//! [`warn_span!`]: self::warn_span
-//! [`error_span!`]: self::error_span
+//! [`span!`]: self::span!
+//! [`event!`]: self::event!
+//! [`trace!`]: self::trace!
+//! [`debug!`]: self::debug!
+//! [`info!`]: self::info!
+//! [`warn!`]: self::warn!
+//! [`error!`]: self::error!
+//! [`trace_span!`]: self::trace_span!
+//! [`debug_span!`]: self::debug_span!
+//! [`info_span!`]: self::info_span!
+//! [`warn_span!`]: self::warn_span!
+//! [`error_span!`]: self::error_span!
 //! [`Level`]: self::Level
 //!
 //! ### For `log` Users

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -434,13 +434,13 @@
 //! Specifying a formatted message in this manner does not allocate by default.
 //!
 //! [struct initializers]: https://doc.rust-lang.org/book/ch05-01-defining-structs.html#using-the-field-init-shorthand-when-variables-and-fields-have-the-same-name
-//! [target]: self::Metadata::target
-//! [parent span]: self::span::Attributes::parent
-//! [determined contextually]: self::span::Attributes::is_contextual
+//! [target]: Metadata::target
+//! [parent span]: span::Attributes::parent
+//! [determined contextually]: span::Attributes::is_contextual
 //! [`fmt::Debug`]: https://doc.rust-lang.org/std/fmt/trait.Debug.html
 //! [`fmt::Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
 //! [fmt]: https://doc.rust-lang.org/std/fmt/#usage
-//! [`Empty`]: self::field::Empty
+//! [`Empty`]: field::Empty
 //!
 //! ### Shorthand Macros
 //!
@@ -454,19 +454,19 @@
 //! These are intended both as a shorthand, and for compatibility with the [`log`]
 //! crate (see the next section).
 //!
-//! [`span!`]: self::span!
-//! [`event!`]: self::event!
-//! [`trace!`]: self::trace!
-//! [`debug!`]: self::debug!
-//! [`info!`]: self::info!
-//! [`warn!`]: self::warn!
-//! [`error!`]: self::error!
-//! [`trace_span!`]: self::trace_span!
-//! [`debug_span!`]: self::debug_span!
-//! [`info_span!`]: self::info_span!
-//! [`warn_span!`]: self::warn_span!
-//! [`error_span!`]: self::error_span!
-//! [`Level`]: self::Level
+//! [`span!`]: span!
+//! [`event!`]: event!
+//! [`trace!`]: trace!
+//! [`debug!`]: debug!
+//! [`info!`]: info!
+//! [`warn!`]: warn!
+//! [`error!`]: error!
+//! [`trace_span!`]: trace_span!
+//! [`debug_span!`]: debug_span!
+//! [`info_span!`]: info_span!
+//! [`warn_span!`]: warn_span!
+//! [`error_span!`]: error_span!
+//! [`Level`]: Level
 //!
 //! ### For `log` Users
 //!
@@ -870,14 +870,14 @@
 //! [spans]: mod@span
 //! [`Span`]: span::Span
 //! [`in_scope`]: span::Span::in_scope
-//! [event]: self::Event
-//! [events]: self::Event
+//! [event]: Event
+//! [events]: Event
 //! [`Subscriber`]: subscriber::Subscriber
 //! [Subscriber::event]: subscriber::Subscriber::event
 //! [`enter`]: subscriber::Subscriber::enter
 //! [`exit`]: subscriber::Subscriber::exit
 //! [`enabled`]: subscriber::Subscriber::enabled
-//! [metadata]: self::Metadata
+//! [metadata]: Metadata
 //! [`field::display`]: field::display
 //! [`field::debug`]: field::debug
 //! [`set_global_default`]: subscriber::set_global_default
@@ -890,7 +890,7 @@
 //! [`tracing-appender`]: https://crates.io/crates/tracing-appender
 //! [`env_logger`]: https://crates.io/crates/env_logger
 //! [`FmtSubscriber`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Subscriber.html
-//! [static verbosity level]: self::level_filters#compile-time-filters
+//! [static verbosity level]: level_filters#compile-time-filters
 //! [instrument]: https://docs.rs/tracing-attributes/latest/tracing_attributes/attr.instrument.html
 //! [flags]: #crate-feature-flags
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -3,7 +3,7 @@
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: self#using-the-macros
+/// [lib]: crate#using-the-macros
 ///
 /// # Examples
 ///
@@ -138,10 +138,10 @@ macro_rules! span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: self#using-the-macros
-/// [attributes]: self#configuring-attributes
-/// [Fields]: self#recording-fields
-/// [`span!`]: self::span
+/// [lib]: crate#using-the-macros
+/// [attributes]: crate#configuring-attributes
+/// [Fields]: crate#recording-fields
+/// [`span!`]: crate::span!
 ///
 /// # Examples
 ///
@@ -219,10 +219,10 @@ macro_rules! trace_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: self#using-the-macros
-/// [attributes]: self#configuring-attributes
-/// [Fields]: self#recording-fields
-/// [`span!`]: self::span
+/// [lib]: crate#using-the-macros
+/// [attributes]: crate#configuring-attributes
+/// [Fields]: crate#recording-fields
+/// [`span!`]: crate::span!
 ///
 /// # Examples
 ///
@@ -300,10 +300,10 @@ macro_rules! debug_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: self#using-the-macros
-/// [attributes]: self#configuring-attributes
-/// [Fields]: self#recording-fields
-/// [`span!`]: self::span
+/// [lib]: crate#using-the-macros
+/// [attributes]: crate#configuring-attributes
+/// [Fields]: crate#recording-fields
+/// [`span!`]: crate::span!
 ///
 /// # Examples
 ///
@@ -381,10 +381,10 @@ macro_rules! info_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: self#using-the-macros
-/// [attributes]: self#configuring-attributes
-/// [Fields]: self#recording-fields
-/// [`span!`]: self::span
+/// [lib]: crate#using-the-macros
+/// [attributes]: crate#configuring-attributes
+/// [Fields]: crate#recording-fields
+/// [`span!`]: crate::span!
 ///
 /// # Examples
 ///
@@ -461,10 +461,10 @@ macro_rules! warn_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: self#using-the-macros
-/// [attributes]: self#configuring-attributes
-/// [Fields]: self#recording-fields
-/// [`span!`]: self::span
+/// [lib]: crate#using-the-macros
+/// [attributes]: crate#configuring-attributes
+/// [Fields]: crate#recording-fields
+/// [`span!`]: crate::span!
 ///
 /// # Examples
 ///
@@ -543,7 +543,7 @@ macro_rules! error_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: self#using-the-macros
+/// [lib]: crate#using-the-macros
 ///
 /// # Examples
 ///
@@ -1049,8 +1049,8 @@ macro_rules! enabled {
 /// documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [`event!`]: self::event
-/// [lib]: self#using-the-macros
+/// [`event!`]: crate::event!
+/// [lib]: crate#using-the-macros
 ///
 /// # Examples
 ///
@@ -1249,8 +1249,8 @@ macro_rules! trace {
 /// documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [`event!`]: self::event
-/// [lib]: self#using-the-macros
+/// [`event!`]: crate::event!
+/// [lib]: crate#using-the-macros
 ///
 /// # Examples
 ///
@@ -1450,8 +1450,8 @@ macro_rules! debug {
 /// documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [`event!`]: self::event
-/// [lib]: self#using-the-macros
+/// [`event!`]: crate::event!
+/// [lib]: crate#using-the-macros
 ///
 /// # Examples
 ///
@@ -1662,8 +1662,8 @@ macro_rules! info {
 /// documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [`event!`]: self::event
-/// [lib]: self#using-the-macros
+/// [`event!`]: crate::event!
+/// [lib]: crate#using-the-macros
 ///
 /// # Examples
 ///
@@ -1867,8 +1867,8 @@ macro_rules! warn {
 /// documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [`event!`]: self::event
-/// [lib]: self#using-the-macros
+/// [`event!`]: crate::event!
+/// [lib]: crate#using-the-macros
 ///
 /// # Examples
 ///

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -3,7 +3,7 @@
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: index.html#using-the-macros
+/// [lib]: self#using-the-macros
 ///
 /// # Examples
 ///
@@ -138,10 +138,10 @@ macro_rules! span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: index.html#using-the-macros
-/// [attributes]: index.html#configuring-attributes
-/// [Fields]: index.html#recording-fields
-/// [`span!`]: macro.span.html
+/// [lib]: self#using-the-macros
+/// [attributes]: self#configuring-attributes
+/// [Fields]: self#recording-fields
+/// [`span!`]: self::span
 ///
 /// # Examples
 ///
@@ -219,10 +219,10 @@ macro_rules! trace_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: index.html#using-the-macros
-/// [attributes]: index.html#configuring-attributes
-/// [Fields]: index.html#recording-fields
-/// [`span!`]: macro.span.html
+/// [lib]: self#using-the-macros
+/// [attributes]: self#configuring-attributes
+/// [Fields]: self#recording-fields
+/// [`span!`]: self::span
 ///
 /// # Examples
 ///
@@ -300,10 +300,10 @@ macro_rules! debug_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: index.html#using-the-macros
-/// [attributes]: index.html#configuring-attributes
-/// [Fields]: index.html#recording-fields
-/// [`span!`]: macro.span.html
+/// [lib]: self#using-the-macros
+/// [attributes]: self#configuring-attributes
+/// [Fields]: self#recording-fields
+/// [`span!`]: self::span
 ///
 /// # Examples
 ///
@@ -381,10 +381,10 @@ macro_rules! info_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: index.html#using-the-macros
-/// [attributes]: index.html#configuring-attributes
-/// [Fields]: index.html#recording-fields
-/// [`span!`]: macro.span.html
+/// [lib]: self#using-the-macros
+/// [attributes]: self#configuring-attributes
+/// [Fields]: self#recording-fields
+/// [`span!`]: self::span
 ///
 /// # Examples
 ///
@@ -461,10 +461,10 @@ macro_rules! warn_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: index.html#using-the-macros
-/// [attributes]: index.html#configuring-attributes
-/// [Fields]: index.html#recording-fields
-/// [`span!`]: macro.span.html
+/// [lib]: self#using-the-macros
+/// [attributes]: self#configuring-attributes
+/// [Fields]: self#recording-fields
+/// [`span!`]: self::span
 ///
 /// # Examples
 ///
@@ -543,7 +543,7 @@ macro_rules! error_span {
 /// See [the top-level documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [lib]: index.html#using-the-macros
+/// [lib]: self#using-the-macros
 ///
 /// # Examples
 ///
@@ -1049,8 +1049,8 @@ macro_rules! enabled {
 /// documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [`event!`]: macro.event.html
-/// [lib]: index.html#using-the-macros
+/// [`event!`]: self::event
+/// [lib]: self#using-the-macros
 ///
 /// # Examples
 ///
@@ -1249,8 +1249,8 @@ macro_rules! trace {
 /// documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [`event!`]: macro.event.html
-/// [lib]: index.html#using-the-macros
+/// [`event!`]: self::event
+/// [lib]: self#using-the-macros
 ///
 /// # Examples
 ///
@@ -1450,8 +1450,8 @@ macro_rules! debug {
 /// documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [`event!`]: macro.event.html
-/// [lib]: index.html#using-the-macros
+/// [`event!`]: self::event
+/// [lib]: self#using-the-macros
 ///
 /// # Examples
 ///
@@ -1662,8 +1662,8 @@ macro_rules! info {
 /// documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [`event!`]: macro.event.html
-/// [lib]: index.html#using-the-macros
+/// [`event!`]: self::event
+/// [lib]: self#using-the-macros
 ///
 /// # Examples
 ///
@@ -1867,8 +1867,8 @@ macro_rules! warn {
 /// documentation][lib] for details on the syntax accepted by
 /// this macro.
 ///
-/// [`event!`]: macro.event.html
-/// [lib]: index.html#using-the-macros
+/// [`event!`]: self::event
+/// [lib]: self#using-the-macros
 ///
 /// # Examples
 ///

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -429,7 +429,7 @@ impl Span {
     /// After the span is constructed, [field values] and/or [`follows_from`]
     /// annotations may be added to it.
     ///
-    /// [metadata]: super::metadata
+    /// [metadata]: super::Metadata
     /// [`Subscriber`]: super::subscriber::Subscriber
     /// [field values]: super::field::ValueSet
     /// [`follows_from`]: super::Span::follows_from
@@ -454,7 +454,7 @@ impl Span {
     /// After the span is constructed, [field values] and/or [`follows_from`]
     /// annotations may be added to it.
     ///
-    /// [metadata]: super::metadata
+    /// [metadata]: super::Metadata
     /// [field values]: super::field::ValueSet
     /// [`follows_from`]: super::Span::follows_from
     pub fn new_root(meta: &'static Metadata<'static>, values: &field::ValueSet<'_>) -> Span {
@@ -478,7 +478,7 @@ impl Span {
     /// After the span is constructed, [field values] and/or [`follows_from`]
     /// annotations may be added to it.
     ///
-    /// [metadata]: super::metadata
+    /// [metadata]: super::Metadata
     /// [field values]: super::field::ValueSet
     /// [`follows_from`]: super::Span::follows_from
     pub fn child_of(
@@ -544,7 +544,8 @@ impl Span {
     /// that the thread from which this function is called is not currently
     /// inside a span, the returned span will be disabled.
     ///
-    /// [considered by the `Subscriber`]: super::subscriber::Subscriber::current
+    /// [considered by the `Subscriber`]:
+    ///     super::subscriber::Subscriber::current_span
     pub fn current() -> Span {
         dispatcher::get_default(|dispatch| {
             if let Some((id, meta)) = dispatch.current_span().into_inner() {
@@ -714,7 +715,7 @@ impl Span {
     /// [syntax]: https://rust-lang.github.io/async-book/01_getting_started/04_async_await_primer.html
     /// [`Span::in_scope`]: #method.in_scope
     /// [instrument]: https://docs.rs/tracing/latest/tracing/trait.Instrument.html
-    /// [attr]: super::super::instrument
+    /// [attr]: macro@crate::instrument
     ///
     /// # Examples
     ///

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -315,7 +315,7 @@
 //! [`entered`]: Span::entered()
 //! [`in_scope`]: Span::in_scope()
 //! [`follows_from`]: Span::follows_from()
-//! [guard]: self::Entered
+//! [guard]: Entered
 //! [parent]: #span-relationships
 pub use tracing_core::span::{Attributes, Id, Record};
 

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -24,7 +24,7 @@
 //! - A string literal providing the span's name.
 //! - Finally, between zero and 32 arbitrary key/value fields.
 //!
-//! [`target`]: ../struct.Metadata.html#method.target
+//! [`target`]: super::Metadata::target
 //!
 //! For example:
 //! ```rust
@@ -315,7 +315,7 @@
 //! [`entered`]: Span::entered()
 //! [`in_scope`]: Span::in_scope()
 //! [`follows_from`]: Span::follows_from()
-//! [guard]: Entered
+//! [guard]: self::Entered
 //! [parent]: #span-relationships
 pub use tracing_core::span::{Attributes, Id, Record};
 
@@ -381,7 +381,7 @@ pub(crate) struct Inner {
 ///
 /// This is returned by the [`Span::enter`] function.
 ///
-/// [`Span::enter`]: ../struct.Span.html#method.enter
+/// [`Span::enter`]: super::Span::enter
 #[derive(Debug)]
 #[must_use = "once a span has been entered, it should be exited"]
 pub struct Entered<'a> {
@@ -429,10 +429,10 @@ impl Span {
     /// After the span is constructed, [field values] and/or [`follows_from`]
     /// annotations may be added to it.
     ///
-    /// [metadata]: ../metadata
-    /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-    /// [field values]: ../field/struct.ValueSet.html
-    /// [`follows_from`]: ../struct.Span.html#method.follows_from
+    /// [metadata]: super::metadata
+    /// [`Subscriber`]: super::subscriber::Subscriber
+    /// [field values]: super::field::ValueSet
+    /// [`follows_from`]: super::Span::follows_from
     pub fn new(meta: &'static Metadata<'static>, values: &field::ValueSet<'_>) -> Span {
         dispatcher::get_default(|dispatch| Self::new_with(meta, values, dispatch))
     }
@@ -454,9 +454,9 @@ impl Span {
     /// After the span is constructed, [field values] and/or [`follows_from`]
     /// annotations may be added to it.
     ///
-    /// [metadata]: ../metadata
-    /// [field values]: ../field/struct.ValueSet.html
-    /// [`follows_from`]: ../struct.Span.html#method.follows_from
+    /// [metadata]: super::metadata
+    /// [field values]: super::field::ValueSet
+    /// [`follows_from`]: super::Span::follows_from
     pub fn new_root(meta: &'static Metadata<'static>, values: &field::ValueSet<'_>) -> Span {
         dispatcher::get_default(|dispatch| Self::new_root_with(meta, values, dispatch))
     }
@@ -478,9 +478,9 @@ impl Span {
     /// After the span is constructed, [field values] and/or [`follows_from`]
     /// annotations may be added to it.
     ///
-    /// [metadata]: ../metadata
-    /// [field values]: ../field/struct.ValueSet.html
-    /// [`follows_from`]: ../struct.Span.html#method.follows_from
+    /// [metadata]: super::metadata
+    /// [field values]: super::field::ValueSet
+    /// [`follows_from`]: super::Span::follows_from
     pub fn child_of(
         parent: impl Into<Option<Id>>,
         meta: &'static Metadata<'static>,
@@ -544,7 +544,7 @@ impl Span {
     /// that the thread from which this function is called is not currently
     /// inside a span, the returned span will be disabled.
     ///
-    /// [considered by the `Subscriber`]: ../subscriber/trait.Subscriber.html#method.current
+    /// [considered by the `Subscriber`]: super::subscriber::Subscriber::current
     pub fn current() -> Span {
         dispatcher::get_default(|dispatch| {
             if let Some((id, meta)) = dispatch.current_span().into_inner() {
@@ -714,7 +714,7 @@ impl Span {
     /// [syntax]: https://rust-lang.github.io/async-book/01_getting_started/04_async_await_primer.html
     /// [`Span::in_scope`]: #method.in_scope
     /// [instrument]: https://docs.rs/tracing/latest/tracing/trait.Instrument.html
-    /// [attr]: ../../attr.instrument.html
+    /// [attr]: super::super::instrument
     ///
     /// # Examples
     ///
@@ -1183,8 +1183,8 @@ impl Span {
     /// span.record("parting", &"you will be remembered");
     /// ```
     ///
-    /// [`field::Empty`]: ../field/struct.Empty.html
-    /// [`Metadata`]: ../struct.Metadata.html
+    /// [`field::Empty`]: super::field::Empty
+    /// [`Metadata`]: super::Metadata
     pub fn record<Q: ?Sized, V>(&self, field: &Q, value: &V) -> &Self
     where
         Q: field::AsField,

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -1097,7 +1097,7 @@ impl Span {
         f()
     }
 
-    /// Returns a [`Field`](../field/struct.Field.html) for the field with the
+    /// Returns a [`Field`][super::field::Field] for the field with the
     /// given `name`, if one exists,
     pub fn field<Q: ?Sized>(&self, field: &Q) -> Option<field::Field>
     where
@@ -1107,7 +1107,7 @@ impl Span {
     }
 
     /// Returns true if this `Span` has a field for the given
-    /// [`Field`](../field/struct.Field.html) or field name.
+    /// [`Field`][super::field::Field] or field name.
     #[inline]
     pub fn has_field<Q: ?Sized>(&self, field: &Q) -> bool
     where

--- a/tracing/src/subscriber.rs
+++ b/tracing/src/subscriber.rs
@@ -12,9 +12,9 @@ pub use tracing_core::dispatcher::DefaultGuard;
 /// executing, new spans or events are dispatched to the subscriber that
 /// tagged that span, instead.
 ///
-/// [`Span`]: ../span/struct.Span.html
-/// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-/// [`Event`]: :../event/struct.Event.html
+/// [`Span`]: super::span::Span
+/// [`Subscriber`]: super::subscriber::Subscriber
+/// [`Event`]: super::event::Event
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn with_default<T, S>(subscriber: S, f: impl FnOnce() -> T) -> T
@@ -33,9 +33,9 @@ where
 /// Note: Libraries should *NOT* call `set_global_default()`! That will cause conflicts when
 /// executables try to set them later.
 ///
-/// [span]: ../span/index.html
-/// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-/// [`Event`]: ../event/struct.Event.html
+/// [span]: super::span
+/// [`Subscriber`]: super::subscriber::Subscriber
+/// [`Event`]: super::event::Event
 pub fn set_global_default<S>(subscriber: S) -> Result<(), SetGlobalDefaultError>
 where
     S: Subscriber + Send + Sync + 'static,
@@ -51,10 +51,10 @@ where
 /// executing, new spans or events are dispatched to the subscriber that
 /// tagged that span, instead.
 ///
-/// [`Span`]: ../span/struct.Span.html
-/// [`Subscriber`]: ../subscriber/trait.Subscriber.html
-/// [`Event`]: :../event/struct.Event.html
-/// [`DefaultGuard`]: ../dispatcher/struct.DefaultGuard.html
+/// [`Span`]: super::span::Span
+/// [`Subscriber`]: super::subscriber::Subscriber
+/// [`Event`]: super::event::Event
+/// [`DefaultGuard`]: super::dispatcher::DefaultGuard
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[must_use = "Dropping the guard unregisters the subscriber."]


### PR DESCRIPTION
## Motivation

#940, I guess. I kept running into the odd broken link in the docs and eventually realized it's because a lot of stuff is reexported in parent modules and so the file path based relative links couldn't possibly work in all contexts. Looks like master already underwent this treatment but I suspect this is easier than backporting.

## Solution

Intra-doc links seem pretty good.

I started with

```
        find -name \*.rs -exec sed -i -e '
            s@\(//. \[[^]]*\]:\s\+\)[:"]\?\.\./\w\+\.\(\w\+\)\.html@\1super::\2@;
            s@\(//. \[[^]]*\]:\s\+\)[:"]\?\.\./\(\w\+\)/\w\+\.\(\w\+\)\.html@\1super::\2::\3@;
            s@\(//. \[[^]]*\]:\s\+\)[:"]\?\.\./\.\./\w\+\.\(\w\+\)\.html@\1super::super::\2@;
            s@\(//. \[[^]]*\]:\s\+\)[:"]\?\.\./\.\./\(\w\+\)/\w\+\.\(\w\+\)\.html@\1super::super::\2::\3@;
            s@\(//. \[[^]]*\]:\s\+\)[:"]\?\.\./\(\w\+\)/index\.html@\1super::\2@;
            s@\(//. \[[^]]*\]:\s\+\)[:"]\?\.\./index\.html@\1super@;
            s@\(//. \[[^]]*\]:\s\+\)[:"]\?\.\./\(\w\+\)/\?$@\1super::\2@;
    
            s@\(//. \[[^]]*\]:\s\+\)[:"]\?\./\w\+\.\(\w\+\)\.html@\1self::\2@;
            s@\(//. \[[^]]*\]:\s\+\)[:"]\?\./\(\w\+\)/\w\+\.\(\w\+\)\.html@\1self::\2::\3@;
            s@\(//. \[[^]]*\]:\s\+\)[:"]\?\./\(\w\+\)/index\.html@\1self::\2@;
            s@\(//. \[[^]]*\]:\s\+\)[:"]\?\./index\.html@\1self@;
            s@\(//. \[[^]]*\]:\s\+\)[:"]\?\./\(\w\+\)/\?$@\1self::\2@;
    
            s@\(//. \[[^]]*\]:\s\+\)[:"]\?\w\+\.\(\w\+\)\.html@\1self::\2@;
            s@\(//. \[[^]]*\]:\s\+\)[:"]\?\(\w\+\)/\w\+\.\(\w\+\)\.html@\1self::\2::\3@;
            s@\(//. \[[^]]*\]:\s\+\)[:"]\?\(\w\+\)/index\.html@\1self::\2@;
            s@\(//. \[[^]]*\]:\s\+\)[:"]\?index\.html@\1self@;
            s@\(//. \[[^]]*\]:\s\+\)[:"]\?\(\w\+\)/\?$@\1self::\2@;
    
            s@\(//. \[[^]]*\]:\s\+[A-Za-z_0-9:]\+\)#method\.\(\w\+\)@\1::\2@;
        ' {} +
```
and then removed redundant `self::`s when I realized you don't actually need a `::` in the links, and fixed stuff up by hand as I ran into errors from

```
x='--cfg docsrs --cfg tracing_unstable'; RUSTFLAGS=$x RUSTDOCFLAGS=$x cargo doc --all-features
```

I hope that's roughly how the docs are supposed to work.

I understand this is a relatively big unsolicited change in that it touches a whole lot of files (definitely went further than I originally intended), I'm happy to revise or split or reduce scope of this PR as desired.