### PR TITLE
Add tracing-chrome to list of related crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ are not maintained by the `tokio` project. These include:
   grouping together logs from the same spans during writing.
 - [`tracing-loki`] provides a layer for shipping logs to [Grafana Loki].
 - [`tracing-logfmt`] provides a layer that formats events and spans into the logfmt format.
+- [`tracing-chrome`] provides a layer that exports trace data that can be viewed in `chrome://tracing`.
 
 (if you're the maintainer of a `tracing` ecosystem crate not in this list,
 please let us know!)
@@ -443,6 +444,7 @@ please let us know!)
 [`tracing-loki`]: https://crates.io/crates/tracing-loki
 [Grafana Loki]: https://grafana.com/oss/loki/
 [`tracing-logfmt`]: https://crates.io/crates/tracing-logfmt
+[`tracing-chrome`]: https://crates.io/crates/tracing-chrome
 
 **Note:** that some of the ecosystem crates are currently unreleased and
 undergoing active development. They may be less stable than `tracing` and


### PR DESCRIPTION
This PR is my response to

> if you're the maintainer of a tracing ecosystem crate not in this list, please let us know!

I have such a crate, `tracing-chrome`, which writes traces in the format used by `chrome://tracing`, which makes for a handy trace viewer that I usually already have installed.