### PR TITLE
tracing: fix the "log" feature making async block futures `!Send`

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1090,6 +1090,25 @@ pub mod __macro_support {
         pub fn disabled_span(&self) -> crate::Span {
             crate::Span::none()
         }
+
+        #[cfg(feature = "log")]
+        pub fn log(
+            &self,
+            logger: &'static dyn log::Log,
+            log_meta: log::Metadata<'_>,
+            values: &ValueSet<'_>,
+        ) {
+            let meta = self.metadata();
+            logger.log(
+                &log::Record::builder()
+                    .file(meta.file())
+                    .module_path(meta.module_path())
+                    .line(meta.line())
+                    .metadata(log_meta)
+                    .args(format_args!("{}", LogValueSet(values)))
+                    .build(),
+            );
+        }
     }
 
     impl Callsite for MacroCallsite {

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1096,8 +1096,57 @@ pub mod __macro_support {
             &self,
             logger: &'static dyn log::Log,
             log_meta: log::Metadata<'_>,
-            values: &ValueSet<'_>,
+            values: &tracing_core::ValueSet<'_>,
         ) {
+            use tracing_core::field::{Field, ValueSet, Visit};
+
+            /// Utility to format [`ValueSet`] for logging.
+            struct LogValueSet<'a>(&'a ValueSet<'a>);
+
+            impl<'a> fmt::Display for LogValueSet<'a> {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    let mut visit = LogVisitor {
+                        f,
+                        is_first: true,
+                        result: Ok(()),
+                    };
+                    self.0.record(&mut visit);
+                    visit.result
+                }
+            }
+
+            struct LogVisitor<'a, 'b> {
+                f: &'a mut fmt::Formatter<'b>,
+                is_first: bool,
+                result: fmt::Result,
+            }
+
+            impl Visit for LogVisitor<'_, '_> {
+                fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+                    let res = if self.is_first {
+                        self.is_first = false;
+                        if field.name() == "message" {
+                            write!(self.f, "{:?}", value)
+                        } else {
+                            write!(self.f, "{}={:?}", field.name(), value)
+                        }
+                    } else {
+                        write!(self.f, " {}={:?}", field.name(), value)
+                    };
+                    if let Err(err) = res {
+                        self.result = self.result.and(Err(err));
+                    }
+                }
+
+                fn record_str(&mut self, field: &Field, value: &str) {
+                    if field.name() == "message" {
+                        self.record_debug(field, &format_args!("{}", value))
+                    } else {
+                        self.record_debug(field, &value)
+                    }
+                }
+            }
+
             let meta = self.metadata();
             logger.log(
                 &log::Record::builder()
@@ -1135,68 +1184,6 @@ pub mod __macro_support {
                 .field("register", &self.register)
                 .field("registration", &self.registration)
                 .finish()
-        }
-    }
-
-    #[cfg(feature = "log")]
-    use tracing_core::field::{Field, ValueSet, Visit};
-
-    /// Utility to format [`ValueSet`] for logging, used by macro-generated code.
-    ///
-    /// /!\ WARNING: This is *not* a stable API! /!\
-    /// This type, and all code contained in the `__macro_support` module, is
-    /// a *private* API of `tracing`. It is exposed publicly because it is used
-    /// by the `tracing` macros, but it is not part of the stable versioned API.
-    /// Breaking changes to this module may occur in small-numbered versions
-    /// without warning.
-    #[cfg(feature = "log")]
-    #[allow(missing_debug_implementations)]
-    pub struct LogValueSet<'a>(pub &'a ValueSet<'a>);
-
-    #[cfg(feature = "log")]
-    impl<'a> fmt::Display for LogValueSet<'a> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            let mut visit = LogVisitor {
-                f,
-                is_first: true,
-                result: Ok(()),
-            };
-            self.0.record(&mut visit);
-            visit.result
-        }
-    }
-
-    #[cfg(feature = "log")]
-    struct LogVisitor<'a, 'b> {
-        f: &'a mut fmt::Formatter<'b>,
-        is_first: bool,
-        result: fmt::Result,
-    }
-
-    #[cfg(feature = "log")]
-    impl Visit for LogVisitor<'_, '_> {
-        fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-            let res = if self.is_first {
-                self.is_first = false;
-                if field.name() == "message" {
-                    write!(self.f, "{:?}", value)
-                } else {
-                    write!(self.f, "{}={:?}", field.name(), value)
-                }
-            } else {
-                write!(self.f, " {}={:?}", field.name(), value)
-            };
-            if let Err(err) = res {
-                self.result = self.result.and(Err(err));
-            }
-        }
-
-        fn record_str(&mut self, field: &Field, value: &str) {
-            if field.name() == "message" {
-                self.record_debug(field, &format_args!("{}", value))
-            } else {
-                self.record_debug(field, &value)
-            }
         }
     }
 }

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1101,7 +1101,13 @@ pub mod __macro_support {
                     .module_path(meta.module_path())
                     .line(meta.line())
                     .metadata(log_meta)
-                    .args(format_args!("{}", crate::log::LogValueSet(values)))
+                    .args(format_args!(
+                        "{}",
+                        crate::log::LogValueSet {
+                            values,
+                            is_first: true
+                        }
+                    ))
                     .build(),
             );
         }
