### PR TITLE
tracing: prepare to release v0.1.34

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,22 @@
+# 0.1.34 (April 14, 2022)
+
+This release includes bug fixes for the "log" support feature and for the use of
+both scoped and global default dispatchers in the same program.
+
+### Fixed
+
+- Failure to use the global default dispatcher when a thread sets a local
+  default dispatcher before the global default is set ([#2065])
+- **log**: Compilation errors due to `async` block/fn futures becoming `!Send`
+  when the "log" feature flag is enabled ([#2073])
+- Broken links in documentation ([#2068])
+
+Thanks to @ben0x539 for contributing to this release!
+
+[#2065]: https://github.com/tokio-rs/tracing/pull/2065
+[#2073]: https://github.com/tokio-rs/tracing/pull/2073
+[#2068]: https://github.com/tokio-rs/tracing/pull/2068
+
 # 0.1.33 (April 9, 2022)
 
 This release adds new `span_enabled!` and `event_enabled!` variants of the

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.33"
+version = "0.1.34"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -16,9 +16,9 @@ Application-level tracing for Rust.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.33
+[crates-url]: https://crates.io/crates/tracing/0.1.34
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.33
+[docs-url]: https://docs.rs/tracing/0.1.34
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -250,7 +250,7 @@ my_future
 is as long as the future's.
 
 The second, and preferred, option is through the
-[`#[instrument]`](https://docs.rs/tracing/0.1.33/tracing/attr.instrument.html)
+[`#[instrument]`](https://docs.rs/tracing/0.1.34/tracing/attr.instrument.html)
 attribute:
 
 ```rust
@@ -297,7 +297,7 @@ span.in_scope(|| {
 // Dropping the span will close it, indicating that it has ended.
 ```
 
-The [`#[instrument]`](https://docs.rs/tracing/0.1.33/tracing/attr.instrument.html) attribute macro
+The [`#[instrument]`](https://docs.rs/tracing/0.1.34/tracing/attr.instrument.html) attribute macro
 can reduce some of this boilerplate:
 
 ```rust


### PR DESCRIPTION
# 0.1.34 (April 14, 2022)

This release includes bug fixes for the "log" support feature and for
the use of both scoped and global default dispatchers in the same
program.

### Fixed

- Failure to use the global default dispatcher when a thread sets a
  local default dispatcher before the global default is set ([#2065])
- **log**: Compilation errors due to `async` block/fn futures becoming
  `!Send` when the "log" feature flag is enabled ([#2073])
- Broken links in documentation ([#2068])

Thanks to @ben0x539 for contributing to this release!

[#2065]: https://github.com/tokio-rs/tracing/pull/2065
[#2073]: https://github.com/tokio-rs/tracing/pull/2073
[#2068]: https://github.com/tokio-rs/tracing/pull/2068