### PR TITLE
subscriber: prepare to release v0.3.13

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.3.13 (Jun 30, 2022)
+
+This release of `tracing-subscriber` fixes a compilation failure due to an
+incorrect `tracing-core` dependency that was introduced in v0.3.12.
+
+### Changed
+
+- **tracing_core**: Updated minimum dependency version to 0.1.28 ([#2190])
+
+[#2190]: https://github.com/tokio-rs/tracing/pull/2190
+
 # 0.3.12 (Jun 29, 2022)
 
 This release of `tracing-subscriber` adds a new `Layer::event_enabled` method,

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.3.12"
+version = "0.3.13"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -21,7 +21,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.3.12
+[docs-url]: https://docs.rs/tracing-subscriber/0.3.13
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -160,7 +160,7 @@
 //! [`time` crate]: https://crates.io/crates/time
 //! [`libstd`]: std
 //! [`liballoc`]: alloc
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.3.12")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.3.13")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.3.13 (Jun 30, 2022)

This release of `tracing-subscriber` fixes a compilation failure due to
an incorrect `tracing-core` dependency that was introduced in v0.3.12.

### Changed

- **tracing_core**: Updated minimum dependency version to 0.1.28 (#2190)