@@ -1143,7 +1149,10 @@ pub mod log {
     use tracing_core::field::{Field, ValueSet, Visit};
 
     /// Utility to format [`ValueSet`]s for logging.
-    pub(crate) struct LogValueSet<'a>(pub(crate) &'a ValueSet<'a>);
+    pub(crate) struct LogValueSet<'a> {
+        pub(crate) values: &'a ValueSet<'a>,
+        pub(crate) is_first: bool,
+    }
 
     impl<'a> fmt::Display for LogValueSet<'a> {
         #[inline]
@@ -1182,10 +1191,10 @@ pub mod log {
 
             let mut visit = LogVisitor {
                 f,
-                is_first: true,
+                is_first: self.is_first,
                 result: Ok(()),
             };
-            self.0.record(&mut visit);
+            self.values.record(&mut visit);
             visit.result
         }
     }

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -570,7 +570,11 @@ impl Span {
             } else {
                 meta.target()
             };
-            span.log(target, level_to_log!(*meta.level()), format_args!("++ {}{}", meta.name(), FmtAttrs(attrs)));
+            span.log(
+                target,
+                level_to_log!(*meta.level()),
+                format_args!("++ {}{}", meta.name(), crate::log::LogValueSet(attrs.values())),
+            );
         }}
 
         span
@@ -1220,7 +1224,11 @@ impl Span {
                 } else {
                     _meta.target()
                 };
-                self.log(target, level_to_log!(*_meta.level()), format_args!("{}{}", _meta.name(), FmtValues(&record)));
+                self.log(
+                    target,
+                    level_to_log!(*_meta.level()),
+                    format_args!("{}{}", _meta.name(), crate::log::LogValueSet(values)),
+                );
             }}
         }
 
@@ -1580,38 +1588,6 @@ const PhantomNotSend: PhantomNotSend = PhantomNotSend { ghost: PhantomData };
 ///
 /// Trivially safe, as `PhantomNotSend` doesn't have any API.
 unsafe impl Sync for PhantomNotSend {}
