### PR TITLE
backport commits from `master` to v0.1.x

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
     name: cargo check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -57,7 +57,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -95,7 +95,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
@@ -137,7 +137,7 @@ jobs:
         - tracing
         - tracing-subscriber
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -180,7 +180,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: "install Rust ${{ env.MSRV }}"
       uses: actions-rs/toolchain@v1
       with:
@@ -223,7 +223,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: "install Rust ${{ env.APPENDER_MSRV }}"
       uses: actions-rs/toolchain@v1
       with:
@@ -268,7 +268,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
@@ -312,7 +312,7 @@ jobs:
         - tracing-tower
       fail-fast: false
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         target: wasm32-unknown-unknown
@@ -333,7 +333,7 @@ jobs:
         subcrate:
         - tracing
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         target: wasm32-unknown-unknown
@@ -353,7 +353,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -3,7 +3,7 @@ name: Security audit
 on:
   schedule:
     - cron: '0 0 * * *'
-    
+
 env:
   # Disable incremental compilation.
   #
@@ -29,7 +29,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'tokio-rs'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: taiki-e/create-gh-release-action@v1
         with:
           prefix: tracing(-[a-z]+)?

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -24,6 +24,7 @@ rust-version = "1.53.0"
 crossbeam-channel = "0.5.0"
 time = { version = "0.3", default-features = false, features = ["formatting"] }
 parking_lot = { optional = true, version = "0.12.0" }
+thiserror = "1"
 
 [dependencies.tracing-subscriber]
 path = "../tracing-subscriber"

