### PR TITLE
Add tracing-web to the list of related crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ please let us know!)
 [`color-eyre`]: https://docs.rs/color-eyre
 [`spandoc`]: https://docs.rs/spandoc
 [`tracing-wasm`]: https://docs.rs/tracing-wasm
-[`tracing-web`]: https://docs.rs/tracing-web
+[`tracing-web`]: https://crates.io/crates/tracing-web
 [`test-log`]: https://crates.io/crates/test-log
 [User Timing API (`window.performance`)]: https://developer.mozilla.org/en-US/docs/Web/API/User_Timing_API
 [`tracing-unwrap`]: https://docs.rs/tracing-unwrap

--- a/README.md
+++ b/README.md
@@ -392,6 +392,8 @@ are not maintained by the `tokio` project. These include:
   _inside_ of functions.
 - [`tracing-wasm`] provides a `Collector`/`Subscriber` implementation that reports
   events and spans via browser `console.log` and [User Timing API (`window.performance`)].
+- [`tracing-web`] provides a layer implementation of level-aware logging of events to web browsers' `console.*` and span events to
+  the [User Timing API (`window.performance`)].
 - [`test-log`] takes care of initializing `tracing` for tests, based on
   environment variables with an `env_logger` compatible syntax.
 - [`tracing-unwrap`] provides convenience methods to report failed unwraps on `Result` or `Option` types to a `Collector`.
@@ -427,6 +429,7 @@ please let us know!)
 [`color-eyre`]: https://docs.rs/color-eyre
 [`spandoc`]: https://docs.rs/spandoc
 [`tracing-wasm`]: https://docs.rs/tracing-wasm
+[`tracing-web`]: https://docs.rs/tracing-web
 [`test-log`]: https://crates.io/crates/test-log
 [User Timing API (`window.performance`)]: https://developer.mozilla.org/en-US/docs/Web/API/User_Timing_API
 [`tracing-unwrap`]: https://docs.rs/tracing-unwrap

--- a/README.md
+++ b/README.md
@@ -392,8 +392,8 @@ are not maintained by the `tokio` project. These include:
   _inside_ of functions.
 - [`tracing-wasm`] provides a `Collector`/`Subscriber` implementation that reports
   events and spans via browser `console.log` and [User Timing API (`window.performance`)].
-- [`tracing-web`] provides a layer implementation of level-aware logging of events to web browsers' `console.*` and span events to
-  the [User Timing API (`window.performance`)].
+- [`tracing-web`] provides a layer implementation of level-aware logging of events
+  to web browsers' `console.*` and span events to the [User Timing API (`window.performance`)].
 - [`test-log`] takes care of initializing `tracing` for tests, based on
   environment variables with an `env_logger` compatible syntax.
 - [`tracing-unwrap`] provides convenience methods to report failed unwraps on `Result` or `Option` types to a `Collector`.

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -788,6 +788,8 @@
 //!    in [bunyan] format, enriched with timing information.
 //!  - [`tracing-wasm`] provides a `Collect`/`Subscribe` implementation that reports
 //!    events and spans via browser `console.log` and [User Timing API (`window.performance`)].
+//!  - [`tracing-web`] provides a layer implementation of level-aware logging of events
+//!    to web browsers' `console.*` and span events to the [User Timing API (`window.performance`)].
 //!  - [`tide-tracing`] provides a [tide] middleware to trace all incoming requests and responses.
 //!  - [`test-log`] takes care of initializing `tracing` for tests, based on
 //!    environment variables with an `env_logger` compatible syntax.

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -824,6 +824,7 @@
 //! [`tracing-bunyan-formatter`]: https://crates.io/crates/tracing-bunyan-formatter
 //! [bunyan]: https://github.com/trentm/node-bunyan
 //! [`tracing-wasm`]: https://docs.rs/tracing-wasm
+//! [`tracing-web`]: https://docs.rs/tracing-web
 //! [User Timing API (`window.performance`)]: https://developer.mozilla.org/en-US/docs/Web/API/User_Timing_API
 //! [`tide-tracing`]: https://crates.io/crates/tide-tracing
 //! [tide]: https://crates.io/crates/tide


### PR DESCRIPTION
Fixes #2280 

## Motivation

I've implemented an alternative to [`tracing-wasm`](https://github.com/storyai/tracing-wasm) to fix some issues that I had when using it (most are open as longer time bug reports, no need to recount them here). It should be more up to date with the current tracing framework and, being layer based, is easier to compose with other subscribers, e.g. supports formatting and timing on event logs out of the box.

## Solution

Add the [`tracing-web`](https://crates.io/crates/tracing-web/) crate to the list of related crates.
