### PR TITLE
chore: port PRs pointed at v0.1.x to master

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -68,6 +68,7 @@ pub struct Subscriber<C, N = format::DefaultFields, E = format::Format, W = fn()
     fmt_event: E,
     fmt_span: format::FmtSpanConfig,
     is_ansi: bool,
+    log_internal_errors: bool,
     _inner: PhantomData<fn(C)>,
 }
 
@@ -117,6 +118,7 @@ where
             fmt_span: self.fmt_span,
             make_writer: self.make_writer,
             is_ansi: self.is_ansi,
+            log_internal_errors: self.log_internal_errors,
             _inner: self._inner,
         }
     }
@@ -146,6 +148,7 @@ where
             fmt_span: self.fmt_span,
             make_writer: self.make_writer,
             is_ansi: self.is_ansi,
+            log_internal_errors: self.log_internal_errors,
             _inner: self._inner,
         }
     }
@@ -181,6 +184,7 @@ impl<C, N, E, W> Subscriber<C, N, E, W> {
             fmt_event: self.fmt_event,
             fmt_span: self.fmt_span,
             is_ansi: self.is_ansi,
+            log_internal_errors: self.log_internal_errors,
             make_writer,
             _inner: self._inner,
         }
@@ -264,6 +268,7 @@ impl<C, N, E, W> Subscriber<C, N, E, W> {
             fmt_event: self.fmt_event,
             fmt_span: self.fmt_span,
             is_ansi: self.is_ansi,
+            log_internal_errors: self.log_internal_errors,
             make_writer: TestWriter::default(),
             _inner: self._inner,
         }
@@ -275,6 +280,24 @@ impl<C, N, E, W> Subscriber<C, N, E, W> {
     pub fn with_ansi(self, ansi: bool) -> Self {
         Subscriber {
             is_ansi: ansi,
+            ..self
+        }
+    }
+
+    /// Sets whether to write errors from [`FormatEvent`] to the writer.
+    /// Defaults to true.
+    ///
+    /// By default, `fmt::Subscriber` will write any `FormatEvent`-internal errors to
+    /// the writer. These errors are unlikely and will only occur if there is a
+    /// bug in the `FormatEvent` implementation or its dependencies.
+    ///
+    /// If writing to the writer fails, the error message is printed to stderr
+    /// as a fallback.
+    ///
+    /// [`FormatEvent`]: crate::fmt::FormatEvent
+    pub fn log_internal_errors(self, log_internal_errors: bool) -> Self {
+        Self {
+            log_internal_errors,
             ..self
         }
     }
@@ -307,6 +330,7 @@ impl<C, N, E, W> Subscriber<C, N, E, W> {
             fmt_event: self.fmt_event,
             fmt_span: self.fmt_span,
             is_ansi: self.is_ansi,
+            log_internal_errors: self.log_internal_errors,
             make_writer: f(self.make_writer),
             _inner: self._inner,
         }
@@ -338,6 +362,7 @@ where
             fmt_span: self.fmt_span,
             make_writer: self.make_writer,
             is_ansi: self.is_ansi,
+            log_internal_errors: self.log_internal_errors,
             _inner: self._inner,
         }
     }
@@ -350,6 +375,7 @@ where
             fmt_span: self.fmt_span.without_time(),
             make_writer: self.make_writer,
             is_ansi: self.is_ansi,
+            log_internal_errors: self.log_internal_errors,
             _inner: self._inner,
         }
     }
@@ -481,6 +507,7 @@ where
             fmt_span: self.fmt_span,
             make_writer: self.make_writer,
             is_ansi: self.is_ansi,
+            log_internal_errors: self.log_internal_errors,
             _inner: self._inner,
         }
     }
@@ -495,6 +522,7 @@ where
             fmt_span: self.fmt_span,
             make_writer: self.make_writer,
             is_ansi: self.is_ansi,
+            log_internal_errors: self.log_internal_errors,
             _inner: self._inner,
         }
     }
