### PR TITLE
doc: remove misleading doc

### DIFF
--- a/tracing/src/collect.rs
+++ b/tracing/src/collect.rs
@@ -5,16 +5,8 @@ pub use tracing_core::collect::*;
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use tracing_core::dispatch::DefaultGuard;
 
-/// Sets this collector as the default for the duration of a closure.
-///
-/// The default collector is used when creating a new [`Span`] or
-/// [`Event`], _if no span is currently executing_. If a span is currently
-/// executing, new spans or events are dispatched to the collector that
-/// tagged that span, instead.
-///
-/// [`Span`]: super::span::Span
-/// [`Collect`]: super::collect::Collect
-/// [`Event`]: tracing_core::Event
+/// Sets this collector as the default for the current thread for the duration
+/// of a closure.
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn with_default<T, C>(collector: C, f: impl FnOnce() -> T) -> T
@@ -43,16 +35,8 @@ where
     crate::dispatch::set_global_default(crate::Dispatch::new(collector))
 }
 
-/// Sets the collector as the default for the duration of the lifetime of the
-/// returned [`DefaultGuard`]
-///
-/// The default collector is used when creating a new [`Span`] or
-/// [`Event`], _if no span is currently executing_. If a span is currently
-/// executing, new spans or events are dispatched to the collector that
-/// tagged that span, instead.
-///
-/// [`Span`]: super::span::Span
-/// [`Event`]: tracing_core::Event
+/// Sets the collector as the default for the current thread for the duration of
+/// the lifetime of the returned [`DefaultGuard`].
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[must_use = "Dropping the guard unregisters the collector."]


### PR DESCRIPTION
There's no automated propagation of subscrbibers between spans, you have
to do this manually.

https://discord.com/channels/500028886025895936/997201342596657232/997210656677830778