### PR TITLE
add must_use for CollectorBuilder::finish

### DIFF
--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -476,6 +476,7 @@ where
         subscribe::Subscribe<Registry> + Send + Sync + 'static,
 {
     /// Finish the builder, returning a new `FmtCollector`.
+    #[must_use = "You may want to use `try_init` or similar to actually install the collector."]
     pub fn finish(self) -> Collector<N, E, F, W> {
         let collector = self.inner.with_collector(Registry::default());
         Collector {

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -476,7 +476,7 @@ where
         subscribe::Subscribe<Registry> + Send + Sync + 'static,
 {
     /// Finish the builder, returning a new `FmtCollector`.
-    #[must_use = "You may want to use `try_init` or similar to actually install the collector."]
+    #[must_use = "you may want to use `try_init` or similar to actually install the collector."]
     pub fn finish(self) -> Collector<N, E, F, W> {
         let collector = self.inner.with_collector(Registry::default());
         Collector {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Follow up to #2239
Discovered that 

```rust
    tracing_subscriber::fmt().with_ansi(false).finish();
    tracing::info!("hello");
```
doesn't actually do anything, because `finish` returns a `Collector` and `init` is the thing that actually installs the collector.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Added `#[must_use]` which suggests using `try_init` instead.
