### PR TITLE
opentelemetry: on_event respects event's explicit parent

### DIFF
--- a/tracing-opentelemetry/src/subscriber.rs
+++ b/tracing-opentelemetry/src/subscriber.rs
@@ -620,8 +620,8 @@ where
     /// [`ERROR`]: tracing::Level::ERROR
     /// [`Error`]: opentelemetry::trace::StatusCode::Error
     fn on_event(&self, event: &Event<'_>, ctx: Context<'_, C>) {
-        // Ignore events that are not in the context of a span
-        if let Some(span) = ctx.lookup_current() {
+        // Ignore events that have no explicit parent set *and* are not in the context of a span
+        if let Some(span) = ctx.event_span(event) {
             // Performing read operations before getting a write lock to avoid a deadlock
             // See https://github.com/tokio-rs/tracing/issues/763
             #[cfg(feature = "tracing-log")]


### PR DESCRIPTION
One can want to have an event added from outside context of a span,
especially in an async code (e.g. between polls of the future, or
between polling multiple futures instrumented with that span). Then it
is expected that the event will be attached indeed to the span specified
as the parent and not the contextual one.
Fixes: #2295 

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation
see #2295 

## Solution
see #2295 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
