### PR TITLE
[wip] Early draft of support for metrics in tracing

### DIFF
--- a/examples/examples/counters.rs
+++ b/examples/examples/counters.rs
@@ -3,7 +3,7 @@
 use tracing::{
     collect::{self, Collect},
     field::{Field, Visit},
-    info, span, warn, Event, Id, Level, Metadata,
+    info, span, warn, Event, Id, Level, Metadata, Metric,
 };
 
 use tracing_core::span::Current;
@@ -93,6 +93,10 @@ impl Collect for CounterCollector {
 
     fn event(&self, event: &Event<'_>) {
         event.record(&mut self.visitor())
+    }
+
+    fn metric(&self, metric: &Metric<'_>) {
+        metric.record(&mut self.visitor())
     }
 
     fn enabled(&self, metadata: &Metadata<'_>) -> bool {

--- a/examples/examples/serde-yak-shave.rs
+++ b/examples/examples/serde-yak-shave.rs
@@ -6,6 +6,7 @@ use tracing_core::{
     event::Event,
     metadata::Metadata,
     span::{Attributes, Current, Id, Record},
+    metric::Metric,
 };
 use tracing_serde::AsSerde;
 
@@ -61,6 +62,13 @@ impl Collect for JsonCollector {
     fn event(&self, event: &Event<'_>) {
         let json = json!({
             "event": event.as_serde(),
+        });
+        println!("{}", json);
+    }
+
+    fn metric(&self, metric: &Metric<'_>) {
+        let json = json!({
+            "metric": metric.as_serde(),
         });
         println!("{}", json);
     }

--- a/examples/examples/sloggish/sloggish_collector.rs
+++ b/examples/examples/sloggish/sloggish_collector.rs
@@ -257,6 +257,10 @@ impl Collect for SloggishCollector {
         writeln!(&mut visitor.stderr).unwrap();
     }
 
+    fn metric(&self, _metric: &tracing::Metric<'_>) {
+        todo!()
+    }
+
     #[inline]
     fn exit(&self, _span: &tracing::Id) {
         // TODO: unify stack with current span

--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -137,7 +137,7 @@
 //! instrumentation.
 use crate::{
     collect::{self, Collect, NoCollector},
-    span, Event, LevelFilter, Metadata,
+    span, Event, LevelFilter, Metadata, Metric,
 };
 
 use core::{
@@ -685,6 +685,19 @@ impl Dispatch {
         self.collector().event(event)
     }
 
+    /// Records that a [`Metric`] has occurred.
+    ///
+    /// This calls the [`metric`] function on the [`Collect`] that this
+    /// `Dispatch` forwards to.
+    ///
+    /// [`Metric`]: super::metric::Metric
+    /// [`Collect`]: super::collect::Collect
+    /// [`metric`]: super::collect::Collect::metric
+    #[inline]
+    pub fn metric(&self, metric: &Metric<'_>) {
+        self.collector().metric(metric)
+    }
+
     /// Records that a span has been can_enter.
     ///
     /// This calls the [`enter`] function on the [`Collect`] that this
@@ -1006,6 +1019,8 @@ mod test {
                 Event::dispatch(&TEST_META, &TEST_META.fields().value_set(&[]))
             }
 
+            fn metric(&self, _: &Metric<'_>) {}
+
             fn enter(&self, _: &span::Id) {}
 
             fn exit(&self, _: &span::Id) {}
@@ -1058,6 +1073,8 @@ mod test {
 
             fn event(&self, _: &Event<'_>) {}
 
+            fn metric(&self, _: &Metric<'_>) {}
+
             fn enter(&self, _: &span::Id) {}
 
             fn exit(&self, _: &span::Id) {}
@@ -1094,6 +1111,8 @@ mod test {
             fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
 
             fn event(&self, _: &Event<'_>) {}
+
+            fn metric(&self, _: &Metric<'_>) {}
 
             fn enter(&self, _: &span::Id) {}
 

--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -28,13 +28,14 @@
 //! ```rust
 //! # pub struct FooCollector;
 //! # use tracing_core::{
-//! #   dispatch, Event, Metadata,
+//! #   dispatch, Event, Metadata, Metric,
 //! #   span::{Attributes, Current, Id, Record}
 //! # };
 //! # impl tracing_core::Collect for FooCollector {
 //! #   fn new_span(&self, _: &Attributes) -> Id { Id::from_u64(0) }
 //! #   fn record(&self, _: &Id, _: &Record) {}
 //! #   fn event(&self, _: &Event) {}
+//! #   fn metric(&self, _: &Metric) {}
 //! #   fn record_follows_from(&self, _: &Id, _: &Id) {}
 //! #   fn enabled(&self, _: &Metadata) -> bool { false }
 //! #   fn enter(&self, _: &Id) {}
@@ -55,13 +56,14 @@
 //! ```rust
 //! # pub struct FooCollector;
 //! # use tracing_core::{
-//! #   dispatch, Event, Metadata,
+//! #   dispatch, Event, Metadata, Metric,
 //! #   span::{Attributes, Current, Id, Record}
 //! # };
 //! # impl tracing_core::Collect for FooCollector {
 //! #   fn new_span(&self, _: &Attributes) -> Id { Id::from_u64(0) }
 //! #   fn record(&self, _: &Id, _: &Record) {}
 //! #   fn event(&self, _: &Event) {}
+//! #   fn metric(&self, _: &Metric) {}
 //! #   fn record_follows_from(&self, _: &Id, _: &Id) {}
 //! #   fn enabled(&self, _: &Metadata) -> bool { false }
 //! #   fn enter(&self, _: &Id) {}
@@ -92,13 +94,14 @@
 //! ```rust
 //! # pub struct FooCollector;
 //! # use tracing_core::{
-//! #   dispatch, Event, Metadata,
+//! #   dispatch, Event, Metadata, Metric,
 //! #   span::{Attributes, Current, Id, Record}
 //! # };
 //! # impl tracing_core::Collect for FooCollector {
 //! #   fn new_span(&self, _: &Attributes) -> Id { Id::from_u64(0) }
 //! #   fn record(&self, _: &Id, _: &Record) {}
 //! #   fn event(&self, _: &Event) {}
+//! #   fn metric(&self, _: &Metric) {}
 //! #   fn record_follows_from(&self, _: &Id, _: &Id) {}
 //! #   fn enabled(&self, _: &Metadata) -> bool { false }
 //! #   fn enter(&self, _: &Id) {}
@@ -518,12 +521,13 @@ impl Dispatch {
     ///    // ...
     /// }
     ///
-    /// # use tracing_core::{span::{Id, Attributes, Current, Record}, Event, Metadata};
+    /// # use tracing_core::{span::{Id, Attributes, Current, Record}, Event, Metadata, Metric};
     /// impl tracing_core::Collect for MyCollector {
     ///     // ...
     /// #   fn new_span(&self, _: &Attributes) -> Id { Id::from_u64(0) }
     /// #   fn record(&self, _: &Id, _: &Record) {}
     /// #   fn event(&self, _: &Event) {}
+    /// #   fn metric(&self, _: &Metric) {}
     /// #   fn record_follows_from(&self, _: &Id, _: &Id) {}
     /// #   fn enabled(&self, _: &Metadata) -> bool { false }
     /// #   fn enter(&self, _: &Id) {}

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -294,6 +294,7 @@ pub mod dispatch;
 pub mod event;
 pub mod field;
 pub mod metadata;
+pub mod metric;
 mod parent;
 pub mod span;
 
@@ -303,6 +304,7 @@ pub use self::{
     collect::Collect,
     dispatch::Dispatch,
     event::Event,
+    metric::Metric,
     field::Field,
     metadata::{Level, LevelFilter, Metadata},
 };

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -152,7 +152,7 @@ pub struct Kind(u8);
 /// often improving performance in short-lived programs.
 ///
 /// ```
-/// use tracing_core::{span, Event, Level, LevelFilter, Collect, Metadata};
+/// use tracing_core::{span, Event, Level, LevelFilter, Collect, Metadata, Metric};
 /// # use tracing_core::span::{Id, Record, Current};
 ///
 /// #[derive(Debug)]
@@ -199,7 +199,12 @@ pub struct Kind(u8);
 ///         // ...
 ///         # drop(event);
 ///     }
-///
+/// 
+///     fn metric(&self, metric: &Metric<'_>) {
+///         // ...
+///         # drop(metric);
+///     }
+/// 
 ///     // ...
 ///     # fn enter(&self, _: &Id) {}
 ///     # fn exit(&self, _: &Id) {}

--- a/tracing-core/src/metric.rs
+++ b/tracing-core/src/metric.rs
@@ -1,0 +1,128 @@
+//! Metrics represent single points in time during the execution of a program.
+use crate::parent::Parent;
+use crate::span::Id;
+use crate::{field, Metadata};
+
+/// `Metric`s represent single points in time where something occurred during the
+/// execution of a program.
+///
+/// An `Metric` can be compared to a log record in unstructured logging, but with
+/// two key differences:
+/// - `Metric`s exist _within the context of a [span]_. Unlike log lines, they
+///   may be located within the trace tree, allowing visibility into the
+///   _temporal_ context in which the Metric occurred, as well as the source
+///   code location.
+/// - Like spans, `Metric`s have structured key-value data known as _[fields]_,
+///   which may include textual message. In general, a majority of the data
+///   associated with an Metric should be in the Metric's fields rather than in
+///   the textual message, as the fields are more structured.
+///
+/// [span]: super::span
+/// [fields]: super::field
+#[derive(Debug)]
+pub struct Metric<'a> {
+    fields: &'a field::ValueSet<'a>,
+    metadata: &'static Metadata<'static>,
+    parent: Parent,
+}
+
+impl<'a> Metric<'a> {
+    /// Constructs a new `Metric` with the specified metadata and set of values,
+    /// and observes it with the current collector.
+    pub fn dispatch(metadata: &'static Metadata<'static>, fields: &'a field::ValueSet<'_>) {
+        let Metric = Metric::new(metadata, fields);
+        crate::dispatch::get_default(|current| {
+            current.Metric(&Metric);
+        });
+    }
+
+    /// Returns a new `Metric` in the current span, with the specified metadata
+    /// and set of values.
+    #[inline]
+    pub fn new(metadata: &'static Metadata<'static>, fields: &'a field::ValueSet<'a>) -> Self {
+        Metric {
+            fields,
+            metadata,
+            parent: Parent::Current,
+        }
+    }
+
+    /// Returns a new `Metric` as a child of the specified span, with the
+    /// provided metadata and set of values.
+    #[inline]
+    pub fn new_child_of(
+        parent: impl Into<Option<Id>>,
+        metadata: &'static Metadata<'static>,
+        fields: &'a field::ValueSet<'a>,
+    ) -> Self {
+        let parent = match parent.into() {
+            Some(p) => Parent::Explicit(p),
+            None => Parent::Root,
+        };
+        Metric {
+            fields,
+            metadata,
+            parent,
+        }
+    }
+
+    /// Constructs a new `Metric` with the specified metadata and set of values,
+    /// and observes it with the current collector and an explicit parent.
+    pub fn child_of(
+        parent: impl Into<Option<Id>>,
+        metadata: &'static Metadata<'static>,
+        fields: &'a field::ValueSet<'_>,
+    ) {
+        let Metric = Self::new_child_of(parent, metadata, fields);
+        crate::dispatch::get_default(|current| {
+            current.Metric(&Metric);
+        });
+    }
+
+    /// Visits all the fields on this `Metric` with the specified [visitor].
+    ///
+    /// [visitor]: super::field::Visit
+    #[inline]
+    pub fn record(&self, visitor: &mut dyn field::Visit) {
+        self.fields.record(visitor);
+    }
+
+    /// Returns an iterator over the set of values on this `Metric`.
+    pub fn fields(&self) -> field::Iter {
+        self.fields.field_set().iter()
+    }
+
+    /// Returns [metadata] describing this `Metric`.
+    ///
+    /// [metadata]: super::Metadata
+    pub fn metadata(&self) -> &'static Metadata<'static> {
+        self.metadata
+    }
+
+    /// Returns true if the new Metric should be a root.
+    pub fn is_root(&self) -> bool {
+        matches!(self.parent, Parent::Root)
+    }
+
+    /// Returns true if the new Metric's parent should be determined based on the
+    /// current context.
+    ///
+    /// If this is true and the current thread is currently inside a span, then
+    /// that span should be the new Metric's parent. Otherwise, if the current
+    /// thread is _not_ inside a span, then the new Metric will be the root of its
+    /// own trace tree.
+    pub fn is_contextual(&self) -> bool {
+        matches!(self.parent, Parent::Current)
+    }
+
+    /// Returns the new Metric's explicitly-specified parent, if there is one.
+    ///
+    /// Otherwise (if the new Metric is a root or is a child of the current span),
+    /// returns `None`.
+    pub fn parent(&self) -> Option<&Id> {
+        match self.parent {
+            Parent::Explicit(ref p) => Some(p),
+            _ => None,
+        }
+    }
+}

--- a/tracing-core/src/metric.rs
+++ b/tracing-core/src/metric.rs
@@ -10,11 +10,11 @@ use crate::{field, Metadata};
 /// two key differences:
 /// - `Metric`s exist _within the context of a [span]_. Unlike log lines, they
 ///   may be located within the trace tree, allowing visibility into the
-///   _temporal_ context in which the Metric occurred, as well as the source
+///   _temporal_ context in which the metric occurred, as well as the source
 ///   code location.
 /// - Like spans, `Metric`s have structured key-value data known as _[fields]_,
 ///   which may include textual message. In general, a majority of the data
-///   associated with an Metric should be in the Metric's fields rather than in
+///   associated with an metric should be in the metric's fields rather than in
 ///   the textual message, as the fields are more structured.
 ///
 /// [span]: super::span
@@ -30,9 +30,9 @@ impl<'a> Metric<'a> {
     /// Constructs a new `Metric` with the specified metadata and set of values,
     /// and observes it with the current collector.
     pub fn dispatch(metadata: &'static Metadata<'static>, fields: &'a field::ValueSet<'_>) {
-        let Metric = Metric::new(metadata, fields);
+        let metric = Metric::new(metadata, fields);
         crate::dispatch::get_default(|current| {
-            current.Metric(&Metric);
+            current.metric(&metric);
         });
     }
 
@@ -73,9 +73,9 @@ impl<'a> Metric<'a> {
         metadata: &'static Metadata<'static>,
         fields: &'a field::ValueSet<'_>,
     ) {
-        let Metric = Self::new_child_of(parent, metadata, fields);
+        let metric = Self::new_child_of(parent, metadata, fields);
         crate::dispatch::get_default(|current| {
-            current.Metric(&Metric);
+            current.metric(&metric);
         });
     }
 
@@ -99,25 +99,25 @@ impl<'a> Metric<'a> {
         self.metadata
     }
 
-    /// Returns true if the new Metric should be a root.
+    /// Returns true if the new metric should be a root.
     pub fn is_root(&self) -> bool {
         matches!(self.parent, Parent::Root)
     }
 
-    /// Returns true if the new Metric's parent should be determined based on the
+    /// Returns true if the new metric's parent should be determined based on the
     /// current context.
     ///
     /// If this is true and the current thread is currently inside a span, then
-    /// that span should be the new Metric's parent. Otherwise, if the current
-    /// thread is _not_ inside a span, then the new Metric will be the root of its
+    /// that span should be the new metric's parent. Otherwise, if the current
+    /// thread is _not_ inside a span, then the new metric will be the root of its
     /// own trace tree.
     pub fn is_contextual(&self) -> bool {
         matches!(self.parent, Parent::Current)
     }
 
-    /// Returns the new Metric's explicitly-specified parent, if there is one.
+    /// Returns the new metric's explicitly-specified parent, if there is one.
     ///
-    /// Otherwise (if the new Metric is a root or is a child of the current span),
+    /// Otherwise (if the new metric is a root or is a child of the current span),
     /// returns `None`.
     pub fn parent(&self) -> Option<&Id> {
         match self.parent {

--- a/tracing-core/tests/common/mod.rs
+++ b/tracing-core/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use tracing_core::{collect::Collect, metadata::Metadata, span, Event};
+use tracing_core::{collect::Collect, metadata::Metadata, span, Event, Metric};
 
 pub struct TestCollectorA;
 impl Collect for TestCollectorA {
@@ -11,6 +11,7 @@ impl Collect for TestCollectorA {
     fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
     fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
     fn event(&self, _: &Event<'_>) {}
+    fn metric(&self, _: &Metric<'_>) {}
     fn enter(&self, _: &span::Id) {}
     fn exit(&self, _: &span::Id) {}
     fn current_span(&self) -> span::Current {
@@ -28,9 +29,11 @@ impl Collect for TestCollectorB {
     fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
     fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
     fn event(&self, _: &Event<'_>) {}
+    fn metric(&self, _: &Metric<'_>) {}
     fn enter(&self, _: &span::Id) {}
     fn exit(&self, _: &span::Id) {}
     fn current_span(&self) -> span::Current {
         span::Current::unknown()
     }
+
 }

--- a/tracing-log/tests/log_tracer.rs
+++ b/tracing-log/tests/log_tracer.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 use tracing::collect::with_default;
 use tracing_core::span::{Attributes, Record};
-use tracing_core::{span, Collect, Event, Level, LevelFilter, Metadata};
+use tracing_core::{span, Collect, Event, Level, LevelFilter, Metadata, Metric};
 use tracing_log::{LogTracer, NormalizeEvent};
 
 struct State {
@@ -52,6 +52,8 @@ impl Collect for TestSubscriber {
             }),
         )
     }
+
+    fn metric(&self, _: &Metric<'_>) {}
 
     fn enter(&self, _span: &span::Id) {}
 

--- a/tracing-mock/src/collector.rs
+++ b/tracing-mock/src/collector.rs
@@ -17,7 +17,7 @@ use tracing::{
     collect::Interest,
     level_filters::LevelFilter,
     span::{self, Attributes, Id},
-    Collect, Event, Metadata,
+    Collect, Event, Metadata, Metric,
 };
 
 #[derive(Debug, Eq, PartialEq)]
@@ -257,6 +257,10 @@ where
             }
             Some(ex) => ex.bad(&self.name, format_args!("observed event {:#?}", event)),
         }
+    }
+
+    fn metric(&self, metric: &Metric<'_>) {
+        todo!()
     }
 
     fn record_follows_from(&self, consequence_id: &Id, cause_id: &Id) {

--- a/tracing-mock/src/collector.rs
+++ b/tracing-mock/src/collector.rs
@@ -259,7 +259,7 @@ where
         }
     }
 
-    fn metric(&self, metric: &Metric<'_>) {
+    fn metric(&self, _metric: &Metric<'_>) {
         todo!()
     }
 

--- a/tracing-opentelemetry/src/subscriber.rs
+++ b/tracing-opentelemetry/src/subscriber.rs
@@ -10,7 +10,7 @@ use std::thread;
 use std::time::{Instant, SystemTime};
 use std::{any::TypeId, ptr::NonNull};
 use tracing_core::span::{self, Attributes, Id, Record};
-use tracing_core::{field, Collect, Event};
+use tracing_core::{field, Collect, Event, Metric};
 #[cfg(feature = "tracing-log")]
 use tracing_log::NormalizeEvent;
 use tracing_subscriber::registry::LookupSpan;
@@ -695,6 +695,10 @@ where
                 }
             }
         };
+    }
+
+    fn on_metric(&self, metric: &Metric<'_>, _ctx: Context<'_, C>) {
+        println!("uck: {:?}", metric);
     }
 
     /// Exports an OpenTelemetry [`Span`] on close.

--- a/tracing-subscriber/benches/filter.rs
+++ b/tracing-subscriber/benches/filter.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::time::Duration;
-use tracing::{dispatch::Dispatch, span, Event, Id, Metadata};
+use tracing::{dispatch::Dispatch, span, Event, Id, Metadata, Metric};
 use tracing_core::span::Current;
 use tracing_subscriber::{prelude::*, reload, EnvFilter};
 mod support;
@@ -17,6 +17,10 @@ impl tracing::Collect for EnabledSubscriber {
 
     fn event(&self, event: &Event<'_>) {
         let _ = event;
+    }
+
+    fn metric(&self, metric: &Metric<'_>) {
+        let _ = metric;
     }
 
     fn record(&self, span: &Id, values: &span::Record<'_>) {

--- a/tracing-subscriber/benches/filter_log.rs
+++ b/tracing-subscriber/benches/filter_log.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::time::Duration;
-use tracing::{dispatch::Dispatch, span, Event, Id, Metadata};
+use tracing::{dispatch::Dispatch, span, Event, Id, Metadata, Metric};
 use tracing_core::span::Current;
 use tracing_subscriber::{prelude::*, EnvFilter};
 
@@ -18,6 +18,10 @@ impl tracing::Collect for EnabledSubscriber {
 
     fn event(&self, event: &Event<'_>) {
         let _ = event;
+    }
+
+    fn metric(&self, metric: &Metric<'_>) {
+        let _ = metric;
     }
 
     fn record(&self, span: &Id, values: &span::Record<'_>) {

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -827,6 +827,7 @@ mod tests {
             span::Id::from_u64(0xDEAD)
         }
         fn event(&self, _event: &Event<'_>) {}
+        fn metric(&self, _metric: &Metric<'_>) {}
         fn record(&self, _span: &span::Id, _values: &span::Record<'_>) {}
         fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
 

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -192,7 +192,7 @@
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [`fmt::format`]: mod@crate::fmt::format
 use std::{any::TypeId, error::Error, io, ptr::NonNull};
-use tracing_core::{collect::Interest, span, Event, Metadata};
+use tracing_core::{collect::Interest, span, Event, Metadata, Metric};
 
 mod fmt_subscriber;
 #[cfg_attr(docsrs, doc(cfg(all(feature = "fmt", feature = "std"))))]
@@ -396,6 +396,11 @@ where
     #[inline]
     fn event(&self, event: &Event<'_>) {
         self.inner.event(event);
+    }
+
+    #[inline]
+    fn metric(&self, metric: &Metric<'_>) {
+        self.inner.metric(metric);
     }
 
     #[inline]

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -17,7 +17,7 @@ use std::{
 use tracing_core::{
     dispatch::{self, Dispatch},
     span::{self, Current, Id},
-    Collect, Event, Interest, Metadata,
+    Collect, Event, Interest, Metadata, Metric,
 };
 
 /// A shared, reusable store for spans.
@@ -278,6 +278,10 @@ impl Collect for Registry {
     /// This is intentionally not implemented, as recording events
     /// is the responsibility of subscribers atop of this registry.
     fn event(&self, _: &Event<'_>) {}
+
+    /// This is intentionally not implemented, as recording metrics
+    /// is the responsibility of subscribers atop of this registry.
+    fn metric(&self, _: &Metric<'_>) {}
 
     fn enter(&self, id: &span::Id) {
         if self

--- a/tracing-subscriber/src/subscribe/layered.rs
+++ b/tracing-subscriber/src/subscribe/layered.rs
@@ -1,7 +1,7 @@
 use tracing_core::{
     collect::{Collect, Interest},
     metadata::Metadata,
-    span, Event, LevelFilter,
+    span, Event, LevelFilter, Metric,
 };
 
 use crate::{
@@ -116,6 +116,11 @@ where
     fn event(&self, event: &Event<'_>) {
         self.inner.event(event);
         self.subscriber.on_event(event, self.ctx());
+    }
+
+    fn metric(&self, metric: &Metric<'_>) {
+        self.inner.metric(metric);
+        self.subscriber.on_metric(metric, self.ctx());
     }
 
     fn enter(&self, span: &span::Id) {

--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -52,12 +52,13 @@
 //!     // ...
 //! }
 //!
-//! # use tracing_core::{span::{Id, Attributes, Record}, Metadata, Event};
+//! # use tracing_core::{span::{Id, Attributes, Record}, Metadata, Event, Metric};
 //! impl Collect for MyCollector {
 //!     // ...
 //! #   fn new_span(&self, _: &Attributes) -> Id { Id::from_u64(1) }
 //! #   fn record(&self, _: &Id, _: &Record) {}
 //! #   fn event(&self, _: &Event) {}
+//! #   fn metric(&self, _: &Metric) {}
 //! #   fn record_follows_from(&self, _: &Id, _: &Id) {}
 //! #   fn enabled(&self, _: &Metadata) -> bool { false }
 //! #   fn enter(&self, _: &Id) {}
@@ -99,11 +100,12 @@
 //! # pub struct MySubscriber {}
 //! # impl<C: Collect> Subscribe<C> for MySubscriber {}
 //! # pub struct MyCollector { }
-//! # use tracing_core::{span::{Id, Attributes, Record}, Metadata, Event};
+//! # use tracing_core::{span::{Id, Attributes, Record}, Metadata, Event, Metric};
 //! # impl Collect for MyCollector {
 //! #   fn new_span(&self, _: &Attributes) -> Id { Id::from_u64(1) }
 //! #   fn record(&self, _: &Id, _: &Record) {}
 //! #   fn event(&self, _: &Event) {}
+//! #   fn metric(&self, _: &Metric) {}
 //! #   fn record_follows_from(&self, _: &Id, _: &Id) {}
 //! #   fn enabled(&self, _: &Metadata) -> bool { false }
 //! #   fn current_span(&self) -> tracing_core::span::Current { tracing_core::span::Current::none() }
@@ -659,7 +661,7 @@ use crate::filter;
 use tracing_core::{
     collect::{Collect, Interest},
     metadata::Metadata,
-    span, Event, LevelFilter,
+    span, Event, LevelFilter, Metric,
 };
 
 use core::{any::TypeId, ptr::NonNull};
@@ -830,6 +832,9 @@ where
     /// Notifies this subscriber that an event has occurred.
     fn on_event(&self, _event: &Event<'_>, _ctx: Context<'_, C>) {}
 
+    /// Notifies this subscriber that a metric has occurred.
+    fn on_metric(&self, _metric: &Metric<'_>, _ctx: Context<'_, C>) {}
+
     /// Notifies this subscriber that a span with the given ID was entered.
     fn on_enter(&self, _id: &span::Id, _ctx: Context<'_, C>) {}
 
@@ -883,11 +888,12 @@ where
     /// # impl MyCollector {
     /// # fn new() -> Self { Self { }}
     /// # }
-    /// # use tracing_core::{span::{Id, Attributes, Record}, Metadata, Event};
+    /// # use tracing_core::{span::{Id, Attributes, Record}, Metadata, Event, Metric};
     /// # impl tracing_core::Collect for MyCollector {
     /// #   fn new_span(&self, _: &Attributes) -> Id { Id::from_u64(1) }
     /// #   fn record(&self, _: &Id, _: &Record) {}
     /// #   fn event(&self, _: &Event) {}
+    /// #   fn metric(&self, _: &Metric) {}
     /// #   fn record_follows_from(&self, _: &Id, _: &Id) {}
     /// #   fn enabled(&self, _: &Metadata) -> bool { false }
     /// #   fn enter(&self, _: &Id) {}
@@ -918,11 +924,12 @@ where
     /// # impl MyCollector {
     /// # fn new() -> Self { Self { }}
     /// # }
-    /// # use tracing_core::{span::{Id, Attributes, Record}, Metadata, Event};
+    /// # use tracing_core::{span::{Id, Attributes, Record}, Metadata, Event, Metric};
     /// # impl tracing_core::Collect for MyCollector {
     /// #   fn new_span(&self, _: &Attributes) -> Id { Id::from_u64(1) }
     /// #   fn record(&self, _: &Id, _: &Record) {}
     /// #   fn event(&self, _: &Event) {}
+    /// #   fn metric(&self, _: &Metric) {}
     /// #   fn record_follows_from(&self, _: &Id, _: &Id) {}
     /// #   fn enabled(&self, _: &Metadata) -> bool { false }
     /// #   fn enter(&self, _: &Id) {}
@@ -986,6 +993,7 @@ where
     /// #   fn new_span(&self, _: &Attributes) -> Id { Id::from_u64(0) }
     /// #   fn record(&self, _: &Id, _: &Record) {}
     /// #   fn event(&self, _: &tracing_core::Event) {}
+    /// #   fn metric(&self, _: &tracing_core::Metric) {}
     /// #   fn record_follows_from(&self, _: &Id, _: &Id) {}
     /// #   fn enabled(&self, _: &Metadata) -> bool { false }
     /// #   fn enter(&self, _: &Id) {}

--- a/tracing-subscriber/src/subscribe/tests.rs
+++ b/tracing-subscriber/src/subscribe/tests.rs
@@ -18,6 +18,7 @@ impl Collect for NopCollector {
     fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
     fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
     fn event(&self, _: &Event<'_>) {}
+    fn metric(&self, _: &Metric<'_>) {}
     fn enter(&self, _: &span::Id) {}
     fn exit(&self, _: &span::Id) {}
 
@@ -63,6 +64,7 @@ impl Collect for StringCollector {
     fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
     fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
     fn event(&self, _: &Event<'_>) {}
+    fn metric(&self, _: &Metric<'_>) {}
     fn enter(&self, _: &span::Id) {}
     fn exit(&self, _: &span::Id) {}
 

--- a/tracing/benches/global_subscriber.rs
+++ b/tracing/benches/global_subscriber.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use tracing::Level;
 
-use tracing::{span, Event, Id, Metadata};
+use tracing::{span, Event, Id, Metadata, Metric};
 use tracing_core::span::Current;
 
 /// A collector that is enabled but otherwise does nothing.
@@ -17,6 +17,10 @@ impl tracing::Collect for EnabledCollector {
 
     fn event(&self, event: &Event<'_>) {
         let _ = event;
+    }
+
+    fn metric(&self, metric: &Metric<'_>) {
+        let _ = metric;
     }
 
     fn record(&self, span: &Id, values: &span::Record<'_>) {

--- a/tracing/benches/subscriber.rs
+++ b/tracing/benches/subscriber.rs
@@ -5,7 +5,7 @@ use std::{
     fmt,
     sync::{Mutex, MutexGuard},
 };
-use tracing::{field, span, Event, Id, Metadata};
+use tracing::{field, span, Event, Id, Metadata, Metric};
 use tracing_core::span::Current;
 
 /// A collector that is enabled but otherwise does nothing.
@@ -19,6 +19,10 @@ impl tracing::Collect for EnabledCollector {
 
     fn event(&self, event: &Event<'_>) {
         let _ = event;
+    }
+
+    fn metric(&self, metric: &Metric<'_>) {
+        let _ = metric;
     }
 
     fn record(&self, span: &Id, values: &span::Record<'_>) {
@@ -73,6 +77,11 @@ impl tracing::Collect for VisitingCollector {
     fn event(&self, event: &Event<'_>) {
         let mut visitor = Visitor(self.0.lock().unwrap());
         event.record(&mut visitor);
+    }
+
+    fn metric(&self, metric: &Metric<'_>) {
+        let mut visitor = Visitor(self.0.lock().unwrap());
+        metric.record(&mut visitor);
     }
 
     fn record_follows_from(&self, span: &Id, follows: &Id) {

--- a/tracing/src/dispatch.rs
+++ b/tracing/src/dispatch.rs
@@ -28,13 +28,14 @@
 //! ```rust
 //! # pub struct FooCollector;
 //! # use tracing_core::{
-//! #   dispatch, Event, Metadata,
+//! #   dispatch, Event, Metadata, Metric,
 //! #   span::{Attributes, Current, Id, Record}
 //! # };
 //! # impl tracing_core::Collect for FooCollector {
 //! #   fn new_span(&self, _: &Attributes) -> Id { Id::from_u64(0) }
 //! #   fn record(&self, _: &Id, _: &Record) {}
 //! #   fn event(&self, _: &Event) {}
+//! #   fn metric(&self, _: &Metric) {}
 //! #   fn record_follows_from(&self, _: &Id, _: &Id) {}
 //! #   fn enabled(&self, _: &Metadata) -> bool { false }
 //! #   fn enter(&self, _: &Id) {}
@@ -55,13 +56,14 @@
 //! ```rust
 //! # pub struct FooCollector;
 //! # use tracing_core::{
-//! #   dispatch, Event, Metadata,
+//! #   dispatch, Event, Metadata, Metric,
 //! #   span::{Attributes, Current, Id, Record}
 //! # };
 //! # impl tracing_core::Collect for FooCollector {
 //! #   fn new_span(&self, _: &Attributes) -> Id { Id::from_u64(0) }
 //! #   fn record(&self, _: &Id, _: &Record) {}
 //! #   fn event(&self, _: &Event) {}
+//! #   fn metric(&self, _: &Metric) {}
 //! #   fn record_follows_from(&self, _: &Id, _: &Id) {}
 //! #   fn enabled(&self, _: &Metadata) -> bool { false }
 //! #   fn enter(&self, _: &Id) {}
@@ -93,13 +95,14 @@
 //! ```rust
 //! # pub struct FooCollector;
 //! # use tracing_core::{
-//! #   dispatch, Event, Metadata,
+//! #   dispatch, Event, Metadata, Metric,
 //! #   span::{Attributes, Current, Id, Record}
 //! # };
 //! # impl tracing_core::Collect for FooCollector {
 //! #   fn new_span(&self, _: &Attributes) -> Id { Id::from_u64(0) }
 //! #   fn record(&self, _: &Id, _: &Record) {}
 //! #   fn event(&self, _: &Event) {}
+//! #   fn metric(&self, _: &Metric) {}
 //! #   fn record_follows_from(&self, _: &Id, _: &Id) {}
 //! #   fn enabled(&self, _: &Metadata) -> bool { false }
 //! #   fn enter(&self, _: &Id) {}

--- a/tracing/src/instrument.rs
+++ b/tracing/src/instrument.rs
@@ -146,6 +146,7 @@ pub trait WithCollector: Sized {
     /// #   }
     /// #   fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record) {}
     /// #   fn event(&self, _: &tracing::Event<'_>) {}
+    /// #   fn metric(&self, _: &tracing::Metric<'_>) {}
     /// #   fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
     /// #   fn enabled(&self, _: &tracing::Metadata) -> bool { false }
     /// #   fn enter(&self, _: &tracing::span::Id) {}
@@ -215,6 +216,7 @@ pub trait WithCollector: Sized {
     /// #   }
     /// #   fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record) {}
     /// #   fn event(&self, _: &tracing::Event<'_>) {}
+    /// #   fn metric(&self, _: &tracing::Metric<'_>) {}
     /// #   fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
     /// #   fn enabled(&self, _: &tracing::Metadata) -> bool { false }
     /// #   fn enter(&self, _: &tracing::span::Id) {}

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -560,6 +560,7 @@
 //! #   fn new_span(&self, _: &Attributes) -> Id { Id::from_u64(0) }
 //! #   fn record(&self, _: &Id, _: &Record) {}
 //! #   fn event(&self, _: &tracing::Event) {}
+//! #   fn metric(&self, _: &tracing::Metric) {}
 //! #   fn record_follows_from(&self, _: &Id, _: &Id) {}
 //! #   fn enabled(&self, _: &Metadata) -> bool { false }
 //! #   fn enter(&self, _: &Id) {}
@@ -603,6 +604,7 @@
 //! #   fn new_span(&self, _: &Attributes) -> Id { Id::from_u64(0) }
 //! #   fn record(&self, _: &Id, _: &Record) {}
 //! #   fn event(&self, _: &tracing::Event) {}
+//! #   fn metric(&self, _: &tracing::Metric) {}
 //! #   fn record_follows_from(&self, _: &Id, _: &Id) {}
 //! #   fn enabled(&self, _: &Metadata) -> bool { false }
 //! #   fn enter(&self, _: &Id) {}
@@ -947,7 +949,7 @@ use tracing_core::*;
 
 #[doc(inline)]
 pub use self::instrument::Instrument;
-pub use self::{collect::Collect, dispatch::Dispatch, event::Event, field::Value};
+pub use self::{collect::Collect, dispatch::Dispatch, event::Event, field::Value, metric::Metric};
 
 #[doc(hidden)]
 pub use self::span::Id;

--- a/tracing/tests/collector.rs
+++ b/tracing/tests/collector.rs
@@ -46,7 +46,7 @@ fn event_macros_dont_infinite_loop() {
             tracing::event!(Level::TRACE, baz = false);
         }
 
-        fn metric(&self, event: &Metric<'_>) {}
+        fn metric(&self, _: &Metric<'_>) {}
 
         fn enter(&self, _: &Id) {}
 

--- a/tracing/tests/collector.rs
+++ b/tracing/tests/collector.rs
@@ -9,7 +9,7 @@ use tracing::{
     collect::{with_default, Collect, Interest},
     field::display,
     span::{Attributes, Id, Record},
-    Event, Level, Metadata,
+    Event, Level, Metadata, Metric,
 };
 
 use tracing_mock::*;
@@ -45,6 +45,8 @@ fn event_macros_dont_infinite_loop() {
             assert!(event.metadata().fields().iter().any(|f| f.name() == "foo"));
             tracing::event!(Level::TRACE, baz = false);
         }
+
+        fn metric(&self, event: &Metric<'_>) {}
 
         fn enter(&self, _: &Id) {}
 


### PR DESCRIPTION
(This is a draft to get some early feedback. Please share any thoughts you have on this!)

## Motivation

TL;DR - It would be really useful to be able to publish service-level and application-level metrics via tracing.

Currently, we can generate some tokio-runtime metrics via tokio-metrics. However, we basically can only log these metrics like a regular log line and analyze them by hand.

The opentelemetry crate already supports publishing metrics. However, because tracing itself doesn't have native support for metrics, the tracing-opentelemetry crate only supports publishing traces.

Therefore, I'm trying to find what is a good way to add into tracing the support for service-level and application-level metrics.

**Note that I'm only talking about OTel in order to explain what an end-to-end solution could look like, but a different layer should be able to do the same for other spcs/vendors. Part of the goal here is not tying this to any given sink.**

## Goal

The eventual goal would be that we should be able to do something like

```rust
// (these are just rough ideas)
metric_counter!(MY_METRIC_NAME, foo = "bar", baz = "qux");
// or
metric!(MY_METRIC_NAME, unit = Gauge, 5,  foo = "bar", baz = "qux");
```

or even integrate metrics into the `#[instrument]` annotation (to enable for example, publishing metrics on each API request count of a service using Hyper/Axum/Tonic).

From there, a concrete implementation of the `Collect` trait would implement an additional `metric(...)` method, which is how (for example) the tracing-opentelemetry Layer could call the OTel Metrics SDK to publish metrics out (or log the metric to some other file, call a different vendor SDK, etc etc).

## Solution

Right now what I did is I duplicated the `event(...)` method from the Collect trait. The definition of `Metric` is also currently just a copy of the `Event` definition.

I'd also need to crate some `metric!(...)` macros to go along with this (I haven't written them yet).

**Is this approach something that could work?** Should I be instead sticking this method in a separate trait? I figure the plumbing is identical for a metric than for an event, so it makes sense to just essentially have the same code path.

## PS

There might be some code that should say `Metric` but says `Event`... I copy pasted stuff here and there and it might not all be entirely renamed correctly, especially comments. But I'm more looking for feedback on the approach itself. I will clean up the code later and add tests etc, once I have more of an idea of if this is the right approach or if this is what we might want to do.

## Glossary

service-level metrics = metrics such as request count, latency, tokio-runtime metrics... metrics that are not tied to the business logic

application-level logic = this is tied to the business logic, oftentimes it might be specific error metrics unique to your own service. Or, for example, keeping separate counters to track different code paths that you are entering into.

## Alternatives
- Instead of duplicating a lot of the Event code, create a `metric!` macro that desugars to an Event. This would require much fewer changes to the codebase and the difference between a Metric and Event is quite small anyways (the delta is: including the metric itself).