### PR TITLE
docs: more intra-doc links

### DIFF
--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -91,9 +91,9 @@
 //! [non_blocking]: mod@non_blocking
 //! [write]: std::io::Write
 //! [guard]: non_blocking::WorkerGuard
-//! [make_writer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/trait.MakeWriter.html
+//! [make_writer]: tracing_subscriber::fmt::MakeWriter
 //! [rolling_struct]: rolling::RollingFileAppender
-//! [fmt_subscriber]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Subscriber.html
+//! [fmt_subscriber]: tracing_subscriber::fmt::Subscriber
 //!
 //! ## Non-Blocking Rolling File Appender
 //!

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -91,7 +91,6 @@
 //! [non_blocking]: mod@non_blocking
 //! [write]: https://doc.rust-lang.org/std/io/trait.Write.html
 //! [guard]: non_blocking::WorkerGuard
-//! [rolling]: rolling
 //! [make_writer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/trait.MakeWriter.html
 //! [rolling_struct]: rolling::RollingFileAppender
 //! [fmt_subscriber]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Subscriber.html

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -89,7 +89,7 @@
 //! The [`non_blocking` module][non_blocking]'s documentation provides more detail on how to use `non_blocking`.
 //!
 //! [non_blocking]: mod@non_blocking
-//! [write]: https://doc.rust-lang.org/std/io/trait.Write.html
+//! [write]: std::io::Write
 //! [guard]: non_blocking::WorkerGuard
 //! [make_writer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/trait.MakeWriter.html
 //! [rolling_struct]: rolling::RollingFileAppender

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -78,7 +78,6 @@ pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 /// terminates abruptly (such as through an uncaught `panic` or a `std::process::exit`), some spans
 /// or events may not be written.
 ///
