### PR TITLE
opentelemetry: fix exception fields defaults in docs

### DIFF
--- a/tracing-opentelemetry/src/layer.rs
+++ b/tracing-opentelemetry/src/layer.rs
@@ -483,7 +483,7 @@ where
     /// These attributes follow the [OpenTelemetry semantic conventions for
     /// exceptions][conv].
     ///
-    /// By default, these fields are enabled
+    /// By default, these attributes are not recorded.
     ///
     /// [conv]: https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/exceptions/
     pub fn with_exception_fields(self, exception_fields: bool) -> Self {
@@ -506,7 +506,7 @@ where
     /// These attributes follow the [OpenTelemetry semantic conventions for
     /// exceptions][conv].
     ///
-    /// By default, this is enabled
+    /// By default, these attributes are not propagated to the span.
     ///
     /// [conv]: https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/exceptions/
     pub fn with_exception_field_propagation(self, exception_field_propagation: bool) -> Self {


### PR DESCRIPTION
## Motivation

Currently, the `tracing-opentelemetry` docs indicate that the support
for OpenTelemetry's exception semantic conventions added in #2135 is
enabled by default. However, this is not the case --- this feature was
changed to opt-in rather than opt-out prior to merging PR #2135.

## Solution

This branch updates the docs to state that these features are disabled
by default, rather than enabled by default.