### PR TITLE
chore: fix `clippy::borrow_deref_ref` lints

### DIFF
--- a/examples/examples/futures-proxy-server.rs
+++ b/examples/examples/futures-proxy-server.rs
@@ -86,7 +86,7 @@ pub struct Args {
     server_addr: SocketAddr,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug)]
 pub enum LogFormat {
     Plain,
     Json,

--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -411,7 +411,7 @@ impl RecordType {
                 RecordType::Value
             }
             syn::Type::Reference(syn::TypeReference { elem, .. }) => {
-                RecordType::parse_from_ty(&*elem)
+                RecordType::parse_from_ty(elem)
             }
             _ => RecordType::Debug,
         }

--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -804,7 +804,7 @@ impl Dispatch {
     /// `T`.
     #[inline]
     pub fn is<T: Any>(&self) -> bool {
-        <dyn Collect>::is::<T>(&*self.collector())
+        <dyn Collect>::is::<T>(self.collector())
     }
 
     /// Returns some reference to the [`Collect`] this `Dispatch` forwards to
@@ -813,7 +813,7 @@ impl Dispatch {
     /// [`Collect`]: super::collect::Collect
     #[inline]
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
-        <dyn Collect>::downcast_ref(&*self.collector())
+        <dyn Collect>::downcast_ref(self.collector())
     }
 }
 

--- a/tracing-error/src/error.rs
+++ b/tracing-error/src/error.rs
@@ -209,7 +209,7 @@ impl ErrorImpl<Erased> {
         // uphold this is UB. since the `From` impl is parameterized over the original error type,
         // the function pointer we construct here will also retain the original type. therefore,
         // when this is consumed by the `error` method, it will be safe to call.
-        unsafe { &*(self.vtable.object_ref)(self) }
+        unsafe { (self.vtable.object_ref)(self) }
     }
 }
 


### PR DESCRIPTION
This fixes some new Clippy lints introduced in the latest Rust version.