### PR TITLE
Add ability to rename timestamp and target.

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -513,6 +513,28 @@ impl<C, T, W> Subscriber<C, format::JsonFields, format::Format<format::Json, T>,
             ..self
         }
     }
+
+    pub fn timestamp_name(
+        self,
+        name: &'static str,
+    ) -> Subscriber<C, format::JsonFields, format::Format<format::Json, T>, W> {
+        Subscriber {
+            fmt_event: self.fmt_event.timestamp_name(name),
+            fmt_fields: format::JsonFields::new(),
+            ..self
+        }
+    }
+
+    pub fn target_name(
+        self,
+        name: &'static str,
+    ) -> Subscriber<C, format::JsonFields, format::Format<format::Json, T>, W> {
+        Subscriber {
+            fmt_event: self.fmt_event.target_name(name),
+            fmt_fields: format::JsonFields::new(),
+            ..self
+        }
+    }
 }
 
 impl<C, N, E, W> Subscriber<C, N, E, W> {

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -514,6 +514,7 @@ impl<C, T, W> Subscriber<C, format::JsonFields, format::Format<format::Json, T>,
         }
     }
 
+    /// Sets `timestamp` field name.
     pub fn timestamp_name(
         self,
         name: &'static str,
@@ -525,6 +526,7 @@ impl<C, T, W> Subscriber<C, format::JsonFields, format::Format<format::Json, T>,
         }
     }
 
+    /// Sets `target` field name.
     pub fn target_name(
         self,
         name: &'static str,

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -95,10 +95,12 @@ impl Json {
         self.display_span_list = display_span_list;
     }
 
+    /// Sets `timestamp` field name.
     pub fn timestamp_name(&mut self, name: &'static str) {
         self.timestamp_name = name;
     }
 
+    /// Sets `target` field name.
     pub fn target_name(&mut self, name: &'static str) {
         self.target_name = name;
     }

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -74,6 +74,8 @@ pub struct Json {
     pub(crate) flatten_event: bool,
     pub(crate) display_current_span: bool,
     pub(crate) display_span_list: bool,
+    pub(crate) timestamp_name: &'static str,
+    pub(crate) target_name: &'static str,
 }
 
 impl Json {
@@ -91,6 +93,14 @@ impl Json {
     /// entered spans. Spans are logged in a list from root to leaf.
     pub fn with_span_list(&mut self, display_span_list: bool) {
         self.display_span_list = display_span_list;
+    }
+
+    pub fn timestamp_name(&mut self, name: &'static str) {
+        self.timestamp_name = name;
+    }
+
+    pub fn target_name(&mut self, name: &'static str) {
+        self.target_name = name;
     }
 }
 
@@ -224,7 +234,7 @@ where
             let mut serializer = serializer.serialize_map(None)?;
 
             if self.display_timestamp {
-                serializer.serialize_entry("timestamp", &timestamp)?;
+                serializer.serialize_entry(self.format.timestamp_name, &timestamp)?;
             }
 
             if self.display_level {
@@ -254,7 +264,7 @@ where
             };
 
             if self.display_target {
-                serializer.serialize_entry("target", meta.target())?;
+                serializer.serialize_entry(self.format.target_name, meta.target())?;
             }
 
             if self.display_filename {
@@ -318,6 +328,8 @@ impl Default for Json {
             flatten_event: false,
             display_current_span: true,
             display_span_list: true,
+            timestamp_name: "timestamp",
+            target_name: "target",
         }
     }
 }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -909,6 +909,7 @@ impl<T> Format<Json, T> {
         self
     }
 
+    /// Sets `timestamp` field name.
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub fn timestamp_name(mut self, name: &'static str) -> Format<Json, T> {
@@ -916,6 +917,7 @@ impl<T> Format<Json, T> {
         self
     }
 
+    /// Sets `target` field name.
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub fn target_name(mut self, name: &'static str) -> Format<Json, T> {

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -908,6 +908,20 @@ impl<T> Format<Json, T> {
         self.format.with_span_list(display_span_list);
         self
     }
+
+    #[cfg(feature = "json")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
+    pub fn timestamp_name(mut self, name: &'static str) -> Format<Json, T> {
+        self.format.timestamp_name(name);
+        self
+    }
+
+    #[cfg(feature = "json")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
+    pub fn target_name(mut self, name: &'static str) -> Format<Json, T> {
+        self.format.target_name(name);
+        self
+    }
 }
 
 impl<C, N, T> FormatEvent<C, N> for Format<Full, T>

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -774,6 +774,26 @@ impl<T, F, W> CollectorBuilder<format::JsonFields, format::Format<format::Json, 
             inner: self.inner.with_span_list(display_span_list),
         }
     }
+
+    pub fn timestamp_name(
+        self,
+        name: &'static str,
+    ) -> CollectorBuilder<format::JsonFields, format::Format<format::Json, T>, F, W> {
+        CollectorBuilder {
+            filter: self.filter,
+            inner: self.inner.timestamp_name(name),
+        }
+    }
+
+    pub fn target_name(
+        self,
+        name: &'static str,
+    ) -> CollectorBuilder<format::JsonFields, format::Format<format::Json, T>, F, W> {
+        CollectorBuilder {
+            filter: self.filter,
+            inner: self.inner.target_name(name),
+        }
+    }
 }
 
 impl<N, E, F, W> CollectorBuilder<N, E, reload::Subscriber<F>, W>

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -775,6 +775,22 @@ impl<T, F, W> CollectorBuilder<format::JsonFields, format::Format<format::Json, 
         }
     }
 
+    /// Sets `timestamp` field name.
+    /// For example:
+    /// ```rust
+    /// tracing_subscriber::fmt()
+    ///     .json()
+    ///     .timestamp_name("time")
+    ///     .init();
+    ///
+    /// tracing::info!("Hello world!");
+    /// ```
+    ///
+    /// will produce:
+    ///
+    /// ```json
+    /// {"time":"2022-05-25T17:32:53.604269Z","level":"INFO","fields":{"message":"Hello"},"target":"playground"}
+    /// ```
     pub fn timestamp_name(
         self,
         name: &'static str,
@@ -785,6 +801,22 @@ impl<T, F, W> CollectorBuilder<format::JsonFields, format::Format<format::Json, 
         }
     }
 
+    /// Sets `target` field name.
+    /// For example:
+    /// ```rust
+    /// tracing_subscriber::fmt()
+    ///     .json()
+    ///     .target_name("from")
+    ///     .init();
+    ///
+    /// tracing::info!("Hello world!");
+    /// ```
+    ///
+    /// will produce:
+    ///
+    /// ```json
+    /// {"timestamp":"2022-05-25T17:32:53.604269Z","level":"INFO","fields":{"message":"Hello"},"from":"playground"}
+    /// ```
     pub fn target_name(
         self,
         name: &'static str,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation
To use the same fields name across the projects.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
It quite ugly, but I see no other choice. Implement own layer / formatter just for renaming a couple of fields?

Resolves #1849; #2115 