### PR TITLE
WIP: dynamic filters override static ones

### DIFF
--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -472,11 +472,14 @@ impl EnvFilter {
     /// traits, but it does not require the trait to be in scope.
     pub fn enabled<S>(&self, metadata: &Metadata<'_>, _: Context<'_, S>) -> bool {
         let level = metadata.level();
+        println!("entering enabled");
 
         // is it possible for a dynamic filter directive to enable this event?
         // if not, we can avoid the thread loca'l access + iterating over the
         // spans in the current scope.
-        if self.has_dynamics && self.dynamics.max_level >= *level {
+        if self.has_dynamics
+        /* && self.dynamics.max_level >= *level */
+        {
             if metadata.is_span() {
                 // If the metadata is a span, see if we care about its callsite.
                 let enabled_by_cs = self
@@ -486,23 +489,32 @@ impl EnvFilter {
                     .map(|by_cs| by_cs.contains_key(&metadata.callsite()))
                     .unwrap_or(false);
                 if enabled_by_cs {
+                    println!("enabled by cs (wat)");
                     return true;
                 }
             }
 
             let enabled_by_scope = {
                 let scope = self.scope.get_or_default().borrow();
+                dbg!(&scope);
                 for filter in &*scope {
                     if filter >= level {
+                        println!("filter {filter:?} enabled this");
                         return true;
                     }
+                }
+                if !scope.is_empty() {
+                    // at least one dynamic filter disabled this
+                    return false;
                 }
                 false
             };
             if enabled_by_scope {
+                println!("enabled_by_scope was true");
                 return true;
             }
         }
+        println!("dynamics didn't decide this");
 
         // is it possible for a static filter directive to enable this event?
         if self.statics.max_level >= *level {

--- a/tracing-subscriber/src/filter/layer_filters/mod.rs
+++ b/tracing-subscriber/src/filter/layer_filters/mod.rs
@@ -565,6 +565,7 @@ where
 
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         let interest = self.filter.callsite_enabled(metadata);
+        println!("Filtered::register_callsite, interest: {interest:?}");
 
         // If the filter didn't disable the callsite, allow the inner layer to
         // register it — since `register_callsite` is also used for purposes
@@ -589,6 +590,7 @@ where
     }
 
     fn enabled(&self, metadata: &Metadata<'_>, cx: Context<'_, S>) -> bool {
+        println!("Inside Filtered::enabled");
         let cx = cx.with_filter(self.id());
         let enabled = self.filter.enabled(metadata, &cx);
         FILTERING.with(|filtering| filtering.set(self.id(), enabled));

--- a/tracing-subscriber/src/layer/layered.rs
+++ b/tracing-subscriber/src/layer/layered.rs
@@ -75,6 +75,7 @@ where
     }
 
     fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        println!("in impl subscriber for layered enabled");
         if self.layer.enabled(metadata, self.ctx()) {
             // if the outer layer enables the callsite metadata, ask the subscriber.
             self.inner.enabled(metadata)
@@ -219,6 +220,7 @@ where
     }
 
     fn enabled(&self, metadata: &Metadata<'_>, ctx: Context<'_, S>) -> bool {
+        println!("in impl layer for layered enabled");
         if self.layer.enabled(metadata, ctx.clone()) {
             // if the outer subscriber enables the callsite metadata, ask the inner layer.
             self.inner.enabled(metadata, ctx)

--- a/tracing-subscriber/tests/env_filter/per_layer.rs
+++ b/tracing-subscriber/tests/env_filter/per_layer.rs
@@ -4,6 +4,37 @@
 use super::*;
 
 #[test]
+fn more_specific_dynamic_directives_override_static_directives() {
+    let filter: EnvFilter = "info,my_target[my_span]=warn".parse().unwrap();
+    let (layer, handle) = layer::mock()
+        // .event(
+        //     event::mock()
+        //         .at_level(Level::INFO)
+        //         .in_scope(vec![span::named("my_span")]),
+        // )
+        .enter(span::mock().at_level(Level::INFO))
+        .event(
+            event::mock()
+                .at_level(Level::WARN)
+                .in_scope(vec![span::named("my_span")]),
+        )
+        .exit(span::mock().at_level(Level::INFO))
+        .done()
+        .run_with_handle();
+
+    let _subscriber = tracing_subscriber::registry()
+        .with(layer.with_filter(filter))
+        .set_default();
+
+    // tracing::info!("should be logged");
+    let _info = tracing::info_span!(target: "my_target", "my_span").entered();
+    tracing::info!(target: "my_target", "should be ignored");
+    tracing::warn!(target: "my_target", "should be logged");
+
+    handle.assert_finished();
+}
+
+#[test]
 fn level_filter_event() {
     let filter: EnvFilter = "info".parse().expect("filter should parse");
     let (layer, handle) = layer::mock()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

See https://github.com/tokio-rs/tracing/issues/1388.
Similar to how more specific static filters can disable things that more general filters would enable (e.g. `foo=info,foo::bar=warn`), it would be nice if dynamic filters could do something similar (although "more specific" is way harder to define here, but let's maybe try)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

1. Always evaluate dynamic filters (not just when their max level is high enough to enable the metadata)
2. If none of the dynamic filters in scope (-> with matching span/fields, right?) enable the metadata, that means it was disabled

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
