### PR TITLE
tracing-core: Add `Dispatch::downgrade()` and `WeakDispatch`

### DIFF
--- a/tracing-core/src/collect.rs
+++ b/tracing-core/src/collect.rs
@@ -79,6 +79,16 @@ use core::ptr::NonNull;
 /// [`event_enabled`]: Collect::event_enabled
 pub trait Collect: 'static {
     /// Invoked when this collector becomes a [`Dispatch`].
+    ///
+    /// ## Avoiding Memory Leaks
+    ///
+    /// Collectors should not store their own [`Dispatch`]. Doing so will prevent
+    /// them from being dropped. Instead, you may call [`Dispatch::downgrade`]
+    /// to construct a [`WeakDispatch`] (analogous to [`std::sync::Weak`]) that is
+    /// safe to stash, and can be [upgraded][`WeakDispatch::upgrade`] into a `Dispatch`.
+    ///
+    /// [`WeakDispatch`]: crate::dispatch::WeakDispatch
+    /// [`WeakDispatch::upgrade`]: crate::dispatch::WeakDispatch::upgrade
     fn on_register_dispatch(&self, collector: &Dispatch) {
         let _ = collector;
     }

--- a/tracing-core/src/collect.rs
+++ b/tracing-core/src/collect.rs
@@ -82,13 +82,21 @@ pub trait Collect: 'static {
     ///
     /// ## Avoiding Memory Leaks
     ///
-    /// Collectors should not store their own [`Dispatch`]. Doing so will prevent
-    /// them from being dropped. Instead, you may call [`Dispatch::downgrade`]
-    /// to construct a [`WeakDispatch`] (analogous to [`std::sync::Weak`]) that is
-    /// safe to stash, and can be [upgraded][`WeakDispatch::upgrade`] into a `Dispatch`.
+    /// Collectors should not store their own [`Dispatch`]. Because the
+    /// `Dispatch` owns the collector, storing the `Dispatch` within the
+    /// collector will create a reference count cycle, preventing the `Dispatch`
+    /// from ever being dropped.
+    ///
+    /// Instead, when it is necessary to store a cyclical reference to the
+    /// `Dispatch` within a collector, use [`Dispatch::downgrade`] to convert a
+    /// `Dispatch` into a [`WeakDispatch`]. This type is analogous to
+    /// [`std::sync::Weak`], and does not create a reference count cycle. A
+    /// [`WeakDispatch`] can be stored within a collector without causing a
+    /// memory leak, and can be [upgraded] into a `Dispatch` temporarily when
+    /// the `Dispatch` must be accessed by the collector.
     ///
     /// [`WeakDispatch`]: crate::dispatch::WeakDispatch
-    /// [`WeakDispatch::upgrade`]: crate::dispatch::WeakDispatch::upgrade
+    /// [upgraded]: crate::dispatch::WeakDispatch::upgrade
     fn on_register_dispatch(&self, collector: &Dispatch) {
         let _ = collector;
     }

--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -153,10 +153,7 @@ use std::{
 };
 
 #[cfg(feature = "alloc")]
-use alloc::sync::{
-    Arc,
-    Weak,
-};
+use alloc::sync::{Arc, Weak};
 
 #[cfg(feature = "alloc")]
 use core::ops::Deref;

