### PR TITLE
feat: mark builders as must_use

### DIFF
--- a/tracing-subscriber/src/filter/env/builder.rs
+++ b/tracing-subscriber/src/filter/env/builder.rs
@@ -11,6 +11,7 @@ use tracing::level_filters::STATIC_MAX_LEVEL;
 ///
 /// [builder]: https://rust-unofficial.github.io/patterns/patterns/creational/builder.html
 #[derive(Debug, Clone)]
+#[must_use]
 pub struct Builder {
     regex: bool,
     env: Option<String>,

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -240,6 +240,7 @@ pub type Formatter<N = format::DefaultFields, E = format::Format, W = fn() -> io
 /// Configures and constructs `Collector`s.
 #[derive(Debug)]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "fmt", feature = "std"))))]
+#[must_use]
 pub struct CollectorBuilder<
     N = format::DefaultFields,
     E = format::Format,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Builders not marked `#[must_use]` can not be initialized sometimes, causing silent failures.
Eg.
```rust
fn main() {
    tracing_subscriber::fmt();
    tracing::info!("hello");
}
```
won't print anything.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Added `#[must_use]` to builder types in the tracing-subscriber crate.
