### PR TITLE
opentelemetry: add support for thread names/ids 

### DIFF
--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -28,6 +28,7 @@ tracing = { path = "../tracing", version = "0.2", default-features = false, feat
 tracing-core = { path = "../tracing-core", version = "0.2" }
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry", "std"] }
 tracing-log = { path = "../tracing-log", version = "0.2", default-features = false, optional = true }
+once_cell = "1"
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/tracing-opentelemetry/src/subscriber.rs
+++ b/tracing-opentelemetry/src/subscriber.rs
@@ -389,6 +389,7 @@ where
     /// [OpenTelemetry semantic conventions for threads][conv].
     ///
     /// By default, thread attributes are enabled.
+    ///
     /// [conv]: https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/span-general/#general-thread-attributes
     pub fn with_threads(self, threads: bool) -> Self {
         Self {

--- a/tracing-opentelemetry/src/subscriber.rs
+++ b/tracing-opentelemetry/src/subscriber.rs
@@ -1,10 +1,12 @@
 use crate::{OtelData, PreSampledTracer};
+use once_cell::unsync;
 use opentelemetry::{
     trace::{self as otel, noop, TraceContextExt},
     Context as OtelContext, Key, KeyValue, Value,
 };
 use std::fmt;
 use std::marker;
+use std::thread;
 use std::time::{Instant, SystemTime};
 use std::{any::TypeId, ptr::NonNull};
 use tracing_core::span::{self, Attributes, Id, Record};
@@ -29,6 +31,7 @@ pub struct OpenTelemetrySubscriber<C, T> {
     tracer: T,
     location: bool,
     tracked_inactivity: bool,
+    with_threads: bool,
     get_context: WithContext,
     _registry: marker::PhantomData<C>,
 }
@@ -292,6 +295,7 @@ where
             tracer,
             location: true,
             tracked_inactivity: true,
+            with_threads: true,
             get_context: WithContext(Self::get_context),
             _registry: marker::PhantomData,
         }
@@ -331,23 +335,34 @@ where
             tracer,
             location: self.location,
             tracked_inactivity: self.tracked_inactivity,
+            with_threads: self.with_threads,
             get_context: WithContext(OpenTelemetrySubscriber::<C, Tracer>::get_context),
             _registry: self._registry,
         }
     }
 
-    /// Sets whether or not span and event metadata should include detailed
-    /// location  information, such as the file, module and line number.
+    /// Sets whether or not span and event metadata should include OpenTelemetry
+    /// attributes with location information, such as the file, module and line number.
+    ///
+    /// These attributes follow the [OpenTelemetry semantic conventions for
+    /// source locations][conv].
     ///
     /// By default, locations are enabled.
+    ///
+    /// [conv]: https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/span-general/#source-code-attributes
     pub fn with_location(self, location: bool) -> Self {
         Self { location, ..self }
     }
 
-    /// Sets whether or not event span's metadata should include detailed location
-    /// information, such as the file, module and line number.
+    /// Sets whether or not span and event metadata should include OpenTelemetry
+    /// attributes with location information, such as the file, module and line number.
     ///
-    /// By default, event locations are enabled.
+    /// These attributes follow the [OpenTelemetry semantic conventions for
+    /// source locations][conv].
+    ///
+    /// By default, locations are enabled.
+    ///
+    /// [conv]: https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/span-general/#source-code-attributes
     #[deprecated(
         since = "0.17.3",
         note = "renamed to `OpenTelemetrySubscriber::with_location`"
@@ -365,6 +380,19 @@ where
     pub fn with_tracked_inactivity(self, tracked_inactivity: bool) -> Self {
         Self {
             tracked_inactivity,
+            ..self
+        }
+    }
+
+    /// Sets whether or not spans record additional attributes for the thread
+    /// name and thread ID of the thread they were created on, following the
+    /// [OpenTelemetry semantic conventions for threads][conv].
+    ///
+    /// By default, thread attributes are enabled.
+    /// [conv]: https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/span-general/#general-thread-attributes
+    pub fn with_threads(self, threads: bool) -> Self {
+        Self {
+            with_threads: threads,
             ..self
         }
     }
@@ -421,6 +449,30 @@ where
             f(builder, &subscriber.tracer);
         }
     }
+
+    fn extra_span_attrs(&self) -> usize {
+        let mut extra_attrs = 0;
+        if self.location {
+            extra_attrs += 3;
+        }
+        if self.with_threads {
+            extra_attrs += 2;
+        }
+        extra_attrs
+    }
+}
+
+thread_local! {
+    static THREAD_ID: unsync::Lazy<u64> = unsync::Lazy::new(|| {
+        // OpenTelemetry's semantic conventions require the thread ID to be
+        // recorded as an integer, but `std::thread::ThreadId` does not expose
+        // the integer value on stable, so we have to convert it to a `usize` by
+        // parsing it. Since this requires allocating a `String`, store it in a
+        // thread local so we only have to do this once.
+        // TODO(eliza): once `std::thread::ThreadId::as_u64` is stabilized
+        // (https://github.com/rust-lang/rust/issues/67939), just use that.
+        thread_id_integer(thread::current().id())
+    });
 }
 
 impl<C, T> Subscribe<C> for OpenTelemetrySubscriber<C, T>
