### PR TITLE
opentelemetry: prepare to release v0.17.3

### DIFF
--- a/tracing-opentelemetry/CHANGELOG.md
+++ b/tracing-opentelemetry/CHANGELOG.md
@@ -1,3 +1,41 @@
+# 0.17.3 (June 7, 2022)
+
+This release adds support for emitting thread names and IDs to OpenTelemetry, as
+well as recording `std::error::Error` values in a structured manner with their
+source chain included. Additionally, this release fixes issues related to event
+and span source code locations.
+
+### Added
+
+- `Layer::with_threads` to enable recording thread names/IDs according to
+  [OpenTelemetry semantic conventions][thread-semconv] ([#2134])
+- `Error::source` chain when recording `std::error::Error` values ([#2122])
+- `Layer::with_location` method (replaces `Layer::with_event_location`)
+  ([#2124])
+
+### Changed
+
+- `std::error::Error` values are now recorded using `fmt::Display` rather than
+  `fmt::Debug` ([#2122])
+
+### Fixed
+
+- Fixed event source code locations overwriting the parent span's source
+  location ([#2099])
+- Fixed `Layer::with_event_location` not controlling whether locations are
+  emitted for spans as well as events ([#2124])
+
+### Deprecated
+
+- `Layer::with_event_location`: renamed to `Layer::with_location`, as it now
+  controls both span and event locations ([#2124])
+
+[thread-semconv]: https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/span-general/#source-code-attributes
+[#2134]: https://github.com/tokio-rs/tracing/pull/2134
+[#2122]: https://github.com/tokio-rs/tracing/pull/2122
+[#2124]: https://github.com/tokio-rs/tracing/pull/2124
+[#2099]: https://github.com/tokio-rs/tracing/pull/2099
+
 # 0.17.2 (February 21, 2022)
 
 This release fixes [an issue][#1944] introduced in v0.17.1 where

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-opentelemetry"
-version = "0.17.2"
+version = "0.17.3"
 authors = [
     "Julian Tescher <julian@tescher.me>",
     "Tokio Contributors <team@tokio.rs>"

--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -17,9 +17,9 @@ Utilities for adding [OpenTelemetry] interoperability to [`tracing`].
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-opentelemetry.svg
-[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.17.2
+[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.17.3
 [docs-badge]: https://docs.rs/tracing-opentelemetry/badge.svg
-[docs-url]: https://docs.rs/tracing-opentelemetry/0.17.2/tracing_opentelemetry
+[docs-url]: https://docs.rs/tracing-opentelemetry/0.17.3/tracing_opentelemetry
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_opentelemetry
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -92,7 +92,7 @@
 //!
 #![deny(unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.17.2")]
+#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.17.3")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.17.3 (June 7, 2022)

This release adds support for emitting thread names and IDs to
OpenTelemetry, as well as recording `std::error::Error` values in a
structured manner with their source chain included. Additionally, this
release fixes issues related to event and span source code locations.

### Added

- `Layer::with_threads` to enable recording thread names/IDs according
  to [OpenTelemetry semantic conventions][thread-semconv] ([#2134])
- `Error::source` chain when recording `std::error::Error` values
  ([#2122])
- `Layer::with_location` method (replaces `Layer::with_event_location`)
  ([#2124])

### Changed

- `std::error::Error` values are now recorded using `fmt::Display`
  rather than `fmt::Debug` ([#2122])

### Fixed

- Fixed event source code locations overwriting the parent span's source
  location ([#2099])
- Fixed `Layer::with_event_location` not controlling whether locations
  are emitted for spans as well as events ([#2124])

### Deprecated

- `Layer::with_event_location`: renamed to `Layer::with_location`, as it
  now controls both span and event locations ([#2124])

[thread-semconv]: https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/span-general/#source-code-attributes
[#2134]: https://github.com/tokio-rs/tracing/pull/2134
[#2122]: https://github.com/tokio-rs/tracing/pull/2122
[#2124]: https://github.com/tokio-rs/tracing/pull/2124
[#2099]: https://github.com/tokio-rs/tracing/pull/2099