### PR TITLE
pass through max_level_hint in reload::Layer

### DIFF
--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -30,7 +30,7 @@ use std::{
 use tracing_core::{
     callsite,
     collect::{Collect, Interest},
-    span, Event, Metadata,
+    span, Event, LevelFilter, Metadata,
 };
 
 /// Wraps a `Filter` or `Subscribe`, allowing it to be reloaded dynamically at runtime.
@@ -135,6 +135,11 @@ where
     fn on_id_change(&self, old: &span::Id, new: &span::Id, ctx: subscribe::Context<'_, C>) {
         try_lock!(self.inner.read()).on_id_change(old, new, ctx)
     }
+
+    #[inline]
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        try_lock!(self.inner.read(), else return None).max_level_hint()
+    }
 }
 
 #[cfg(all(feature = "registry", feature = "std"))]
@@ -187,6 +192,11 @@ where
     #[inline]
     fn on_close(&self, id: span::Id, ctx: subscribe::Context<'_, C>) {
         try_lock!(self.inner.read()).on_close(id, ctx)
+    }
+
+    #[inline]
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        try_lock!(self.inner.read(), else return None).max_level_hint()
     }
 }
 


### PR DESCRIPTION
## Motivation

When using a `reload` layer, the fast-path current level check doesn't work, as the `max_level_hint` is just `None`, which `rebuild_interest` interprets as `TRACE`

## Solution

Pass through to the underlying layer/filter. On poisons, when already panicking, just return `None`
