### PR TITLE
backport: subscriber: implement `FIlter` for `reload::Subscriber`

### DIFF
--- a/tracing-subscriber/src/filter/layer_filters/mod.rs
+++ b/tracing-subscriber/src/filter/layer_filters/mod.rs
@@ -529,7 +529,7 @@ impl<L, F, S> Filtered<L, F, S> {
     /// #
     /// # // specifying the Registry type is required
     /// # let _: &reload::Handle<filter::Filtered<fmt::Layer<Registry, _, _, fn() -> std::io::Stdout>,
-    /// # filter::LevelFilter, Registry>, _>
+    /// # filter::LevelFilter, Registry>, Registry>
     /// # = &reload_handle;
     /// #
     /// info!("This will be logged to stderr");

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -258,7 +258,6 @@ impl<L, S> Handle<L, S> {
     /// [`Layer`]: crate::layer::Layer
     /// [`Filter`]: crate::layer::Filter
     /// [`Filtered`]: crate::filter::Filtered
-``
     ///
     /// [this issue]: https://github.com/tokio-rs/tracing/issues/1629
     pub fn reload(&self, new_value: impl Into<L>) -> Result<(), Error> {

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -235,7 +235,10 @@ impl<L, S> Layer<L, S> {
         (this, handle)
     }
 
-    /// Returns a `Handle` that can be used to reload the wrapped `Layer` or `Filter`.
+    /// Returns a `Handle` that can be used to reload the wrapped [`Layer`] or [`Filter`].
+    ///
+    /// [`Layer`]: crate::layer::Layer
+    /// [`Filter`]: crate::filter::Filter
     pub fn handle(&self) -> Handle<L, S> {
         Handle {
             inner: Arc::downgrade(&self.inner),

--- a/tracing-subscriber/tests/reload.rs
+++ b/tracing-subscriber/tests/reload.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "reload")]
+#![cfg(feature = "registry")]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tracing_core::{
     span::{Attributes, Id, Record},
@@ -27,6 +27,17 @@ impl Subscriber for NopSubscriber {
     fn event(&self, _: &Event<'_>) {}
     fn enter(&self, _: &Id) {}
     fn exit(&self, _: &Id) {}
+}
+
+pub struct NopLayer;
+impl<S: Subscriber> tracing_subscriber::Layer<S> for NopLayer {
+    fn register_callsite(&self, _m: &Metadata<'_>) -> Interest {
+        Interest::sometimes()
+    }
+
+    fn enabled(&self, _m: &Metadata<'_>, _: layer::Context<'_, S>) -> bool {
+        true
+    }
 }
 
 #[test]
@@ -63,6 +74,54 @@ fn reload_handle() {
     let subscriber = tracing_core::dispatcher::Dispatch::new(layer.with_subscriber(NopSubscriber));
 
     tracing_core::dispatcher::with_default(&subscriber, || {
+        assert_eq!(FILTER1_CALLS.load(Ordering::SeqCst), 0);
+        assert_eq!(FILTER2_CALLS.load(Ordering::SeqCst), 0);
+
+        event();
+
+        assert_eq!(FILTER1_CALLS.load(Ordering::SeqCst), 1);
+        assert_eq!(FILTER2_CALLS.load(Ordering::SeqCst), 0);
+
+        handle.reload(Filter::Two).expect("should reload");
+
+        event();
+
+        assert_eq!(FILTER1_CALLS.load(Ordering::SeqCst), 1);
+        assert_eq!(FILTER2_CALLS.load(Ordering::SeqCst), 1);
+    })
+}
+
+#[test]
+fn reload_filter() {
+    static FILTER1_CALLS: AtomicUsize = AtomicUsize::new(0);
+    static FILTER2_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    enum Filter {
+        One,
+        Two,
+    }
+
+    impl<S: Subscriber> tracing_subscriber::layer::Filter<S> for Filter {
+        fn enabled(&self, m: &Metadata<'_>, _: &layer::Context<'_, S>) -> bool {
+            println!("ENABLED: {:?}", m);
+            match self {
+                Filter::One => FILTER1_CALLS.fetch_add(1, Ordering::SeqCst),
+                Filter::Two => FILTER2_CALLS.fetch_add(1, Ordering::SeqCst),
+            };
+            true
+        }
+    }
+    fn event() {
+        tracing::trace!("my event");
+    }
+
+    let (filter, handle) = Layer::new(Filter::One);
+
+    let dispatcher = tracing_core::Dispatch::new(
+        tracing_subscriber::registry().with(NopLayer.with_filter(filter)),
+    );
+
+    tracing_core::dispatcher::with_default(&dispatcher, || {
         assert_eq!(FILTER1_CALLS.load(Ordering::SeqCst), 0);
         assert_eq!(FILTER2_CALLS.load(Ordering::SeqCst), 0);
 

--- a/tracing-subscriber/tests/reload.rs
+++ b/tracing-subscriber/tests/reload.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "reload")]
+#![cfg(feature = "std")]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tracing_core::{
     span::{Attributes, Id, Record},
@@ -28,7 +28,6 @@ impl Subscriber for NopSubscriber {
     fn enter(&self, _: &Id) {}
     fn exit(&self, _: &Id) {}
 }
-
 
 #[test]
 fn reload_handle() {

--- a/tracing-subscriber/tests/reload.rs
+++ b/tracing-subscriber/tests/reload.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "registry")]
+#![cfg(feature = "reload")]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tracing_core::{
     span::{Attributes, Id, Record},
@@ -29,16 +29,6 @@ impl Subscriber for NopSubscriber {
     fn exit(&self, _: &Id) {}
 }
 
-pub struct NopLayer;
-impl<S: Subscriber> tracing_subscriber::Layer<S> for NopLayer {
-    fn register_callsite(&self, _m: &Metadata<'_>) -> Interest {
-        Interest::sometimes()
-    }
-
-    fn enabled(&self, _m: &Metadata<'_>, _: layer::Context<'_, S>) -> bool {
-        true
-    }
-}
 
 #[test]
 fn reload_handle() {
@@ -92,7 +82,19 @@ fn reload_handle() {
 }
 
 #[test]
+#[cfg(feature = "registry")]
 fn reload_filter() {
+    struct NopLayer;
+    impl<S: Subscriber> tracing_subscriber::Layer<S> for NopLayer {
+        fn register_callsite(&self, _m: &Metadata<'_>) -> Interest {
+            Interest::sometimes()
+        }
+
+        fn enabled(&self, _m: &Metadata<'_>, _: layer::Context<'_, S>) -> bool {
+            true
+        }
+    }
+
     static FILTER1_CALLS: AtomicUsize = AtomicUsize::new(0);
     static FILTER2_CALLS: AtomicUsize = AtomicUsize::new(0);
 


### PR DESCRIPTION
The old `Layer` has an extra `S` parameter, but I found that the way I setup the impls, this passes all tests

@hawkw and @davidbarsky , I did my best in the cherry-pick, but some of the docs may have been messed up, so please review carefully!