### PR TITLE
opentelemetry: add semconv exception fields

### DIFF
--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -1186,7 +1186,11 @@ mod tests {
     #[test]
     fn records_error_fields() {
         let tracer = TestTracer(Arc::new(Mutex::new(None)));
-        let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
+        let subscriber = tracing_subscriber::registry().with(
+            layer()
+                .with_tracer(tracer.clone())
+                .with_exception_fields(true),
+        );
 
         let err = TestDynError::new("base error")
             .with_parent("intermediate error")
@@ -1328,7 +1332,11 @@ mod tests {
     #[test]
     fn propagates_error_fields_from_event_to_span() {
         let tracer = TestTracer(Arc::new(Mutex::new(None)));
-        let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
+        let subscriber = tracing_subscriber::registry().with(
+            layer()
+                .with_tracer(tracer.clone())
+                .with_exception_field_propagation(true),
+        );
 
         let err = TestDynError::new("base error")
             .with_parent("intermediate error")

--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -267,8 +267,8 @@ impl<'a, 'b> field::Visit for SpanEventVisitor<'a, 'b> {
     }
 }
 
-#[derive(Clone, Copy)]
 /// Control over opentelemetry conventional exception fields
+#[derive(Clone, Copy)]
 struct ExceptionFieldConfig {
     /// If an error value is recorded on an event/span, should the otel fields
     /// be added
@@ -425,8 +425,8 @@ where
             tracked_inactivity: true,
             with_threads: true,
             exception_config: ExceptionFieldConfig {
-                record: true,
-                propagate: true,
+                record: false,
+                propagate: false,
             },
             get_context: WithContext(Self::get_context),
             _registry: marker::PhantomData,


### PR DESCRIPTION
When an error value is recorded, it should add the `exception.message` and
`exception.stacktrace` fields from the opentelemetry semantic conventions to the
span/event. Ideally the `exception.type` field would be provided also, but there
is currently not a mechanism to determine the type name of a trait object.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

Motivated by comment on another PR - https://github.com/tokio-rs/tracing/pull/2122#issuecomment-1133181925

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->