### PR TITLE
backport recent commits from `master`

### DIFF
--- a/tracing-attributes/src/attr.rs
+++ b/tracing-attributes/src/attr.rs
@@ -12,6 +12,7 @@ pub(crate) struct InstrumentArgs {
     pub(crate) name: Option<LitStr>,
     target: Option<LitStr>,
     pub(crate) parent: Option<Expr>,
+    pub(crate) follows_from: Option<Expr>,
     pub(crate) skips: HashSet<Ident>,
     pub(crate) skip_all: bool,
     pub(crate) fields: Option<Fields>,
@@ -130,6 +131,12 @@ impl Parse for InstrumentArgs {
                 }
                 let parent = input.parse::<ExprArg<kw::parent>>()?;
                 args.parent = Some(parent.value);
+            } else if lookahead.peek(kw::follows_from) {
+                if args.target.is_some() {
+                    return Err(input.error("expected only a single `follows_from` argument"));
+                }
+                let follows_from = input.parse::<ExprArg<kw::follows_from>>()?;
+                args.follows_from = Some(follows_from.value);
             } else if lookahead.peek(kw::level) {
                 if args.level.is_some() {
                     return Err(input.error("expected only a single `level` argument"));
@@ -399,6 +406,7 @@ mod kw {
     syn::custom_keyword!(level);
     syn::custom_keyword!(target);
     syn::custom_keyword!(parent);
+    syn::custom_keyword!(follows_from);
     syn::custom_keyword!(name);
     syn::custom_keyword!(err);
     syn::custom_keyword!(ret);

--- a/tracing-attributes/src/attr.rs
+++ b/tracing-attributes/src/attr.rs
@@ -11,6 +11,7 @@ pub(crate) struct InstrumentArgs {
     level: Option<Level>,
     pub(crate) name: Option<LitStr>,
     target: Option<LitStr>,
+    pub(crate) parent: Option<Expr>,
     pub(crate) skips: HashSet<Ident>,
     pub(crate) skip_all: bool,
     pub(crate) fields: Option<Fields>,
@@ -123,6 +124,12 @@ impl Parse for InstrumentArgs {
                 }
                 let target = input.parse::<StrArg<kw::target>>()?.value;
                 args.target = Some(target);
+            } else if lookahead.peek(kw::parent) {
+                if args.target.is_some() {
+                    return Err(input.error("expected only a single `parent` argument"));
+                }
+                let parent = input.parse::<ExprArg<kw::parent>>()?;
+                args.parent = Some(parent.value);
             } else if lookahead.peek(kw::level) {
                 if args.level.is_some() {
                     return Err(input.error("expected only a single `level` argument"));
@@ -182,6 +189,23 @@ struct StrArg<T> {
 }
 
 impl<T: Parse> Parse for StrArg<T> {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let _ = input.parse::<T>()?;
+        let _ = input.parse::<Token![=]>()?;
+        let value = input.parse()?;
+        Ok(Self {
+            value,
+            _p: std::marker::PhantomData,
+        })
+    }
+}
+
+struct ExprArg<T> {
+    value: Expr,
+    _p: std::marker::PhantomData<T>,
+}
+
+impl<T: Parse> Parse for ExprArg<T> {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let _ = input.parse::<T>()?;
         let _ = input.parse::<Token![=]>()?;
@@ -374,6 +398,7 @@ mod kw {
     syn::custom_keyword!(skip_all);
     syn::custom_keyword!(level);
     syn::custom_keyword!(target);
+    syn::custom_keyword!(parent);
     syn::custom_keyword!(name);
     syn::custom_keyword!(err);
     syn::custom_keyword!(ret);

--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -217,7 +217,7 @@ fn gen_block<B: ToTokens>(
         let mk_fut = match (err_event, ret_event) {
             (Some(err_event), Some(ret_event)) => quote_spanned!(block.span()=>
                 async move {
-                    match async move { #block }.await {
+                    match async move #block.await {
                         #[allow(clippy::unit_arg)]
                         Ok(x) => {
                             #ret_event;
@@ -232,7 +232,7 @@ fn gen_block<B: ToTokens>(
             ),
             (Some(err_event), None) => quote_spanned!(block.span()=>
                 async move {
-                    match async move { #block }.await {
+                    match async move #block.await {
                         #[allow(clippy::unit_arg)]
                         Ok(x) => Ok(x),
                         Err(e) => {
@@ -244,13 +244,13 @@ fn gen_block<B: ToTokens>(
             ),
             (None, Some(ret_event)) => quote_spanned!(block.span()=>
                 async move {
-                    let x = async move { #block }.await;
+                    let x = async move #block.await;
                     #ret_event;
                     x
                 }
             ),
             (None, None) => quote_spanned!(block.span()=>
-                async move { #block }
+                async move #block
             ),
         };
 

--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -135,6 +135,8 @@ fn gen_block<B: ToTokens>(
 
         let target = args.target();
 
+        let parent = args.parent.iter();
+
         // filter out skipped fields
         let quoted_fields: Vec<_> = param_names
             .iter()
@@ -182,6 +184,7 @@ fn gen_block<B: ToTokens>(
 
         quote!(tracing::span!(
             target: #target,
+            #(parent: #parent,)*
             #level,
             #span_name,
             #(#quoted_fields,)*

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -368,6 +368,24 @@ mod expand;
 ///     fn my_method(&self) {}
 /// }
 /// ```
+/// Specifying [`follows_from`] relationships:
+/// ```
+/// # use tracing_attributes::instrument;
+/// #[instrument(follows_from = causes)]
+/// pub fn my_function(causes: &[tracing::Id]) {
+///     // ...
+/// }
+/// ```
+/// Any expression of type `impl IntoIterator<Item = impl Into<Option<Id>>>`
+/// may be provided to `follows_from`; e.g.:
+/// ```
+/// # use tracing_attributes::instrument;
+/// #[instrument(follows_from = [cause])]
+/// pub fn my_function(cause: &tracing::span::EnteredSpan) {
+///     // ...
+/// }
+/// ```
+///
 ///
 /// To skip recording an argument, pass the argument's name to the `skip`:
 ///
@@ -524,6 +542,8 @@ mod expand;
 /// [`INFO`]: https://docs.rs/tracing/latest/tracing/struct.Level.html#associatedconstant.INFO
 /// [empty field]: https://docs.rs/tracing/latest/tracing/field/struct.Empty.html
 /// [field syntax]: https://docs.rs/tracing/latest/tracing/#recording-fields
+/// [`follows_from`]: https://docs.rs/tracing/latest/tracing/struct.Span.html#method.follows_from
+/// [`tracing`]: https://github.com/tokio-rs/tracing
 /// [`fmt::Debug`]: std::fmt::Debug
 #[proc_macro_attribute]
 pub fn instrument(

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -345,6 +345,29 @@ mod expand;
 ///     // ...
 /// }
 /// ```
+/// Overriding the generated span's parent:
+/// ```
+/// # use tracing_attributes::instrument;
+/// #[instrument(parent = None)]
+/// pub fn my_function() {
+///     // ...
+/// }
+/// ```
+/// ```
+/// # use tracing_attributes::instrument;
+/// // A struct which owns a span handle.
+/// struct MyStruct
+/// {
+///     span: tracing::Span
+/// }
+///
+/// impl MyStruct
+/// {
+///     // Use the struct's `span` field as the parent span
+///     #[instrument(parent = &self.span, skip(self))]
+///     fn my_method(&self) {}
+/// }
+/// ```
 ///
 /// To skip recording an argument, pass the argument's name to the `skip`:
 ///

--- a/tracing-attributes/tests/async_fn.rs
+++ b/tracing-attributes/tests/async_fn.rs
@@ -1,5 +1,6 @@
 use tracing_mock::*;
 
+use std::convert::Infallible;
 use std::{future::Future, pin::Pin, sync::Arc};
 use tracing::subscriber::with_default;
 use tracing_attributes::instrument;
@@ -49,6 +50,22 @@ async fn repro_1613(var: bool) {
 async fn repro_1613_2() {
     // hello world
     // else
+}
+
+// Reproduces https://github.com/tokio-rs/tracing/issues/1831
+#[instrument]
+#[deny(unused_braces)]
+fn repro_1831() -> Pin<Box<dyn Future<Output = ()>>> {
+    Box::pin(async move {})
+}
+
+// This replicates the pattern used to implement async trait methods on nightly using the
+// `type_alias_impl_trait` feature
+#[instrument(ret, err)]
+#[deny(unused_braces)]
+#[allow(clippy::manual_async_fn)]
+fn repro_1831_2() -> impl Future<Output = Result<(), Infallible>> {
+    async { Ok(()) }
 }
 
 #[test]

--- a/tracing-attributes/tests/follows_from.rs
+++ b/tracing-attributes/tests/follows_from.rs
@@ -1,0 +1,99 @@
+use tracing::{subscriber::with_default, Id, Level, Span};
+use tracing_attributes::instrument;
+use tracing_mock::*;
+
+#[instrument(follows_from = causes, skip(causes))]
+fn with_follows_from_sync(causes: impl IntoIterator<Item = impl Into<Option<Id>>>) {}
+
+#[instrument(follows_from = causes, skip(causes))]
+async fn with_follows_from_async(causes: impl IntoIterator<Item = impl Into<Option<Id>>>) {}
+
+#[instrument(follows_from = [&Span::current()])]
+fn follows_from_current() {}
+
+#[test]
+fn follows_from_sync_test() {
+    let cause_a = span::mock().named("cause_a");
+    let cause_b = span::mock().named("cause_b");
+    let cause_c = span::mock().named("cause_c");
+    let consequence = span::mock().named("with_follows_from_sync");
+
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(cause_a.clone())
+        .new_span(cause_b.clone())
+        .new_span(cause_c.clone())
+        .new_span(consequence.clone())
+        .follows_from(consequence.clone(), cause_a)
+        .follows_from(consequence.clone(), cause_b)
+        .follows_from(consequence.clone(), cause_c)
+        .enter(consequence.clone())
+        .exit(consequence)
+        .done()
+        .run_with_handle();
+
+    with_default(subscriber, || {
+        let cause_a = tracing::span!(Level::TRACE, "cause_a");
+        let cause_b = tracing::span!(Level::TRACE, "cause_b");
+        let cause_c = tracing::span!(Level::TRACE, "cause_c");
+
+        with_follows_from_sync(&[cause_a, cause_b, cause_c])
+    });
+
+    handle.assert_finished();
+}
+
+#[test]
+fn follows_from_async_test() {
+    let cause_a = span::mock().named("cause_a");
+    let cause_b = span::mock().named("cause_b");
+    let cause_c = span::mock().named("cause_c");
+    let consequence = span::mock().named("with_follows_from_async");
+
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(cause_a.clone())
+        .new_span(cause_b.clone())
+        .new_span(cause_c.clone())
+        .new_span(consequence.clone())
+        .follows_from(consequence.clone(), cause_a)
+        .follows_from(consequence.clone(), cause_b)
+        .follows_from(consequence.clone(), cause_c)
+        .enter(consequence.clone())
+        .exit(consequence)
+        .done()
+        .run_with_handle();
+
+    with_default(subscriber, || {
+        block_on_future(async {
+            let cause_a = tracing::span!(Level::TRACE, "cause_a");
+            let cause_b = tracing::span!(Level::TRACE, "cause_b");
+            let cause_c = tracing::span!(Level::TRACE, "cause_c");
+
+            with_follows_from_async(&[cause_a, cause_b, cause_c]).await
+        })
+    });
+
+    handle.assert_finished();
+}
+
+#[test]
+fn follows_from_current_test() {
+    let cause = span::mock().named("cause");
+    let consequence = span::mock().named("follows_from_current");
+
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(cause.clone())
+        .enter(cause.clone())
+        .new_span(consequence.clone())
+        .follows_from(consequence.clone(), cause.clone())
+        .enter(consequence.clone())
+        .exit(consequence)
+        .exit(cause)
+        .done()
+        .run_with_handle();
+
+    with_default(subscriber, || {
+        tracing::span!(Level::TRACE, "cause").in_scope(follows_from_current)
+    });
+
+    handle.assert_finished();
+}

--- a/tracing-attributes/tests/parents.rs
+++ b/tracing-attributes/tests/parents.rs
@@ -1,0 +1,102 @@
+use tracing::{subscriber::with_default, Id, Level};
+use tracing_attributes::instrument;
+use tracing_mock::*;
+
+#[instrument]
+fn with_default_parent() {}
+
+#[instrument(parent = parent_span, skip(parent_span))]
+fn with_explicit_parent<P>(parent_span: P)
+where
+    P: Into<Option<Id>>,
+{
+}
+
+#[test]
+fn default_parent_test() {
+    let contextual_parent = span::mock().named("contextual_parent");
+    let child = span::mock().named("with_default_parent");
+
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(
+            contextual_parent
+                .clone()
+                .with_contextual_parent(None)
+                .with_explicit_parent(None),
+        )
+        .new_span(
+            child
+                .clone()
+                .with_contextual_parent(Some("contextual_parent"))
+                .with_explicit_parent(None),
+        )
+        .enter(child.clone())
+        .exit(child.clone())
+        .enter(contextual_parent.clone())
+        .new_span(
+            child
+                .clone()
+                .with_contextual_parent(Some("contextual_parent"))
+                .with_explicit_parent(None),
+        )
+        .enter(child.clone())
+        .exit(child)
+        .exit(contextual_parent)
+        .done()
+        .run_with_handle();
+
+    with_default(subscriber, || {
+        let contextual_parent = tracing::span!(Level::TRACE, "contextual_parent");
+
+        with_default_parent();
+
+        contextual_parent.in_scope(|| {
+            with_default_parent();
+        });
+    });
+
+    handle.assert_finished();
+}
+
+#[test]
+fn explicit_parent_test() {
+    let contextual_parent = span::mock().named("contextual_parent");
+    let explicit_parent = span::mock().named("explicit_parent");
+    let child = span::mock().named("with_explicit_parent");
+
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(
+            contextual_parent
+                .clone()
+                .with_contextual_parent(None)
+                .with_explicit_parent(None),
+        )
+        .new_span(
+            explicit_parent
+                .with_contextual_parent(None)
+                .with_explicit_parent(None),
+        )
+        .enter(contextual_parent.clone())
+        .new_span(
+            child
+                .clone()
+                .with_contextual_parent(Some("contextual_parent"))
+                .with_explicit_parent(Some("explicit_parent")),
+        )
+        .enter(child.clone())
+        .exit(child)
+        .exit(contextual_parent)
+        .done()
+        .run_with_handle();
+
+    with_default(subscriber, || {
+        let contextual_parent = tracing::span!(Level::INFO, "contextual_parent");
+        let explicit_parent = tracing::span!(Level::INFO, "explicit_parent");
+
+        contextual_parent.in_scope(|| {
+            with_explicit_parent(&explicit_parent);
+        });
+    });
+
+    handle.assert_finished();
+}

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -56,6 +56,10 @@ use crate::stdlib::{
 ///   Additionally, subscribers which wish to perform a behaviour once for each
 ///   callsite, such as allocating storage for data related to that callsite,
 ///   can perform it in `register_callsite`.
+///
+///   See also the [documentation on the callsite registry][cs-reg] for details
+///   on [`register_callsite`].
+///
 /// - [`clone_span`] is called every time a span ID is cloned, and [`try_close`]
 ///   is called when a span ID is dropped. By default, these functions do
 ///   nothing. However, they can be used to implement reference counting for
@@ -70,10 +74,11 @@ use crate::stdlib::{
 /// [`enabled`]: Subscriber::enabled
 /// [`clone_span`]: Subscriber::clone_span
 /// [`try_close`]: Subscriber::try_close
+/// [cs-reg]: crate::callsite#registering-callsites
 pub trait Subscriber: 'static {
     // === Span registry methods ==============================================
 
-    /// Registers a new callsite with this subscriber, returning whether or not
+    /// Registers a new [callsite] with this subscriber, returning whether or not
     /// the subscriber is interested in being notified about the callsite.
     ///
     /// By default, this function assumes that the subscriber's [filter]
@@ -127,6 +132,9 @@ pub trait Subscriber: 'static {
     /// return `Interest::Never`, as a new subscriber may be added that _is_
     /// interested.
     ///
+    /// See the [documentation on the callsite registry][cs-reg] for more
+    /// details on how and when the `register_callsite` method is called.
+    ///
     /// # Notes
     /// This function may be called again when a new subscriber is created or
     /// when the registry is invalidated.
@@ -135,10 +143,12 @@ pub trait Subscriber: 'static {
     /// _may_ still see spans and events originating from that callsite, if
     /// another subscriber expressed interest in it.
     ///
-    /// [filter]: Subscriber::enabled()
+    /// [callsite]: crate::callsite
+    /// [filter]: Self::enabled
     /// [metadata]: super::metadata::Metadata
     /// [`enabled`]: Subscriber::enabled()
     /// [`rebuild_interest_cache`]: super::callsite::rebuild_interest_cache
+    /// [cs-reg]: crate::callsite#registering-callsites
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         if self.enabled(metadata) {
             Interest::always()

--- a/tracing-mock/src/subscriber.rs
+++ b/tracing-mock/src/subscriber.rs
@@ -23,6 +23,10 @@ use tracing::{
 #[derive(Debug, Eq, PartialEq)]
 pub enum Expect {
     Event(MockEvent),
+    FollowsFrom {
+        consequence: MockSpan,
+        cause: MockSpan,
+    },
     Enter(MockSpan),
     Exit(MockSpan),
     CloneSpan(MockSpan),
@@ -35,6 +39,7 @@ pub enum Expect {
 struct SpanState {
     name: &'static str,
     refs: usize,
+    meta: &'static Metadata<'static>,
 }
 
 struct Running<F: Fn(&Metadata<'_>) -> bool> {
@@ -94,6 +99,12 @@ where
 
     pub fn enter(mut self, span: MockSpan) -> Self {
         self.expected.push_back(Expect::Enter(span));
+        self
+    }
+
+    pub fn follows_from(mut self, consequence: MockSpan, cause: MockSpan) -> Self {
+        self.expected
+            .push_back(Expect::FollowsFrom { consequence, cause });
         self
     }
 
@@ -250,8 +261,37 @@ where
         }
     }
 
-    fn record_follows_from(&self, _span: &Id, _follows: &Id) {
-        // TODO: it should be possible to expect spans to follow from other spans
+    fn record_follows_from(&self, consequence_id: &Id, cause_id: &Id) {
+        let spans = self.spans.lock().unwrap();
+        if let Some(consequence_span) = spans.get(consequence_id) {
+            if let Some(cause_span) = spans.get(cause_id) {
+                println!(
+                    "[{}] record_follows_from: {} (id={:?}) follows {} (id={:?})",
+                    self.name, consequence_span.name, consequence_id, cause_span.name, cause_id,
+                );
+                match self.expected.lock().unwrap().pop_front() {
+                    None => {}
+                    Some(Expect::FollowsFrom {
+                        consequence: ref expected_consequence,
+                        cause: ref expected_cause,
+                    }) => {
+                        if let Some(name) = expected_consequence.name() {
+                            assert_eq!(name, consequence_span.name);
+                        }
+                        if let Some(name) = expected_cause.name() {
+                            assert_eq!(name, cause_span.name);
+                        }
+                    }
+                    Some(ex) => ex.bad(
+                        &self.name,
+                        format_args!(
+                            "consequence {:?} followed cause {:?}",
+                            consequence_span.name, cause_span.name
+                        ),
+                    ),
+                }
+            }
+        };
     }
 
     fn new_span(&self, span: &Attributes<'_>) -> Id {
@@ -284,6 +324,7 @@ where
             id.clone(),
             SpanState {
                 name: meta.name(),
+                meta,
                 refs: 1,
             },
         );
@@ -415,6 +456,18 @@ where
             }
         }
     }
+
+    fn current_span(&self) -> tracing_core::span::Current {
+        let stack = self.current.lock().unwrap();
+        match stack.last() {
+            Some(id) => {
+                let spans = self.spans.lock().unwrap();
+                let state = spans.get(id).expect("state for current span");
+                tracing_core::span::Current::new(id.clone(), state.meta)
+            }
+            None => tracing_core::span::Current::none(),
+        }
+    }
 }
 
 impl MockHandle {
@@ -441,6 +494,10 @@ impl Expect {
             Expect::Event(e) => panic!(
                 "\n[{}] expected event {}\n[{}] but instead {}",
                 name, e, name, what,
+            ),
+            Expect::FollowsFrom { consequence, cause } => panic!(
+                "\n[{}] expected consequence {} to follow cause {} but instead {}",
+                name, consequence, cause, what,
             ),
             Expect::Enter(e) => panic!(
                 "\n[{}] expected to enter {}\n[{}] but instead {}",


### PR DESCRIPTION
This branch backports the following commits from `master`:

* attributes: permit `#[instrument(follows_from = …)]` (#2093)
* 21b6ddc6 attributes: permit setting parent span via `#[instrument(parent = …)]` (#2091)
* 3d7a18b1 attributes: remove extra braces around `async` blocks (#2090)
* f9685177 core: document the `callsite` module (#2088)

After this, we'll prep a new `tracing-attributes` release, and 
add additional docs to the changes in #2083 based on those
added in #2093