-
-#[cfg(feature = "log")]
-struct FmtValues<'a>(&'a Record<'a>);
-
-#[cfg(feature = "log")]
-impl<'a> fmt::Display for FmtValues<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut res = Ok(());
-        let mut is_first = true;
-        self.0.record(&mut |k: &field::Field, v: &dyn fmt::Debug| {
-            res = write!(f, "{} {}={:?}", if is_first { ";" } else { "" }, k, v);
-            is_first = false;
-        });
-        res
-    }
-}
-
-#[cfg(feature = "log")]
-struct FmtAttrs<'a>(&'a Attributes<'a>);
-
-#[cfg(feature = "log")]
-impl<'a> fmt::Display for FmtAttrs<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut res = Ok(());
-        let mut is_first = true;
-        self.0.record(&mut |k: &field::Field, v: &dyn fmt::Debug| {
-            res = write!(f, "{} {}={:?}", if is_first { ";" } else { "" }, k, v);
-            is_first = false;
-        });
-        res
-    }
-}
 
 #[cfg(test)]
 mod test {

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -570,10 +570,11 @@ impl Span {
             } else {
                 meta.target()
             };
+            let values = attrs.values();
             span.log(
                 target,
                 level_to_log!(*meta.level()),
-                format_args!("++ {}{}", meta.name(), crate::log::LogValueSet(attrs.values())),
+                format_args!("++ {};{}", meta.name(), crate::log::LogValueSet { values, is_first: false }),
             );
         }}
 
@@ -1039,7 +1040,7 @@ impl Span {
 
         if_log_enabled! { crate::Level::TRACE, {
             if let Some(_meta) = self.meta {
-                self.log(ACTIVITY_LOG_TARGET, log::Level::Trace, format_args!("-> {}", _meta.name()));
+                self.log(ACTIVITY_LOG_TARGET, log::Level::Trace, format_args!("-> {};", _meta.name()));
             }
         }}
     }
@@ -1056,7 +1057,7 @@ impl Span {
 
         if_log_enabled! { crate::Level::TRACE, {
             if let Some(_meta) = self.meta {
-                self.log(ACTIVITY_LOG_TARGET, log::Level::Trace, format_args!("<- {}", _meta.name()));
+                self.log(ACTIVITY_LOG_TARGET, log::Level::Trace, format_args!("<- {};", _meta.name()));
             }
         }}
     }
@@ -1227,7 +1228,7 @@ impl Span {
                 self.log(
                     target,
                     level_to_log!(*_meta.level()),
-                    format_args!("{}{}", _meta.name(), crate::log::LogValueSet(values)),
+                    format_args!("{};{}", _meta.name(), crate::log::LogValueSet { values, is_first: false }),
                 );
             }}
         }
@@ -1333,7 +1334,7 @@ impl Span {
                                 .module_path(meta.module_path())
                                 .file(meta.file())
                                 .line(meta.line())
-                                .args(format_args!("{}; span={}", message, inner.id.into_u64()))
+                                .args(format_args!("{} span={}", message, inner.id.into_u64()))
                                 .build(),
                         );
                     } else {
@@ -1454,7 +1455,7 @@ impl Drop for Span {
                 self.log(
                     LIFECYCLE_LOG_TARGET,
                     log::Level::Trace,
-                    format_args!("-- {}", meta.name()),
+                    format_args!("-- {};", meta.name()),
                 );
             }
         }}

--- a/tracing/test-log-support/src/lib.rs
+++ b/tracing/test-log-support/src/lib.rs
@@ -63,6 +63,7 @@ impl Test {
         Test { state }
     }
 
