### PR TITLE
tracing-subscriber: impl `LookupSpan` for `Box<LS>` and `Arc<LS>`

### DIFF
--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -1656,7 +1656,7 @@ feature! {
     }
 
 
-    impl<C, S> Subscribe<C> for Vec<S>
+    impl<C, S> Subscribe<C> for alloc::vec::Vec<S>
     where
         S: Subscribe<C>,
         C: Collect,


### PR DESCRIPTION
These implementations mirror those provided by tracing-core for `Collect` on `Box<C>` and `Arc<C>`.