@@ -524,6 +552,7 @@ where
             make_writer: self.make_writer,
             // always disable ANSI escapes in JSON mode!
             is_ansi: false,
+            log_internal_errors: self.log_internal_errors,
             _inner: self._inner,
         }
     }
@@ -590,6 +619,7 @@ impl<C, N, E, W> Subscriber<C, N, E, W> {
             fmt_span: self.fmt_span,
             make_writer: self.make_writer,
             is_ansi: self.is_ansi,
+            log_internal_errors: self.log_internal_errors,
             _inner: self._inner,
         }
     }
@@ -620,6 +650,7 @@ impl<C, N, E, W> Subscriber<C, N, E, W> {
             fmt_span: self.fmt_span,
             make_writer: self.make_writer,
             is_ansi: self.is_ansi,
+            log_internal_errors: self.log_internal_errors,
             _inner: self._inner,
         }
     }
@@ -633,6 +664,7 @@ impl<C> Default for Subscriber<C> {
             fmt_span: format::FmtSpanConfig::default(),
             make_writer: io::stdout,
             is_ansi: cfg!(feature = "ansi"),
+            log_internal_errors: false,
             _inner: PhantomData,
         }
     }
@@ -752,6 +784,11 @@ where
             {
                 fields.was_ansi = self.is_ansi;
                 extensions.insert(fields);
+            } else {
+                eprintln!(
+                    "[tracing-subscriber] Unable to format the following event, ignoring: {:?}",
+                    attrs
+                );
             }
         }
 
@@ -898,7 +935,20 @@ where
                 .is_ok()
             {
                 let mut writer = self.make_writer.make_writer_for(event.metadata());
-                let _ = io::Write::write_all(&mut writer, buf.as_bytes());
+                let res = io::Write::write_all(&mut writer, buf.as_bytes());
+                if self.log_internal_errors {
+                    if let Err(e) = res {
+                        eprintln!("[tracing-subscriber] Unable to write an event to the Writer for this Subscriber! Error: {}\n", e);
+                    }
+                }
+            } else if self.log_internal_errors {
+                let err_msg = format!("Unable to format the following event. Name: {}; Fields: {:?}\n",
+                    event.metadata().name(), event.fields());
+                let mut writer = self.make_writer.make_writer_for(event.metadata());
+                let res = io::Write::write_all(&mut writer, err_msg.as_bytes());
+                if let Err(e) = res {
+                    eprintln!("[tracing-subscriber] Unable to write an \"event formatting error\" to the Writer for this Subscriber! Error: {}\n", e);
+                }
             }
 
             buf.clear();