--- a/tracing-appender/src/rolling/builder.rs
+++ b/tracing-appender/src/rolling/builder.rs
@@ -1,0 +1,167 @@
+use super::{RollingFileAppender, Rotation};
+use std::{io, path::Path};
+use thiserror::Error;
+
+/// A [builder] for configuring [`RollingFileAppender`]s.
+///
+/// [builder]: https://rust-unofficial.github.io/patterns/patterns/creational/builder.html
+#[derive(Debug)]
+pub struct Builder {
+    pub(super) rotation: Rotation,
+    pub(super) prefix: Option<String>,
+}
+
+/// Errors returned by [`Builder::build`].
+#[derive(Error, Debug)]
+#[error("{context}: {source}")]
+pub struct InitError {
+    context: &'static str,
+    #[source]
+    source: io::Error,
+}
+
+impl InitError {
+    pub(crate) fn ctx(context: &'static str) -> impl FnOnce(io::Error) -> Self {
+        move |source| Self { context, source }
+    }
+}
+
+impl Builder {
+    /// Returns a new `Builder` for configuring a [`RollingFileAppender`], with
+    /// the default parameters.
+    ///
+    /// # Default Values
+    ///
+    /// The default values for the builder are:
+    ///
+    /// | Parameter | Default Value | Notes |
+    /// | :-------- | :------------ | :---- |
+    /// | [`rotation`] | [`Rotation::NEVER`] | By default, log files will never be rotated. |
+    /// | [`filename_prefix`] | `""` | By default, log file names will not have a prefix. |
+    ///
+    /// [`rotation`]: Self::rotation
+    /// [`filename_prefix`]: Self::filename_prefix
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            rotation: Rotation::NEVER,
+            prefix: None,
+        }
+    }
+
+    /// Sets the [rotation strategy] for log files.
+    ///
+    /// By default, this is [`Rotation::NEVER`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn docs() {
+    /// use tracing_appender::rolling::{Rotation, RollingFileAppender};
+    ///
+    /// let appender = RollingFileAppender::builder()
+    ///     .rotation(Rotation::HOURLY) // rotate log files once every hour
+    ///     // ...
+    ///     .build("/var/log")
+    ///     .expect("failed to initialize rolling file appender");
+    ///
+    /// # drop(appender)
+    /// # }
+    /// ```
+    ///
+    /// [rotation strategy]: Rotation
+    #[must_use]
+    pub fn rotation(self, rotation: Rotation) -> Self {
+        Self { rotation, ..self }
+    }
+
+    /// Sets the prefix for log filenames. The prefix is output before the
+    /// timestamp in the file name, and if it is non-empty, it is followed by a
+    /// dot (`.`).
+    ///
+    /// By default, log files do not have a prefix.
+    ///
+    /// # Examples
+    ///
+    /// Setting a prefix:
+    ///
+    /// ```
+    /// use tracing_appender::rolling::RollingFileAppender;
+    ///
+    /// # fn docs() {
+    /// let appender = RollingFileAppender::builder()
+    ///     .filename_prefix("myapp.log") // log files will have names like "myapp.log.2019-01-01"
+    ///     // ...
+    ///     .build("/var/log")
+    ///     .expect("failed to initialize rolling file appender");
+    /// # drop(appender)
+    /// # }
+    /// ```
+    ///
+    /// No prefix:
+    ///
+    /// ```
+    /// use tracing_appender::rolling::RollingFileAppender;
+    ///
+    /// # fn docs() {
+    /// let appender = RollingFileAppender::builder()
+    ///     .filename_prefix("") // log files will have names like "2019-01-01"
+    ///     // ...
+    ///     .build("/var/log")
+    ///     .expect("failed to initialize rolling file appender");
+    /// # drop(appender)
+    /// # }
+    /// ```
+    ///
+    /// [rotation strategy]: Rotation
+    #[must_use]
+    pub fn filename_prefix(self, prefix: impl Into<String>) -> Self {
+        let prefix = prefix.into();
+        // If the configured prefix is the empty string, then don't include a
+        // separator character.
+        let prefix = if prefix.is_empty() {
+            None
+        } else {
+            Some(prefix)
+        };
+        Self { prefix, ..self }
+    }
+
+    /// Builds a new [`RollingFileAppender`] with the configured parameters,
+    /// emitting log files to the provided directory.
+    ///
+    /// Unlike [`RollingFileAppender::new`], this returns a `Result` rather than
+    /// panicking when the appender cannot be initialized.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tracing_appender::rolling::{Rotation, RollingFileAppender};
+    ///
+    /// # fn docs() {
+    /// let appender = RollingFileAppender::builder()
+    ///     .rotation(Rotation::DAILY) // rotate log files once per day
+    ///     .filename_prefix("myapp.log") // log files will have names like "myapp.log.2019-01-01"
+    ///     .build("/var/log/myapp") // write log files to the '/var/log/myapp' directory
+    ///     .expect("failed to initialize rolling file appender");
+    /// # drop(appender);
+    /// # }
+    /// ```
+    ///
+    /// This is equivalent to
+    /// ```
+    /// # fn docs() {
+    /// let appender = tracing_appender::rolling::daily("myapp.log", "/var/log/myapp");
+    /// # drop(appender);
+    /// # }
+    /// ```
+    pub fn build(&self, directory: impl AsRef<Path>) -> Result<RollingFileAppender, InitError> {
+        RollingFileAppender::from_builder(self, directory)
+    }
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -137,6 +137,15 @@ pub trait Callsite: Sync {
 
     /// Returns the [metadata] associated with the callsite.
     ///
+    /// <div class="example-wrap" style="display:inline-block">
+    /// <pre class="ignore" style="white-space:normal;font:inherit;">
+    ///
+    /// **Note:** Implementations of this method should not produce [`Metadata`]
+    /// that share the same callsite [`Identifier`] but otherwise differ in any
+    /// way (e.g., have different `name`s).
+    ///
+    /// </pre></div>
+    ///
     /// [metadata]: super::metadata::Metadata
     fn metadata(&self) -> &Metadata<'_>;
 

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -75,7 +75,7 @@ use std::{
 use tracing_core::{
     callsite, span,
     subscriber::{Interest, Subscriber},
-    Event, Metadata,
+    Event, LevelFilter, Metadata,
 };
 
 /// Wraps a `Layer` or `Filter`, allowing it to be reloaded dynamically at runtime.
@@ -173,6 +173,11 @@ where
     fn on_id_change(&self, old: &span::Id, new: &span::Id, ctx: layer::Context<'_, S>) {
         try_lock!(self.inner.read()).on_id_change(old, new, ctx)
     }
+
+    #[inline]
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        try_lock!(self.inner.read(), else return None).max_level_hint()
+    }
 }
 
 // ===== impl Filter =====
