### PR TITLE
opentelemetry: feature-flag `MetricsSubscriber`

### DIFF
--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -20,10 +20,12 @@ edition = "2018"
 rust-version = "1.46.0"
 
 [features]
-default = ["tracing-log"]
+default = ["tracing-log", "metrics"]
+# Enables support for exporting OpenTelemetry metrics
+metrics = ["opentelemetry/metrics"]
 
 [dependencies]
-opentelemetry = { version = "0.17", default-features = false, features = ["trace", "metrics"] }
+opentelemetry = { version = "0.17", default-features = false, features = ["trace"] }
 tracing = { path = "../tracing", version = "0.2", default-features = false, features = ["std"] }
 tracing-core = { path = "../tracing-core", version = "0.2" }
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry", "std"] }
@@ -44,3 +46,7 @@ bench = false
 [[bench]]
 name = "trace"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -101,6 +101,12 @@ $ firefox http://localhost:16686/
 
 ![Jaeger UI](trace.png)
 
+## Feature Flags
+
+ - `metrics`: Enables the [`MetricsSubscriber`] type, a [subscriber] that
+   exports OpenTelemetry metrics from specifically-named events. This enables
+   the `metrics` feature flag on the `opentelemetry` crate.
+
 ## Supported Rust Versions
 
 Tracing Opentelemetry is built against the latest stable release. The minimum

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -76,6 +76,13 @@
 //! });
 //! ```
 //!
+//! ## Feature Flags
+//!
+//! - `metrics`: Enables the [`MetricsSubscriber`] type, a [subscriber] that
+//!   exports OpenTelemetry metrics from specifically-named events. This enables
+//!   the `metrics` feature flag on the `opentelemetry` crate.  *Enabled by
+//!   default*.
+//!
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported
@@ -90,6 +97,7 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
+//! [subscriber]: tracing_subscriber::subscribe
 #![deny(unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 #![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.16.0")]
@@ -98,8 +106,18 @@
     html_favicon_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/favicon.ico",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
 )]
+#![cfg_attr(
+    docsrs,
+    // Allows displaying cfgs/feature flags in the documentation.
+    feature(doc_cfg, doc_auto_cfg),
+    // Allows adding traits to RustDoc's list of "notable traits"
+    feature(doc_notable_trait),
+    // Fail the docs build if any intra-docs links are broken
+    deny(rustdoc::broken_intra_doc_links),
+)]
 
 /// Implementation of the trace::Subscriber trait; publishes OpenTelemetry metrics.
+#[cfg(feature = "metrics")]
 mod metrics;
 /// Span extension which enables OpenTelemetry context management.
 mod span_ext;
@@ -108,6 +126,7 @@ mod subscriber;
 /// Protocols for OpenTelemetry Tracers that are compatible with Tracing
 mod tracer;
 
+#[cfg(feature = "metrics")]
 pub use metrics::MetricsSubscriber;
 pub use span_ext::OpenTelemetrySpanExt;
 pub use subscriber::{subscriber, OpenTelemetrySubscriber};

--- a/tracing-opentelemetry/src/metrics.rs
+++ b/tracing-opentelemetry/src/metrics.rs
@@ -320,6 +320,7 @@ impl<'a> Visit for MetricVisitor<'a> {
 ///
 /// In the future, this can be improved by associating each `Metric` instance to
 /// its callsite, eliminating the need for any maps.
+#[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
 pub struct MetricsSubscriber {
     meter: Meter,
     instruments: Instruments,

--- a/tracing-opentelemetry/tests/metrics_publishing.rs
+++ b/tracing-opentelemetry/tests/metrics_publishing.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "metrics")]
 use async_trait::async_trait;
 use futures_util::{Stream, StreamExt as _};
 use opentelemetry::{


### PR DESCRIPTION
In the upstream `opentelemetry` crate, the `trace` and `metrics`
features are gated by separate feature flags. This allows users who are
only using OpenTelemetry for tracing, or who are only using it for
metrics, to pick and choose what they depend on.

Currently, the release version of `tracing-opentelemetry` only provides
tracing functionality, and therefore, it only depends on `opentelemetry`
with the `trace` feature enabled. However, the metrics support added in
#2185 adds a dependency on the `opentelemetry/metrics` feature. This is
currently always enabled. We should probably follow the same approach as
upstream `opentelemetry`, and allow enabling/disabling metrics and
tracing separately.

This branch adds a `metrics` feature to `tracing-opentelemetry`, and
makes the `MetricsSubscriber` from #2185 gated on the `metrics` feature.
This feature flag is on by default, like the upstream
`opentelemetry/metrics` feature, but it can be disabled using
`default-features = false`.

We should probably do something similar for the tracing components of
the crate, and make them gated on a `trace` feature flag, but adding a
feature flag to released APIs is not semver-compatible, so we should
save that until the next breaking release.