### PR TITLE
tracing-core,tracing-subscriber: more `downcast_ref` & `is` methods

### DIFF
--- a/tracing-core/src/collect.rs
+++ b/tracing-core/src/collect.rs
@@ -471,6 +471,54 @@ impl dyn Collect {
     }
 }
 
+impl dyn Collect + Send {
+    /// Returns `true` if this `Collector` is the same type as `T`.
+    pub fn is<T: Any>(&self) -> bool {
+        self.downcast_ref::<T>().is_some()
+    }
+
+    /// Returns some reference to this `Collector` value if it is of type `T`,
+    /// or `None` if it isn't.
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+        unsafe {
+            let raw = self.downcast_raw(TypeId::of::<T>())?;
+            Some(&*(raw.cast().as_ptr()))
+        }
+    }
+}
+
+impl dyn Collect + Sync {
+    /// Returns `true` if this `Collector` is the same type as `T`.
+    pub fn is<T: Any>(&self) -> bool {
+        self.downcast_ref::<T>().is_some()
+    }
+
+    /// Returns some reference to this `Collector` value if it is of type `T`,
+    /// or `None` if it isn't.
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+        unsafe {
+            let raw = self.downcast_raw(TypeId::of::<T>())?;
+            Some(&*(raw.cast().as_ptr()))
+        }
+    }
+}
+
+impl dyn Collect + Send + Sync {
+    /// Returns `true` if this `Collector` is the same type as `T`.
+    pub fn is<T: Any>(&self) -> bool {
+        self.downcast_ref::<T>().is_some()
+    }
+
+    /// Returns some reference to this `Collector` value if it is of type `T`,
+    /// or `None` if it isn't.
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+        unsafe {
+            let raw = self.downcast_raw(TypeId::of::<T>())?;
+            Some(&*(raw.cast().as_ptr()))
+        }
+    }
+}
+
 /// Indicates a [`Collect`]'s interest in a particular callsite.
 ///
 /// Collectors return an `Interest` from their [`register_callsite`] methods


### PR DESCRIPTION
Adds inherent `downcast_ref` and `is` inherent methods to:
  - `dyn Subscriber + Send`
  - `dyn Subscriber + Sync`
  - `dyn Subscriber + Send + Sync`
  - `Layered`

These additional implementations reduce the circumstances in which one
must cast to `dyn Subscriber` (which, previously, was the only type for
which `downcast_ref` and `is` were available).