--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -150,11 +150,13 @@ use core::{
 use std::{
     cell::{Cell, RefCell, RefMut},
     error,
-    sync::Weak,
 };
 
 #[cfg(feature = "alloc")]
-use alloc::sync::Arc;
+use alloc::sync::{
+    Arc,
+    Weak,
+};
 
 #[cfg(feature = "alloc")]
 use core::ops::Deref;

--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -885,7 +885,25 @@ where
 }
 
 impl WeakDispatch {
-    /// Attempts to upgrade the `WeakDispatch` to a `Dispatch`.
+    /// Attempts to upgrade the `WeakDispatch` to a [`Dispatch`].
+    ///
+    /// Returns `None` if the inner `Dispatch` has already been dropped.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// # use tracing_core::collect::NoCollector;
+    /// # use tracing_core::dispatch::Dispatch;
+    /// static COLLECTOR: NoCollector = NoCollector::new();
+    /// let strong = Dispatch::new(COLLECTOR);
+    /// let weak = strong.downgrade();
+    ///
+    /// // The strong here keeps it alive, so we can still access the object.
+    /// assert!(weak.upgrade().is_some());
+    ///
+    /// drop(strong); // But not any more.
+    /// assert!(weak.upgrade().is_none());
+    /// ```
     pub fn upgrade(&self) -> Option<Dispatch> {
         #[cfg(feature = "alloc")]
         let collector = match &self.collector {

--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -589,7 +589,6 @@ impl Dispatch {
     }
 
     /// Creates a [`WeakDispatch`] from this `Dispatch`.
-    #[cfg(feature = "alloc")]
     pub fn downgrade(&self) -> WeakDispatch {
         #[cfg(feature = "alloc")]
         let collector = match &self.collector {
@@ -885,9 +884,9 @@ where
 }
 
 impl WeakDispatch {
-    /// Attempts to upgrade the `WeakDispatch` to a [`Dispatch`].
+    /// Attempts to upgrade this `WeakDispatch` to a [`Dispatch`].
     ///
-    /// Returns `None` if the inner `Dispatch` has already been dropped.
+    /// Returns `None` if the referenced `Dispatch` has already been dropped.
     ///
     /// ## Examples
     ///
@@ -922,19 +921,19 @@ impl fmt::Debug for WeakDispatch {
         match &self.collector {
             #[cfg(feature = "alloc")]
             Kind::Global(collector) => f
-                .debug_tuple("Dispatch::Global")
+                .debug_tuple("WeakDispatch::Global")
                 .field(&format_args!("{:p}", collector))
                 .finish(),
 
             #[cfg(feature = "alloc")]
             Kind::Scoped(collector) => f
-                .debug_tuple("Dispatch::Scoped")
+                .debug_tuple("WeakDispatch::Scoped")
                 .field(&format_args!("{:p}", collector))
                 .finish(),
 
             #[cfg(not(feature = "alloc"))]
             collector => f
-                .debug_tuple("Dispatch::Global")
+                .debug_tuple("WeakDispatch::Global")
                 .field(&format_args!("{:p}", collector))
                 .finish(),
         }

--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -626,7 +626,7 @@ impl Dispatch {
             Kind::Scoped(dispatch) => Kind::Scoped(Arc::downgrade(dispatch)),
         };
         #[cfg(not(feature = "alloc"))]
-        let collector = &self.collector;
+        let collector = self.collector;
 
         WeakDispatch { collector }
     }

--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -721,13 +721,21 @@ where
     ///
     /// ## Avoiding Memory Leaks
     ///
-    /// Subscribers should not store their own [`Dispatch`]. Doing so will prevent
-    /// them from being dropped. Instead, you may call [`Dispatch::downgrade`]
-    /// to construct a [`WeakDispatch`] (analogous to [`std::sync::Weak`]) that is
-    /// safe to stash, and can be [upgraded][`WeakDispatch::upgrade`] into a `Dispatch`.
+    /// Subscribers should not store the [`Dispatch`] pointing to the collector
+    /// that they are a part of. Because the `Dispatch` owns the collector,
+    /// storing the `Dispatch` within the collector will create a reference
+    /// count cycle, preventing the `Dispatch` from ever being dropped.
     ///
-    /// [`WeakDispatch`]: tracing::dispatch::WeakDispatch
-    /// [`WeakDispatch::upgrade`]: tracing::dispatch::WeakDispatch::upgrade
+    /// Instead, when it is necessary to store a cyclical reference to the
+    /// `Dispatch` within a subscriber, use [`Dispatch::downgrade`] to convert a
+    /// `Dispatch` into a [`WeakDispatch`]. This type is analogous to
+    /// [`std::sync::Weak`], and does not create a reference count cycle. A
+    /// [`WeakDispatch`] can be stored within a subscriber without causing a
+    /// memory leak, and can be [upgraded] into a `Dispatch` temporarily when
+    /// the `Dispatch` must be accessed by the subscriber.
+    ///
+    /// [`WeakDispatch`]: crate::dispatch::WeakDispatch
+    /// [upgraded]: crate::dispatch::WeakDispatch::upgrade
     ///
     /// [collector]: tracing_core::Collect
     fn on_register_dispatch(&self, collector: &Dispatch) {

--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -734,9 +734,8 @@ where
     /// memory leak, and can be [upgraded] into a `Dispatch` temporarily when
     /// the `Dispatch` must be accessed by the subscriber.
     ///
-    /// [`WeakDispatch`]: crate::dispatch::WeakDispatch
-    /// [upgraded]: crate::dispatch::WeakDispatch::upgrade
-    ///
+    /// [`WeakDispatch`]: tracing_core::dispatch::WeakDispatch
+    /// [upgraded]: tracing_core::dispatch::WeakDispatch::upgrade
     /// [collector]: tracing_core::Collect
     fn on_register_dispatch(&self, collector: &Dispatch) {
         let _ = collector;

--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -719,6 +719,16 @@ where
     /// Performs late initialization when installing this subscriber as a
     /// [collector].
     ///
+    /// ## Avoiding Memory Leaks
+    ///
+    /// Subscribers should not store their own [`Dispatch`]. Doing so will prevent
+    /// them from being dropped. Instead, you may call [`Dispatch::downgrade`]
+    /// to construct a [`WeakDispatch`] (analogous to [`std::sync::Weak`]) that is
+    /// safe to stash, and can be [upgraded][`WeakDispatch::upgrade`] into a `Dispatch`.
+    ///
+    /// [`WeakDispatch`]: tracing::dispatch::WeakDispatch
+    /// [`WeakDispatch::upgrade`]: tracing::dispatch::WeakDispatch::upgrade
+    ///
     /// [collector]: tracing_core::Collect
     fn on_register_dispatch(&self, collector: &Dispatch) {
         let _ = collector;

--- a/tracing/src/dispatch.rs
+++ b/tracing/src/dispatch.rs
@@ -148,7 +148,7 @@ pub use tracing_core::dispatch::with_default;
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use tracing_core::dispatch::DefaultGuard;
 pub use tracing_core::dispatch::{
-    get_default, set_global_default, Dispatch, SetGlobalDefaultError,
+    get_default, set_global_default, Dispatch, SetGlobalDefaultError, WeakDispatch,
 };
 
 /// Private API for internal use by tracing's macros.


### PR DESCRIPTION
Allows collectors and subscribers to stash their own `Dispatch` without causing a memory leak.

## Motivation
Resolves a shortcoming of https://github.com/tokio-rs/tracing/pull/2269: that it's impossible for collectors or subscribers to stash a copy of their own `Dispatch` without creating a reference cycle that would prevent them from being dropped. 

## Solution
Introduces `WeakDispatch` (analogous to `std::sync::Weak`) that holds a weak pointer to a collector. `WeakDispatch` can be created via `Dispatch::downgrade`, and can be transformed into a `Dispatch` via `WeakDispatch::upgrade`. 
