### PR TITLE
Add `Filter::event_enabled`

### DIFF
--- a/tracing-subscriber/src/filter/subscriber_filters/combinator.rs
+++ b/tracing-subscriber/src/filter/subscriber_filters/combinator.rs
@@ -403,7 +403,12 @@ where
     /// If the wrapped filter would enable a span or event, it will be disabled. If
     /// it would disable a span or event, that span or event will be enabled.
     ///
+    /// This inversion only considers the [`enabled`] filter;
+    /// it does not call the [`event_enabled`] filter.
+    ///
     /// [`Filter`]: crate::subscribe::Filter
+    /// [`enabled`]: crate::subscribe::Filter::enabled
+    /// [`event_enabled`]: crate::subscribe::Filter::event_enabled
     pub(crate) fn new(a: A) -> Self {
         Self { a, _s: PhantomData }
     }

--- a/tracing-subscriber/src/filter/subscriber_filters/combinator.rs
+++ b/tracing-subscriber/src/filter/subscriber_filters/combinator.rs
@@ -403,12 +403,16 @@ where
     /// If the wrapped filter would enable a span or event, it will be disabled. If
     /// it would disable a span or event, that span or event will be enabled.
     ///
-    /// This inversion only considers the [`enabled`] filter;
-    /// it does not call the [`event_enabled`] filter.
+    /// This inverts the values returned by the [`enabled`] and [`callsite_enabled`]
+    /// methods on the wrapped filter; it does *not* invert [`event_enabled`], as
+    /// implementing that method is optional, and filters which do not implement
+    /// filtering on event field values will return `true` even for events that their
+    /// [`enabled`] method would disable.
     ///
     /// [`Filter`]: crate::subscribe::Filter
     /// [`enabled`]: crate::subscribe::Filter::enabled
     /// [`event_enabled`]: crate::subscribe::Filter::event_enabled
+    /// [`callsite_enabled`]: crate::subscribe::Filter::callsite_enabled
     pub(crate) fn new(a: A) -> Self {
         Self { a, _s: PhantomData }
     }

--- a/tracing-subscriber/src/filter/subscriber_filters/combinator.rs
+++ b/tracing-subscriber/src/filter/subscriber_filters/combinator.rs
@@ -138,6 +138,11 @@ where
     }
 
     #[inline]
+    fn event_enabled(&self, event: &tracing_core::Event<'_>, cx: &Context<'_, S>) -> bool {
+        self.a.event_enabled(event, cx) && self.b.event_enabled(event, cx)
+    }
+
+    #[inline]
     fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         self.a.on_new_span(attrs, id, ctx.clone());
         self.b.on_new_span(attrs, id, ctx)
@@ -325,6 +330,11 @@ where
     }
 
     #[inline]
+    fn event_enabled(&self, event: &tracing_core::Event<'_>, cx: &Context<'_, S>) -> bool {
+        self.a.event_enabled(event, cx) || self.b.event_enabled(event, cx)
+    }
+
+    #[inline]
     fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         self.a.on_new_span(attrs, id, ctx.clone());
         self.b.on_new_span(attrs, id, ctx)
@@ -419,6 +429,14 @@ where
     fn max_level_hint(&self) -> Option<LevelFilter> {
         // TODO(eliza): figure this out???
         None
+    }
+
+    #[inline]
+    fn event_enabled(&self, event: &tracing_core::Event<'_>, cx: &Context<'_, S>) -> bool {
+        // Never disable based on event_enabled; we "disabled" it in `enabled`,
+        // so the `not` has already been applied and filtered this not out.
+        let _ = (event, cx);
+        true
     }
 
     #[inline]

