### PR TITLE
docs: remove old msrv note

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -119,8 +119,6 @@
 //! tracing = "0.1"
 //! ```
 //!
-//! *Compiler support: requires rustc 1.39+*
-//!
 //! ## Recording Spans and Events
 //!
 //! Spans and events are recorded using macros.


### PR DESCRIPTION
there's a correct one towards the top, so this only needs to be removed