@@ -453,9 +505,9 @@ where
             builder.trace_id = Some(self.tracer.new_trace_id());
         }
 
-        let builder_attrs = builder
-            .attributes
-            .get_or_insert(Vec::with_capacity(attrs.fields().len() + 3));
+        let builder_attrs = builder.attributes.get_or_insert(Vec::with_capacity(
+            attrs.fields().len() + self.extra_span_attrs(),
+        ));
 
         if self.location {
             let meta = attrs.metadata();
@@ -470,6 +522,17 @@ where
 
             if let Some(line) = meta.line() {
                 builder_attrs.push(KeyValue::new("code.lineno", line as i64));
+            }
+        }
+
+        if self.with_threads {
+            THREAD_ID.with(|id| builder_attrs.push(KeyValue::new("thread.id", **id as i64)));
+            if let Some(name) = std::thread::current().name() {
+                // TODO(eliza): it's a bummer that we have to allocate here, but
+                // we can't easily get the string as a `static`. it would be
+                // nice if `opentelemetry` could also take `Arc<str>`s as
+                // `String` values...
+                builder_attrs.push(KeyValue::new("thread.name", name.to_owned()));
             }
         }
 
@@ -696,14 +759,27 @@ impl Timings {
     }
 }
 
+fn thread_id_integer(id: thread::ThreadId) -> u64 {
+    let thread_id = format!("{:?}", id);
+    thread_id
+        .trim_start_matches("ThreadId(")
+        .trim_end_matches(')')
+        .parse::<u64>()
+        .expect("thread ID should parse as an integer")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::OtelData;
     use opentelemetry::trace::{noop, SpanKind, TraceFlags};
-    use std::borrow::Cow;
-    use std::sync::{Arc, Mutex};
-    use std::time::SystemTime;
+    use std::{
+        borrow::Cow,
+        collections::HashMap,
+        sync::{Arc, Mutex},
+        thread,
+        time::SystemTime,
+    };
     use tracing_subscriber::prelude::*;
 
     #[derive(Debug, Clone)]
@@ -928,5 +1004,49 @@ mod tests {
         assert!(!keys.contains(&"code.filepath"));
         assert!(!keys.contains(&"code.namespace"));
         assert!(!keys.contains(&"code.lineno"));
+    }
+
+    #[test]
+    fn includes_thread() {
+        let thread = thread::current();
+        let expected_name = thread
+            .name()
+            .map(|name| Value::String(Cow::Owned(name.to_owned())));
+        let expected_id = Value::I64(thread_id_integer(thread.id()) as i64);
+
+        let tracer = TestTracer(Arc::new(Mutex::new(None)));
+        let subscriber = tracing_subscriber::registry()
+            .with(subscriber().with_tracer(tracer.clone()).with_threads(true));
+
+        tracing::collect::with_default(subscriber, || {
+            tracing::debug_span!("request");
+        });
+
+        let attributes = tracer
+            .with_data(|data| data.builder.attributes.as_ref().unwrap().clone())
+            .drain(..)
+            .map(|keyval| (keyval.key.as_str().to_string(), keyval.value))
+            .collect::<HashMap<_, _>>();
+        assert_eq!(attributes.get("thread.name"), expected_name.as_ref());
+        assert_eq!(attributes.get("thread.id"), Some(&expected_id));
+    }
+
+    #[test]
+    fn excludes_thread() {
+        let tracer = TestTracer(Arc::new(Mutex::new(None)));
+        let subscriber = tracing_subscriber::registry()
+            .with(subscriber().with_tracer(tracer.clone()).with_threads(false));
+
+        tracing::collect::with_default(subscriber, || {
+            tracing::debug_span!("request");
+        });
+
+        let attributes = tracer.with_data(|data| data.builder.attributes.as_ref().unwrap().clone());
+        let keys = attributes
+            .iter()
+            .map(|attr| attr.key.as_str())
+            .collect::<Vec<&str>>();
+        assert!(!keys.contains(&"thread.name"));
+        assert!(!keys.contains(&"thread.id"));
     }
 }


### PR DESCRIPTION
OpenTelemetry has [semantic conventions][1] for reporting thread names
and IDs on spans. This branch adds support for recording thread names
and IDs according to these conventions.

[1]: https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/span-general/#source-code-attributes