@@ -217,6 +222,11 @@ where
     #[inline]
     fn on_close(&self, id: span::Id, ctx: layer::Context<'_, S>) {
         try_lock!(self.inner.read()).on_close(id, ctx)
+    }
+
+    #[inline]
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        try_lock!(self.inner.read(), else return None).max_level_hint()
     }
 }
 

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -16,9 +16,9 @@ Application-level tracing for Rust.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.35
+[crates-url]: https://crates.io/crates/tracing
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.35
+[docs-url]: https://docs.rs/tracing
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -1136,7 +1136,7 @@ impl Span {
     ///
     /// // Now, record a value for parting as well.
     /// // (note that the field name is passed as a string slice)
-    /// span.record("parting", &"goodbye world!");
+    /// span.record("parting", "goodbye world!");
     /// ```
     /// However, it may also be used to record a _new_ value for a field whose
     /// value was already recorded:
@@ -1154,7 +1154,7 @@ impl Span {
     ///     }
     ///     Err(_) => {
     ///         // Things are no longer okay!
-    ///         span.record("is_okay", &false);
+    ///         span.record("is_okay", false);
     ///     }
     /// }
     /// ```
@@ -1181,17 +1181,17 @@ impl Span {
     /// // Now, you try to record a value for a new field, `new_field`, which was not
     /// // declared as `Empty` or populated when you created `span`.
     /// // You won't get any error, but the assignment will have no effect!
-    /// span.record("new_field", &"interesting_value_you_really_need");
+    /// span.record("new_field", "interesting_value_you_really_need");
     ///
     /// // Instead, all fields that may be recorded after span creation should be declared up front,
     /// // using field::Empty when a value is not known, as we did for `parting`.
     /// // This `record` call will indeed replace field::Empty with "you will be remembered".
-    /// span.record("parting", &"you will be remembered");
+    /// span.record("parting", "you will be remembered");
     /// ```
     ///
     /// [`field::Empty`]: super::field::Empty
     /// [`Metadata`]: super::Metadata
-    pub fn record<Q: ?Sized, V>(&self, field: &Q, value: &V) -> &Self
+    pub fn record<Q: ?Sized, V>(&self, field: &Q, value: V) -> &Self
     where
         Q: field::AsField,
         V: field::Value,
@@ -1201,7 +1201,7 @@ impl Span {
                 self.record_all(
                     &meta
                         .fields()
-                        .value_set(&[(&field, Some(value as &dyn field::Value))]),
+                        .value_set(&[(&field, Some(&value as &dyn field::Value))]),
                 );
             }
         }
@@ -1614,4 +1614,10 @@ mod test {
     impl AssertSync for Span {}
     impl AssertSync for Entered<'_> {}
     impl AssertSync for EnteredSpan {}
+
+    #[test]
+    fn test_record_backwards_compat() {
+        Span::current().record("some-key", &"some text");
+        Span::current().record("some-key", &false);
+    }
 }

--- a/tracing/src/subscriber.rs
+++ b/tracing/src/subscriber.rs
@@ -5,12 +5,12 @@ pub use tracing_core::subscriber::*;
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use tracing_core::dispatcher::DefaultGuard;
 
-/// Sets this subscriber as the default for the duration of a closure.
+/// Sets this [`Subscriber`] as the default for the current thread for the
+/// duration of a closure.
 ///
 /// The default subscriber is used when creating a new [`Span`] or
-/// [`Event`], _if no span is currently executing_. If a span is currently
-/// executing, new spans or events are dispatched to the subscriber that
-/// tagged that span, instead.
+/// [`Event`].
+///
 ///
 /// [`Span`]: super::span::Span
 /// [`Subscriber`]: super::subscriber::Subscriber
@@ -43,13 +43,10 @@ where
     crate::dispatcher::set_global_default(crate::Dispatch::new(subscriber))
 }
 
-/// Sets the subscriber as the default for the duration of the lifetime of the
-/// returned [`DefaultGuard`]
+/// Sets the [`Subscriber`] as the default for the current thread for the
+/// duration of the lifetime of the returned [`DefaultGuard`].
 ///
-/// The default subscriber is used when creating a new [`Span`] or
-/// [`Event`], _if no span is currently executing_. If a span is currently
-/// executing, new spans or events are dispatched to the subscriber that
-/// tagged that span, instead.
+/// The default subscriber is used when creating a new [`Span`] or [`Event`].
 ///
 /// [`Span`]: super::span::Span
 /// [`Subscriber`]: super::subscriber::Subscriber


### PR DESCRIPTION
This backports the following commits from `master` to `v0.1.x`:

* cf3ab0e2 core: implement `PartialEq`, `Eq` for `Metadata`, `FieldSet` (#2229)
* 7f70dc6d appender: add a builder for constructing `RollingFileAppender`s (#2227)
* 9b9e6a55 core: remove misleading dispatcher docs (#2220)
* b2501d5b tracing: allow owned values and fat pointers in `Span::record` (#2212)
* 2c39b609 appender: name spawned thread (#2219)
* c09a660d docs: remove hard coded version link from readme (#2208)
* 7f90b545 chore(ci): update actions/checkout action to v3 (#2213)
* e73747fe subscriber: pass through `max_level_hint` in `reload` (#2204)