### PR TITLE
Document that `event_enabled!` does not call `Collect::event_enabled`

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -806,6 +806,9 @@ macro_rules! event {
 /// This is similar to [`enabled!`], but queries the current collector specifically for
 /// an event, whereas [`enabled!`] queries for an event _or_ span.
 ///
+/// Although it shares the name, this *does not* call [`Collect::event_enabled`].
+/// `Collect::event_enabled` is only called once the event fields are available.
+///
 /// See the documentation for [`enabled!]` for more details on using this macro.
 /// See also [`span_enabled!`].
 ///

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -829,6 +829,7 @@ macro_rules! event {
 /// }
 /// ```
 ///
+/// [`Collect::event_enabled`]: crate::Collect::event_enabled
 /// [`enabled!`]: crate::enabled
 /// [`span_enabled!`]: crate::span_enabled
 #[macro_export]
@@ -958,7 +959,6 @@ macro_rules! span_enabled {
 ///
 ///
 /// [`Metadata`]: crate::Metadata
-/// [`Collect::event_enabled`]: crate::Collect::event_enabled
 /// [`is_event`]: crate::Metadata::is_event
 /// [`is_span`]: crate::Metadata::is_span
 /// [`enabled!`]: crate::enabled

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -958,6 +958,7 @@ macro_rules! span_enabled {
 ///
 ///
 /// [`Metadata`]: crate::Metadata
+/// [`Collect::event_enabled`]: crate::Collect::event_enabled
 /// [`is_event`]: crate::Metadata::is_event
 /// [`is_span`]: crate::Metadata::is_span
 /// [`enabled!`]: crate::enabled


### PR DESCRIPTION
Although it shares the name, `event_enabled!` *does not* call `Collect::event_enabled`. `Collect::event_enabled` is only called once the event fields are available.