### PR TITLE
[wip] draft API for passing timer into formatters

### DIFF
--- a/examples/examples/fmt.rs
+++ b/examples/examples/fmt.rs
@@ -6,6 +6,7 @@ fn main() {
     tracing_subscriber::fmt()
         // enable everything
         .with_max_level(tracing::Level::TRACE)
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::NEW)
         // sets this to be the default, global collector for this application.
         .init();
 

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -186,7 +186,8 @@ where
         let meta = event.metadata();
         write!(&mut writer, "  ")?;
 
-        self.format_timestamp(&mut writer)?;
+        self.format_timestamp(ctx.timestamp(), &mut writer)?;
+        writer.write_char('_')?;
 
         let style = if self.display_level && writer.has_ansi_escapes() {
             Pretty::style_for(meta.level())


### PR DESCRIPTION
This is a rough draft of an API for passing timestamps into _any_ formatter, rather than just ones that use `fmt::Format`. I haven't done all of the plumbing for this change yet, just sketched out the APIs.

It's not clear if we can do this without a breaking change, unfortunately, since the `with_timer` method changes a type parameter of `fmt::Format`. We would want to change `with_timer` to not require that the event formatter be `fmt::Format`...but if we did that, we would no longer be able to change its type parameter.

One non-breaking option is to leave that system in place but deprecate it in favor of a new API that works with any event formatter, but then we would have to come up with a better name...