### PR TITLE
tracing: prepare to release v0.1.36

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,33 @@
+# 0.1.36 (July 29, 2022)
+
+This release adds support for owned values and fat pointers as arguments to the
+`Span::record` method, as well as updating the minimum `tracing-core` version
+and several documentation improvements.
+
+### Fixed
+
+- Incorrect docs in `dispatcher::set_default` ([#2220])
+- Compilation with `-Z minimal-versions` ([#2246])
+
+### Added
+
+- Support for owned values and fat pointers in `Span::record` ([#2212])
+- Documentation improvements ([#2208], [#2163])
+
+### Changed
+
+- `tracing-core`: updated to [0.1.29][core-0.1.29]
+
+Thanks to @fredr, @cgbur, @jyn514, @matklad, and @CAD97 for contributing to this
+release!
+
+[core-0.1.29]: https://github.com/tokio-rs/tracing/releases/tag/tracing-core-0.1.29
+[#2220]: https://github.com/tokio-rs/tracing/pull/2220
+[#2246]: https://github.com/tokio-rs/tracing/pull/2246
+[#2212]: https://github.com/tokio-rs/tracing/pull/2212
+[#2208]: https://github.com/tokio-rs/tracing/pull/2208
+[#2163]: https://github.com/tokio-rs/tracing/pull/2163
+
 # 0.1.35 (June 8, 2022)
 
 This release reduces the overhead of callsite registration by using new

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.35"
+version = "0.1.36"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
@@ -28,7 +28,7 @@ edition = "2018"
 rust-version = "1.49.0"
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.28", default-features = false }
+tracing-core = { path = "../tracing-core", version = "0.1.29", default-features = false }
 log = { version = "0.4.17", optional = true }
 tracing-attributes = { path = "../tracing-attributes", version = "0.1.22", optional = true }
 cfg-if = "1.0.0"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -250,7 +250,7 @@ my_future
 is as long as the future's.
 
 The second, and preferred, option is through the
-[`#[instrument]`](https://docs.rs/tracing/0.1.35/tracing/attr.instrument.html)
+[`#[instrument]`](https://docs.rs/tracing/0.1.36/tracing/attr.instrument.html)
 attribute:
 
 ```rust
@@ -297,7 +297,7 @@ span.in_scope(|| {
 // Dropping the span will close it, indicating that it has ended.
 ```
 
-The [`#[instrument]`](https://docs.rs/tracing/0.1.35/tracing/attr.instrument.html) attribute macro
+The [`#[instrument]`](https://docs.rs/tracing/0.1.36/tracing/attr.instrument.html) attribute macro
 can reduce some of this boilerplate:
 
 ```rust

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -811,7 +811,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing = { version = "0.1.35", default-features = false }
+//!   tracing = { version = "0.1.36", default-features = false }
 //!   ```
 //!
 //! <pre class="ignore" style="white-space:normal;font:inherit;">
@@ -894,7 +894,7 @@
 //! [flags]: #crate-feature-flags
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.35")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.36")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.1.36 (July 29, 2022)

This release adds support for owned values and fat pointers as arguments
to the `Span::record` method, as well as updating the minimum
`tracing-core` version and several documentation improvements.

### Fixed

- Incorrect docs in `dispatcher::set_default` ([#2220])
- Compilation with `-Z minimal-versions` ([#2246])

### Added

- Support for owned values and fat pointers in `Span::record` ([#2212])
- Documentation improvements ([#2208], [#2163])

### Changed

- `tracing-core`: updated to [0.1.29][core-0.1.29]

Thanks to @fredr, @cgbur, @jyn514, @matklad, and @CAD97 for contributing
to this release!

[core-0.1.29]: https://github.com/tokio-rs/tracing/releases/tag/tracing-core-0.1.29
[#2220]: https://github.com/tokio-rs/tracing/pull/2220
[#2246]: https://github.com/tokio-rs/tracing/pull/2246
[#2212]: https://github.com/tokio-rs/tracing/pull/2212
[#2208]: https://github.com/tokio-rs/tracing/pull/2208
[#2163]: https://github.com/tokio-rs/tracing/pull/2163