### PR TITLE
log: prepare to release v0.1.3

### DIFF
--- a/tracing-log/CHANGELOG.md
+++ b/tracing-log/CHANGELOG.md
@@ -1,3 +1,29 @@
+# 0.1.3 (April 21st, 2022)
+
+### Added
+
+- **log-tracer**: Added `LogTracer::with_interest_cache` to enable a limited
+ form of per-record `Interest` caching for `log` records ([#1636])
+
+### Changed
+
+- Updated minimum supported Rust version (MSRV) to Rust 1.49.0 ([#1913])
+
+### Fixed
+
+- **log-tracer**: Fixed `LogTracer` not honoring `tracing` max level filters
+  ([#1543])
+- Broken links in documentation ([#2068], [#2077])
+
+Thanks to @Millione, @teozkr, @koute, @Folyd, and @ben0x539 for contributing to
+this release!
+
+[#1636]: https://github.com/tokio-rs/tracing/pulls/1636
+[#1913]: https://github.com/tokio-rs/tracing/pulls/1913
+[#1543]: https://github.com/tokio-rs/tracing/pulls/1543
+[#2068]: https://github.com/tokio-rs/tracing/pulls/2068
+[#2077]: https://github.com/tokio-rs/tracing/pulls/2077
+
 # 0.1.2 (February 19th, 2020)
 
 ### Added

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-log"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -100,7 +100,7 @@
 //! [`tracing::Event`]: https://docs.rs/tracing/latest/tracing/struct.Event.html
 //! [flags]: https://docs.rs/tracing/latest/tracing/#crate-feature-flags
 //! [`Builder::with_interest_cache`]: log_tracer::Builder::with_interest_cache
-#![doc(html_root_url = "https://docs.rs/tracing-log/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/tracing-log/0.1.3")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.1.3 (April 21st, 2022)

### Added

- **log-tracer**: Added `LogTracer::with_interest_cache` to enable a
 limited form of per-record `Interest` caching for `log` records
 ([#1636])

### Changed

- Updated minimum supported Rust version (MSRV) to Rust 1.49.0 ([#1913])

### Fixed

- **log-tracer**: Fixed `LogTracer` not honoring `tracing` max level
  filters ([#1543])
- Broken links in documentation ([#2068], [#2077])

Thanks to @Millione, @teozkr, @koute, @Folyd, and @ben0x539 for
contributing to this release!

[#1636]: https://github.com/tokio-rs/tracing/pulls/1636
[#1913]: https://github.com/tokio-rs/tracing/pulls/1913
[#1543]: https://github.com/tokio-rs/tracing/pulls/1543
[#2068]: https://github.com/tokio-rs/tracing/pulls/2068
[#2077]: https://github.com/tokio-rs/tracing/pulls/2077
