### PR TITLE
opentelemetry: Fix example in README.md

### DIFF
--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -33,10 +33,10 @@ Utilities for adding [OpenTelemetry] interoperability to [`tracing`].
 ## Overview
 
 [`tracing`] is a framework for instrumenting Rust programs to collect
-structured, event-based diagnostic information. This crate provides a layer
-that connects spans from multiple systems into a trace and emits them to
-[OpenTelemetry]-compatible distributed tracing systems for processing and
-visualization.
+structured, event-based diagnostic information. This crate provides a
+subscriber that connects spans from multiple systems into a trace and
+emits them to [OpenTelemetry]-compatible distributed tracing systems
+for processing and visualization.
 
 The crate provides the following types:
 
@@ -59,14 +59,14 @@ The crate provides the following types:
 ### Basic Usage
 
 ```rust
-use opentelemetry::exporter::trace::stdout;
+use opentelemetry::sdk::export::trace::stdout;
 use tracing::{error, span};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Registry;
 
 fn main() {
     // Install a new OpenTelemetry trace pipeline
-    let (tracer, _uninstall) = stdout::new_pipeline().install();
+    let tracer = stdout::new_pipeline().install_simple();
 
     // Create a tracing layer with the configured tracer
     let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);


### PR DESCRIPTION
The example code for `tracing-opentelemetry` in the README.md file was based on
older versions of `tracing`, `tracing-opentelemetry` and `opentelemetry`. It
did not compile with the latest versions of these crates.

## Motivation

Developers should be able to copy/paste example code and it should work.


## Solution

Following some type renames allows this code to work.

This is @lilymara-onesignal's branch #1414 but rebased to point at the
`v0.1.x` branch as the base. I think we will also want to update the use
of the otel APIs on `master`, but `master` currently uses the correct
`tracing` type names _for v0.2.x_.

Co-authored-by: Lily Mara <lilymara@onesignal.com>

Closes #1414