### PR TITLE
Add special field `otel.trace_id`

### DIFF
--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -25,9 +25,12 @@
 //! * `otel.kind`: Set the span kind to one of the supported OpenTelemetry [span kinds].
 //! * `otel.status_code`: Set the span status code to one of the supported OpenTelemetry [span status codes].
 //! * `otel.status_message`: Set the span status message.
+//! * `otel.trace_id`: Set the [`TraceId`] of the span. Expects a [lower-hex formatted string].
 //!
 //! [span kinds]: https://docs.rs/opentelemetry/latest/opentelemetry/trace/enum.SpanKind.html
 //! [span status codes]: https://docs.rs/opentelemetry/latest/opentelemetry/trace/enum.StatusCode.html
+//! [`TraceId`]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#spancontext
+//! [lower-hex formatted string]: https://docs.rs/opentelemetry/latest/opentelemetry/trace/struct.TraceId.html#method.from_hex
 //!
 //! ### Semantic Conventions
 //!


### PR DESCRIPTION
## Motivation

The `TraceId` is used in opentelemetry to determine which spans from different services belong to a certain trace. So it is important to set the same `TraceId` on all services that produce spans for a trace.

There is a way to set the `TraceId` in `tracing-opentelemetry` but it is [only documented in a unit test](https://github.com/tokio-rs/tracing/blob/master/tracing-opentelemetry/src/subscriber.rs#L922) and not very ergonomic, especially in an `async` context.

It would be easier to write services that contribute to a distributed trace if the `TraceId` could be set manually.

## Solution

This PR adds `otel.trace_id` as one of `tracing-opentelemetry` special span attributes, enabling users to manually set the `TraceId` for a span and its child spans.

## For Discussion

Currently, `otel.trace_id` only works with `.record_debug()` and `.record_str()`, however, `TraceId`s being internally `u128` further methods like `.record_i64()` and `.record_u128()` could be adapted as well.