### PR TITLE
Update to latest unstable opentelemetry

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -52,14 +52,14 @@ inferno = "0.11.6"
 tempfile = "3"
 
 # opentelemetry example
-opentelemetry = { version = "0.17.0", default-features = false, features = ["trace"] }
-opentelemetry-jaeger = "0.16.0"
+opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust", default-features = false, features = ["trace"] }
+opentelemetry-jaeger = { git = "https://github.com/open-telemetry/opentelemetry-rust.git" }
 
 # fmt examples
 snafu = "0.6.10"
 thiserror = "1.0.31"
 
-# valuable examples 
+# valuable examples
 valuable = { version = "0.1.0", features = ["derive"] }
 
 [target.'cfg(tracing_unstable)'.dependencies]

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -25,7 +25,7 @@ default = ["tracing-log", "metrics"]
 metrics = ["opentelemetry/metrics"]
 
 [dependencies]
-opentelemetry = { version = "0.17.0", default-features = false, features = ["trace"] }
+opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", default-features = false, features = ["trace"] }
 tracing = { path = "../tracing", version = "0.1.35", default-features = false, features = ["std"] }
 tracing-core = { path = "../tracing-core", version = "0.1.28" }
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3.0", default-features = false, features = ["registry", "std"] }
@@ -39,7 +39,7 @@ thiserror = { version = "1.0.31", optional = true }
 [dev-dependencies]
 async-trait = "0.1.56"
 criterion = { version = "0.3.6", default-features = false }
-opentelemetry-jaeger = "0.16.0"
+opentelemetry-jaeger = { git = "https://github.com/open-telemetry/opentelemetry-rust.git" }
 futures-util = { version = "0.3", default-features = false }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -24,7 +24,7 @@
 //! in your span name.
 //! * `otel.kind`: Set the span kind to one of the supported OpenTelemetry [span kinds].
 //! * `otel.status_code`: Set the span status code to one of the supported OpenTelemetry [span status codes].
-//! * `otel.status_message`: Set the span status message.
+//! * `otel.error_description`: Set the span error description when the status code is "error".
 //!
 //! [span kinds]: opentelemetry::trace::SpanKind
 //! [span status codes]: opentelemetry::trace::StatusCode

--- a/tracing-opentelemetry/src/tracer.rs
+++ b/tracing-opentelemetry/src/tracer.rs
@@ -1,4 +1,5 @@
-use opentelemetry::sdk::trace::{SamplingDecision, SamplingResult, Tracer, TracerProvider};
+use opentelemetry::sdk::trace::{Tracer, TracerProvider};
+use opentelemetry::trace::{OrderMap, SamplingDecision, SamplingResult};
 use opentelemetry::{
     trace as otel,
     trace::{
@@ -86,7 +87,7 @@ impl PreSampledTracer for Tracer {
                 trace_id,
                 &builder.name,
                 builder.span_kind.as_ref().unwrap_or(&SpanKind::Internal),
-                builder.attributes.as_deref().unwrap_or(&[]),
+                builder.attributes.as_ref().unwrap_or(&OrderMap::new()),
                 builder.links.as_deref().unwrap_or(&[]),
                 self.instrumentation_library(),
             ));
@@ -203,7 +204,7 @@ mod tests {
             // Existing sampling result defers
             ("previous_drop_result_always_on", Sampler::AlwaysOn, OtelContext::new(), Some(SamplingResult { decision: SamplingDecision::Drop, attributes: vec![], trace_state: Default::default() }), false),
             ("previous_record_and_sample_result_always_off", Sampler::AlwaysOff, OtelContext::new(), Some(SamplingResult { decision: SamplingDecision::RecordAndSample, attributes: vec![], trace_state: Default::default() }), true),
- 
+
             // Existing local parent, defers
             ("previous_drop_result_always_on", Sampler::AlwaysOn, OtelContext::new(), Some(SamplingResult { decision: SamplingDecision::Drop, attributes: vec![], trace_state: Default::default() }), false),
             ("previous_record_and_sample_result_always_off", Sampler::AlwaysOff, OtelContext::new(), Some(SamplingResult { decision: SamplingDecision::RecordAndSample, attributes: vec![], trace_state: Default::default() }), true),

--- a/tracing-opentelemetry/tests/trace_state_propagation.rs
+++ b/tracing-opentelemetry/tests/trace_state_propagation.rs
@@ -1,4 +1,4 @@
-use async_trait::async_trait;
+use futures_util::future::BoxFuture;
 use opentelemetry::{
     propagation::TextMapPropagator,
     sdk::{
@@ -158,15 +158,14 @@ fn build_sampled_context() -> (Context, impl Subscriber, TestExporter, TracerPro
 #[derive(Clone, Default, Debug)]
 struct TestExporter(Arc<Mutex<Vec<SpanData>>>);
 
-#[async_trait]
 impl SpanExporter for TestExporter {
-    async fn export(
+    fn export(
         &mut self,
         mut batch: Vec<SpanData>,
-    ) -> opentelemetry::sdk::export::trace::ExportResult {
+    ) -> BoxFuture<'static, opentelemetry::sdk::export::trace::ExportResult> {
         if let Ok(mut inner) = self.0.lock() {
             inner.append(&mut batch);
         }
-        Ok(())
+        Box::pin(async { Ok(()) })
     }
 }


### PR DESCRIPTION
This PR updates the version of `tracing-opentelemetry` on the v0.1.x branch to work with the unreleased changes on the main branch of opentelemetry-rust. Not even close to mergeable; at the very least we need a new release of `opentelemetry`. I also took quite a few shortcuts in getting this to compile. But this ended up being enough work that I figured I'd throw up, in case it's helpful to anyone else in the meantime.

Maintainers: feel free to close if you'd rather not have this around clogging up the pipes.