### PR TITLE
fix minimal-versions correctness (v0.1.x)

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,57 +11,57 @@ default = []
 [dev-dependencies]
 
 # tracing crates
-tracing = { path = "../tracing", version = "0.1" }
-tracing-core = { path = "../tracing-core", version = "0.1" }
+tracing = { path = "../tracing", version = "0.1.35" }
+tracing-core = { path = "../tracing-core", version = "0.1.28" }
 tracing-error = { path = "../tracing-error" }
 tracing-flame = { path = "../tracing-flame" }
 tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", features = ["json", "env-filter"] }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.3.0", features = ["json", "env-filter"] }
 tracing-futures = { version = "0.2.1", path = "../tracing-futures", features = ["futures-01"] }
-tracing-attributes = { path = "../tracing-attributes", version = "0.1.2" }
-tracing-log = { path = "../tracing-log", version = "0.1.1", features = ["env_logger"] }
+tracing-attributes = { path = "../tracing-attributes", version = "0.1.22" }
+tracing-log = { path = "../tracing-log", version = "0.1.3", features = ["env_logger"] }
 tracing-serde = { path = "../tracing-serde" }
 tracing-opentelemetry = { path = "../tracing-opentelemetry" }
 tracing-journald = { path = "../tracing-journald" }
-tracing-appender = { path = "../tracing-appender", version = "0.2" }
+tracing-appender = { path = "../tracing-appender", version = "0.2.0" }
 
 # serde example
-serde_json = "1.0"
+serde_json = "1.0.82"
 
-futures = "0.3"
-tokio = { version = "1.1", features = ["full"] }
+futures = "0.3.21"
+tokio = { version = "1.20.1", features = ["full"] }
 
 # env-logger example
-env_logger = "0.9"
+env_logger = "0.9.0"
 
 # tower examples
-tower = { version = "0.4.4", features = ["full"] }
-http = "0.2"
-hyper = { version = "0.14.11", features = ["full"] }
-rand = "0.7"
+tower = { version = "0.4.13", features = ["full"] }
+http = "0.2.8"
+hyper = { version = "0.14.20", features = ["full"] }
+rand = "0.7.3"
 bytes = "1"
-argh = "0.1.5"
+argh = "0.1.8"
 
 # sloggish example
-ansi_term = "0.12"
-humantime = "2.0"
-log = "0.4"
+ansi_term = "0.12.1"
+humantime = "2.1.0"
+log = "0.4.17"
 
 # inferno example
-inferno = "0.11.0"
+inferno = "0.11.6"
 tempfile = "3"
 
 # opentelemetry example
-opentelemetry = { version = "0.17", default-features = false, features = ["trace"] }
-opentelemetry-jaeger = "0.16"
+opentelemetry = { version = "0.17.0", default-features = false, features = ["trace"] }
+opentelemetry-jaeger = "0.16.0"
 
 # fmt examples
 snafu = "0.6.10"
