### PR TITLE
Add a method to `Targets` to get the default level

### DIFF
--- a/tracing-subscriber/src/filter/targets.rs
+++ b/tracing-subscriber/src/filter/targets.rs
@@ -277,22 +277,48 @@ impl Targets {
         self
     }
 
-    /// Returns the explicitly set default level for this filter, if any.
+    /// Returns the default level for this filter, if set.
     ///
-    /// If a default level was set explicitly using [`with_default`](Self::with_default), that level
-    /// will be returned. Otherwise `None` will be returned.
+    /// The default level can be set for a filter either by using
+    /// [`with_default`](Self::with_default) or when parsing from a filter string that includes a
+    /// level without a target (e.g. `"trace"`).
     ///
-    /// A return value of `None` is behaviourly equivalent to [`LevelFilter::OFF`], but
-    /// distinguishes between an explicitly set default level or the default one. If you only care
-    /// about the behaviour you can use `unwrap_or`:
+    /// # Examples
     ///
     /// ```
     /// use tracing_subscriber::filter::{LevelFilter, Targets};
     ///
-    /// let filter = Targets::new();
-    /// let default_level = filter.default_level().unwrap_or(LevelFilter::OFF);
+    /// let filter = Targets::new().with_default(LevelFilter::INFO);
+    /// assert_eq!(filter.default_level(), Some(LevelFilter::INFO));
     ///
-    /// assert_eq!(default_level, LevelFilter::OFF);
+    /// let filter: Targets = "info".parse().unwrap();
+    /// assert_eq!(filter.default_level(), Some(LevelFilter::INFO));
+    /// ```
+    ///
+    /// The default level is `None` if no default is set:
+    ///
+    /// ```
+    /// use tracing_subscriber::filter::Targets;
+    ///
+    /// let filter = Targets::new();
+    /// assert_eq!(filter.default_level(), None);
+    ///
+    /// let filter: Targets = "my_crate=info".parse().unwrap();
+    /// assert_eq!(filter.default_level(), None);
+    /// ```
+    ///
+    /// Note that an unset default level (`None`) behaves like `LevelFilter::OFF` when the filter is
+    /// used, but it could also be set explicitly which may be useful to distinguish (such as when
+    /// merging multiple `Targets`).
+    ///
+    /// ```
+    /// use tracing_subscriber::filter::{LevelFilter, Targets};
+    ///
+    /// let filter = Targets::new().with_default(LevelFilter::OFF);
+    /// assert_eq!(filter.default_level(), Some(LevelFilter::OFF));
+    ///
+    /// let filter: Targets = "off".parse().unwrap();
+    /// assert_eq!(filter.default_level(), Some(LevelFilter::OFF));
     /// ```
     pub fn default_level(&self) -> Option<LevelFilter> {
         self.0.directives().into_iter().find_map(|d| {

--- a/tracing-subscriber/src/filter/targets.rs
+++ b/tracing-subscriber/src/filter/targets.rs
@@ -277,7 +277,10 @@ impl Targets {
         self
     }
 
-    /// Returns the default level for this filter, if set.
+    /// Returns the default level for this filter, if one is set.
+    ///
+    /// The default level is used to filter any spans or events with targets
+    /// that do not match any of the configured set of prefixes.
     ///
     /// The default level can be set for a filter either by using
     /// [`with_default`](Self::with_default) or when parsing from a filter string that includes a
@@ -307,7 +310,7 @@ impl Targets {
     /// assert_eq!(filter.default_level(), None);
     /// ```
     ///
-    /// Note that an unset default level (`None`) behaves like `LevelFilter::OFF` when the filter is
+    /// Note that an unset default level (`None`) behaves like [`LevelFilter::OFF`] when the filter is
     /// used, but it could also be set explicitly which may be useful to distinguish (such as when
     /// merging multiple `Targets`).
     ///

--- a/tracing-subscriber/src/filter/targets.rs
+++ b/tracing-subscriber/src/filter/targets.rs
@@ -295,11 +295,13 @@ impl Targets {
     /// assert_eq!(default_level, LevelFilter::OFF);
     /// ```
     pub fn default_level(&self) -> Option<LevelFilter> {
-        self.0
-            .directives()
-            .into_iter()
-            .find(|d| d.target.is_none())
-            .map(|d| d.level)
+        self.0.directives().into_iter().find_map(|d| {
+            if d.target.is_none() {
+                Some(d.level)
+            } else {
+                None
+            }
+        })
     }
 
     /// Returns an iterator over the [target]-[`LevelFilter`] pairs in this filter.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

This makes it possible to fully "override" some base `Targets` filter with another (e.g. user-supplied) filter. Without some way to obtain the default, only explicit targets can be overridden (via `IntoIter` and friends).

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

We can add a method to `Targets` that filters the underlying `DirectiveSet` for the default directive. This works because `DirectiveSet::add` will replace directives with the same `target`/`field_names`, which is always `None`/`vec![]` for the directive added by `with_default` (and in fact we are only concerned with `target`, since no other `Targets` API allows adding directives with a `None` target).

Ideally the method would be named `default`, corresponding to `with_default`, however this conflicts with `Default::default` and so would be a breaking change (and harm ergonomics). `default_level` seemed a better name than `get_default`, since "getters" of this style are generally considered unidiomatic<sup>[citation needed]</sup>.

Example usage:

```rust
let mut filter = Targets::new().with_target("some_module", LevelFilter::INFO);

// imagine this came from `RUST_LOG` or similar
let override: Targets = "trace".parse().unwrap();

// merge the override
if let Some(default) = override.default_level() {
    filter = filter.with_default(default);
}
for (target, level) in override.iter() {
    filter = filter.with_target(target, level);
}
```