### PR TITLE
chore(ci): update actions/checkout action to v3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,7 +38,7 @@ jobs:
     name: cargo check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -56,7 +56,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -94,7 +94,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
@@ -136,7 +136,7 @@ jobs:
         - tracing
         - tracing-subscriber
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -179,7 +179,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: "install Rust ${{ env.MSRV }}"
       uses: actions-rs/toolchain@v1
       with:
@@ -222,7 +222,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: "install Rust ${{ env.APPENDER_MSRV }}"
       uses: actions-rs/toolchain@v1
       with:
@@ -267,7 +267,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
@@ -311,7 +311,7 @@ jobs:
         - tracing-tower
       fail-fast: false
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         target: wasm32-unknown-unknown
@@ -332,7 +332,7 @@ jobs:
         subcrate:
         - tracing
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         target: wasm32-unknown-unknown
@@ -352,7 +352,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -3,7 +3,7 @@ name: Security audit
 on:
   schedule:
     - cron: '0 0 * * *'
-    
+
 env:
   # Disable incremental compilation.
   #
@@ -29,7 +29,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'tokio-rs'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: taiki-e/create-gh-release-action@v1
         with:
           prefix: tracing(-[a-z]+)?


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
Older versions use node 12 which is no longer supported (end-of-life on April 30, 2022). Also, `@main`/`@master` is not very good as they may run into unreleased breaking changes.