### PR TITLE
tracing-subscriber: correct fmt::init() documentation

### DIFF
--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -1188,10 +1188,13 @@ pub fn try_init() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 /// If the `tracing-log` feature is enabled, this will also install
 /// the LogTracer to convert `Log` records into `tracing` `Event`s.
 ///
-/// This is shorthand for
+/// If the `env-filter` feature is enabled, this is shorthand for
 ///
 /// ```rust
-/// tracing_subscriber::fmt().init()
+/// # use tracing_subscriber::EnvFilter;
+/// tracing_subscriber::fmt()
+///     .with_env_filter(EnvFilter::from_default_env())
+///     .init();
 /// ```
 ///
 /// # Panics

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -1185,6 +1185,9 @@ pub fn try_init() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 /// Install a global tracing subscriber that listens for events and
 /// filters based on the value of the [`RUST_LOG` environment variable].
 ///
+/// The configuration of the subscriber initialized by this function
+/// depends on what [feature flags](crate#feature-flags) are enabled.
+///
 /// If the `tracing-log` feature is enabled, this will also install
 /// the LogTracer to convert `Log` records into `tracing` `Event`s.
 ///


### PR DESCRIPTION
# correct fmt::init() documentation

Previously the documentation for `fmt::init()` was misleading. It stated that it was shorthand for `fmt().init()`. This lead to confusion as users would expect the same behavior from both. However `fmt::init()` would, whether you used the env-filter feature or not, rely on RUST_LOG to set the tracing level. `fmt().init()` does not do this and it must be set with a specific configuration via `with_env_filter`.

The documentation has been updated to no longer state that it is 1:1 shorthand for the other. The documentation now specifically points out that you must be using the `env-filter` feature and gives a correct example to mimic the `fmt::init()` behavior using `fmt().init()`.

fixes: #2217 #1329 