### PR TITLE
Make FieldSet implement AsSerde

### DIFF
--- a/tracing-serde/src/lib.rs
+++ b/tracing-serde/src/lib.rs
@@ -533,6 +533,14 @@ impl<'a> AsSerde<'a> for Level {
     }
 }
 
+impl<'a> AsSerde<'a> for FieldSet {
+    type Serializable = SerializeFieldSet<'a>;
+
+    fn as_serde(&'a self) -> Self::Serializable {
+        SerializeFieldSet(self)
+    }
+}
+
 impl<'a> self::sealed::Sealed for Event<'a> {}
 
 impl<'a> self::sealed::Sealed for Attributes<'a> {}
@@ -544,6 +552,8 @@ impl self::sealed::Sealed for Level {}
 impl<'a> self::sealed::Sealed for Record<'a> {}
 
 impl<'a> self::sealed::Sealed for Metadata<'a> {}
+
+impl self::sealed::Sealed for FieldSet {}
 
 mod sealed {
     pub trait Sealed {}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

I've wanted to serialize fieldset of current span.

## Solution

Expose already existing `SerializeFieldSet` for users by implementing `AsSerde` for `FieldSet`.
