### PR TITLE
fix Layered's max_level_hint impl

### DIFF
--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -480,9 +480,9 @@ where
     #[must_use = "you may want to use `try_init` or similar to actually install the collector."]
     pub fn finish(self) -> Collector<N, E, F, W> {
         let collector = self.inner.with_collector(Registry::default());
-        Collector {
-            inner: self.filter.with_collector(collector),
-        }
+        let mut inner = self.filter.with_collector(collector);
+        inner.inner_is_registry = true;
+        Collector { inner }
     }
 
     /// Install this collector as the global default if one is

--- a/tracing-subscriber/tests/option.rs
+++ b/tracing-subscriber/tests/option.rs
@@ -1,7 +1,22 @@
 #![cfg(feature = "registry")]
-use tracing::level_filters::LevelFilter;
-use tracing::Collect;
-use tracing_subscriber::prelude::*;
+use tracing_core::{collect::Interest, Collect, LevelFilter, Metadata};
+use tracing_subscriber::{prelude::*, subscribe};
+
+// A basic layer that returns its inner for `max_level_hint`
+struct BasicLayer(Option<LevelFilter>);
+impl<C: Collect> tracing_subscriber::Subscribe<C> for BasicLayer {
+    fn register_callsite(&self, _m: &Metadata<'_>) -> Interest {
+        Interest::sometimes()
+    }
+
+    fn enabled(&self, _m: &Metadata<'_>, _: subscribe::Context<'_, C>) -> bool {
+        true
+    }
+
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        self.0
+    }
+}
 
 // This test is just used to compare to the tests below
 #[test]
@@ -38,4 +53,27 @@ fn just_option_some_subscriber() {
 fn just_option_none_subscriber() {
     let collector = tracing_subscriber::registry().with(Some(LevelFilter::ERROR));
     assert_eq!(collector.max_level_hint(), Some(LevelFilter::ERROR));
+}
+
+/// Test that the `Layered` impl fallthrough the `max_level_hint` and `None` doesn't disable
+/// everything, as well as ensuring the `Some` case also works.
+#[test]
+fn layered_fallthrough() {
+    // None means the other layer takes control
+    let subscriber = tracing_subscriber::registry()
+        .with(BasicLayer(None))
+        .with(None::<LevelFilter>);
+    assert_eq!(subscriber.max_level_hint(), None);
+
+    // The `None`-returning layer still wins
+    let subscriber = tracing_subscriber::registry()
+        .with(BasicLayer(None))
+        .with(Some(LevelFilter::ERROR));
+    assert_eq!(subscriber.max_level_hint(), None);
+
+    // Check that we aren't doing anything truly wrong
+    let subscriber = tracing_subscriber::registry()
+        .with(BasicLayer(Some(LevelFilter::DEBUG)))
+        .with(None::<LevelFilter>);
+    assert_eq!(subscriber.max_level_hint(), Some(LevelFilter::DEBUG));
 }


### PR DESCRIPTION
## Motivation

Fixes: https://github.com/tokio-rs/tracing/issues/2265

## Solution

When there are no per-layer filters, the `Layered` `pick_level_hint` function is wrong. It prioritizes `Some(_)` over `None`, even though `None` is basically `Some(TRACE)`. This was not notices because most people are doing one of:
1. global filtering which works differently (as far as I can tell)
3. per-layer filtering, whose code-path seems to work (it also short-circuits `None`)
4. 3. the fmt subscriber, which happened to work with this change

In this branch we also have to fix the fmt `Collector`, which implements `Collect` and erroneously passes through to a layer that unconditionally returns `None`. This is the correct option for the layer itself, but overrides the behavior we want for the subscriber, which is to follow the `F` field directly. We set `inner_is_registry` directly to combat this problem