-thiserror = "1.0.26"
+thiserror = "1.0.31"
 
 # valuable examples 
 valuable = { version = "0.1.0", features = ["derive"] }
 
 [target.'cfg(tracing_unstable)'.dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1", features = ["valuable"]}
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", features = ["json", "env-filter", "valuable"]}
+tracing-core = { path = "../tracing-core", version = "0.1.28", features = ["valuable"]}
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.3.0", features = ["json", "env-filter", "valuable"]}

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -21,22 +21,22 @@ edition = "2018"
 rust-version = "1.53.0"
 
 [dependencies]
-crossbeam-channel = "0.5.0"
-time = { version = "0.3", default-features = false, features = ["formatting"] }
-parking_lot = { optional = true, version = "0.12.0" }
+crossbeam-channel = "0.5.6"
+time = { version = "0.3.2", default-features = false, features = ["formatting"] }
+parking_lot = { optional = true, version = "0.12.1" }
 thiserror = "1"
 
 [dependencies.tracing-subscriber]
 path = "../tracing-subscriber"
-version = "0.3"
+version = "0.3.0"
 default-features = false
 features = ["fmt", "std"]
 
 [dev-dependencies]
 
-criterion = { version = "0.3", default_features = false }
-tracing = { path = "../tracing", version = "0.1" }
-time = { version = "0.3", default-features = false, features = ["formatting", "parsing"] }
+criterion = { version = "0.3.6", default-features = false }
+tracing = { path = "../tracing", version = "0.1.35" }
+time = { version = "0.3.2", default-features = false, features = ["formatting", "parsing"] }
 tempfile = "3"
 
 [[bench]]

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -40,16 +40,16 @@ async-await = []
 
 [dependencies]
 proc-macro2 = "1"
-syn = { version = "1.0.43", default-features = false, features = ["full", "parsing", "printing", "visit", "visit-mut", "clone-impls", "extra-traits", "proc-macro"] }
+syn = { version = "1.0.98", default-features = false, features = ["full", "parsing", "printing", "visit", "visit-mut", "clone-impls", "extra-traits", "proc-macro"] }
 quote = "1"
 
 [dev-dependencies]
-tracing = { path = "../tracing", version = "0.1" }
+tracing = { path = "../tracing", version = "0.1.35" }
 tracing-mock = { path = "../tracing-mock", features = ["tokio-test"] }
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.3.0", features = ["env-filter"] }
 tokio-test = { version = "0.3.0" }
-tracing-core = { path = "../tracing-core", version = "0.1"}
-async-trait = "0.1.44"
+tracing-core = { path = "../tracing-core", version = "0.1.28"}
+async-trait = "0.1.56"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -34,10 +34,10 @@ std = ["once_cell"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-once_cell = { version = "1.12", optional = true }
+once_cell = { version = "1.13.0", optional = true }
 
 [target.'cfg(tracing_unstable)'.dependencies]
-valuable = { version = "0.1.0", optional = true, default_features = false }
+valuable = { version = "0.1.0", optional = true, default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -39,8 +39,8 @@ default = ["traced-error"]
 traced-error = []
 
 [dependencies]
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry", "fmt"] }
-tracing = { path = "../tracing", version = "0.1.12", default-features = false, features = ["std"] }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.3.0", default-features = false, features = ["registry", "fmt"] }
+tracing = { path = "../tracing", version = "0.1.35", default-features = false, features = ["std"] }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/tracing-flame/Cargo.toml
+++ b/tracing-flame/Cargo.toml
@@ -26,9 +26,9 @@ default = ["smallvec"]
 smallvec = ["tracing-subscriber/smallvec"]
 
 [dependencies]
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry", "fmt"] }
-tracing = { path = "../tracing", version = "0.1.12", default-features = false, features = ["std"] }
-once_cell = "1.12"
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.3.0", default-features = false, features = ["registry", "fmt"] }
+tracing = { path = "../tracing", version = "0.1.35", default-features = false, features = ["std"] }
+once_cell = "1.13.0"
 
 
 [dev-dependencies]

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -27,17 +27,21 @@ tokio = ["tokio_01"]
 std = ["tracing/std"]
 
 [dependencies]
-futures_01 = { package = "futures", version = "0.1", optional = true }
-futures = { version = "0.3.0", optional = true }
-futures-task = { version = "0.3", optional = true }
-pin-project-lite = { version = "0.2.4", optional = true }
-tracing = { path = "../tracing", version = "0.1", default-features = false }
-tokio-executor = { version = "0.1", optional = true }
-tokio_01 = { package = "tokio", version = "0.1", optional = true }
+futures_01 = { package = "futures", version = "0.1.31", optional = true }
+futures = { version = "0.3.21", optional = true }
+futures-task = { version = "0.3.21", optional = true }
+pin-project-lite = { version = "0.2.9", optional = true }
+tracing = { path = "../tracing", version = "0.1.35", default-features = false }
+tokio-executor = { version = "0.1.10", optional = true }
+tokio_01 = { package = "tokio", version = "0.1.22", optional = true }
+
+# Fix minimal-versions
+tokio-threadpool = { version = "0.1.18", optional = true }
+mio = { version = "0.6.23", optional = true }
 
 [dev-dependencies]
-tokio-test = "0.4"
-tracing-core = { path = "../tracing-core", version = "0.1.2" }
+tokio-test = "0.4.2"
+tracing-core = { path = "../tracing-core", version = "0.1.28" }
 tracing-mock = { path = "../tracing-mock", features = ["tokio-test"] }
 
 [badges]

--- a/tracing-journald/Cargo.toml
+++ b/tracing-journald/Cargo.toml
@@ -16,11 +16,11 @@ keywords = ["tracing", "journald"]
 rust-version = "1.49.0"
 
 [dependencies]
-libc = "0.2.107"
-tracing-core = { path = "../tracing-core", version = "0.1.10" }
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry"] }
+libc = "0.2.126"
+tracing-core = { path = "../tracing-core", version = "0.1.28" }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.3.0", default-features = false, features = ["registry"] }
 
 [dev-dependencies]
-serde_json = "1.0.68"
-serde = { version = "1.0.130", features = ["derive"] }
-tracing = { path = "../tracing", version = "0.1" }
+serde_json = "1.0.82"
+serde = { version = "1.0.140", features = ["derive"] }
+tracing = { path = "../tracing", version = "0.1.35" }

--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -156,7 +156,7 @@ impl Layer {
     #[cfg(not(unix))]
     fn send_payload(&self, _opayload: &[u8]) -> io::Result<()> {
         Err(io::Error::new(
-            io::ErrorKind::Unsupported,
+            io::ErrorKind::Other,
             "journald not supported on non-Unix",
         ))
     }
@@ -177,7 +177,7 @@ impl Layer {
     #[cfg(all(unix, not(target_os = "linux")))]
     fn send_large_payload(&self, _payload: &[u8]) -> io::Result<usize> {
         Err(io::Error::new(
-            io::ErrorKind::Unsupported,
+            io::ErrorKind::Other,
             "Large payloads not supported on non-Linux OS",
         ))
     }

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -25,17 +25,17 @@ trace-logger = []
 interest-cache = ["lru", "ahash"]
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.17"}
-log = { version = "0.4" }
-once_cell = "1.12"
-env_logger = { version = "0.8", optional = true }
-lru = { version = "0.7.0", optional = true }
-ahash = { version = "0.7.4", optional = true }
+tracing-core = { path = "../tracing-core", version = "0.1.28"}
+log = { version = "0.4.17" }
+once_cell = "1.13.0"
+env_logger = { version = "0.8.4", optional = true }
+lru = { version = "0.7.7", optional = true }
+ahash = { version = "0.7.6", optional = true }
 
 [dev-dependencies]
-tracing = { path = "../tracing", version = "0.1"}
+tracing = { path = "../tracing", version = "0.1.35"}
 tracing-subscriber = { path = "../tracing-subscriber" }
-criterion = { version = "0.3", default_features = false }
+criterion = { version = "0.3.6", default-features = false }
 
 [badges]
 maintenance = { status = "actively-maintained" }

--- a/tracing-macros/Cargo.toml
+++ b/tracing-macros/Cargo.toml
@@ -18,11 +18,11 @@ license = "MIT"
 rust-version = "1.49.0"
 
 [dependencies]
-tracing = "0.1.18"
+tracing = "0.1.35"
 
 [dev-dependencies]
-tracing-log = "0.1"
-env_logger = "0.7"
+tracing-log = "0.1.3"
+env_logger = "0.7.1"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/tracing-mock/Cargo.toml
+++ b/tracing-mock/Cargo.toml
@@ -18,9 +18,12 @@ rust-version = "1.49.0"
 publish = false
 
 [dependencies]
-tracing = { path = "../tracing", version = "0.1", default-features = false }
-tracing-core = { path = "../tracing-core", version = "0.1", default-features = false }
-tokio-test = { version = "0.4", optional = true }
+tracing = { path = "../tracing", version = "0.1.35", default-features = false }
+tracing-core = { path = "../tracing-core", version = "0.1.28", default-features = false }
+tokio-test = { version = "0.4.2", optional = true }
+
+# Fix minimal-versions; tokio-test fails with otherwise acceptable 0.1.0
+tokio-stream = { version = "0.1.9", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -23,17 +23,21 @@ rust-version = "1.46.0"
 default = ["tracing-log"]
 
 [dependencies]
-opentelemetry = { version = "0.17", default-features = false, features = ["trace"] }
-tracing = { path = "../tracing", version = "0.1", default-features = false, features = ["std"] }
-tracing-core = { path = "../tracing-core", version = "0.1" }
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry", "std"] }
-tracing-log = { path = "../tracing-log", version = "0.1", default-features = false, optional = true }
+opentelemetry = { version = "0.17.0", default-features = false, features = ["trace"] }
+tracing = { path = "../tracing", version = "0.1.35", default-features = false, features = ["std"] }
+tracing-core = { path = "../tracing-core", version = "0.1.28" }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.3.0", default-features = false, features = ["registry", "std"] }
+tracing-log = { path = "../tracing-log", version = "0.1.3", default-features = false, optional = true }
 once_cell = "1"
 
+# Fix minimal-versions
+async-trait = { version = "0.1.56", optional = true }
+thiserror = { version = "1.0.31", optional = true }
+
 [dev-dependencies]
-async-trait = "0.1"
-criterion = { version = "0.3", default_features = false }
-opentelemetry-jaeger = "0.16"
+async-trait = "0.1.56"
+criterion = { version = "0.3.6", default-features = false }
+opentelemetry-jaeger = "0.16.0"
 
 [lib]
 bench = false

--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -23,14 +23,14 @@ valuable = ["valuable_crate", "valuable-serde", "tracing-core/valuable"]
 
 [dependencies]
 serde = "1"
-tracing-core = { path = "../tracing-core", version = "0.1.22"}
+tracing-core = { path = "../tracing-core", version = "0.1.28"}
 
 [dev-dependencies]
 serde_json = "1"
 
 [target.'cfg(tracing_unstable)'.dependencies]
-valuable_crate = { package = "valuable", version = "0.1.0", optional = true, default_features = false }
-valuable-serde = { version = "0.1.0", optional = true, default_features = false }
+valuable_crate = { package = "valuable", version = "0.1.0", optional = true, default-features = false }
+valuable-serde = { version = "0.1.0", optional = true, default-features = false }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -41,44 +41,44 @@ local-time = ["time/local-offset"]
 tracing-core = { path = "../tracing-core", version = "0.1.28", default-features = false }
 
 # only required by the filter feature
-tracing = { optional = true, path = "../tracing", version = "0.1", default-features = false }
+tracing = { optional = true, path = "../tracing", version = "0.1.35", default-features = false }
 matchers = { optional = true, version = "0.1.0" }
 regex = { optional = true, version = "1", default-features = false, features = ["std"] }
-smallvec = { optional = true, version = "1.2.0" }
-once_cell = { optional = true, version = "1.12" }
+smallvec = { optional = true, version = "1.9.0" }
+once_cell = { optional = true, version = "1.13.0" }
 
 # fmt
-tracing-log = { path = "../tracing-log", version = "0.1.2", optional = true, default-features = false, features = ["log-tracer", "std"] }
-ansi_term = { version = "0.12", optional = true }
-time = { version = "0.3", features = ["formatting"], optional = true }
+tracing-log = { path = "../tracing-log", version = "0.1.3", optional = true, default-features = false, features = ["log-tracer", "std"] }
+ansi_term = { version = "0.12.1", optional = true }
+time = { version = "0.3.2", features = ["formatting"], optional = true }
 
 # only required by the json feature
-serde_json = { version = "1.0", optional = true }
-serde = { version = "1.0", optional = true }
+serde_json = { version = "1.0.82", optional = true }
+serde = { version = "1.0.140", optional = true }
 tracing-serde = { path = "../tracing-serde", version = "0.1.3", optional = true }
 
 # opt-in deps
-parking_lot = { version = "0.12", optional = true }
+parking_lot = { version = "0.12.1", optional = true }
 
 # registry
-sharded-slab = { version = "0.1.0", optional = true }
+sharded-slab = { version = "0.1.4", optional = true }
 thread_local = { version = "1.1.4", optional = true }
 
 [target.'cfg(tracing_unstable)'.dependencies]
-valuable_crate = { package = "valuable", version = "0.1.0", optional = true, default_features = false }
-valuable-serde = { version = "0.1.0", optional = true, default_features = false }
+valuable_crate = { package = "valuable", version = "0.1.0", optional = true, default-features = false }
+valuable-serde = { version = "0.1.0", optional = true, default-features = false }
 
 [dev-dependencies]
-tracing = { path = "../tracing", version = "0.1" }
+tracing = { path = "../tracing", version = "0.1.35" }
 tracing-mock = { path = "../tracing-mock" }
-log = "0.4"
-tracing-log = { path = "../tracing-log", version = "0.1.2" }
-criterion = { version = "0.3", default_features = false }
+log = "0.4.17"
+tracing-log = { path = "../tracing-log", version = "0.1.3" }
+criterion = { version = "0.3.6", default-features = false }
 regex = { version = "1", default-features = false, features = ["std"] }
-tracing-futures = { path = "../tracing-futures", version = "0.2", default-features = false, features = ["std-future", "std"] }
+tracing-futures = { path = "../tracing-futures", version = "0.2.0", default-features = false, features = ["std-future", "std"] }
 tokio = { version = "1", features = ["rt", "macros"] }
 # Enable the `time` crate's `macros` feature, for examples.
-time = { version = "0.3", features = ["formatting", "macros"] }
+time = { version = "0.3.2", features = ["formatting", "macros"] }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -25,14 +25,14 @@ tower-make = [
 ]
 
 [dependencies]
-tracing = { path = "../tracing", version = "0.1", default-features = false, features = ["std"] }
+tracing = { path = "../tracing", version = "0.1.35", default-features = false, features = ["std"] }
 tracing-futures = { version = "0.2.1", path = "../tracing-futures", features = ["std-future"] }
-futures = "0.3"
-tower-service = "0.3"
-tower-layer = { version = "0.3", optional = true }
-tower_make = { package = "tower-make", version = "0.3", optional = true }
-pin-project-lite = { version = "0.2.4", optional = true }
-http = { version = "0.2", optional = true }
+futures = "0.3.21"
+tower-service = "0.3.2"
+tower-layer = { version = "0.3.1", optional = true }
+tower_make = { package = "tower-make", version = "0.3.0", optional = true }
+pin-project-lite = { version = "0.2.9", optional = true }
+http = { version = "0.2.8", optional = true }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -28,15 +28,15 @@ edition = "2018"
 rust-version = "1.49.0"
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.27", default-features = false }
-log = { version = "0.4", optional = true }
-tracing-attributes = { path = "../tracing-attributes", version = "0.1.20", optional = true }
+tracing-core = { path = "../tracing-core", version = "0.1.28", default-features = false }
+log = { version = "0.4.17", optional = true }
+tracing-attributes = { path = "../tracing-attributes", version = "0.1.22", optional = true }
 cfg-if = "1.0.0"
-pin-project-lite = "0.2"
+pin-project-lite = "0.2.9"
 
 [dev-dependencies]
-criterion = { version = "0.3", default_features = false }
-log = "0.4"
+criterion = { version = "0.3.6", default-features = false }
+log = "0.4.17"
 tracing-mock = { path = "../tracing-mock" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/tracing/test-log-support/Cargo.toml
+++ b/tracing/test-log-support/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 
 [dependencies]
 tracing = { path = "..", features = ["log", "log-always"] }
-log = { version = "0.4", features = ["std"] }
+log = { version = "0.4.0", features = ["std"] }


### PR DESCRIPTION
Essentially a cherry-pick of #2231, but redone by hand.

## Tests

- `cargo minimal-versions msrv verify -- cargo check --all-features`
- `cargo minimal-versions msrv verify -- cargo check --no-default-features`

## Methodology

- `cargo update && cargo upgrade --to-lockfile`
  - Identify [a bug](https://github.com/killercup/cargo-edit/issues/750) and manually resolve it
- loop; upgrade transitive deps
  - `cargo minimal-versions check --all-features`
  - Identify failing dep
  - `cargo minimal-versions tree -i dep --all-features`
  - Find the closest dependency leading to pulling in `dep`
  - `cargo add fixdep --optional` to force a more recent more-minimal-versions-correct version
- loop; downgrade to msrv
  - `cargo minimal-versions msrv verify -- cargo check --all-features`
  - Identify failing dep
  - `cargo minimal-versions tree -i dep --all-features`
  - Find the version that supports MSRV from lib.rs
  - `cargo upgrade dep@msrv`