### PR TITLE
Fixed macro valueset to support debug and display named parameters

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -2196,14 +2196,14 @@ macro_rules! valueset {
     // };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&debug(&$val) as &Value)) },
+            @ { $($out),*, (&$next, Some(&$crate::field::debug(&$val) as &Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&display(&$val) as &Value)) },
+            @ { $($out),*, (&$next, Some(&$crate::field::display(&$val) as &Value)) },
             $next,
             $($rest)*
         )
@@ -2224,27 +2224,27 @@ macro_rules! valueset {
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, ?$($k:ident).+, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&debug(&$($k).+) as &Value)) },
+            @ { $($out),*, (&$next, Some(&$crate::field::debug(&$($k).+) as &Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, %$($k:ident).+, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&display(&$($k).+) as &Value)) },
+            @ { $($out),*, (&$next, Some(&$crate::field::display(&$($k).+) as &Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = ?$val:expr) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&debug(&$val) as &Value)) },
+            @ { $($out),*, (&$next, Some(&$crate::field::debug(&$val) as &Value)) },
             $next,
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = %$val:expr) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&display(&$val) as &Value)) },
+            @ { $($out),*, (&$next, Some(&$crate::field::display(&$val) as &Value)) },
             $next,
         )
     };
@@ -2262,13 +2262,13 @@ macro_rules! valueset {
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, ?$($k:ident).+) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&debug(&$($k).+) as &Value)) },
+            @ { $($out),*, (&$next, Some(&$crate::field::debug(&$($k).+) as &Value)) },
             $next,
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, %$($k:ident).+) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&display(&$($k).+) as &Value)) },
+            @ { $($out),*, (&$next, Some(&$crate::field::display(&$($k).+) as &Value)) },
             $next,
         )
     };
@@ -2276,14 +2276,14 @@ macro_rules! valueset {
     // Handle literal names
     (@ { $(,)* $($out:expr),* }, $next:expr, $k:literal = ?$val:expr, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&debug(&$val) as &Value)) },
+            @ { $($out),*, (&$next, Some(&$crate::field::debug(&$val) as &Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $k:literal = %$val:expr, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&display(&$val) as &Value)) },
+            @ { $($out),*, (&$next, Some(&$crate::field::display(&$val) as &Value)) },
             $next,
             $($rest)*
         )
@@ -2297,13 +2297,13 @@ macro_rules! valueset {
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $k:literal = ?$val:expr) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&debug(&$val) as &Value)) },
+            @ { $($out),*, (&$next, Some(&$crate::field::debug(&$val) as &Value)) },
             $next,
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $k:literal = %$val:expr) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&display(&$val) as &Value)) },
+            @ { $($out),*, (&$next, Some(&$crate::field::display(&$val) as &Value)) },
             $next,
         )
     };
@@ -2323,7 +2323,7 @@ macro_rules! valueset {
     ($fields:expr, $($kvs:tt)+) => {
         {
             #[allow(unused_imports)]
-            use $crate::field::{debug, display, Value};
+            use $crate::field::Value;
             let mut iter = $fields.iter();
             $fields.value_set($crate::valueset!(
                 @ { },

--- a/tracing/tests/macros.rs
+++ b/tracing/tests/macros.rs
@@ -12,6 +12,15 @@ use tracing::{
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
+fn span_with_reserved_name() {
+    let debug = 1;
+    let display = 1;
+    span!(target: "foo_events", Level::DEBUG, "foo", debug);
+    span!(target: "foo_events", Level::DEBUG, "foo", display);
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
 fn span() {
     span!(target: "foo_events", Level::DEBUG, "foo", bar.baz = ?2, quux = %3, quuux = 4);
     span!(target: "foo_events", Level::DEBUG, "foo", bar.baz = 2, quux = 3);


### PR DESCRIPTION
Signed-off-by: Eloi DEMOLIS <eloi.demolis@clever-cloud.com>

## Motivation

Following issue #2278 I implemented and tested the fix mentionned.

## Solution

I changed the `valueset` macro used (among others) by the `span` macro which is used internally by (notably) the `instrument` proc macro. The important change being at this [line](https://github.com/Wonshtrum/tracing/blob/master/tracing/src/macros.rs#L2326):
```rust
use $crate::field::Value;
```
which doesn't overrides `debug` and `display` anymore.

I'm new to this crate so I don't know the full implications of this, but for me it mainly fixed this use case:
```rust
#[tracing::instrument]
fn test(debug: bool, display: bool) {
    todo!();
}
```