+    #[track_caller]
     pub fn assert_logged(&self, expected: &str) {
         let last = match self.state.last_log.lock().unwrap().take() {
             Some(last) => last,
@@ -75,6 +76,7 @@ impl Test {
         assert_eq!(last.as_str().trim(), expected);
     }
 
+    #[track_caller]
     pub fn assert_not_logged(&self) {
         if let Some(last) = self.state.last_log.lock().unwrap().take() {
             panic!(

--- a/tracing/test-log-support/tests/log_no_trace.rs
+++ b/tracing/test-log-support/tests/log_no_trace.rs
@@ -20,18 +20,18 @@ fn test_always_log() {
     test.assert_logged("hello world; thingy=42 other_thingy=666");
 
     let foo = span!(Level::TRACE, "foo");
-    test.assert_logged("foo");
+    test.assert_logged("foo;");
 
     foo.in_scope(|| {
-        test.assert_logged("-> foo");
+        test.assert_logged("-> foo;");
 
         trace!({foo = 3, bar = 4}, "hello {};", "san francisco");
         test.assert_logged("hello san francisco; foo=3 bar=4");
     });
-    test.assert_logged("<- foo");
+    test.assert_logged("<- foo;");
 
     drop(foo);
-    test.assert_logged("-- foo");
+    test.assert_logged("-- foo;");
 
     trace!(foo = 1, bar = 2, "hello world");
     test.assert_logged("hello world foo=1 bar=2");

--- a/tracing/test-log-support/tests/log_with_trace.rs
+++ b/tracing/test-log-support/tests/log_with_trace.rs
@@ -63,7 +63,7 @@ fn log_with_trace() {
     test.assert_logged("-- foo; span=1");
 
     let foo = span!(Level::TRACE, "foo", bar = 3, baz = false);
-    test.assert_logged("++ foo; bar=3 baz=false; span=2");
+    test.assert_logged("++ foo; bar=3 baz=false span=2");
 
     drop(foo);
     test.assert_logged("-- foo; span=2");

--- a/tracing/test-log-support/tests/span_activity_filtered_separately.rs
+++ b/tracing/test-log-support/tests/span_activity_filtered_separately.rs
@@ -21,7 +21,7 @@ fn span_activity_filtered_separately() {
 
     let foo = span!(Level::TRACE, "foo");
     // Creating a span goes to the `tracing::span` target.
-    test.assert_logged("foo");
+    test.assert_logged("foo;");
 
     foo.in_scope(|| {
         // enter should not be logged
@@ -35,7 +35,7 @@ fn span_activity_filtered_separately() {
 
     drop(foo);
     // drop should be logged
-    test.assert_logged("-- foo");
+    test.assert_logged("-- foo;");
 
     trace!(foo = 1, bar = 2, "hello world");
     test.assert_logged("hello world foo=1 bar=2");
@@ -57,7 +57,7 @@ fn span_activity_filtered_separately() {
 
     let bar = span!(Level::INFO, "bar");
     // lifecycles for INFO spans should be logged
-    test.assert_logged("bar");
+    test.assert_logged("bar;");
 
     bar.in_scope(|| {
         // entering the INFO span should not be logged
@@ -68,9 +68,9 @@ fn span_activity_filtered_separately() {
 
     drop(foo);
     // drop should be logged
-    test.assert_logged("-- foo");
+    test.assert_logged("-- foo;");
 
     drop(bar);
     // dropping the INFO should be logged.
-    test.assert_logged("-- bar");
+    test.assert_logged("-- bar;");
 }

--- a/tracing/test-log-support/tests/span_lifecycle_can_be_enabled.rs
+++ b/tracing/test-log-support/tests/span_lifecycle_can_be_enabled.rs
@@ -19,21 +19,21 @@ fn span_lifecycle_can_be_enabled() {
     test.assert_logged("hello world; thingy=42 other_thingy=666");
 
     let foo = span!(Level::TRACE, "foo");
-    test.assert_logged("foo");
+    test.assert_logged("foo;");
 
     foo.in_scope(|| {
         // enter should be logged
-        test.assert_logged("-> foo");
+        test.assert_logged("-> foo;");
 
         trace!({foo = 3, bar = 4}, "hello {};", "san francisco");
         test.assert_logged("hello san francisco; foo=3 bar=4");
     });
     // exit should be logged
-    test.assert_logged("<- foo");
+    test.assert_logged("<- foo;");
 
     drop(foo);
     // drop should be logged
-    test.assert_logged("-- foo");
+    test.assert_logged("-- foo;");
 
     trace!(foo = 1, bar = 2, "hello world");
     test.assert_logged("hello world foo=1 bar=2");
@@ -44,10 +44,10 @@ fn span_lifecycle_can_be_enabled() {
 
     foo.in_scope(|| {
         // entering the span should be logged
-        test.assert_logged("-> foo");
+        test.assert_logged("-> foo;");
     });
     // exiting the span should be logged
-    test.assert_logged("<- foo");
+    test.assert_logged("<- foo;");
 
     foo.record("baz", &true);
     // recording a field should be logged
@@ -55,20 +55,20 @@ fn span_lifecycle_can_be_enabled() {
 
     let bar = span!(Level::INFO, "bar");
     // lifecycles for INFO spans should be logged
-    test.assert_logged("bar");
+    test.assert_logged("bar;");
 
     bar.in_scope(|| {
         // entering the INFO span should be logged
-        test.assert_logged("-> bar");
+        test.assert_logged("-> bar;");
     });
     // exiting the INFO span should be logged
-    test.assert_logged("<- bar");
+    test.assert_logged("<- bar;");
 
     drop(foo);
     // drop should be logged.
-    test.assert_logged("-- foo");
+    test.assert_logged("-- foo;");
 
     drop(bar);
     // dropping the INFO should be logged.
-    test.assert_logged("-- bar");
+    test.assert_logged("-- bar;");
 }

--- a/tracing/tests/future_send.rs
+++ b/tracing/tests/future_send.rs
@@ -1,4 +1,8 @@
-use std::future::{self, Future};
+// These tests reproduce the following issues:
+// - https://github.com/tokio-rs/tracing/issues/1487
+// - https://github.com/tokio-rs/tracing/issues/1793
+
+use core::future::{self, Future};
 #[test]
 fn async_fn_is_send() {
     async fn some_async_fn() {

--- a/tracing/tests/future_send.rs
+++ b/tracing/tests/future_send.rs
@@ -1,0 +1,19 @@
+use std::future::{self, Future};
+#[test]
+fn async_fn_is_send() {
+    async fn some_async_fn() {
+        tracing::info!("{}", future::ready("test").await);
+    }
+
+    assert_send(some_async_fn())
+}
+
+#[test]
+fn async_block_is_send() {
+    assert_send(async {
+        tracing::info!("{}", future::ready("test").await);
+    })
+}
+
+
+fn assert_send<F: Future + Send>(_f: F) {}

--- a/tracing/tests/future_send.rs
+++ b/tracing/tests/future_send.rs
@@ -19,5 +19,4 @@ fn async_block_is_send() {
     })
 }
 
-
 fn assert_send<F: Future + Send>(_f: F) {}


### PR DESCRIPTION
## Motivation

Currently, enabling the `log` feature can cause a compilation error when
using `tracing` macros in async functions or blocks. This is because,
when the `log` feature is enabled, the `tracing` macros will construct a
`log::Record`, which is not `Send`, causing the async fn/block future to
become `!Send`. This can break compilation when the future is `Send`
without the `log` feature enabled. This is really not great, as it makes
the feature no longer purely additive.

## Solution

This branch fixes the issue by moving the `log::Record` construction
behind a function call. Because the `log::Record` is now only
constructed inside of a function, the `log::Record` is now never a local
variable within the async block, so it no longer affects the future's
auto traits. 

It's kind of a shame that the compiler can't otherwise determine that
the `log::Record` can never be held across an await point, but sticking
it in a separate function makes this obvious to the compiler. Also, as a
side benefit, this may reduce the size of macro-generated code when the
`log` feature is enabled a bit, which could improve performance
marginally in some cases.

I added two tests ensuring that `async fn` and `async` block futures are
`Send` when containing `tracing` macro calls. Previously, on `master`,
these failed when the `log` feature is enabled. After this change, the
tests now pass. Thanks to @Noah-Kennedy for the original MCRE these
tests were based on!

Finally, while I was here, I took advantage of the opportunity to clean
up the log integration code a bit. Now that the `log::Record`
construction is behind a function call in `__macro_support`, the
`LogValueSet` type, which is used to wrap a `ValueSet` and implement
`fmt::Display` to add it to the textual message of `log::Record`, no
longer needs to be exposed to the macros, so it can be made properly
private, rather than `#[doc(hidden)] pub`. Also, I noticed that the
`span` module implemented its own versions of `LogValueSet` (`FmtAttrs`
and `FmtValues`), which were essentially duplicating the same behavior
for logging span fields. I removed these and changed this code to use
the `LogValueSet` type instead (which will format string `message`
fields slightly nicer as well).

Fixes #1793
Fixes #1487
