### PR TITLE
Add accessor functions necessary for structured serde

### DIFF
--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -958,7 +958,7 @@ impl<'a> ValueSet<'a> {
     }
 
     /// Returns true if this `ValueSet` contains _no_ values.
-    pub(crate) fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         let my_callsite = self.callsite();
         self.values
             .iter()

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -935,6 +935,19 @@ impl<'a> ValueSet<'a> {
         }
     }
 
+    /// Returns the number of fields in this `ValueSet` that would be visited
+    /// by a given [visitor] to the [`ValueSet::record()`] method.
+    ///
+    /// [visitor]: Visit
+    /// [`ValueSet::record()`]: ValueSet::record()
+    pub fn record_len(&self) -> usize {
+        let my_callsite = self.callsite();
+        self.values
+            .iter()
+            .filter(|(field, _)| field.callsite() == my_callsite)
+            .count()
+    }
+
     /// Returns `true` if this `ValueSet` contains a value for the given `Field`.
     pub(crate) fn contains(&self, field: &Field) -> bool {
         field.callsite() == self.callsite()

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -940,7 +940,7 @@ impl<'a> ValueSet<'a> {
     ///
     /// [visitor]: Visit
     /// [`ValueSet::record()`]: ValueSet::record()
-    pub fn record_len(&self) -> usize {
+    pub fn len(&self) -> usize {
         let my_callsite = self.callsite();
         self.values
             .iter()

--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -229,8 +229,8 @@ impl<'a> Record<'a> {
     /// when [`Record::record()`] is called
     ///
     /// [`Record::record()`]: Record::record()
-    pub fn record_len(&self) -> usize {
-        self.values.record_len()
+    pub fn len(&self) -> usize {
+        self.values.len()
     }
 
     /// Returns `true` if this `Record` contains a value for the given `Field`.

--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -233,7 +233,6 @@ impl<'a> Record<'a> {
         self.values.record_len()
     }
 
-
     /// Returns `true` if this `Record` contains a value for the given `Field`.
     pub fn contains(&self, field: &field::Field) -> bool {
         self.values.contains(field)

--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -225,6 +225,15 @@ impl<'a> Record<'a> {
         self.values.record(visitor)
     }
 
+    /// Returns the number of fields that would be visited from this `Record`
+    /// when [`Record::record()`] is called
+    ///
+    /// [`Record::record()`]: Record::record()
+    pub fn record_len(&self) -> usize {
+        self.values.record_len()
+    }
+
+
     /// Returns `true` if this `Record` contains a value for the given `Field`.
     pub fn contains(&self, field: &field::Field) -> bool {
         self.values.contains(field)


### PR DESCRIPTION
## Motivation

This PR adds two new accessor functions that are useful for creating a structured serde implementation for tracing.

This is a sort of "distilled" version of https://github.com/tokio-rs/tracing/pull/2113, based on the `v0.1.x` branch.

As it is unlikely that "structured serde" will be 1:1 compatible with the existing JSON-based `tracing-serde` (or at least - I'm not sure how to do it in a reasonable amount of effort), these functions will allow me to make a separate crate to hold me over until breaking formatting changes are possible in `tracing-serde`.

CC @hawkw, as we've discussed this pretty extensively