@@ -1195,6 +1245,69 @@ mod test {
     fn sanitize_timings(s: String) -> String {
         let re = Regex::new("time\\.(idle|busy)=([0-9.]+)[mµn]s").unwrap();
         re.replace_all(s.as_str(), "timing").to_string()
+    }
+
+    #[test]
+    fn format_error_print_to_stderr() {
+        struct AlwaysError;
+
+        impl std::fmt::Debug for AlwaysError {
+            fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                Err(std::fmt::Error)
+            }
+        }
+
+        let make_writer = MockMakeWriter::default();
+        let subscriber = crate::fmt::Collector::builder()
+            .with_writer(make_writer.clone())
+            .with_level(false)
+            .with_ansi(false)
+            .with_timer(MockTime)
+            .finish();
+
+        with_default(subscriber, || {
+            tracing::info!(?AlwaysError);
+        });
+        let actual = sanitize_timings(make_writer.get_string());
+
+        // Only assert the start because the line number and callsite may change.
+        let expected = concat!(
+            "Unable to format the following event. Name: event ",
+            file!(),
+            ":"
+        );
+        assert!(
+            actual.as_str().starts_with(expected),
+            "\nactual = {}\nshould start with expected = {}\n",
+            actual,
+            expected
+        );
+    }
+
+    #[test]
+    fn format_error_ignore_if_log_internal_errors_is_false() {
+        struct AlwaysError;
+
+        impl std::fmt::Debug for AlwaysError {
+            fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                Err(std::fmt::Error)
+            }
+        }
+
+        let make_writer = MockMakeWriter::default();
+        let subscriber = crate::fmt::Collector::builder()
+            .with_writer(make_writer.clone())
+            .with_level(false)
+            .with_ansi(false)
+            .with_timer(MockTime)
+            .log_internal_errors(false)
+            .finish();
+
+        with_default(subscriber, || {
+            tracing::info!(?AlwaysError);
+        });
+        let actual = sanitize_timings(make_writer.get_string());
+        assert_eq!("", actual.as_str());
     }
 
     #[test]

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -892,8 +892,9 @@ impl<N, E, F, W> CollectorBuilder<N, E, F, W> {
     /// Sets the maximum [verbosity level] that will be enabled by the
     /// collector.
     ///
-    /// If the max level has already been set, this replaces that configuration
-    /// with the new maximum level.
+    /// If the max level has already been set, or a [`EnvFilter`] was added by
+    /// [`with_env_filter`], this replaces that configuration with the new
+    /// maximum level.
     ///
     /// # Examples
     ///
@@ -915,7 +916,8 @@ impl<N, E, F, W> CollectorBuilder<N, E, F, W> {
     ///     .finish();
     /// ```
     /// [verbosity level]: tracing_core::Level
-    /// [`EnvFilter`]: super::filter::EnvFilter
+    /// [`EnvFilter`]: struct@crate::filter::EnvFilter
+    /// [`with_env_filter`]: fn@Self::with_env_filter
     pub fn with_max_level(
         self,
         filter: impl Into<LevelFilter>,
@@ -972,8 +974,26 @@ impl<N, E, F, W> CollectorBuilder<N, E, F, W> {
         }
     }
 
-    /// Sets the function that the collector being built should use to format
-    /// events that occur.
+    /// Sets the [event formatter][`FormatEvent`] that the subscriber being built
+    /// will use to format events that occur.
+    ///
+    /// The event formatter may be any type implementing the [`FormatEvent`]
+    /// trait, which is implemented for all functions taking a [`FmtContext`], a
+    /// [`Writer`], and an [`Event`].
+    ///
+    /// # Examples
+    ///
+    /// Setting a type implementing [`FormatEvent`] as the formatter:
+    ///
+    /// ```rust
+    /// use tracing_subscriber::fmt::format;
+    ///
+    /// let subscriber = tracing_subscriber::fmt()
+    ///     .event_format(format().compact())
+    ///     .finish();
+    /// ```
+    ///
+    /// [`Writer`]: struct@self::format::Writer
     pub fn event_format<E2>(self, fmt_event: E2) -> CollectorBuilder<N, E2, F, W>
     where
         E2: FormatEvent<Registry, N> + 'static,
@@ -1000,7 +1020,6 @@ impl<N, E, F, W> CollectorBuilder<N, E, F, W> {
     ///     .with_writer(io::stderr)
     ///     .init();
     /// ```
-    ///
     pub fn with_writer<W2>(self, make_writer: W2) -> CollectorBuilder<N, E, F, W2>
     where
         W2: for<'writer> MakeWriter<'writer> + 'static,
@@ -1039,6 +1058,82 @@ impl<N, E, F, W> CollectorBuilder<N, E, F, W> {
         CollectorBuilder {
             filter: self.filter,
             inner: self.inner.with_writer(TestWriter::default()),
+        }
+    }
+
+    /// Updates the event formatter by applying a function to the existing event formatter.
+    ///
+    /// This sets the event formatter that the collector being built will use to record fields.
+    ///
+    /// # Examples
+    ///
+    /// Updating an event formatter:
+    ///
+    /// ```rust
+    /// let subscriber = tracing_subscriber::fmt()
+    ///     .map_event_format(|e| e.compact())
+    ///     .finish();
+    /// ```
+    pub fn map_event_format<E2>(self, f: impl FnOnce(E) -> E2) -> CollectorBuilder<N, E2, F, W>
+    where
+        E2: FormatEvent<Registry, N> + 'static,
+        N: for<'writer> FormatFields<'writer> + 'static,
+        W: for<'writer> MakeWriter<'writer> + 'static,
+    {
+        CollectorBuilder {
+            filter: self.filter,
+            inner: self.inner.map_event_format(f),
+        }
+    }
+
+    /// Updates the field formatter by applying a function to the existing field formatter.
+    ///
+    /// This sets the field formatter that the subscriber being built will use to record fields.
+    ///
+    /// # Examples
+    ///
+    /// Updating a field formatter:
+    ///
+    /// ```rust
+    /// use tracing_subscriber::field::MakeExt;
+    /// let subscriber = tracing_subscriber::fmt()
+    ///     .map_fmt_fields(|f| f.debug_alt())
+    ///     .finish();
+    /// ```
+    pub fn map_fmt_fields<N2>(self, f: impl FnOnce(N) -> N2) -> CollectorBuilder<N2, E, F, W>
+    where
+        N2: for<'writer> FormatFields<'writer> + 'static,
+    {
+        CollectorBuilder {
+            filter: self.filter,
+            inner: self.inner.map_fmt_fields(f),
+        }
+    }
+
+    /// Updates the [`MakeWriter`] by applying a function to the existing [`MakeWriter`].
+    ///
+    /// This sets the [`MakeWriter`] that the subscriber being built will use to write events.
+    ///
+    /// # Examples
+    ///
+    /// Redirect output to stderr if level is <= WARN:
+    ///
+    /// ```rust
+    /// use tracing::Level;
+    /// use tracing_subscriber::fmt::{self, writer::MakeWriterExt};
+    ///
+    /// let stderr = std::io::stderr.with_max_level(Level::WARN);
+    /// let collector = tracing_subscriber::fmt()
+    ///     .map_writer(move |w| stderr.or_else(w))
+    ///     .finish();
+    /// ```
+    pub fn map_writer<W2>(self, f: impl FnOnce(W) -> W2) -> CollectorBuilder<N, E, F, W2>
+    where
+        W2: for<'writer> MakeWriter<'writer> + 'static,
+    {
+        CollectorBuilder {
+            filter: self.filter,
+            inner: self.inner.map_writer(f),
         }
     }
 }

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -463,6 +463,7 @@ impl Default for CollectorBuilder {
             filter: Collector::DEFAULT_MAX_LEVEL,
             inner: Default::default(),
         }
+        .log_internal_errors(true)
     }
 }
 
