### PR TITLE
tracing-core: relax `get_default`'s argument to `FnOnce`

### DIFF
--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -384,9 +384,9 @@ impl SetGlobalDefaultError {
 /// [dispatcher]: super::dispatch::Dispatch
 #[cfg(feature = "std")]
 #[inline(always)]
-pub fn get_default<T, F>(mut f: F) -> T
+pub fn get_default<T, F>(f: F) -> T
 where
-    F: FnMut(&Dispatch) -> T,
+    F: FnOnce(&Dispatch) -> T,
 {
     if SCOPED_COUNT.load(Ordering::Acquire) == 0 {
         // fast path if no scoped dispatcher has been set; just use the global
@@ -399,10 +399,12 @@ where
 
 #[cfg(feature = "std")]
 #[inline(never)]
-fn get_default_slow<T, F>(mut f: F) -> T
+fn get_default_slow<T, F>(f: F) -> T
 where
-    F: FnMut(&Dispatch) -> T,
+    F: FnOnce(&Dispatch) -> T,
 {
+    use core::{mem, ptr};
+
     // While this guard is active, additional calls to collector functions on
     // the default dispatcher will not be able to access the dispatch context.
     // Dropping the guard will allow the dispatch context to be re-entered.
@@ -413,6 +415,58 @@ where
             self.0.set(true);
         }
     }
+
+    /// Allows (unsafely) invoking an `FnOnce` in contexts where the compiler
+    /// cannot prove that the function will only be invoked once.
+    struct UnsafeFnMut<F, R>
+    where
+        F: FnOnce(&Dispatch) -> R,
+    {
+        /// The `FnOnce` that `UnsafeFnMut::call` invokes.
+        /// It's wrapped in `ManuallyDrop` to mitigate the risk of double-frees.
+        fn_once: mem::ManuallyDrop<F>,
+
+        /// In debug builds, `called` keeps track of whether `UnsafeFnMut::call` has
+        /// already been invoked, and panics if so.
+        #[cfg(debug_assertions)]
+        called: core::sync::atomic::AtomicBool,
+    }
+
+    impl<F, R> UnsafeFnMut<F, R>
+    where
+        F: FnOnce(&Dispatch) -> R,
+    {
+        fn new(f: F) -> Self {
+            Self {
+                fn_once: mem::ManuallyDrop::new(f),
+                #[cfg(debug_assertions)]
+                called: core::sync::atomic::AtomicBool::new(false),
+            }
+        }
+
+        /// Invoke `self.fn_once`.
+        ///
+        /// **SAFETY:** This function must only be called once!
+        /// Otherwise,`self.fn_once` will be dropped more than once,
+        /// potentially double-freeing its captures.
+        unsafe fn call(&self, arg: &Dispatch) -> R {
+            #[cfg(debug_assertions)]
+            debug_assert!(
+                !self.called.swap(true, core::sync::atomic::Ordering::SeqCst),
+                "`UnsafeFnMut::call` has been invoked more than once!"
+            );
+
+            let fn_once = &self.fn_once as *const mem::ManuallyDrop<F>;
+            let fn_mut = |arg| {
+                let fn_mut = mem::ManuallyDrop::into_inner(ptr::read(fn_once));
+                fn_mut(arg) // `self.fn_once` is dropped here
+            };
+
+            fn_mut(arg)
+        }
+    }
+
+    let f = UnsafeFnMut::new(f);
 
     CURRENT_STATE
         .try_with(|state| {
@@ -426,12 +480,12 @@ where
                     // keep getting the global on every `get_default_slow` call.
                     .get_or_insert_with(|| get_global().clone());
 
-                return f(&*default);
+                unsafe { f.call(&*default) }
+            } else {
+                unsafe { f.call(&Dispatch::none()) }
             }
-
-            f(&Dispatch::none())
         })
-        .unwrap_or_else(|_| f(&Dispatch::none()))
+        .unwrap_or_else(|_| unsafe { f.call(&Dispatch::none()) })
 }
 
 /// Executes a closure with a reference to this thread's current [dispatcher].
@@ -466,9 +520,9 @@ pub fn get_current<T>(f: impl FnOnce(&Dispatch) -> T) -> Option<T> {
 ///
 /// [dispatcher]: super::dispatcher::Dispatch
 #[cfg(not(feature = "std"))]
-pub fn get_default<T, F>(mut f: F) -> T
+pub fn get_default<T, F>(f: F) -> T
 where
-    F: FnMut(&Dispatch) -> T,
+    F: FnOnce(&Dispatch) -> T,
 {
     f(get_global())
 }


### PR DESCRIPTION
## Motivation
This change increases the flexibility of `get_default`, by relaxing the bound on its argument from `FnMut` to `FnOnce`.

## Solution
It was already the case that `get_default`'s argument was only invoked at-most once. However, the compiler could not prove this, and thus required that the argument be `FnMut`. This commit introduces `UnsafeFnMut`, a type that wraps an `FnOnce` and provides an unsafe interface for invoking it in cases where the compiler cannot otherwise prove that it's only invoked at-most once.