-/// [`NonBlocking`]: NonBlocking
 /// Since spans/events and events recorded near a crash are often necessary for diagnosing the failure,
 /// `WorkerGuard` provides a mechanism to ensure that _all_ buffered logs are flushed to their output.
 /// `WorkerGuard` should be assigned in the `main` function or whatever the entrypoint of the program is.

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -120,8 +120,8 @@ pub struct WorkerGuard {
 /// crate. Therefore, it can be used with the [`tracing_subscriber::fmt`][fmt] module
 /// or with any other subscriber/layer implementation that uses the `MakeWriter` trait.
 ///
-/// [make_writer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/trait.MakeWriter.html
-/// [fmt]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/index.html
+/// [make_writer]: tracing_subscriber::fmt::MakeWriter
+/// [fmt]: mod@tracing_subscriber::fmt
 #[derive(Clone, Debug)]
 pub struct NonBlocking {
     error_counter: ErrorCounter,

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -17,10 +17,6 @@
 //! will be created daily
 //! - [`Rotation::never()`][never()]: This will result in log file located at `some_directory/log_file_name`
 //!
-//! [minutely]: minutely
-//! [hourly]: hourly
-//! [daily]: daily
-//! [never]: never
 //!
 //! # Examples
 //!
@@ -126,10 +122,6 @@ impl RollingFileAppender {
     /// - [`Rotation::daily()`][daily],
     /// - [`Rotation::never()`][never()]
     ///
-    /// [minutely]: minutely
-    /// [hourly]: hourly
-    /// [daily]: daily
-    /// [never]: never
     ///
     /// # Examples
     /// ```rust

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -501,7 +501,7 @@ mod expand;
 /// [`INFO`]: https://docs.rs/tracing/latest/tracing/struct.Level.html#associatedconstant.INFO
 /// [empty field]: https://docs.rs/tracing/latest/tracing/field/struct.Empty.html
 /// [field syntax]: https://docs.rs/tracing/latest/tracing/#recording-fields
-/// [`fmt::Debug`]: https://doc.rust-lang.org/std/fmt/trait.Debug.html
+/// [`fmt::Debug`]: std::fmt::Debug
 #[proc_macro_attribute]
 pub fn instrument(
     args: proc_macro::TokenStream,

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -123,11 +123,6 @@
 //! currently default `Dispatch`. This is used primarily by `tracing`
 //! instrumentation.
 //!
-//! [`Subscriber`]: Subscriber
-//! [`with_default`]: with_default
-//! [`set_global_default`]: set_global_default
-//! [`get_default`]: get_default
-//! [`Dispatch`]: Dispatch
 use crate::{
     callsite, span,
     subscriber::{self, NoSubscriber, Subscriber},
@@ -151,7 +146,6 @@ use crate::stdlib::{
 
 /// `Dispatch` trace data to a [`Subscriber`].
 ///
-/// [`Subscriber`]: Subscriber
 #[derive(Clone)]
 pub struct Dispatch {
     subscriber: Arc<dyn Subscriber + Send + Sync>,
@@ -579,7 +573,7 @@ impl Dispatch {
     /// [`Subscriber`]: super::subscriber::Subscriber
     /// [`drop_span`]: super::subscriber::Subscriber::drop_span
     /// [`new_span`]: super::subscriber::Subscriber::new_span
-    /// [`try_close`]: #method.try_close
+    /// [`try_close`]: Entered::try_close()
     #[inline]
     #[deprecated(since = "0.1.2", note = "use `Dispatch::try_close` instead")]
     pub fn drop_span(&self, id: span::Id) {

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -100,7 +100,6 @@
 //! [`record_value`]: Visit::record_value
 //! [`record_debug`]: Visit::record_debug
 //!
-//! [`Value`]: Value
 //! [span]: super::span
 //! [`Event`]: super::event::Event
 //! [`Metadata`]: super::metadata::Metadata
@@ -110,7 +109,6 @@
 //! [`record`]: super::subscriber::Subscriber::record
 //! [`event`]:  super::subscriber::Subscriber::event
 //! [`Value::record`]: Value::record
-//! [`Visit`]: Visit
 use crate::callsite;
 use crate::stdlib::{
     borrow::Borrow,
@@ -249,13 +247,11 @@ pub struct Iter {
 /// <code>std::error::Error</code> trait.
 /// </pre></div>
 ///
-/// [`Value`]: Value
 /// [recorded]: Value::record
 /// [`Subscriber`]: super::subscriber::Subscriber
 /// [records an `Event`]: super::subscriber::Subscriber::event
 /// [set of `Value`s added to a `Span`]: super::subscriber::Subscriber::record
 /// [`Event`]: super::event::Event
-/// [`ValueSet`]: ValueSet
 pub trait Visit {
     /// Visits an arbitrary type implementing the [`valuable`] crate's `Valuable` trait.
     ///

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -47,13 +47,13 @@ use crate::stdlib::{
 ///
 /// [span]: super::span
 /// [event]: super::event
-/// [name]: #method.name
-/// [target]: #method.target
-/// [fields]: #method.fields
-/// [verbosity level]: #method.level
-/// [file name]: #method.file
-/// [line number]: #method.line
-/// [module path]: #method.module
+/// [name]: Metadata::name()
+/// [target]: Metadata::target()
+/// [fields]: Metadata::fields()
+/// [verbosity level]: Metadata::level()
+/// [file name]: Metadata::file()
+/// [line number]: Metadata::line()
+/// [module path]: Metadata::module_path()
 /// [`Subscriber`]: super::subscriber::Subscriber
 /// [`id`]: Metadata::id
 /// [callsite identifier]: super::callsite::Identifier
@@ -604,8 +604,7 @@ impl LevelFilter {
     /// Returns the most verbose [`Level`] that this filter accepts, or `None`
     /// if it is [`OFF`].
     ///
-    /// [`Level`]: super::Level
-    /// [`OFF`]: #associatedconstant.OFF
+    /// [`OFF`]: LevelFilter::OFF
     pub const fn into_level(self) -> Option<Level> {
         self.0
     }

--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -39,7 +39,6 @@ pub struct Record<'a> {
 /// - "some", with the current span's [`Id`] and [`Metadata`].
 ///
 /// [the `Subscriber` considers]: super::subscriber::Subscriber::current_span
-/// [`Id`]: Id
 /// [`Metadata`]: super::metadata::Metadata
 #[derive(Debug)]
 pub struct Current {
@@ -73,7 +72,7 @@ impl Id {
 
     /// Constructs a new span ID from the given `NonZeroU64`.
     ///
-    /// Unlike [`Id::from_u64`](#method.from_u64), this will never panic.
+    /// Unlike [`Id::from_u64`](Id::from_u64()), this will never panic.
     #[inline]
     pub const fn from_non_zero_u64(id: NonZeroU64) -> Self {
         Id(id)
@@ -273,9 +272,9 @@ impl Current {
     /// `None`, but in this case, that is because the subscriber does not keep
     /// track of the currently-entered span.
     ///
-    /// [`id`]: #method.id
-    /// [`metadata`]: #method.metadata
-    /// [`into_inner`]: #method.into_inner
+    /// [`id`]: Current::id()
+    /// [`metadata`]: Current::metadata()
+    /// [`into_inner`]: Current::into_inner()
     pub fn is_known(&self) -> bool {
         !matches!(self.inner, CurrentInner::Unknown)
     }

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -67,7 +67,6 @@ use crate::stdlib::{
 /// [ID]: super::span::Id
 /// [`new_span`]: Subscriber::new_span
 /// [`register_callsite`]: Subscriber::register_callsite
-/// [`Interest`]: Interest
 /// [`enabled`]: Subscriber::enabled
 /// [`clone_span`]: Subscriber::clone_span
 /// [`try_close`]: Subscriber::try_close
@@ -136,10 +135,9 @@ pub trait Subscriber: 'static {
     /// _may_ still see spans and events originating from that callsite, if
     /// another subscriber expressed interest in it.
     ///
-    /// [filter]: #method.enabled
+    /// [filter]: Subscriber::enabled()
     /// [metadata]: super::metadata::Metadata
-    /// [`Interest`]: Interest
-    /// [`enabled`]: #method.enabled
+    /// [`enabled`]: Subscriber::enabled()
     /// [`rebuild_interest_cache`]: super::callsite::rebuild_interest_cache
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         if self.enabled(metadata) {
@@ -168,7 +166,7 @@ pub trait Subscriber: 'static {
     /// [metadata]: super::metadata::Metadata
     /// [interested]: Interest
     /// [`Interest::sometimes`]: Interest::sometimes
-    /// [`register_callsite`]: #method.register_callsite
+    /// [`register_callsite`]: Subscriber::register_callsite()
     fn enabled(&self, metadata: &Metadata<'_>) -> bool;
 
     /// Returns the highest [verbosity level][level] that this `Subscriber` will
@@ -192,7 +190,6 @@ pub trait Subscriber: 'static {
     /// level changes.
     ///
     /// [level]: super::Level
-    /// [`Interest`]: Interest
     /// [rebuild]: super::callsite::rebuild_interest_cache
     fn max_level_hint(&self) -> Option<LevelFilter> {
         None

--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -60,7 +60,7 @@ use tracing::{Metadata, Span};
 /// [fields]: https://docs.rs/tracing/latest/tracing/field/index.html
 /// [futures]: https://doc.rust-lang.org/std/future/trait.Future.html
 /// [`tracing-futures`]: https://docs.rs/tracing-futures/
-/// [`with_spans`]: #method.with_spans
+/// [`with_spans`]: SpanTrace::with_spans()
 #[derive(Clone)]
 pub struct SpanTrace {
     span: Span,

--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -53,11 +53,10 @@ use tracing::{Metadata, Span};
 /// Additionally, if custom formatting is desired, the [`with_spans`] method can
 /// be used to visit each span in the trace, formatting them in order.
 ///
-/// [`tracing`]: https://docs.rs/tracing
 /// [`Backtrace`]: std::backtrace::Backtrace
-/// [span]: https://docs.rs/tracing/latest/tracing/span/index.html
-/// [parents]: https://docs.rs/tracing/latest/tracing/span/index.html#span-relationships
-/// [fields]: https://docs.rs/tracing/latest/tracing/field/index.html
+/// [span]: mod@tracing::span
+/// [parents]: mod@tracing::span#span-relationships
+/// [fields]: tracing::field
 /// [futures]: std::future::Future
 /// [`tracing-futures`]: https://docs.rs/tracing-futures/
 /// [`with_spans`]: SpanTrace::with_spans()
@@ -114,8 +113,8 @@ impl SpanTrace {
     /// indicate whether to continue iterating over spans; if it returns
     /// `false`, no additional spans will be visited.
     ///
-    /// [fields]: https://docs.rs/tracing/latest/tracing/field/index.html
-    /// [`Metadata`]: https://docs.rs/tracing/latest/tracing/struct.Metadata.html
+    /// [fields]: tracing::field
+    /// [`Metadata`]: tracing::Metadata
     pub fn with_spans(&self, f: impl FnMut(&'static Metadata<'static>, &str) -> bool) {
         self.span.with_subscriber(|(id, s)| {
             if let Some(getcx) = s.downcast_ref::<WithContext>() {

--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -54,11 +54,11 @@ use tracing::{Metadata, Span};
 /// be used to visit each span in the trace, formatting them in order.
 ///
 /// [`tracing`]: https://docs.rs/tracing
-/// [`Backtrace`]: https://doc.rust-lang.org/std/backtrace/struct.Backtrace.html
+/// [`Backtrace`]: std::backtrace::Backtrace
 /// [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 /// [parents]: https://docs.rs/tracing/latest/tracing/span/index.html#span-relationships
 /// [fields]: https://docs.rs/tracing/latest/tracing/field/index.html
-/// [futures]: https://doc.rust-lang.org/std/future/trait.Future.html
+/// [futures]: std::future::Future
 /// [`tracing-futures`]: https://docs.rs/tracing-futures/
 /// [`with_spans`]: SpanTrace::with_spans()
 #[derive(Clone)]

--- a/tracing-error/src/layer.rs
+++ b/tracing-error/src/layer.rs
@@ -15,10 +15,10 @@ use tracing_subscriber::{
 /// when formatting the fields of each span in a trace. When no formatter is
 /// provided, the [default format] is used instead.
 ///
-/// [`Layer`]: https://docs.rs/tracing-subscriber/0.3/tracing_subscriber/layer/trait.Layer.html
+/// [`Layer`]: tracing_subscriber::layer::Layer
 /// [`SpanTrace`]: super::SpanTrace
-/// [field formatter]: https://docs.rs/tracing-subscriber/0.3/tracing_subscriber/fmt/trait.FormatFields.html
-/// [default format]: https://docs.rs/tracing-subscriber/0.3/tracing_subscriber/fmt/format/struct.DefaultFields.html
+/// [field formatter]: tracing_subscriber::fmt::FormatFields
+/// [default format]: tracing_subscriber::fmt::format::DefaultFields
 pub struct ErrorLayer<S, F = DefaultFields> {
     format: F,
 
@@ -69,7 +69,7 @@ where
 {
     /// Returns a new `ErrorLayer` with the provided [field formatter].
     ///
-    /// [field formatter]: https://docs.rs/tracing-subscriber/0.2.10/tracing_subscriber/fmt/trait.FormatFields.html
+    /// [field formatter]: tracing_subscriber::fmt::FormatFields
     pub fn new(format: F) -> Self {
         Self {
             format,

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -157,12 +157,6 @@
 //! }
 //! ```
 //!
-//! [`SpanTrace`]: SpanTrace
-//! [`ErrorLayer`]: ErrorLayer
-//! [`TracedError`]: TracedError
-//! [`InstrumentResult`]: InstrumentResult
-//! [`InstrumentError`]: InstrumentError
-//! [`ExtractSpanTrace`]: ExtractSpanTrace
 //! [`in_current_span()`]: InstrumentResult#tymethod.in_current_span
 //! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 //! [events]: https://docs.rs/tracing/latest/tracing/struct.Event.html

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -163,7 +163,7 @@
 //! [`Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
 //! [subscriber layer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/trait.Layer.html
 //! [`tracing`]: https://docs.rs/tracing
-//! [`std::error::Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
+//! [`std::error::Error`]: std::error::Error
 //!
 //! ## Supported Rust Versions
 //!

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -158,12 +158,11 @@
 //! ```
 //!
 //! [`in_current_span()`]: InstrumentResult#tymethod.in_current_span
-//! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
-//! [events]: https://docs.rs/tracing/latest/tracing/struct.Event.html
-//! [`Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
-//! [subscriber layer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/trait.Layer.html
-//! [`tracing`]: https://docs.rs/tracing
-//! [`std::error::Error`]: std::error::Error
+//! [span]: mod@tracing::span
+//! [events]: tracing::Event
+//! [`Subscriber`]: tracing::Subscriber
+//! [subscriber layer]: tracing_subscriber::layer::Layer
+//! [`tracing`]: tracing
 //!
 //! ## Supported Rust Versions
 //!

--- a/tracing-flame/src/lib.rs
+++ b/tracing-flame/src/lib.rs
@@ -91,8 +91,6 @@
 //!
 //! [`tracing`]: https://docs.rs/tracing
 //! [`inferno`]: https://docs.rs/inferno
-//! [`FlameLayer`]: FlameLayer
-//! [`FlushGuard`]: FlushGuard
 //! [`inferno-flamegraph`]: https://docs.rs/inferno/0.9.5/inferno/index.html#producing-a-flame-graph
 //!
 //! ## Supported Rust Versions
@@ -212,7 +210,6 @@ thread_local! {
 /// flush the writer.
 ///
 /// [`flush_on_drop`]: FlameLayer::flush_on_drop
-/// [`FlushGuard`]: FlushGuard
 #[derive(Debug)]
 pub struct FlameLayer<S, W> {
     out: Arc<Mutex<W>>,

--- a/tracing-flame/src/lib.rs
+++ b/tracing-flame/src/lib.rs
@@ -89,7 +89,6 @@
 //! the execution of your program. This representation is best created with a
 //! _flamechart_, which _does not_ sort or collapse identical stack frames.
 //!
-//! [`tracing`]: https://docs.rs/tracing
 //! [`inferno`]: https://docs.rs/inferno
 //! [`inferno-flamegraph`]: https://docs.rs/inferno/0.9.5/inferno/index.html#producing-a-flame-graph
 //!

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -55,8 +55,6 @@
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 //! [`Subscriber`]: https://docs.rs/tracing/latest/tracing/subscriber/index.html
-//! [`Instrument`]: Instrument
-//! [`WithSubscriber`]: WithSubscriber
 //! [`futures`]: https://crates.io/crates/futures
 //!
 //! ## Supported Rust Versions

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -52,9 +52,8 @@
 //!
 //! The `tokio`, `std-future` and `std` features are enabled by default.
 //!
-//! [`tracing`]: https://crates.io/crates/tracing
-//! [span]: https://docs.rs/tracing/latest/tracing/span/index.html
-//! [`Subscriber`]: https://docs.rs/tracing/latest/tracing/subscriber/index.html
+//! [span]: tracing::span!
+//! [`Subscriber`]: tracing::subscriber
 //! [`futures`]: https://crates.io/crates/futures
 //!
 //! ## Supported Rust Versions
@@ -119,7 +118,7 @@ pub mod executor;
 /// Extension trait allowing futures, streams, sinks, and executors to be
 /// instrumented with a `tracing` [span].
 ///
-/// [span]: https://docs.rs/tracing/latest/tracing/span/index.html
+/// [span]: mod@tracing::span
 pub trait Instrument: Sized {
     /// Instruments this type with the provided `Span`, returning an
     /// `Instrumented` wrapper.
@@ -148,7 +147,7 @@ pub trait Instrument: Sized {
     /// # }
     /// ```
     ///
-    /// [entered]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.enter
+    /// [entered]: tracing::Span::enter
     fn instrument(self, span: Span) -> Instrumented<Self> {
         Instrumented { inner: self, span }
     }
@@ -183,8 +182,8 @@ pub trait Instrument: Sized {
     /// # }
     /// ```
     ///
-    /// [current]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.current
-    /// [entered]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#method.enter
+    /// [current]: tracing::Span::current
+    /// [entered]: tracing::Span::enter
     #[inline]
     fn in_current_span(self) -> Instrumented<Self> {
         self.instrument(Span::current())
@@ -194,7 +193,7 @@ pub trait Instrument: Sized {
 /// Extension trait allowing futures, streams, and sinks to be instrumented with
 /// a `tracing` [`Subscriber`].
 ///
-/// [`Subscriber`]: https://docs.rs/tracing/latest/tracing/subscriber/trait.Subscriber.html
+/// [`Subscriber`]: tracing::Subscriber
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub trait WithSubscriber: Sized {
@@ -206,8 +205,8 @@ pub trait WithSubscriber: Sized {
     /// When the wrapped type is an executor, the subscriber will be set as the
     /// default for any futures spawned on that executor.
     ///
-    /// [`Subscriber`]: https://docs.rs/tracing/latest/tracing/subscriber/trait.Subscriber.html
-    /// [default]: https://docs.rs/tracing/latest/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [`Subscriber`]: tracing::Subscriber
+    /// [default]: tracing::dispatcher#setting-the-default-subscriber
     fn with_subscriber<S>(self, subscriber: S) -> WithDispatch<Self>
     where
         S: Into<Dispatch>,
@@ -229,8 +228,8 @@ pub trait WithSubscriber: Sized {
     /// This can be used to propagate the current dispatcher context when
     /// spawning a new future.
     ///
-    /// [`Subscriber`]: https://docs.rs/tracing/latest/tracing/subscriber/trait.Subscriber.html
-    /// [default]: https://docs.rs/tracing/latest/tracing/dispatcher/index.html#setting-the-default-subscriber
+    /// [`Subscriber`]: tracing::Subscriber
+    /// [default]: tracing::dispatcher#setting-the-default-subscriber
     #[inline]
     fn with_current_subscriber(self) -> WithDispatch<Self> {
         WithDispatch {

--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! [`tracing`] is a framework for instrumenting Rust programs to collect
 //! scoped, structured, and async-aware diagnostics. `tracing-journald` provides a
-//! [`tracing-subscriber::Layer`][layer] implementation for logging `tracing` spans
+//! [`tracing-subscriber::Layer`] implementation for logging `tracing` spans
 //! and events to [`systemd-journald`][journald], on Linux distributions that
 //! use `systemd`.
 //!
@@ -15,7 +15,6 @@
 //!
 //! [msrv]: #supported-rust-versions
 //! [`tracing`]: https://crates.io/crates/tracing
-//! [layer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/trait.Layer.html
 //! [journald]: https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html
 //!
 //! ## Supported Rust Versions

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -93,11 +93,6 @@
 //!
 //! [`init`]: LogTracer::init
 //! [`init_with_filter`]: LogTracer::init_with_filter
-//! [`AsTrace`]: AsTrace
-//! [`AsLog`]: AsLog
-//! [`LogTracer`]: LogTracer
-//! [`TraceLogger`]: TraceLogger
-//! [`env_logger`]: env_logger
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [`log`]: https://crates.io/crates/log
 //! [`env_logger` crate]: https://crates.io/crates/env-logger
@@ -488,7 +483,6 @@ impl AsLog for tracing_core::LevelFilter {
 /// regardless of the source of its source.
 ///
 /// [`normalized_metadata`]: NormalizeEvent#normalized_metadata
-/// [`AsTrace`]: AsTrace
 /// [`log::Record`]: https://docs.rs/log/0.4.7/log/struct.Record.html
 pub trait NormalizeEvent<'a>: crate::sealed::Sealed {
     /// If this `Event` comes from a `log`, this method provides a new

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -94,10 +94,7 @@
 //! [`init`]: LogTracer::init
 //! [`init_with_filter`]: LogTracer::init_with_filter
 //! [`tracing`]: https://crates.io/crates/tracing
-//! [`log`]: https://crates.io/crates/log
 //! [`env_logger` crate]: https://crates.io/crates/env-logger
-//! [`log::Log`]: https://docs.rs/log/latest/log/trait.Log.html
-//! [`log::Record`]: https://docs.rs/log/latest/log/struct.Record.html
 //! [`tracing::Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
 //! [`Subscriber`]: https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
 //! [`tracing::Event`]: https://docs.rs/tracing/latest/tracing/struct.Event.html
@@ -483,7 +480,6 @@ impl AsLog for tracing_core::LevelFilter {
 /// regardless of the source of its source.
 ///
 /// [`normalized_metadata`]: NormalizeEvent#normalized_metadata
-/// [`log::Record`]: https://docs.rs/log/0.4.7/log/struct.Record.html
 pub trait NormalizeEvent<'a>: crate::sealed::Sealed {
     /// If this `Event` comes from a `log`, this method provides a new
     /// normalized `Metadata` which has all available attributes

--- a/tracing-log/src/log_tracer.rs
+++ b/tracing-log/src/log_tracer.rs
@@ -93,7 +93,7 @@ impl LogTracer {
     /// # }
     /// ```
     ///
-    /// [`init`]: #method.init
+    /// [`init`]: LogTracer::init()
     /// [`init_with_filter`]: .#method.init_with_filter
     pub fn new() -> Self {
         Self {
@@ -109,7 +109,7 @@ impl LogTracer {
     /// The [`builder`] function can be used to customize the `LogTracer` before
     /// initializing it.
     ///
-    /// [`builder`]: #method.builder
+    /// [`builder`]: LogTracer::builder()
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn init_with_filter(level: log::LevelFilter) -> Result<(), SetLoggerError> {
@@ -143,8 +143,8 @@ impl LogTracer {
     /// If you know in advance you want to filter some log levels,
     /// use [`builder`] or [`init_with_filter`] instead.
     ///
-    /// [`init_with_filter`]: #method.init_with_filter
-    /// [`builder`]: #method.builder
+    /// [`init_with_filter`]: LogTracer::init_with_filter()
+    /// [`builder`]: LogTracer::builder()
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn init() -> Result<(), SetLoggerError> {
@@ -208,7 +208,6 @@ impl log::Log for LogTracer {
 impl Builder {
     /// Returns a new `Builder` to construct a [`LogTracer`].
     ///
-    /// [`LogTracer`]: LogTracer
     pub fn new() -> Self {
         Self::default()
     }

--- a/tracing-log/src/trace_logger.rs
+++ b/tracing-log/src/trace_logger.rs
@@ -8,9 +8,9 @@
 //! `tracing` events as `log` records, the ["log" and "log-always" feature
 //! flags][flags] on the `tracing` crate should be used instead.
 //!
-//! [`log`]: https://docs.rs/log/0.4.8/log/index.html
+//! [`log`]: log
 //! [`Subscriber`]: https://docs.rs/tracing/0.1.7/tracing/subscriber/trait.Subscriber.html
-//! [`log::Record`]: https://docs.rs/log/0.4.8/log/struct.Record.html
+//! [`log::Record`]:log::Record
 //! [flags]: https://docs.rs/tracing/latest/tracing/#crate-feature-flags
 #![deprecated(
     since = "0.1.1",

--- a/tracing-log/src/trace_logger.rs
+++ b/tracing-log/src/trace_logger.rs
@@ -10,7 +10,6 @@
 //!
 //! [`log`]: https://docs.rs/log/0.4.8/log/index.html
 //! [`Subscriber`]: https://docs.rs/tracing/0.1.7/tracing/subscriber/trait.Subscriber.html
-//! [`TraceLogger`]: TraceLogger
 //! [`log::Record`]: https://docs.rs/log/0.4.8/log/struct.Record.html
 //! [flags]: https://docs.rs/tracing/latest/tracing/#crate-feature-flags
 #![deprecated(
@@ -53,7 +52,6 @@ thread_local! {
 }
 /// Configures and constructs a [`TraceLogger`].
 ///
-/// [`TraceLogger`]: TraceLogger
 #[derive(Debug)]
 pub struct Builder {
     log_span_closes: bool,
@@ -95,7 +93,6 @@ impl Builder {
     /// Configures whether or not the [`TraceLogger`] being constructed will log
     /// when a span closes.
     ///
-    /// [`TraceLogger`]: TraceLogger
     pub fn with_span_closes(self, log_span_closes: bool) -> Self {
         Self {
             log_span_closes,
@@ -106,7 +103,6 @@ impl Builder {
     /// Configures whether or not the [`TraceLogger`] being constructed will
     /// include the fields of parent spans when formatting events.
     ///
-    /// [`TraceLogger`]: TraceLogger
     pub fn with_parent_fields(self, parent_fields: bool) -> Self {
         Self {
             parent_fields,
@@ -120,7 +116,6 @@ impl Builder {
     /// If this is set to false, fields from the current span will still be
     /// recorded as context, but the actual entry will not create a log record.
     ///
-    /// [`TraceLogger`]: TraceLogger
     pub fn with_span_entry(self, log_enters: bool) -> Self {
         Self { log_enters, ..self }
     }
@@ -128,7 +123,6 @@ impl Builder {
     /// Configures whether or not the [`TraceLogger`] being constructed will log
     /// when a span is exited.
     ///
-    /// [`TraceLogger`]: TraceLogger
     pub fn with_span_exits(self, log_exits: bool) -> Self {
         Self { log_exits, ..self }
     }
@@ -136,7 +130,6 @@ impl Builder {
     /// Configures whether or not the [`TraceLogger`] being constructed will
     /// include span IDs when formatting log output.
     ///
-    /// [`TraceLogger`]: TraceLogger
     pub fn with_ids(self, log_ids: bool) -> Self {
         Self { log_ids, ..self }
     }
@@ -144,14 +137,12 @@ impl Builder {
     /// Configures whether or not the [`TraceLogger`] being constructed will
     /// include the names of parent spans as context when formatting events.
     ///
-    /// [`TraceLogger`]: TraceLogger
     pub fn with_parent_names(self, log_parent: bool) -> Self {
         Self { log_parent, ..self }
     }
 
     /// Complete the builder, returning a configured [`TraceLogger`].
     ///
-    /// [`TraceLogger`]: TraceLogger
     pub fn finish(self) -> TraceLogger {
         TraceLogger::from_builder(self)
     }

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -26,8 +26,8 @@
 //! * `otel.status_code`: Set the span status code to one of the supported OpenTelemetry [span status codes].
 //! * `otel.status_message`: Set the span status message.
 //!
-//! [span kinds]: https://docs.rs/opentelemetry/latest/opentelemetry/trace/enum.SpanKind.html
-//! [span status codes]: https://docs.rs/opentelemetry/latest/opentelemetry/trace/enum.StatusCode.html
+//! [span kinds]: opentelemetry::trace::SpanKind
+//! [span status codes]: opentelemetry::trace::StatusCode
 //!
 //! ### Semantic Conventions
 //!

--- a/tracing-opentelemetry/src/span_ext.rs
+++ b/tracing-opentelemetry/src/span_ext.rs
@@ -4,7 +4,7 @@ use opentelemetry::{trace::SpanContext, Context, KeyValue};
 /// Utility functions to allow tracing [`Span`]s to accept and return
 /// [OpenTelemetry] [`Context`]s.
 ///
-/// [`Span`]: https://docs.rs/tracing/latest/tracing/struct.Span.html
+/// [`Span`]: tracing::Span
 /// [OpenTelemetry]: https://opentelemetry.io
 /// [`Context`]: opentelemetry::Context
 pub trait OpenTelemetrySpanExt {

--- a/tracing-subscriber/src/field/delimited.rs
+++ b/tracing-subscriber/src/field/delimited.rs
@@ -53,7 +53,7 @@ impl<D, V> VisitDelimited<D, V> {
     /// Returns a new [`Visit`] implementation that wraps `inner` so that
     /// each formatted field is separated by the provided `delimiter`.
     ///
-    /// [`Visit`]: https://docs.rs/tracing-core/0.1.6/tracing_core/field/trait.Visit.html
+    /// [`Visit`]: tracing_core::field::Visit
     pub fn new(delimiter: D, inner: V) -> Self {
         Self {
             delimiter,

--- a/tracing-subscriber/src/field/mod.rs
+++ b/tracing-subscriber/src/field/mod.rs
@@ -22,7 +22,7 @@ pub mod display;
 /// data to, configuration variables that determine the visitor's behavior, or
 /// `()` when no input is required to produce a visitor.
 ///
-/// [visitors]: https://docs.rs/tracing-core/latest/tracing_core/field/trait.Visit.html
+/// [visitors]: tracing_core::field::Visit
 pub trait MakeVisitor<T> {
     /// The visitor type produced by this `MakeVisitor`.
     type Visitor: Visit;
@@ -33,7 +33,7 @@ pub trait MakeVisitor<T> {
 
 /// A [visitor] that produces output once it has visited a set of fields.
 ///
-/// [visitor]: https://docs.rs/tracing-core/latest/tracing_core/field/trait.Visit.html
+/// [visitor]: tracing_core::field::Visit
 pub trait VisitOutput<Out>: Visit {
     /// Completes the visitor, returning any output.
     ///
@@ -82,10 +82,10 @@ pub trait VisitOutput<Out>: Visit {
 ///     r.record(&mut visitor);
 /// }
 /// ```
-/// [visitor]: https://docs.rs/tracing-core/latest/tracing_core/field/trait.Visit.html
-/// [attr]: https://docs.rs/tracing-core/latest/tracing_core/span/struct.Attributes.html
-/// [rec]: https://docs.rs/tracing-core/latest/tracing_core/span/struct.Record.html
-/// [event]: https://docs.rs/tracing-core/latest/tracing_core/event/struct.Event.html
+/// [visitor]: tracing_core::field::Visit
+/// [attr]: tracing_core::span::Attributes
+/// [rec]: tracing_core::span::Record
+/// [event]: tracing_core::event::Event
 pub trait RecordFields: crate::sealed::Sealed<RecordFieldsMarker> {
     /// Record all the fields in `self` with the provided `visitor`.
     fn record(&self, visitor: &mut dyn Visit);

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -224,8 +224,8 @@ impl EnvFilter {
     /// `RUST_LOG` is the default environment variable used by
     /// [`EnvFilter::from_default_env`] and [`EnvFilter::try_from_default_env`].
     ///
-    /// [`EnvFilter::from_default_env`]: #method.from_default_env
-    /// [`EnvFilter::try_from_default_env`]: #method.try_from_default_env
+    /// [`EnvFilter::from_default_env`]: EnvFilter::from_default_env()
+    /// [`EnvFilter::try_from_default_env`]: EnvFilter::try_from_default_env()
     pub const DEFAULT_ENV: &'static str = "RUST_LOG";
 
     // === constructors, etc ===

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -416,7 +416,7 @@ impl EnvFilter {
     /// spans and events, the previous directive is overwritten.
     ///
     /// [`LevelFilter`]: super::LevelFilter
-    /// [`Level`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Level.html
+    /// [`Level`]: tracing_core::Level
     ///
     /// # Examples
     ///

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -444,7 +444,7 @@ where
     /// Sets whether or not the [thread ID] of the current thread is displayed
     /// when formatting events
     ///
-    /// [thread ID]: https://doc.rust-lang.org/stable/std/thread/struct.ThreadId.html
+    /// [thread ID]: std::thread::ThreadId
     pub fn with_thread_ids(self, display_thread_ids: bool) -> Layer<S, N, format::Format<L, T>, W> {
         Layer {
             fmt_event: self.fmt_event.with_thread_ids(display_thread_ids),
@@ -455,7 +455,7 @@ where
     /// Sets whether or not the [name] of the current thread is displayed
     /// when formatting events
     ///
-    /// [name]: https://doc.rust-lang.org/stable/std/thread/index.html#naming-threads
+    /// [name]: std::thread#naming-threads
     pub fn with_thread_names(
         self,
         display_thread_names: bool,

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -393,7 +393,7 @@ where
     /// `Layer`s added to this subscriber.
     ///
     /// [lifecycle]: https://docs.rs/tracing/latest/tracing/span/index.html#the-span-lifecycle
-    /// [time]: #method.without_time
+    /// [time]: Layer::without_time()
     pub fn with_span_events(self, kind: FmtSpan) -> Self {
         Layer {
             fmt_span: self.fmt_span.with_kind(kind),
@@ -510,7 +510,7 @@ where
     /// - [`Layer::flatten_event`] can be used to enable flattening event fields into the root
     /// object.
     ///
-    /// [`Layer::flatten_event`]: #method.flatten_event
+    /// [`Layer::flatten_event`]: Layer::flatten_event()
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub fn json(self) -> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -80,9 +80,9 @@ use tracing_log::NormalizeEvent;
 /// **Note**: This is an experimental feature. [Unstable features][unstable]
 /// must be enabled in order to use `valuable` support.
 ///
-/// [`Json::flatten_event`]: #method.flatten_event
-/// [`Json::with_current_span`]: #method.with_current_span
-/// [`Json::with_span_list`]: #method.with_span_list
+/// [`Json::flatten_event`]: Json::flatten_event()
+/// [`Json::with_current_span`]: Json::with_current_span()
+/// [`Json::with_span_list`]: Json::with_span_list()
 /// [`valuable`]: https://crates.io/crates/valuable
 /// [unstable]: crate#unstable-features
 /// [`valuable::Valuable`]: https://docs.rs/valuable/latest/valuable/trait.Valuable.html
@@ -341,7 +341,6 @@ impl Default for Json {
 
 /// The JSON [`FormatFields`] implementation.
 ///
-/// [`FormatFields`]: FormatFields
 #[derive(Debug)]
 pub struct JsonFields {
     // reserve the ability to add fields to this without causing a breaking
@@ -352,7 +351,6 @@ pub struct JsonFields {
 impl JsonFields {
     /// Returns a new JSON [`FormatFields`] implementation.
     ///
-    /// [`FormatFields`]: FormatFields
     pub fn new() -> Self {
         Self { _private: () }
     }
@@ -422,7 +420,6 @@ impl<'a> FormatFields<'a> for JsonFields {
 /// The [visitor] produced by [`JsonFields`]'s [`MakeVisitor`] implementation.
 ///
 /// [visitor]: crate::field::Visit
-/// [`JsonFields`]: JsonFields
 /// [`MakeVisitor`]: crate::field::MakeVisitor
 pub struct JsonVisitor<'a> {
     values: BTreeMap<&'a str, serde_json::Value>,

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -281,7 +281,6 @@ pub fn json() -> Format<Json> {
 /// Returns a [`FormatFields`] implementation that formats fields using the
 /// provided function or closure.
 ///
-/// [`FormatFields`]: FormatFields
 pub fn debug_fn<F>(f: F) -> FieldFn<F>
 where
     F: Fn(&mut Writer<'_>, &Field, &dyn fmt::Debug) -> fmt::Result + Clone,
@@ -313,13 +312,11 @@ pub struct Writer<'writer> {
 /// A [`FormatFields`] implementation that formats fields by calling a function
 /// or closure.
 ///
-/// [`FormatFields`]: FormatFields
 #[derive(Debug, Clone)]
 pub struct FieldFn<F>(F);
 /// The [visitor] produced by [`FieldFn`]'s [`MakeVisitor`] implementation.
 ///
 /// [visitor]: super::super::field::Visit
-/// [`FieldFn`]: FieldFn
 /// [`MakeVisitor`]: super::super::field::MakeVisitor
 pub struct FieldFnVisitor<'a, F> {
     f: F,
@@ -664,8 +661,6 @@ impl<F, T> Format<F, T> {
     ///
     /// - [`Format::flatten_event`] can be used to enable flattening event fields into the root
     /// object.
-    ///
-    /// [`Format::flatten_event`]: #method.flatten_event
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub fn json(self) -> Format<Json, T> {
@@ -1157,7 +1152,6 @@ where
 
 /// The default [`FormatFields`] implementation.
 ///
-/// [`FormatFields`]: FormatFields
 #[derive(Debug)]
 pub struct DefaultFields {
     // reserve the ability to add fields to this without causing a breaking
@@ -1179,7 +1173,6 @@ pub struct DefaultVisitor<'a> {
 impl DefaultFields {
     /// Returns a new default [`FormatFields`] implementation.
     ///
-    /// [`FormatFields`]: FormatFields
     pub fn new() -> Self {
         Self { _private: () }
     }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -750,7 +750,7 @@ impl<F, T> Format<F, T> {
     /// Sets whether or not the [thread ID] of the current thread is displayed
     /// when formatting events
     ///
-    /// [thread ID]: https://doc.rust-lang.org/stable/std/thread/struct.ThreadId.html
+    /// [thread ID]: std::thread::ThreadId
     pub fn with_thread_ids(self, display_thread_id: bool) -> Format<F, T> {
         Format {
             display_thread_id,
@@ -761,7 +761,7 @@ impl<F, T> Format<F, T> {
     /// Sets whether or not the [name] of the current thread is displayed
     /// when formatting events
     ///
-    /// [name]: https://doc.rust-lang.org/stable/std/thread/index.html#naming-threads
+    /// [name]: std::thread#naming-threads
     pub fn with_thread_names(self, display_thread_name: bool) -> Format<F, T> {
         Format {
             display_thread_name,

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -184,7 +184,6 @@
 //! [`EnvFilter`]: super::filter::EnvFilter
 //! [`env_logger`]: https://docs.rs/env_logger/
 //! [`filter`]: super::filter
-//! [`SubscriberBuilder`]: SubscriberBuilder
 //! [`FmtSubscriber`]: Subscriber
 //! [`Subscriber`]:
 //!     https://docs.rs/tracing/latest/tracing/trait.Subscriber.html
@@ -598,7 +597,7 @@ where
     /// `Layer`s added to this subscriber.
     ///
     /// [lifecycle]: https://docs.rs/tracing/latest/tracing/span/index.html#the-span-lifecycle
-    /// [time]: #method.without_time
+    /// [time]: SubscriberBuilder::without_time()
     pub fn with_span_events(self, kind: format::FmtSpan) -> Self {
         SubscriberBuilder {
             inner: self.inner.with_span_events(kind),
@@ -893,7 +892,7 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
     /// # Ok(())}
     /// ```
     /// [`EnvFilter`]: super::filter::EnvFilter
-    /// [`with_max_level`]: #method.with_max_level
+    /// [`with_max_level`]: SubscriberBuilder::with_max_level()
     #[cfg(feature = "env-filter")]
     #[cfg_attr(docsrs, doc(cfg(feature = "env-filter")))]
     pub fn with_env_filter(

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -668,7 +668,7 @@ where
     /// Sets whether or not the [name] of the current thread is displayed
     /// when formatting events
     ///
-    /// [name]: https://doc.rust-lang.org/stable/std/thread/index.html#naming-threads
+    /// [name]: std::thread#naming-threads
     pub fn with_thread_names(
         self,
         display_thread_names: bool,
@@ -682,7 +682,7 @@ where
     /// Sets whether or not the [thread ID] of the current thread is displayed
     /// when formatting events
     ///
-    /// [thread ID]: https://doc.rust-lang.org/stable/std/thread/struct.ThreadId.html
+    /// [thread ID]: std::thread::ThreadId
     pub fn with_thread_ids(
         self,
         display_thread_ids: bool,

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -340,7 +340,7 @@ impl Subscriber {
     ///
     /// This can be overridden with the [`SubscriberBuilder::with_max_level`] method.
     ///
-    /// [verbosity level]: https://docs.rs/tracing-core/0.1.5/tracing_core/struct.Level.html
+    /// [verbosity level]: tracing_core::Level
     /// [`SubscriberBuilder::with_max_level`]: SubscriberBuilder::with_max_level
     pub const DEFAULT_MAX_LEVEL: LevelFilter = LevelFilter::INFO;
 
@@ -935,7 +935,7 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
     ///     .with_max_level(LevelFilter::OFF)
     ///     .finish();
     /// ```
-    /// [verbosity level]: https://docs.rs/tracing-core/0.1.5/tracing_core/struct.Level.html
+    /// [verbosity level]: tracing_core::Level
     /// [`EnvFilter`]: struct@crate::filter::EnvFilter
     /// [`with_env_filter`]: fn@Self::with_env_filter
     pub fn with_max_level(

--- a/tracing-subscriber/src/fmt/time/time_crate.rs
+++ b/tracing-subscriber/src/fmt/time/time_crate.rs
@@ -19,10 +19,10 @@ use time::{format_description::well_known, formatting::Formattable, OffsetDateTi
 ///    documentation</a> for more details.
 /// </pre></div>
 ///
-/// [local time]: https://docs.rs/time/0.3/time/struct.OffsetDateTime.html#method.now_local
-/// [UTC time]: https://docs.rs/time/0.3/time/struct.OffsetDateTime.html#method.now_utc
-/// [formatter]: https://docs.rs/time/0.3/time/formatting/trait.Formattable.html
-/// [`time` crate]: https://docs.rs/time/0.3/time/
+/// [local time]: time::OffsetDateTime::now_local
+/// [UTC time]:     time::OffsetDateTime::now_utc
+/// [formatter]:    time::formatting::Formattable
+/// [`time` crate]: time
 #[derive(Clone, Debug)]
 #[cfg_attr(
     docsrs,
@@ -37,10 +37,10 @@ pub struct LocalTime<F> {
 ///
 /// To format the current [local time] instead, use the [`LocalTime`] type.
 ///
-/// [local time]: https://docs.rs/time/0.3/time/struct.OffsetDateTime.html#method.now_local
-/// [UTC time]: https://docs.rs/time/0.3/time/struct.OffsetDateTime.html#method.now_utc
-/// [formatter]: https://docs.rs/time/0.3/time/formatting/trait.Formattable.html
-/// [`time` crate]: https://docs.rs/time/0.3/time/
+/// [local time]: time::OffsetDateTime::now_local
+/// [UTC time]:     time::OffsetDateTime::now_utc
+/// [formatter]:    time::formatting::Formattable
+/// [`time` crate]: time
 #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
 #[derive(Clone, Debug)]
 pub struct UtcTime<F> {
@@ -55,8 +55,8 @@ pub struct UtcTime<F> {
 /// handle any errors. However, this also means the offset cannot change while the program is
 /// running (the offset will not change across DST changes).
 ///
-/// [formatter]: https://docs.rs/time/0.3/time/formatting/trait.Formattable.html
-/// [`time` crate]: https://docs.rs/time/0.3/time/
+/// [formatter]: time::formatting::Formattable
+/// [`time` crate]: time
 #[derive(Clone, Debug)]
 #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
 pub struct OffsetTime<F> {
@@ -81,7 +81,7 @@ impl LocalTime<well_known::Rfc3339> {
     /// # drop(collector);
     /// ```
     ///
-    /// [local time]: https://docs.rs/time/0.3/time/struct.OffsetDateTime.html#method.now_local
+    /// [local time]: time::OffsetDateTime::now_local
     /// [RFC 3339]: https://datatracker.ietf.org/doc/html/rfc3339
     /// [ISO 8601]: https://en.wikipedia.org/wiki/ISO_8601
     pub fn rfc_3339() -> Self {
@@ -163,12 +163,12 @@ impl<F: Formattable> LocalTime<F> {
     /// # drop(collector);
     /// ```
     ///
-    /// [local time]: https://docs.rs/time/latest/time/struct.OffsetDateTime.html#method.now_local
-    /// [`time` crate]: https://docs.rs/time/0.3/time/
-    /// [`Formattable`]: https://docs.rs/time/0.3/time/formatting/trait.Formattable.html
-    /// [well-known formats]: https://docs.rs/time/0.3/time/format_description/well_known/index.html
-    /// [`format_description!`]: https://docs.rs/time/0.3/time/macros/macro.format_description.html
-    /// [`time::format_description::parse`]: https://docs.rs/time/0.3/time/format_description/fn.parse.html
+    /// [local time]: time::OffsetDateTime::now_local()
+    /// [`time` crate]: time
+    /// [`Formattable`]: time::formatting::Formattable
+    /// [well-known formats]: time::format_description::well_known
+    /// [`format_description!`]: time::macros::format_description!
+    /// [`time::format_description::parse`]: time::format_description::parse()
     /// [`time` book]: https://time-rs.github.io/book/api/format-description.html
     pub fn new(format: F) -> Self {
         Self { format }
@@ -212,7 +212,7 @@ impl UtcTime<well_known::Rfc3339> {
     /// # drop(collector);
     /// ```
     ///
-    /// [local time]: https://docs.rs/time/0.3/time/struct.OffsetDateTime.html#method.now_utc
+    /// [local time]: time::OffsetDateTime::now_utc
     /// [RFC 3339]: https://datatracker.ietf.org/doc/html/rfc3339
     /// [ISO 8601]: https://en.wikipedia.org/wiki/ISO_8601
     pub fn rfc_3339() -> Self {
@@ -280,12 +280,12 @@ impl<F: Formattable> UtcTime<F> {
     /// # drop(collector);
     /// ```
     ///
-    /// [UTC time]: https://docs.rs/time/latest/time/struct.OffsetDateTime.html#method.now_utc
-    /// [`time` crate]: https://docs.rs/time/0.3/time/
-    /// [`Formattable`]: https://docs.rs/time/0.3/time/formatting/trait.Formattable.html
-    /// [well-known formats]: https://docs.rs/time/0.3/time/format_description/well_known/index.html
-    /// [`format_description!`]: https://docs.rs/time/0.3/time/macros/macro.format_description.html
-    /// [`time::format_description::parse`]: https://docs.rs/time/0.3/time/format_description/fn.parse.html
+    /// [UTC time]: time::OffsetDateTime::now_utc()
+    /// [`time` crate]: time
+    /// [`Formattable`]: time::formatting::Formattable
+    /// [well-known formats]: time::format_description::well_known
+    /// [`format_description!`]: time::macros::format_description!
+    /// [`time::format_description::parse`]: time::format_description::parse
     /// [`time` book]: https://time-rs.github.io/book/api/format-description.html
     pub fn new(format: F) -> Self {
         Self { format }
@@ -357,7 +357,7 @@ impl OffsetTime<well_known::Rfc3339> {
     /// }
     /// ```
     ///
-    /// [local time offset]: https://docs.rs/time/0.3/time/struct.UtcOffset.html#method.current_local_offset
+    /// [local time offset]: time::UtcOffset::current_local_offset
     /// [RFC 3339]: https://datatracker.ietf.org/doc/html/rfc3339
     /// [ISO 8601]: https://en.wikipedia.org/wiki/ISO_8601
     pub fn local_rfc_3339() -> Result<Self, time::error::IndeterminateOffset> {
@@ -435,13 +435,13 @@ impl<F: time::formatting::Formattable> OffsetTime<F> {
     /// # drop(collector);
     /// ```
     ///
-    /// [`time` crate]: https://docs.rs/time/0.3/time/
-    /// [timezone offset]: https://docs.rs/time/latest/time/struct.UtcOffset.html
-    /// [`Formattable`]: https://docs.rs/time/0.3/time/formatting/trait.Formattable.html
-    /// [local offset]: https://docs.rs/time/0.3.5/time/struct.UtcOffset.html#method.current_local_offset
-    /// [well-known formats]: https://docs.rs/time/0.3/time/format_description/well_known/index.html
-    /// [`format_description!`]: https://docs.rs/time/0.3/time/macros/macro.format_description.html
-    /// [`time::format_description::parse`]: https://docs.rs/time/0.3/time/format_description/fn.parse.html
+    /// [`time` crate]: time
+    /// [timezone offset]: time::UtcOffset
+    /// [`Formattable`]: time::formatting::Formattable
+    /// [local offset]: time::UtcOffset::current_local_offset()
+    /// [well-known formats]: time::format_description::well_known
+    /// [`format_description!`]: time::macros::format_description
+    /// [`time::format_description::parse`]: time::format_description::parse
     /// [`time` book]: https://time-rs.github.io/book/api/format-description.html
     pub fn new(offset: time::UtcOffset, format: F) -> Self {
         Self { offset, format }

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -1,6 +1,6 @@
 //! Abstractions for creating [`io::Write`] instances.
 //!
-//! [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
+//! [`io::Write`]: std::io::Write
 use std::{
     fmt,
     io::{self, Write},
@@ -96,7 +96,7 @@ use tracing_core::Metadata;
 pub trait MakeWriter<'a> {
     /// The concrete [`io::Write`] implementation returned by [`make_writer`].
     ///
-    /// [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
+    /// [`io::Write`]: std::io::Write
     /// [`make_writer`]: MakeWriter::make_writer
     type Writer: io::Write;
 
@@ -505,9 +505,9 @@ pub trait MakeWriterExt<'a>: MakeWriter<'a> {
 /// [`fmt::Layer`]: super::Layer
 /// [capturing]: https://doc.rust-lang.org/book/ch11-02-running-tests.html#showing-function-output
 /// [nocapture]: https://doc.rust-lang.org/cargo/commands/cargo-test.html
-/// [`io::stdout`]: https://doc.rust-lang.org/std/io/fn.stdout.html
-/// [`io::stderr`]: https://doc.rust-lang.org/std/io/fn.stderr.html
-/// [`print!`]: https://doc.rust-lang.org/std/macro.print.html
+/// [`io::stdout`]: std::io::stdout
+/// [`io::stderr`]: std::io::stderr
+/// [`print!`]: std::print!
 #[derive(Default, Debug)]
 pub struct TestWriter {
     _p: (),
@@ -646,9 +646,9 @@ pub struct Tee<A, B> {
 /// requires the `Writer` type to implement [`io::Write`], it's necessary to add
 /// a newtype that forwards the trait implementation.
 ///
-/// [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
-/// [`MutexGuard`]: https://doc.rust-lang.org/std/sync/struct.MutexGuard.html
-/// [`Mutex`]: https://doc.rust-lang.org/std/sync/struct.Mutex.html
+/// [`io::Write`]: std::io::Write
+/// [`MutexGuard`]: std::sync::MutexGuard
+/// [`Mutex`]: std::sync::Mutex
 #[derive(Debug)]
 pub struct MutexGuardWriter<'a, W>(MutexGuard<'a, W>);
 

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -97,7 +97,7 @@ pub trait MakeWriter<'a> {
     /// The concrete [`io::Write`] implementation returned by [`make_writer`].
     ///
     /// [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
-    /// [`make_writer`]: #tymethod.make_writer
+    /// [`make_writer`]: MakeWriter::make_writer
     type Writer: io::Write;
 
     /// Returns an instance of [`Writer`].
@@ -109,7 +109,7 @@ pub trait MakeWriter<'a> {
     /// creating a [`io::Write`] instance is expensive, be sure to cache it when implementing
     /// [`MakeWriter`] to improve performance.
     ///
-    /// [`Writer`]: #associatedtype.Writer
+    /// [`Writer`]: MakeWriter::Writer
     /// [`fmt::Layer`]: crate::fmt::Layer
     /// [`fmt::Subscriber`]: crate::fmt::Subscriber
     /// [`io::Write`]: std::io::Write
@@ -649,7 +649,6 @@ pub struct Tee<A, B> {
 /// [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 /// [`MutexGuard`]: https://doc.rust-lang.org/std/sync/struct.MutexGuard.html
 /// [`Mutex`]: https://doc.rust-lang.org/std/sync/struct.Mutex.html
-/// [`MakeWriter`]: MakeWriter
 #[derive(Debug)]
 pub struct MutexGuardWriter<'a, W>(MutexGuard<'a, W>);
 
@@ -734,7 +733,6 @@ impl<'a> MakeWriter<'a> for TestWriter {
 impl BoxMakeWriter {
     /// Constructs a `BoxMakeWriter` wrapping a type implementing [`MakeWriter`].
     ///
-    /// [`MakeWriter`]: MakeWriter
     pub fn new<M>(make_writer: M) -> Self
     where
         M: for<'a> MakeWriter<'a> + Send + Sync + 'static,

--- a/tracing-subscriber/src/layer/context.rs
+++ b/tracing-subscriber/src/layer/context.rs
@@ -101,7 +101,7 @@ where
     ///
     /// [register]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/trait.Subscriber.html#method.register_callsite
     /// [`enabled`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/trait.Subscriber.html#method.enabled
-    /// [`Context::enabled`]: #method.enabled
+    /// [`Context::enabled`]: Context::enabled()
     #[inline]
     pub fn event(&self, event: &Event<'_>) {
         if let Some(subscriber) = self.subscriber {

--- a/tracing-subscriber/src/layer/context.rs
+++ b/tracing-subscriber/src/layer/context.rs
@@ -26,7 +26,7 @@ use crate::{filter::FilterId, registry::Registry};
 /// ```
 ///
 /// [`Layer`]: super::Layer
-/// [`Subscriber`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html
+/// [`Subscriber`]: tracing_core::Subscriber
 /// [stored data]: crate::registry::SpanRef
 /// [`LookupSpan`]: crate::registry::LookupSpan
 #[derive(Debug)]
@@ -99,8 +99,8 @@ where
     ///   check whether the event would be enabled. This allows `Layer`s to
     ///   elide constructing the event if it would not be recorded.
     ///
-    /// [register]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/trait.Subscriber.html#method.register_callsite
-    /// [`enabled`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/trait.Subscriber.html#method.enabled
+    /// [register]: tracing_core::subscriber::Subscriber::register_callsite()
+    /// [`enabled`]: tracing_core::subscriber::Subscriber::enabled()
     /// [`Context::enabled`]: Context::enabled()
     #[inline]
     pub fn event(&self, event: &Event<'_>) {

--- a/tracing-subscriber/src/layer/layered.rs
+++ b/tracing-subscriber/src/layer/layered.rs
@@ -18,7 +18,7 @@ use core::{any::TypeId, cmp, fmt, marker::PhantomData};
 /// [`Layer`]s.
 ///
 /// [`Layer`]: crate::Layer
-/// [`Subscriber`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html
+/// [`Subscriber`]: tracing_core::Subscriber
 #[derive(Clone)]
 pub struct Layered<L, I, S = I> {
     /// The layer.

--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -629,15 +629,15 @@
 //! # Ok(()) }
 //! ```
 //!
-//! [`Subscriber`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/trait.Subscriber.html
-//! [span IDs]: https://docs.rs/tracing-core/latest/tracing_core/span/struct.Id.html
+//! [`Subscriber`]: tracing_core::subscriber::Subscriber
+//! [span IDs]: tracing_core::span::Id
 //! [the current span]: Context::current_span
 //! [`register_callsite`]: Layer::register_callsite
 //! [`enabled`]: Layer::enabled
 //! [`on_enter`]: Layer::on_enter
 //! [`Layer::register_callsite`]: Layer::register_callsite
 //! [`Layer::enabled`]: Layer::enabled
-//! [`Interest::never()`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/struct.Interest.html#method.never
+//! [`Interest::never()`]: tracing_core::subscriber::Interest::never()
 //! [`Filtered`]: crate::filter::Filtered
 //! [`filter`]: crate::filter
 //! [`Targets`]: crate::filter::Targets
@@ -749,10 +749,10 @@ where
     /// globally enable or disable those callsites, it should always return
     /// [`Interest::always()`].
     ///
-    /// [`Interest`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Interest.html
-    /// [`Subscriber::register_callsite`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html#method.register_callsite
-    /// [`Interest::never()`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/struct.Interest.html#method.never
-    /// [`Interest::always()`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/struct.Interest.html#method.always
+    /// [`Interest`]: tracing_core::Interest
+    /// [`Subscriber::register_callsite`]: tracing_core::Subscriber::register_callsite()
+    /// [`Interest::never()`]: tracing_core::subscriber::Interest::never()
+    /// [`Interest::always()`]: tracing_core::subscriber::Interest::always()
     /// [`self.enabled`]: Layer::enabled()
     /// [`Layer::enabled`]: Layer::enabled()
     /// [`on_event`]: Layer::on_event()
@@ -792,8 +792,8 @@ where
     /// See [the trait-level documentation] for more information on filtering
     /// with `Layer`s.
     ///
-    /// [`Interest`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Interest.html
-    /// [`Subscriber::enabled`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html#method.enabled
+    /// [`Interest`]: tracing_core::Interest
+    /// [`Subscriber::enabled`]: tracing_core::Subscriber::enabled()
     /// [`Layer::register_callsite`]: Layer::register_callsite()
     /// [`on_event`]: Layer::on_event()
     /// [`on_enter`]: Layer::on_enter()
@@ -996,7 +996,7 @@ where
     ///     .with_subscriber(MySubscriber::new());
     ///```
     ///
-    /// [`Subscriber`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html
+    /// [`Subscriber`]: tracing_core::Subscriber
     fn with_subscriber(mut self, mut inner: S) -> Layered<Self, S>
     where
         Self: Sized,

--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -753,11 +753,11 @@ where
     /// [`Subscriber::register_callsite`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html#method.register_callsite
     /// [`Interest::never()`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/struct.Interest.html#method.never
     /// [`Interest::always()`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/struct.Interest.html#method.always
-    /// [`self.enabled`]: #method.enabled
-    /// [`Layer::enabled`]: #method.enabled
-    /// [`on_event`]: #method.on_event
-    /// [`on_enter`]: #method.on_enter
-    /// [`on_exit`]: #method.on_exit
+    /// [`self.enabled`]: Layer::enabled()
+    /// [`Layer::enabled`]: Layer::enabled()
+    /// [`on_event`]: Layer::on_event()
+    /// [`on_enter`]: Layer::on_enter()
+    /// [`on_exit`]: Layer::on_exit()
     /// [the trait-level documentation]: #filtering-with-layers
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         if self.enabled(metadata, Context::none()) {
@@ -793,12 +793,11 @@ where
     /// with `Layer`s.
     ///
     /// [`Interest`]: https://docs.rs/tracing-core/latest/tracing_core/struct.Interest.html
-    /// [`Context`]: Context
     /// [`Subscriber::enabled`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html#method.enabled
-    /// [`Layer::register_callsite`]: #method.register_callsite
-    /// [`on_event`]: #method.on_event
-    /// [`on_enter`]: #method.on_enter
-    /// [`on_exit`]: #method.on_exit
+    /// [`Layer::register_callsite`]: Layer::register_callsite()
+    /// [`on_event`]: Layer::on_event()
+    /// [`on_enter`]: Layer::on_enter()
+    /// [`on_exit`]: Layer::on_exit()
     /// [the trait-level documentation]: #filtering-with-layers
     fn enabled(&self, metadata: &Metadata<'_>, ctx: Context<'_, S>) -> bool {
         let _ = (metadata, ctx);

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -149,8 +149,8 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
-//! [`tracing`]: https://docs.rs/tracing/latest/tracing/
-//! [`Subscriber`]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/trait.Subscriber.html
+//! [`Subscriber`]: tracing_core::subscriber::Subscriber
+//! [`tracing`]: https://docs.rs/tracing/latest/tracing
 //! [`EnvFilter`]: filter::EnvFilter
 //! [`fmt`]: mod@fmt
 //! [`tracing-log`]: https://crates.io/crates/tracing-log

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -158,8 +158,8 @@
 //! [`env_logger` crate]: https://crates.io/crates/env_logger
 //! [`parking_lot`]: https://crates.io/crates/parking_lot
 //! [`time` crate]: https://crates.io/crates/time
-//! [`libstd`]: https://doc.rust-lang.org/std/index.html
-//! [`liballoc`]: https://doc.rust-lang.org/alloc/index.html
+//! [`libstd`]: std
+//! [`liballoc`]: alloc
 #![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.3.11")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",

--- a/tracing-subscriber/src/registry/extensions.rs
+++ b/tracing-subscriber/src/registry/extensions.rs
@@ -78,7 +78,7 @@ impl<'a> ExtensionsMut<'a> {
     /// should be able to reuse timestamp _x_.
     ///
     /// Therefore, extensions should generally be newtypes, rather than common
-    /// types like [`String`](https://doc.rust-lang.org/std/string/struct.String.html), to avoid accidental
+    /// types like [`String`](std::string::String), to avoid accidental
     /// cross-`Layer` clobbering.
     ///
     /// ## Panics

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -104,7 +104,6 @@ pub trait LookupSpan<'a> {
     /// capable of performing more sophisiticated queries.
     /// </pre>
     ///
-    /// [`SpanData`]: SpanData
     fn span_data(&'a self, id: &Id) -> Option<Self::Data>;
 
     /// Returns a [`SpanRef`] for the span with the given `Id`, if it exists.
@@ -116,9 +115,7 @@ pub trait LookupSpan<'a> {
     /// rather than the [`span_data`] method; while _implementors_ of this trait
     /// should only implement `span_data`.
     ///
-    /// [`SpanRef`]: SpanRef
-    /// [`SpanData`]: SpanData
-    /// [`span_data`]: #method.span_data
+    /// [`span_data`]: LookupSpan::span_data()
     fn span(&'a self, id: &Id) -> Option<SpanRef<'_, Self>>
     where
         Self: Sized,

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -55,8 +55,7 @@
 //! require the root subscriber to be a registry.
 //!
 //! [`Layer`]: crate::layer::Layer
-//! [`Subscriber`]:
-//!     https://docs.rs/tracing-core/latest/tracing_core/subscriber/trait.Subscriber.html
+//! [`Subscriber`]: tracing_core::Subscriber
 //! [ctx]: crate::layer::Context
 //! [lookup]: crate::layer::Context::span()
 use tracing_core::{field::FieldSet, span::Id, Metadata};
@@ -357,7 +356,7 @@ where
 
     /// Returns a list of [fields] defined by the span.
     ///
-    /// [fields]: https://docs.rs/tracing-core/latest/tracing_core/field/index.html
+    /// [fields]: tracing_core::field
     pub fn fields(&self) -> &FieldSet {
         self.data.metadata().fields()
     }

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -75,16 +75,16 @@ use tracing_core::{
 /// the distributed tracing system. These IDs can be associated with
 /// `tracing` spans using [fields] and/or [stored span data].
 ///
-/// [span IDs]: https://docs.rs/tracing-core/latest/tracing_core/span/struct.Id.html
-/// [slab]: https://docs.rs/crate/sharded-slab/
+/// [span IDs]: tracing_core::span::Id
+/// [slab]: sharded_slab
 /// [`Layer`]: crate::Layer
 /// [added]: crate::layer::Layer#composing-layers
 /// [extensions]: super::Extensions
 /// [closed]: https://docs.rs/tracing/latest/tracing/span/index.html#closing-spans
-/// [considered closed]: https://docs.rs/tracing-core/latest/tracing_core/subscriber/trait.Subscriber.html#method.try_close
+/// [considered closed]: tracing_core::subscriber::Subscriber::try_close()
 /// [`Span`]: https://docs.rs/tracing/latest/tracing/span/struct.Span.html
 /// [ot]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#spancontext
-/// [fields]: https://docs.rs/tracing-core/latest/tracing-core/field/index.html
+/// [fields]: tracing_core::field
 /// [stored span data]: crate::registry::SpanData::extensions_mut
 #[cfg(feature = "registry")]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "registry", feature = "std"))))]
@@ -114,10 +114,11 @@ pub struct Data<'a> {
 
 /// Stored data associated with a span.
 ///
-/// This type is pooled using `sharded_slab::Pool`; when a span is dropped, the
-/// `DataInner` entry at that span's slab index is cleared in place and reused
-/// by a future span. Thus, the `Default` and `sharded_slab::Clear`
-/// implementations for this type are load-bearing.
+/// This type is pooled using [`sharded_slab::Pool`]; when a span is
+/// dropped, the `DataInner` entry at that span's slab index is cleared
+/// in place and reused by a future span. Thus, the `Default` and
+/// [`sharded_slab::Clear`] implementations for this type are
+/// load-bearing.
 #[derive(Debug)]
 struct DataInner {
     filter_map: FilterMap,

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -102,7 +102,6 @@ pub struct Registry {
 /// [`Layer`s], such as formatted fields, metrics, or distributed traces should
 /// be stored in the [extensions] typemap.
 ///
-/// [`Registry`]: Registry
 /// [`Layer`s]: crate::layer::Layer
 /// [extensions]: Extensions
 #[cfg(feature = "registry")]
@@ -173,7 +172,6 @@ fn id_to_idx(id: &Id) -> usize {
 ///    greater than 0, `CloseGuard` decrements the counter by one and
 ///    _does not_ remove the span from the [`Registry`].
 ///
-/// [`Registry`]: Registry
 pub(crate) struct CloseGuard<'a> {
     id: Id,
     registry: &'a Registry,
@@ -189,7 +187,6 @@ impl Registry {
     /// processed an `on_close` notification via the `CLOSE_COUNT` thread-local.
     /// For additional details, see [`CloseGuard`].
     ///
-    /// [`CloseGuard`]: CloseGuard
     pub(crate) fn start_close(&self, id: Id) -> CloseGuard<'_> {
         CLOSE_COUNT.with(|count| {
             let c = count.get();
@@ -216,7 +213,6 @@ thread_local! {
     /// track how many layers have processed the close.
     /// For additional details, see [`CloseGuard`].
     ///
-    /// [`CloseGuard`]: CloseGuard
     static CLOSE_COUNT: Cell<usize> = Cell::new(0);
 }
 

--- a/tracing/src/dispatcher.rs
+++ b/tracing/src/dispatcher.rs
@@ -123,10 +123,6 @@
 //! instrumentation.
 //!
 //! [`Subscriber`]: crate::Subscriber
-//! [`with_default`]: with_default
-//! [`set_global_default`]: set_global_default
-//! [`get_default`]: get_default
-//! [`Dispatch`]: Dispatch
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use tracing_core::dispatcher::set_default;

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -466,7 +466,6 @@
 //! [`info_span!`]: info_span!
 //! [`warn_span!`]: warn_span!
 //! [`error_span!`]: error_span!
-//! [`Level`]: Level
 //!
 //! ### For `log` Users
 //!

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -437,9 +437,9 @@
 //! [target]: Metadata::target
 //! [parent span]: span::Attributes::parent
 //! [determined contextually]: span::Attributes::is_contextual
-//! [`fmt::Debug`]: https://doc.rust-lang.org/std/fmt/trait.Debug.html
-//! [`fmt::Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
-//! [fmt]: https://doc.rust-lang.org/std/fmt/#usage
+//! [`fmt::Debug`]: std::fmt::Debug
+//! [`fmt::Display`]: std::fmt::Display
+//! [fmt]: std::fmt#usage
 //! [`Empty`]: field::Empty
 //!
 //! ### Shorthand Macros

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -714,7 +714,7 @@ impl Span {
     ///
     /// [syntax]: https://rust-lang.github.io/async-book/01_getting_started/04_async_await_primer.html
     /// [`Span::in_scope`]: Span::in_scope()
-    /// [instrument]: https://docs.rs/tracing/latest/tracing/trait.Instrument.html
+    /// [instrument]: crate::Instrument
     /// [attr]: macro@crate::instrument
     ///
     /// # Examples

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -713,7 +713,7 @@ impl Span {
     ///   ```
     ///
     /// [syntax]: https://rust-lang.github.io/async-book/01_getting_started/04_async_await_primer.html
-    /// [`Span::in_scope`]: #method.in_scope
+    /// [`Span::in_scope`]: Span::in_scope()
     /// [instrument]: https://docs.rs/tracing/latest/tracing/trait.Instrument.html
     /// [attr]: macro@crate::instrument
     ///
@@ -1230,7 +1230,7 @@ impl Span {
     ///
     /// See also [`is_none`].
     ///
-    /// [`is_none`]: #method.is_none
+    /// [`is_none`]: Span::is_none()
     #[inline]
     pub fn is_disabled(&self) -> bool {
         self.inner.is_none()
@@ -1244,8 +1244,8 @@ impl Span {
     /// rather than constructed by `Span::none`, this method will return
     /// `false`, while `is_disabled` will return `true`.
     ///
-    /// [`Span::none`]: #method.none
-    /// [`is_disabled`]: #method.is_disabled
+    /// [`Span::none`]: Span::none()
+    /// [`is_disabled`]: Span::is_disabled()
     #[inline]
     pub fn is_none(&self) -> bool {
         self.is_disabled() && self.meta.is_none()


### PR DESCRIPTION
## Motivation

Intra-doc links are neat and get checked by rustdoc. #940.

## Solution

Continuing from #2068, this changes more links in doc comments from full URLs to intra-doc links and cleans up some redundant <code>[&grave;Foo&grave;]: Foo</code>-style links, partly with the help of `cargo intraconv` which I've since been pointed at.

Primarily,
* `#foo` links turned into `Blah::foo`
* intra-doc links for stuff in `std` etc
* intra-doc links to non-optional dependencies

For the latter I've tried to be conservative so that people who build their own docs with some features disabled don't get broken links (but possibly missed some since this was kinda manual, and there were already warnings for unresolved references without some features). For `std` I have not been conservative even though `std` is optional in places as there were already a bunch of intra-doc links to `std`.
