### PR TITLE
opentelemetry: prepare for v0.18.0 release

### DIFF
--- a/tracing-opentelemetry/CHANGELOG.md
+++ b/tracing-opentelemetry/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 0.18.0 (September 18, 2022)
+
+### Breaking Changes
+
+- Upgrade to `v0.18.0` of `opentelemetry` ([#2303])
+  For list of breaking changes in OpenTelemetry, see the
+  [v0.18.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/CHANGELOG.md#v0180).
+
+### Fixed
+
+- `on_event` respects event's explicit parent ([#2296])
+
+Thanks to @wprzytula for contributing to this release!
+
 # 0.17.4 (July 1, 2022)
 
 This release adds optional support for recording `std::error::Error`s using

--- a/tracing-opentelemetry/CHANGELOG.md
+++ b/tracing-opentelemetry/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 Thanks to @wprzytula for contributing to this release!
 
+[#2303]: https://github.com/tokio-rs/tracing/pull/2303
+[#2296]: https://github.com/tokio-rs/tracing/pull/2296
+
 # 0.17.4 (July 1, 2022)
 
 This release adds optional support for recording `std::error::Error`s using

--- a/tracing-opentelemetry/Cargo.toml
+++ b/tracing-opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-opentelemetry"
-version = "0.17.4"
+version = "0.18.0"
 authors = [
     "Julian Tescher <julian@tescher.me>",
     "Tokio Contributors <team@tokio.rs>"

--- a/tracing-opentelemetry/README.md
+++ b/tracing-opentelemetry/README.md
@@ -17,9 +17,9 @@ Utilities for adding [OpenTelemetry] interoperability to [`tracing`].
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-opentelemetry.svg
-[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.17.4
+[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.18.0
 [docs-badge]: https://docs.rs/tracing-opentelemetry/badge.svg
-[docs-url]: https://docs.rs/tracing-opentelemetry/0.17.4/tracing_opentelemetry
+[docs-url]: https://docs.rs/tracing-opentelemetry/0.18.0/tracing_opentelemetry
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_opentelemetry
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -100,7 +100,7 @@
 //! [subscriber]: tracing_subscriber::subscribe
 #![deny(unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.17.4")]
+#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.18.0")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
Changelog:

### Breaking Changes

- Upgrade to `v0.18.0` of `opentelemetry` ([#2303])
  For list of breaking changes in OpenTelemetry, see the
  [v0.18.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/CHANGELOG.md#v0180).

### Fixed

- `on_event` respects event's explicit parent ([#2296])
