### PR TITLE
attributes: prepare to release v0.1.21

### DIFF
--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,3 +1,31 @@
+# 0.1.21 (April 26, 2022)
+
+This release adds support for setting explicit parent and follows-from spans
+in the `#[instrument]` attribute.
+
+### Added
+
+- `#[instrument(follows_from = ...)]` argument for setting one or more
+  follows-from span ([#2093])
+- `#[instrument(parent = ...)]` argument for overriding the generated span's
+  parent ([#2091])
+
+### Fixed
+
+- Extra braces around `async` blocks in expanded code (causes a Clippy warning)
+  ([#2090])
+- Broken documentation links ([#2068], [#2077])
+
+Thanks to @jarrodldavis, @ben0x539, and new contributor @jswrenn for
+contributing to this release!
+
+
+[#2093]: https://github.com/tokio-rs/tracing/pull/2093
+[#2091]: https://github.com/tokio-rs/tracing/pull/2091
+[#2090]: https://github.com/tokio-rs/tracing/pull/2090
+[#2077]: https://github.com/tokio-rs/tracing/pull/2077
+[#2068]: https://github.com/tokio-rs/tracing/pull/2068
+
 # 0.1.20 (March 8, 2022)
 
 ### Fixed

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-attributes"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.20"
+version = "0.1.21"
 authors = [
     "Tokio Contributors <team@tokio.rs>",
     "Eliza Weisman <eliza@buoyant.io>",

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -18,7 +18,7 @@ Macro attributes for application-level tracing.
 [crates-badge]: https://img.shields.io/crates/v/tracing-attributes.svg
 [crates-url]: https://crates.io/crates/tracing-attributes
 [docs-badge]: https://docs.rs/tracing-attributes/badge.svg
-[docs-url]: https://docs.rs/tracing-attributes/0.1.20
+[docs-url]: https://docs.rs/tracing-attributes/0.1.21
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_attributes
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -47,7 +47,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing-attributes = "0.1.20"
+tracing-attributes = "0.1.21"
 ```
 
 

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tracing-attributes = "0.1.20"
+//! tracing-attributes = "0.1.21"
 //! ```
 //!
 //! The [`#[instrument]`][instrument] attribute can now be added to a function
@@ -52,7 +52,7 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
-#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.20")]
+#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.21")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.1.21 (April 26, 2022)

This release adds support for setting explicit parent and follows-from
spans in the `#[instrument]` attribute.

### Added

- `#[instrument(follows_from = ...)]` argument for setting one or more
  follows-from span ([#2093])
- `#[instrument(parent = ...)]` argument for overriding the generated
  span's parent ([#2091])

### Fixed

- Extra braces around `async` blocks in expanded code (causes a Clippy
  warning) ([#2090])
- Broken documentation links ([#2068], [#2077])

Thanks to @jarrodldavis, @ben0x539, and new contributor @jswrenn for
contributing to this release!

[#2093]: https://github.com/tokio-rs/tracing/pull/2093
[#2091]: https://github.com/tokio-rs/tracing/pull/2091
[#2090]: https://github.com/tokio-rs/tracing/pull/2090
[#2077]: https://github.com/tokio-rs/tracing/pull/2077
[#2068]: https://github.com/tokio-rs/tracing/pull/2068