### PR TITLE
subscriber: prepare to release v0.3.14

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,4 +1,25 @@
-# 0.3.13 (Jun 30, 2022)
+# 0.3.14 (Jul 1, 2022)
+
+This release fixes multiple filtering bugs in the `Layer` implementations for
+`Option<impl Layer>` and `Vec<impl Layer>`.
+
+### Fixed
+
+- **layer**: `Layer::event_enabled` implementation for `Option<impl Layer<S>>`
+  returning `false` when the `Option` is `None`, disabling all events globally
+  ([#2193])
+- **layer**: `Layer::max_level_hint` implementation for `Option<impl Layer<S>>`
+  incorrectly disabling max level filtering when the option is `None` ([#2195])
+- **layer**: `Layer::max_level_hint` implementation for `Vec<impl Layer<S>>`
+  returning `LevelFilter::ERROR` rather than `LevelFilter::OFF` when the `Vec`
+  is empty ([#2195])
+
+Thanks to @CAD97 and @guswynn for contributing to this release!
+
+[#2193]: https://github.com/tokio-rs/tracing/pull/2193
+[#2195]: https://github.com/tokio-rs/tracing/pull/2195
+
+# 0.3.13 (Jun 30, 2022) (YANKED)
 
 This release of `tracing-subscriber` fixes a compilation failure due to an
 incorrect `tracing-core` dependency that was introduced in v0.3.12.
@@ -9,7 +30,7 @@ incorrect `tracing-core` dependency that was introduced in v0.3.12.
 
 [#2190]: https://github.com/tokio-rs/tracing/pull/2190
 
-# 0.3.12 (Jun 29, 2022)
+# 0.3.12 (Jun 29, 2022) (YANKED)
 
 This release of `tracing-subscriber` adds a new `Layer::event_enabled` method,
 which allows `Layer`s to filter events *after* their field values are recorded;

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.3.13"
+version = "0.3.14"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -21,7 +21,7 @@ Utilities for implementing and composing [`tracing`][tracing] subscribers.
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.3.13
+[docs-url]: https://docs.rs/tracing-subscriber/0.3.14
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -160,7 +160,7 @@
 //! [`time` crate]: https://crates.io/crates/time
 //! [`libstd`]: std
 //! [`liballoc`]: alloc
-#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.3.13")]
+#![doc(html_root_url = "https://docs.rs/tracing-subscriber/0.3.14")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.3.14 (Jul 1, 2022)

This release fixes multiple filtering bugs in the `Layer`
implementations for `Option<impl Layer>` and `Vec<impl Layer>`.

### Fixed

- **layer**: `Layer::event_enabled` implementation for `Option<impl
  Layer<S>>` returning `false` when the `Option` is `None`, disabling
  all events globally ([#2193])
- **layer**: `Layer::max_level_hint` implementation for `Option<impl
  Layer<S>>` incorrectly disabling max level filtering when the option
  is `None` ([#2195])
- **layer**: `Layer::max_level_hint` implementation for `Vec<impl
  Layer<S>>` returning `LevelFilter::ERROR` rather than
  `LevelFilter::OFF` when the `Vec` is empty ([#2195])

Thanks to @CAD97 and @guswynn for contributing to this release!

[#2193]: https://github.com/tokio-rs/tracing/pull/2193
[#2195]: https://github.com/tokio-rs/tracing/pull/2195