### PR TITLE
attributes: remove extra braces around `async` blocks

### DIFF
--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -217,7 +217,7 @@ fn gen_block<B: ToTokens>(
         let mk_fut = match (err_event, ret_event) {
             (Some(err_event), Some(ret_event)) => quote_spanned!(block.span()=>
                 async move {
-                    match async move { #block }.await {
+                    match async move #block.await {
                         #[allow(clippy::unit_arg)]
                         Ok(x) => {
                             #ret_event;
@@ -232,7 +232,7 @@ fn gen_block<B: ToTokens>(
             ),
             (Some(err_event), None) => quote_spanned!(block.span()=>
                 async move {
-                    match async move { #block }.await {
+                    match async move #block.await {
                         #[allow(clippy::unit_arg)]
                         Ok(x) => Ok(x),
                         Err(e) => {
@@ -244,13 +244,13 @@ fn gen_block<B: ToTokens>(
             ),
             (None, Some(ret_event)) => quote_spanned!(block.span()=>
                 async move {
-                    let x = async move { #block }.await;
+                    let x = async move #block.await;
                     #ret_event;
                     x
                 }
             ),
             (None, None) => quote_spanned!(block.span()=>
-                async move { #block }
+                async move #block
             ),
         };
 

--- a/tracing-attributes/tests/async_fn.rs
+++ b/tracing-attributes/tests/async_fn.rs
@@ -1,5 +1,6 @@
 use tracing_mock::*;
 
+use std::convert::Infallible;
 use std::{future::Future, pin::Pin, sync::Arc};
 use tracing::collect::with_default;
 use tracing_attributes::instrument;
@@ -49,6 +50,19 @@ async fn repro_1613(var: bool) {
 async fn repro_1613_2() {
     // hello world
     // else
+}
+
+// Reproduces https://github.com/tokio-rs/tracing/issues/1831
+#[instrument]
+#[deny(unused_braces)]
+fn repro_1831() -> Pin<Box<dyn Future<Output = ()>>> {
+    Box::pin(async move { () })
+}
+
+#[instrument(ret, err)]
+#[deny(unused_braces)]
+fn repro_1831_2() -> impl Future<Output = Result<(), Infallible>> {
+    async { Ok(()) }
 }
 
 #[test]


### PR DESCRIPTION
- [x] add repros for `unused_braces` issue
- [x] remove extra braces from async blocks

Fixes #1831

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

When using an `async` block (as an alternative to `async fn`, e.g. when implementing a trait), `#[instrument]` adds extra braces around the wrapped `async` block. This causes `rustc` to emit an `unused_braces` lint in some cases (usually for single-line `async` blocks, as far as I can tell). See #1831 for an example.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Since the `async` block extracted by `AsyncInfo::from_fn` already has braces around its statements, there's no need to wrap it with additional braces. This updates `gen_block` to remove those extra braces when generating the code providing the value of `__tracing_instrument_future`.
