### PR TITLE
Allow constants as field names via a sigil

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -1172,6 +1172,9 @@ macro_rules! trace {
     (target: $target:expr, $($k:ident).+ $($field:tt)* ) => (
         $crate::event!(target: $target, $crate::Level::TRACE, { $($k).+ $($field)* })
     );
+    (target: $target:expr, ^$($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::TRACE, { ^$($k).+ $($field)* })
+    );
     (target: $target:expr, ?$($k:ident).+ $($field:tt)* ) => (
         $crate::event!(target: $target, $crate::Level::TRACE, { ?$($k).+ $($field)* })
     );
@@ -1187,6 +1190,13 @@ macro_rules! trace {
             $crate::Level::TRACE,
             { $($field)+ },
             $($arg)+
+        )
+    );
+    (^$($k:ident).+ = $($field:tt)*) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::TRACE,
+            { ^$($k).+ = $($field)*}
         )
     );
     ($($k:ident).+ = $($field:tt)*) => (
@@ -1359,6 +1369,9 @@ macro_rules! debug {
     (target: $target:expr, $($k:ident).+ $($field:tt)* ) => (
         $crate::event!(target: $target, $crate::Level::DEBUG, { $($k).+ $($field)* })
     );
+    (target: $target:expr, ^$($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::DEBUG, { ^$($k).+ $($field)* })
+    );
     (target: $target:expr, ?$($k:ident).+ $($field:tt)* ) => (
         $crate::event!(target: $target, $crate::Level::DEBUG, { ?$($k).+ $($field)* })
     );
@@ -1381,6 +1394,13 @@ macro_rules! debug {
             target: module_path!(),
             $crate::Level::DEBUG,
             { $($k).+ = $($field)*}
+        )
+    );
+    (^$($k:ident).+ = $($field:tt)*) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::DEBUG,
+            { ^$($k).+ = $($field)*}
         )
     );
     (?$($k:ident).+ = $($field:tt)*) => (
@@ -1571,6 +1591,9 @@ macro_rules! info {
     (target: $target:expr, $($k:ident).+ $($field:tt)* ) => (
         $crate::event!(target: $target, $crate::Level::INFO, { $($k).+ $($field)* })
     );
+    (target: $target:expr, ^$($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::INFO, { ^$($k).+ $($field)* })
+    );
     (target: $target:expr, ?$($k:ident).+ $($field:tt)* ) => (
         $crate::event!(target: $target, $crate::Level::INFO, { ?$($k).+ $($field)* })
     );
@@ -1593,6 +1616,13 @@ macro_rules! info {
             target: module_path!(),
             $crate::Level::INFO,
             { $($k).+ = $($field)*}
+        )
+    );
+    (^$($k:ident).+ = $($field:tt)*) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::INFO,
+            { ^$($k).+ = $($field)*}
         )
     );
     (?$($k:ident).+ = $($field:tt)*) => (
@@ -1776,6 +1806,9 @@ macro_rules! warn {
     (target: $target:expr, $($k:ident).+ $($field:tt)* ) => (
         $crate::event!(target: $target, $crate::Level::WARN, { $($k).+ $($field)* })
     );
+    (target: $target:expr, ^$($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::WARN, { ^$($k).+ $($field)* })
+    );
     (target: $target:expr, ?$($k:ident).+ $($field:tt)* ) => (
         $crate::event!(target: $target, $crate::Level::WARN, { ?$($k).+ $($field)* })
     );
@@ -1798,6 +1831,13 @@ macro_rules! warn {
             target: module_path!(),
             $crate::Level::WARN,
             { $($k).+ = $($field)*}
+        )
+    );
+    (^$($k:ident).+ = $($field:tt)*) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::WARN,
+            { ^$($k).+ = $($field)*}
         )
     );
     (?$($k:ident).+ = $($field:tt)*) => (
@@ -1977,6 +2017,9 @@ macro_rules! error {
     (target: $target:expr, $($k:ident).+ $($field:tt)* ) => (
         $crate::event!(target: $target, $crate::Level::ERROR, { $($k).+ $($field)* })
     );
+    (target: $target:expr, ^$($k:ident).+ $($field:tt)* ) => (
+        $crate::event!(target: $target, $crate::Level::ERROR, { ^$($k).+ $($field)* })
+    );
     (target: $target:expr, ?$($k:ident).+ $($field:tt)* ) => (
         $crate::event!(target: $target, $crate::Level::ERROR, { ?$($k).+ $($field)* })
     );
@@ -1999,6 +2042,13 @@ macro_rules! error {
             target: module_path!(),
             $crate::Level::ERROR,
             { $($k).+ = $($field)*}
+        )
+    );
+    (^$($k:ident).+ = $($field:tt)*) => (
+        $crate::event!(
+            target: module_path!(),
+            $crate::Level::ERROR,
+            { ^$($k).+ = $($field)*}
         )
     );
     (?$($k:ident).+ = $($field:tt)*) => (
@@ -2191,21 +2241,21 @@ macro_rules! valueset {
     // (@{ $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = _, $($rest:tt)*) => {
     //     $crate::valueset!(@ { $($out),*, (&$next, None) }, $next, $($rest)*)
     // };
-    (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, $(^)?$($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
         $crate::valueset!(
             @ { $($out),*, (&$next, Some(&debug(&$val) as &Value)) },
             $next,
             $($rest)*
         )
     };
-    (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, $(^)?$($k:ident).+ = %$val:expr, $($rest:tt)*) => {
         $crate::valueset!(
             @ { $($out),*, (&$next, Some(&display(&$val) as &Value)) },
             $next,
             $($rest)*
         )
     };
-    (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = $val:expr, $($rest:tt)*) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, $(^)?$($k:ident).+ = $val:expr, $($rest:tt)*) => {
         $crate::valueset!(
             @ { $($out),*, (&$next, Some(&$val as &Value)) },
             $next,
@@ -2233,19 +2283,19 @@ macro_rules! valueset {
             $($rest)*
         )
     };
-    (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = ?$val:expr) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, $(^)?$($k:ident).+ = ?$val:expr) => {
         $crate::valueset!(
             @ { $($out),*, (&$next, Some(&debug(&$val) as &Value)) },
             $next,
         )
     };
-    (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = %$val:expr) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, $(^)?$($k:ident).+ = %$val:expr) => {
         $crate::valueset!(
             @ { $($out),*, (&$next, Some(&display(&$val) as &Value)) },
             $next,
         )
     };
-    (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = $val:expr) => {
+    (@ { $(,)* $($out:expr),* }, $next:expr, $(^)?$($k:ident).+ = $val:expr) => {
         $crate::valueset!(
             @ { $($out),*, (&$next, Some(&$val as &Value)) },
             $next,
@@ -2345,6 +2395,9 @@ macro_rules! fieldset {
     };
 
     // == recursive cases (more tts) ==
+    (@ { $(,)* $($out:expr),* } ^$($k:ident).+ = $val:tt, $($rest:tt)*) => {
+        $crate::fieldset!(@ { $($out),*, $($k).+ } $($rest)*)
+    };
     (@ { $(,)* $($out:expr),* } $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
         $crate::fieldset!(@ { $($out),*, $crate::__tracing_stringify!($($k).+) } $($rest)*)
     };


### PR DESCRIPTION
(Work In Progress)

NOTE: I welcome help! If anyone would like to work directly on this PR, I'm happy to add you as a collaborator to my fork. Maintainers are already able (and welcome) to push directly to this PR as well.

TODO
- [ ] Finish covering all the event entry points, I'm fairly sure I missed all the "parent"-related entry points, for example.
- [ ] Design discussion, ie maybe refactor everything according to review feedback(?)
- [ ] Tests, tests, tests
- [ ] Example code in `examples/`
- [ ] Documentation updates in all the places

Kudos to @toomanybees who spent some hours working with me on this already.

## Motivation

As discussed [here](https://github.com/tokio-rs/tracing/discussions/2253), I would like to be able to be able to use a constant for a field name. Using a variable would be even nicer, but this PR focuses on the constant use case. There are cases (ahem, Open Telemetry logging) where there is a very large number of canonical field names, and typing them out by hand is cumbersome and error-prone. Putting the values into constants enables intellisense autocomplete with associated hovering documentation, etc.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Introduce a new sigil (I arbitrarily chose `^`, but it could be something else) to use to indicate when you would like to use the a constant value for the field name, instead of having a literal field name.

```rust
// before
tracing::info!(cloud.account.id = 123, "created the cloud account id");

// after
tracing::info!(^CLOUD_ACCOUNT_ID = 123, "created the cloud account id");
```

For example, let's say we would like the field name to be `cloud.account.id`. Today this has to be done literally. This is cumbersome and error-prone, as there's no way to provide intellisense-like features for arbitrary dotted names.

```rust
tracing::info!(cloud.account.id = 123, "created the cloud account id");
// CORRECT output: `cloud.account.id=123`
```

A naive attempt to use a constant results in the constant's _name_ being used as the field name:

```rust
const CLOUD_ACCOUNT_ID: &'static str = "cloud.account.id";
tracing::info!(CLOUD_ACCOUNT_ID = 123, "created the cloud account id");
// INCORRECT output: `CLOUD_ACCOUNT_ID=123`
```

This PR introduces the concept of using the `^` sigil to indicate that the identifier is a constant. Rust Analyzer provides intellisense support for completing the constant name despite being inside a macro and despite the sigil.

```rust
const CLOUD_ACCOUNT_ID: &'static str = "cloud.account.id";
tracing::info!(^CLOUD_ACCOUNT_ID = 123, "created the cloud account id");
// CORRECT output: `cloud.account.id=123`
```

## Design Discussion

I'm not at all certain I've taken the best approach. We should consider at least the following points:

- Is using a sigil the best way to achieve this?
- Is `^` the best sigil to use?
- Instead of assuming a `&'static str`, should we be employing something more flexible? For example, can we involve a trait here?
- Is there a way to make this usable by more than constants?
- I based this off of `v0.1.x` -- should I be basing this off of `master` as well or instead? Has something fundamentally changed in `master` that would require a different approach?
- I have only touched events, because that is where I am using this. Should spans also be updated accordingly?
- The macros don't support paths (ie `::`), so to use this requires bringing the constants into local scope. Should the macros be refactored to support paths (`$k:path`) instead of just identifiers (`$k:ident`)?