### PR TITLE
Update tracing-subscriber version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To use `tracing-subscriber`, add the following to your `Cargo.toml`:
 ```toml
 [dependencies]
 tracing = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3"
 ```
 
 Then create and install a collector, for example using [`init()`]:


### PR DESCRIPTION
`tracing-subscriber` has been on `0.3` for almost a year now.

I naively copied the versions from the README, and when trying to use the library with the current versions of e.g. `tracing-opentelemetry`, I ran into the same error message as seen in this issue: https://github.com/tokio-rs/tracing/issues/852