### PR TITLE
enabled! consults log::log_enabled! when appropriate

### DIFF
--- a/tracing/test-log-support/tests/log_enabled_no_trace.rs
+++ b/tracing/test-log-support/tests/log_enabled_no_trace.rs
@@ -1,0 +1,46 @@
+use test_log_support::Test;
+use tracing::{enabled, error, warn, Level};
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn test_log_enabled() {
+    static OTHER_MODULE: &str = "other_module";
+
+    let test = Test::with_filters(&[
+        (module_path!(), log::LevelFilter::Error),
+        (OTHER_MODULE, log::LevelFilter::Warn),
+    ]);
+
+    if enabled!(Level::ERROR) {
+        error!(msg = 1);
+    }
+    test.assert_logged("msg=1");
+
+    if enabled!(Level::WARN) {
+        panic!("warn level unexpectedly enabled");
+    }
+
+    if enabled!(target: module_path!(), Level::ERROR) {
+        error!(msg = 5);
+    }
+    test.assert_logged("msg=5");
+
+    if enabled!(target: module_path!(), Level::WARN) {
+        panic!(
+            "warn level unexpectedly enabled for target {}",
+            module_path!()
+        );
+    }
+
+    if enabled!(target: OTHER_MODULE, Level::WARN) {
+        warn!(target: OTHER_MODULE, msg = 7);
+    }
+    test.assert_logged("msg=7");
+
+    if enabled!(target: OTHER_MODULE, Level::INFO) {
+        panic!(
+            "info level unexpectedly enabled for target {}",
+            OTHER_MODULE
+        );
+    }
+}

--- a/tracing/test-log-support/tests/log_enabled_with_trace.rs
+++ b/tracing/test-log-support/tests/log_enabled_with_trace.rs
@@ -1,0 +1,57 @@
+use test_log_support::Test;
+use tracing::{enabled, warn, Level};
+use tracing_core::span::Current;
+
+pub struct LevelCollector {
+    max_level: tracing::Level,
+}
+
+impl tracing::Collect for LevelCollector {
+    fn enabled(&self, metadata: &tracing::Metadata) -> bool {
+        metadata.level() <= &self.max_level
+    }
+    fn new_span(&self, _: &tracing::span::Attributes) -> tracing::span::Id {
+        use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
+        static NEXT: AtomicU64 = AtomicU64::new(1);
+        tracing::span::Id::from_u64(NEXT.fetch_add(1, Relaxed))
+    }
+    fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record) {}
+    fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+    fn event(&self, _: &tracing::Event) {}
+    fn enter(&self, _: &tracing::span::Id) {}
+    fn exit(&self, _: &tracing::span::Id) {}
+    fn try_close(&self, _: tracing::span::Id) -> bool {
+        true
+    }
+    fn current_span(&self) -> Current {
+        Current::unknown()
+    }
+}
+
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn log_with_trace_enabled() {
+    tracing::collect::set_global_default(LevelCollector {
+        max_level: Level::ERROR,
+    })
+    .expect("set global should succeed");
+
+    let test = Test::with_filters(&[
+        (module_path!(), log::LevelFilter::Warn),
+    ]);
+
+    // should evaluate to true because a logger is interested even
+    // though the tracing collector is not.
+    if enabled!(Level::WARN) {
+        warn!(msg = 2);
+    }
+    test.assert_logged("msg=2");
+
+    if enabled!(target: module_path!(), Level::INFO) {
+        panic!(
+            "info level unexpectedly enabled for target {}",
+            module_path!()
+        );
+    }
+}


### PR DESCRIPTION
This is an attempt at fixing #2036. I am not confident this is the right way to do this and I have a few questions, but I figured I would put up a PR to get some guidance and feedback. 

## Motivation

Libraries and applications can use `enabled!` to determine whether anyone is actually going to consume an expensive event before constructing it. However, currently `enabled!` only factors in whether the event will be consumed as a tracing event, and not whether it would be consumed as a log message. 

## Solution

Update the macro to consult `log::log_enabled` in cases where `log` or `log-always` is enabled and the event is not going to be emitted as a tracing event.
