### PR TITLE
Update tracing-opentelemetry readme example

### DIFF
--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -66,7 +66,7 @@ use tracing_subscriber::Registry;
 
 fn main() {
     // Install a new OpenTelemetry trace pipeline
-    let (tracer, _uninstall) = stdout::new_pipeline().install();
+    let tracer = opentelemetry::sdk::export::trace::stdout::new_pipeline().install_simple();
 
     // Create a tracing subscriber with the configured tracer
     let telemetry = tracing_opentelemetry::subscriber().with_tracer(tracer);


### PR DESCRIPTION
## Motivation

Line 69 is no longer valid in newer `opentelemetry` versions, I think they changed some exports and function signatures. Still trying to find out how I can set this up, but I'm pretty sure this is a good place to start.

## Solution

**Note that the example is still not completely correct with this change!** Example still won't compile, but I'm not sure what's needed to fix this.