--- a/tracing-subscriber/src/filter/subscriber_filters/mod.rs
+++ b/tracing-subscriber/src/filter/subscriber_filters/mod.rs
@@ -298,6 +298,12 @@ pub trait FilterExt<S>: subscribe::Filter<S> {
 
     /// Inverts `self`, returning a filter that enables spans and events only if
     /// `self` would *not* enable them.
+    ///
+    /// Inverts [`enabled`] but ignores [`event_enabled`],
+    /// as most filters do not use `event_enabled`.
+    ///
+    /// [`enabled`]: crate::subscribe::Filter::enabled
+    /// [`event_enabled`]: crate::subscribe::Filter::event_enabled
     fn not(self) -> combinator::Not<Self, S>
     where
         Self: Sized,

--- a/tracing-subscriber/src/filter/subscriber_filters/mod.rs
+++ b/tracing-subscriber/src/filter/subscriber_filters/mod.rs
@@ -1025,11 +1025,7 @@ impl FilterState {
     /// Run a second filtering pass, e.g. for Subscribe::event_enabled.
     fn and(&self, filter: FilterId, f: impl FnOnce() -> bool) -> bool {
         let map = self.enabled.get();
-        let enabled = if self.enabled.get().is_enabled(filter) {
-            f()
-        } else {
-            false
-        };
+        let enabled = map.is_enabled(filter) && f();
         self.enabled.set(map.set(filter, enabled));
         enabled
     }

--- a/tracing-subscriber/src/filter/subscriber_filters/mod.rs
+++ b/tracing-subscriber/src/filter/subscriber_filters/mod.rs
@@ -299,11 +299,16 @@ pub trait FilterExt<S>: subscribe::Filter<S> {
     /// Inverts `self`, returning a filter that enables spans and events only if
     /// `self` would *not* enable them.
     ///
-    /// Inverts [`enabled`] but ignores [`event_enabled`],
-    /// as most filters do not use `event_enabled`.
+    /// This inverts the values returned by the [`enabled`] and [`callsite_enabled`]
+    /// methods on the wrapped filter; it does *not* invert [`event_enabled`], as
+    /// implementing that method is optional, and filters which do not implement
+    /// filtering on event field values will return `true` even for events that their
+    /// [`enabled`] method would disable.
     ///
+    /// [`Filter`]: crate::subscribe::Filter
     /// [`enabled`]: crate::subscribe::Filter::enabled
     /// [`event_enabled`]: crate::subscribe::Filter::event_enabled
+    /// [`callsite_enabled`]: crate::subscribe::Filter::callsite_enabled
     fn not(self) -> combinator::Not<Self, S>
     where
         Self: Sized,

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -275,6 +275,13 @@ impl Collect for Registry {
 
     fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
 
+    fn event_enabled(&self, _event: &Event<'_>) -> bool {
+        if self.has_per_subscriber_filters() {
+            return FilterState::event_enabled();
+        }
+        true
+    }
+
     /// This is intentionally not implemented, as recording events
     /// is the responsibility of subscribers atop of this registry.
     fn event(&self, _: &Event<'_>) {}

--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -1394,6 +1394,7 @@ pub trait Filter<S> {
     /// By default, this method returns `true`, indicating that no events are
     /// filtered out based on their fields.
     ///
+    /// [`enabled`]: crate::subscribe::Filter::enabled
     /// [`on_event`]: crate::subscribe::Subscribe::on_event
     #[inline] // collapse this to a constant please mrs optimizer
     fn event_enabled(&self, event: &Event<'_>, cx: &Context<'_, S>) -> bool {

--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -1385,7 +1385,14 @@ pub trait Filter<S> {
     /// Called before the filtered subscribers' [`on_event`], to determine if
     /// `on_event` should be called.
     ///
-    /// This gives a chance to filter events based on their fields.
+    /// This gives a chance to filter events based on their fields. Note,
+    /// however, that this *does not* override [`enabled`], and is not even
+    /// called if [`enabled`] returns `false`.
+    ///
+    /// ## Default Implementation
+    ///
+    /// By default, this method returns `true`, indicating that no events are
+    /// filtered out based on their fields.
     ///
     /// [`on_event`]: crate::subscribe::Subscribe::on_event
     #[inline] // collapse this to a constant please mrs optimizer

--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -1382,6 +1382,18 @@ pub trait Filter<S> {
         None
     }
 
+    /// Called before the filtered subscribers' [`on_event`], to determine if
+    /// `on_event` should be called.
+    ///
+    /// This gives a chance to filter events based on their fields.
+    ///
+    /// [`on_event`]: crate::subscribe::Subscribe::on_event
+    #[inline] // collapse this to a constant please mrs optimizer
+    fn event_enabled(&self, event: &Event<'_>, cx: &Context<'_, S>) -> bool {
+        let _ = (event, cx);
+        true
+    }
+
     /// Notifies this filter that a new span was constructed with the given
     /// `Attributes` and `Id`.
     ///

--- a/tracing-subscriber/tests/subscriber_filters/main.rs
+++ b/tracing-subscriber/tests/subscriber_filters/main.rs
@@ -3,6 +3,7 @@
 mod support;
 use self::support::*;
 mod filter_scopes;
+mod per_event;
 mod targets;
 mod trees;
 mod vec;

--- a/tracing-subscriber/tests/subscriber_filters/per_event.rs
+++ b/tracing-subscriber/tests/subscriber_filters/per_event.rs
@@ -1,0 +1,61 @@
+use crate::support::*;
+use tracing::Level;
+use tracing_subscriber::{field::Visit, prelude::*, subscribe::Filter};
+
+struct FilterEvent;
+
+impl<S> Filter<S> for FilterEvent {
+    fn enabled(
+        &self,
+        _meta: &tracing::Metadata<'_>,
+        _cx: &tracing_subscriber::subscribe::Context<'_, S>,
+    ) -> bool {
+        true
+    }
+
+    fn event_enabled(
+        &self,
+        event: &tracing::Event<'_>,
+        _cx: &tracing_subscriber::subscribe::Context<'_, S>,
+    ) -> bool {
+        struct ShouldEnable(bool);
+        impl Visit for ShouldEnable {
+            fn record_bool(&mut self, field: &tracing_core::Field, value: bool) {
+                if field.name() == "enable" {
+                    self.0 = value;
+                }
+            }
+
+            fn record_debug(
+                &mut self,
+                _field: &tracing_core::Field,
+                _value: &dyn core::fmt::Debug,
+            ) {
+            }
+        }
+        let mut should_enable = ShouldEnable(false);
+        event.record(&mut should_enable);
+        should_enable.0
+    }
+}
+
+#[test]
+fn per_subscriber_event_field_filtering() {
+    let (expect, handle) = subscriber::mock()
+        .event(event::mock().at_level(Level::TRACE))
+        .event(event::mock().at_level(Level::INFO))
+        .done()
+        .run_with_handle();
+
+    let _subscriber = tracing_subscriber::registry()
+        .with(expect.with_filter(FilterEvent))
+        .set_default();
+
+    tracing::trace!(enable = true, "hello trace");
+    tracing::debug!("hello debug");
+    tracing::info!(enable = true, "hello info");
+    tracing::warn!(enable = false, "hello warn");
+    tracing::error!("hello error");
+
+    handle.assert_finished();
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Like for `Collect` and `Subscribe`, allow per-layer `Filter`s to filter based on event fields.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add `Filter::event_enabled`, plumb it through the combinator implementations, and call it from `Filtered`.

The bit I'm the least confident about is the check in `Registry`'s implementation, but I *think* it matches what `event` is doing and everything seems to function correctly.