### PR TITLE
subscriber: added explicit `with_timestamp` method for any impls that use `without_time`

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -280,15 +280,26 @@ where
         }
     }
 
-    /// Do not emit timestamps with spans and event.
-    pub fn without_time(self) -> Subscriber<C, N, format::Format<L, ()>, W> {
+    /// Enable timestamps for log messages using the [`timer`] field in [`Self`].
+    ///
+    /// [`timer`]: super::time::FormatTime
+    pub fn with_timestamp(
+        self,
+        display_timestamp: bool,
+    ) -> Subscriber<C, N, format::Format<L, T>, W> {
         Subscriber {
-            fmt_event: self.fmt_event.without_time(),
-            fmt_fields: self.fmt_fields,
-            fmt_span: self.fmt_span.without_time(),
-            make_writer: self.make_writer,
-            is_ansi: self.is_ansi,
-            _inner: self._inner,
+            fmt_event: self.fmt_event.with_timestamp(display_timestamp),
+            fmt_span: self.fmt_span.with_timestamp(display_timestamp),
+            ..self
+        }
+    }
+
+    /// Do not emit timestamps with spans and event.
+    pub fn without_time(self) -> Subscriber<C, N, format::Format<L, T>, W> {
+        Subscriber {
+            fmt_event: self.fmt_event.with_timestamp(false),
+            fmt_span: self.fmt_span.with_timestamp(false),
+            ..self
         }
     }
 

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -295,11 +295,14 @@ where
     }
 
     /// Do not emit timestamps with spans and event.
-    pub fn without_time(self) -> Subscriber<C, N, format::Format<L, T>, W> {
+    pub fn without_time(self) -> Subscriber<C, N, format::Format<L, ()>, W> {
         Subscriber {
-            fmt_event: self.fmt_event.with_timestamp(false),
+            fmt_event: self.fmt_event.without_time(),
             fmt_span: self.fmt_span.with_timestamp(false),
-            ..self
+            fmt_fields: self.fmt_fields,
+            make_writer: self.make_writer,
+            is_ansi: self.is_ansi,
+            _inner: self._inner,
         }
     }
 

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -716,8 +716,19 @@ impl<F, T> Format<F, T> {
     }
 
     /// Do not emit timestamps with log messages.
-    pub fn without_time(self) -> Format<F, T> {
-        self.with_timestamp(false)
+    pub fn without_time(self) -> Format<F, ()> {
+        Format {
+            format: self.format,
+            timer: Some(()),
+            display_timestamp: false,
+            ansi: self.ansi,
+            display_target: self.display_target,
+            display_level: self.display_level,
+            display_thread_id: self.display_thread_id,
+            display_thread_name: self.display_thread_name,
+            display_filename: self.display_filename,
+            display_line_number: self.display_line_number,
+        }
     }
 
     /// Enable timestamps for log messages using the [`timer`] field in [`Self`].

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -546,11 +546,24 @@ where
         }
     }
 
-    /// Do not emit timestamps with log messages.
-    pub fn without_time(self) -> CollectorBuilder<N, format::Format<L, ()>, F, W> {
+    /// Enable timestamps for log messages using the [`timer`] field in [`Self`].
+    ///
+    /// [`timer`]: time::FormatTime
+    pub fn with_timestamp(
+        self,
+        display_timestamp: bool,
+    ) -> CollectorBuilder<N, format::Format<L, T>, F, W> {
         CollectorBuilder {
             filter: self.filter,
-            inner: self.inner.without_time(),
+            inner: self.inner.with_timestamp(display_timestamp),
+        }
+    }
+
+    /// Do not emit timestamps with log messages.
+    pub fn without_time(self) -> CollectorBuilder<N, format::Format<L, T>, F, W> {
+        CollectorBuilder {
+            filter: self.filter,
+            inner: self.inner.with_timestamp(false),
         }
     }
 

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -560,10 +560,10 @@ where
     }
 
     /// Do not emit timestamps with log messages.
-    pub fn without_time(self) -> CollectorBuilder<N, format::Format<L, T>, F, W> {
+    pub fn without_time(self) -> CollectorBuilder<N, format::Format<L, ()>, F, W> {
         CollectorBuilder {
             filter: self.filter,
-            inner: self.inner.with_timestamp(false),
+            inner: self.inner.without_time(),
         }
     }
 

--- a/tracing-subscriber/src/fmt/time/mod.rs
+++ b/tracing-subscriber/src/fmt/time/mod.rs
@@ -116,6 +116,18 @@ impl From<Instant> for Uptime {
     }
 }
 
+impl<T> FormatTime for Option<T>
+where
+    T: FormatTime,
+{
+    fn format_time(&self, w: &mut Writer<'_>) -> fmt::Result {
+        match self {
+            Some(t) => t.format_time(w),
+            None => Ok(()),
+        }
+    }
+}
+
 impl FormatTime for SystemTime {
     fn format_time(&self, w: &mut Writer<'_>) -> fmt::Result {
         write!(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

* Using `.without_time()` is inconsistent and lacks the ergonimics of current `Builder::with_flag` methods.

Example of how timestamps are currently toggled:
```rs
impl Opts {
    pub fn init(&self) -> Result<(), SetGlobalDefaultError> {
        let filter = EnvFilter::builder()
            .with_env_var("RUST_LOG")
            .with_default_directive(LevelFilter::DEBUG.into())
            .from_env_lossy();
        // Initialize tracing;
        let collector = fmt::Subscriber::builder()
            .with_env_filter(filter)
            .with_line_number(self.line_number)
            .with_file(self.file)
            .with_thread_ids(self.thread_ids)
            .with_target(self.target)
            .with_ansi(self.ansi);
        // life becomes difficult from here on
        if !self.timestamp {
            return tracing::subscriber::set_global_default(collector.without_time().finish());
        };
        tracing::subscriber::set_global_default(collector.finish())
    }
}
```

## Solution

* Added `tracing_subscriber::fmt::Layer::with_timestamp(self, display_timestamp: bool)`
* Changed timer type to an `Option`:
```diff
pub struct Format<F = Full, T = SystemTime> {
    // ..
-   pub(crate) timer: <T>,
+   pub(crate) timer: Option<T>,
    // ..
}
```
* Retained all `without_time()` methods to maintain backwards compatibility
