### PR TITLE
subscriber: fix clippy lints

### DIFF
--- a/tracing-opentelemetry/benches/trace.rs
+++ b/tracing-opentelemetry/benches/trace.rs
@@ -75,9 +75,7 @@ where
         let span = ctx.span(&id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
 
-        if let Some(no_data) = extensions.remove::<NoDataSpan>() {
-            drop(no_data)
-        }
+        extensions.remove::<NoDataSpan>();
     }
 }
 

--- a/tracing-subscriber/src/layer/layered.rs
+++ b/tracing-subscriber/src/layer/layered.rs
@@ -435,7 +435,7 @@ where
             // (rather than calling into the inner type), clear the current
             // per-layer filter interest state.
             #[cfg(feature = "registry")]
-            drop(filter::FilterState::take_interest());
+            filter::FilterState::take_interest();
 
             return outer;
         }

--- a/tracing-subscriber/tests/registry_with_subscriber.rs
+++ b/tracing-subscriber/tests/registry_with_subscriber.rs
@@ -4,7 +4,7 @@ use tracing_subscriber::prelude::*;
 
 #[tokio::test]
 async fn future_with_subscriber() {
-    let _default = tracing_subscriber::registry().init();
+    tracing_subscriber::registry().init();
     let span = tracing::info_span!("foo");
     let _e = span.enter();
     let span = tracing::info_span!("bar");


### PR DESCRIPTION
This fixes a Clippy lint for explicitly calling `drop` on a value
without a `Drop` impl, and a lint for `let` bindings whose
value is `()`.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>