### PR TITLE
tracing-journald: prepare to release v0.3.0

### DIFF
--- a/tracing-journald/CHANGELOG.md
+++ b/tracing-journald/CHANGELOG.md
@@ -1,3 +1,26 @@
+# 0.3.0 (April 21, 2022)
+
+This is a breaking release which changes the format in which span fields
+are output to `journald`. Previously, span field names were prefixed with the
+depth of the span in the current trace tree. However, these prefixes are
+unnecessary, as `journald` has built in support for duplicated field names.
+
+See PR [#1986] for details on this change.
+
+## Changed
+
+- Removed span field prefixes ([#1986])
+- Renamed `S{num}_NAME` fields to `SPAN_NAME` ([#1986])
+
+### Fixed
+
+- Fixed broken links in documentation ([#2077])
+
+Thanks to @wiktorsikora and @ben0x539 for contributing to this release!
+
+[#1986]: https://github.com/tokio-rs/tracing/pull/1986
+[#2077]: https://github.com/tokio-rs/tracing/pull/2077
+
 # 0.2.4 (March 17, 2022)
 
 ### Fixed

--- a/tracing-journald/Cargo.toml
+++ b/tracing-journald/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-journald"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
# 0.3.0 (April 21, 2022)

This is a breaking release which changes the format in which span fields
are output to `journald`. Previously, span field names were prefixed
with the depth of the span in the current trace tree. However, these
prefixes are unnecessary, as `journald` has built in support for
duplicated field names.

See PR [#1986] for details on this change.

## Changed

- Removed span field prefixes ([#1986])
- Renamed `S{num}_NAME` fields to `SPAN_NAME` ([#1986])

### Fixed

- Fixed broken links in documentation ([#2077])

Thanks to @wiktorsikora and @ben0x539 for contributing to this release!

[#1986]: https://github.com/tokio-rs/tracing/pull/1986
[#2077]: https://github.com/tokio-rs/tracing/pull/2077