### PR TITLE
core: give `SetGlobalDefaultError` a useful `Debug` impl

### DIFF
--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -349,20 +349,31 @@ pub fn has_been_set() -> bool {
 }
 
 /// Returned if setting the global dispatcher fails.
-#[derive(Debug)]
 pub struct SetGlobalDefaultError {
     _no_construct: (),
 }
 
+impl fmt::Debug for SetGlobalDefaultError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("SetGlobalDefaultError")
+            .field(&Self::MESSAGE)
+            .finish()
+    }
+}
+
 impl fmt::Display for SetGlobalDefaultError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.pad("a global default trace dispatcher has already been set")
+        f.pad(Self::MESSAGE)
     }
 }
 
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl error::Error for SetGlobalDefaultError {}
+
+impl SetGlobalDefaultError {
+    const MESSAGE: &'static str = "a global default trace dispatcher has already been set";
+}
 
 /// Executes a closure with a reference to this thread's current [dispatcher].
 ///


### PR DESCRIPTION
## Motivation

When a global default dispatcher has already been set, the
`dispatch::set_global_default` function fails with a
`SetGlobalDefaultError`. The `fmt::Display` impl for this type includes
a message explaining that the error indicates that a global default has
already been set, but the `fmt::Debug` impl is derived, and just looks
like this:
```
SetGlobalDefaultError { _no_construct: () }
```
which isn't particularly helpful.

Unfortunately, when `unwrap()`ping or `expect()`ing a `Result`, the
`fmt::Debug` implementation for the error type is used, rather than
`fmt::Display`. This means that the error message will not explain to
the user why setting the global default dispatcher failed, which is a
bummer.

## Solution

This branch replaces the derived `Debug` impl with a manually
implemented one that prints the same message as the `Display` impl, but
formatted like a tuple struct with a single string field. This avoids
emitting `Debug` output that's *just* a textual human-readable message,
rather than looking like Rust code, but ensures the message is visible
to the user when writing code like
```rust
tracing::dispatch::set_global_default(foo).unwrap();
```

The mesasge now looks like:
```
SetGlobalDefaultError("a global default trace dispatcher has already been set")
```
which should be a bit easier to debug.
