### PR TITLE
tracing-core: impl<C: Collect + ?Sized> Collect for Box<C>, Arc<C>

### DIFF
--- a/tracing-core/src/collect.rs
+++ b/tracing-core/src/collect.rs
@@ -606,7 +606,10 @@ impl Collect for NoCollector {
 }
 
 #[cfg(feature = "alloc")]
-impl Collect for alloc::boxed::Box<dyn Collect + Send + Sync + 'static> {
+impl<C> Collect for alloc::boxed::Box<C>
+where
+    C: Collect + ?Sized,
+{
     #[inline]
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         self.as_ref().register_callsite(metadata)
@@ -677,7 +680,10 @@ impl Collect for alloc::boxed::Box<dyn Collect + Send + Sync + 'static> {
 }
 
 #[cfg(feature = "alloc")]
-impl Collect for alloc::sync::Arc<dyn Collect + Send + Sync + 'static> {
+impl<C> Collect for alloc::sync::Arc<C>
+where
+    C: Collect + ?Sized,
+{
     #[inline]
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         self.as_ref().register_callsite(metadata)


### PR DESCRIPTION
These broader impls supersede the previous impls where the inner type was a
`dyn Collect`. With these generic impls, you no longer must (but still can,
if you wish) cast the inner type of a boxed or arc'd collector to
`dyn Collect` to use it as a `Collect`.