@@ -615,6 +616,27 @@ where
     pub fn with_ansi(self, ansi: bool) -> CollectorBuilder<N, format::Format<L, T>, F, W> {
         CollectorBuilder {
             inner: self.inner.with_ansi(ansi),
+            ..self
+        }
+    }
+
+    /// Sets whether to write errors from [`FormatEvent`] to the writer.
+    /// Defaults to true.
+    ///
+    /// By default, `fmt::Collector` will write any `FormatEvent`-internal errors to
+    /// the writer. These errors are unlikely and will only occur if there is a
+    /// bug in the `FormatEvent` implementation or its dependencies.
+    ///
+    /// If writing to the writer fails, the error message is printed to stderr
+    /// as a fallback.
+    ///
+    /// [`FormatEvent`]: crate::fmt::FormatEvent
+    pub fn log_internal_errors(
+        self,
+        log_internal_errors: bool,
+    ) -> CollectorBuilder<N, format::Format<L, T>, F, W> {
+        CollectorBuilder {
+            inner: self.inner.log_internal_errors(log_internal_errors),
             ..self
         }
     }


### PR DESCRIPTION
I noticed that #1871 and #2102 targeted the `v0.1.x` branch and they were never ported to master. This branch fixes that.

(On an aside, I discovered the `-Xfind-renames` flag on `git cherry-pick`, which makes handling the layer -> subscriber rename much easier.)