### PR TITLE
opentelemetry: prepare to release v0.17.4

### DIFF
--- a/tracing-opentelemetry/CHANGELOG.md
+++ b/tracing-opentelemetry/CHANGELOG.md
@@ -1,3 +1,22 @@
+# 0.17.4 (July 1, 2022)
+
+This release adds optional support for recording `std::error::Error`s using
+[OpenTelemetry's semantic conventions for exceptions][exn-semconv].
+
+### Added
+
+- `Layer::with_exception_fields` to enable emitting `exception.message` and
+  `exception.backtrace` semantic-convention fields when an `Error` is recorded
+  as a span or event field ([#2135])
+- `Layer::with_exception_field_propagation` to enable setting `exception.message` and
+  `exception.backtrace` semantic-convention fields on the current span when an
+  event with an `Error` field is recorded ([#2135])
+
+Thanks to @lilymara-onesignal for contributing to this release!
+
+[thread-semconv]: https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/exceptions/
+[#2135]: https://github.com/tokio-rs/tracing/pull/2135
+
 # 0.17.3 (June 7, 2022)
 
 This release adds support for emitting thread names and IDs to OpenTelemetry, as

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-opentelemetry"
-version = "0.17.3"
+version = "0.17.4"
 authors = [
     "Julian Tescher <julian@tescher.me>",
     "Tokio Contributors <team@tokio.rs>"

--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -17,9 +17,9 @@ Utilities for adding [OpenTelemetry] interoperability to [`tracing`].
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-opentelemetry.svg
-[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.17.3
+[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.17.4
 [docs-badge]: https://docs.rs/tracing-opentelemetry/badge.svg
-[docs-url]: https://docs.rs/tracing-opentelemetry/0.17.3/tracing_opentelemetry
+[docs-url]: https://docs.rs/tracing-opentelemetry/0.17.4/tracing_opentelemetry
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_opentelemetry
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -92,7 +92,7 @@
 //!
 #![deny(unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.17.3")]
+#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.17.4")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.17.4 (July 1, 2022)

This release adds optional support for recording `std::error::Error`s
using OpenTelemetry's [semantic conventions for exceptions][exn-semconv].

### Added

- `Layer::with_exception_fields` to enable emitting `exception.message`
  and `exception.backtrace` semantic-convention fields when an `Error`
  is recorded as a span or event field ([#2135])
- `Layer::with_exception_field_propagation` to enable setting
  `exception.message` and `exception.backtrace` semantic-convention
  fields on the current span when an event with an `Error` field is
  recorded ([#2135])

Thanks to @lilymara-onesignal for contributing to this release!

[thread-semconv]: https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/exceptions/
[#2135]: https://github.com/tokio-rs/tracing/pull/2135