### PR TITLE
attributes: update trybuild, fix warnings

### DIFF
--- a/tracing-attributes/tests/async_fn.rs
+++ b/tracing-attributes/tests/async_fn.rs
@@ -14,6 +14,7 @@ async fn test_async_fn(polls: usize) -> Result<(), ()> {
 
 // Reproduces a compile error when returning an `impl Trait` from an
 // instrumented async fn (see https://github.com/tokio-rs/tracing/issues/1615)
+#[allow(dead_code)] // this is just here to test whether it compiles.
 #[instrument]
 async fn test_ret_impl_trait(n: i32) -> Result<impl Iterator<Item = i32>, ()> {
     let n = n;
@@ -22,6 +23,7 @@ async fn test_ret_impl_trait(n: i32) -> Result<impl Iterator<Item = i32>, ()> {
 
 // Reproduces a compile error when returning an `impl Trait` from an
 // instrumented async fn (see https://github.com/tokio-rs/tracing/issues/1615)
+#[allow(dead_code)] // this is just here to test whether it compiles.
 #[instrument(err)]
 async fn test_ret_impl_trait_err(n: i32) -> Result<impl Iterator<Item = i32>, &'static str> {
     Ok((0..10).filter(move |x| *x < n))
@@ -53,6 +55,7 @@ async fn repro_1613_2() {
 }
 
 // Reproduces https://github.com/tokio-rs/tracing/issues/1831
+#[allow(dead_code)] // this is just here to test whether it compiles.
 #[instrument]
 #[deny(unused_braces)]
 fn repro_1831() -> Pin<Box<dyn Future<Output = ()>>> {
@@ -61,6 +64,7 @@ fn repro_1831() -> Pin<Box<dyn Future<Output = ()>>> {
 
 // This replicates the pattern used to implement async trait methods on nightly using the
 // `type_alias_impl_trait` feature
+#[allow(dead_code)] // this is just here to test whether it compiles.
 #[instrument(ret, err)]
 #[deny(unused_braces)]
 #[allow(clippy::manual_async_fn)]

--- a/tracing-attributes/tests/ui/async_instrument.stderr
+++ b/tracing-attributes/tests/ui/async_instrument.stderr
@@ -34,6 +34,15 @@ error[E0277]: `(&str,)` doesn't implement `std::fmt::Display`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: this error originates in the attribute macro `tracing::instrument` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error[E0277]: `(&str,)` doesn't implement `std::fmt::Display`
+  --> tests/ui/async_instrument.rs:15:34
+   |
+15 | async fn opaque_unsatisfied() -> impl std::fmt::Display {
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^ `(&str,)` cannot be formatted with the default formatter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `(&str,)`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+
 error[E0308]: mismatched types
   --> tests/ui/async_instrument.rs:23:5
    |


### PR DESCRIPTION
* **attributes: suppress dead code warnings for compile tests**

  The `async_fn` test file in `tracing-attributes` contains several
  functions that exist just to test whether they _compile_, rather than
  make assertions about their behavior. Because these functions are never
  called, they (naturally) emit dead code warnings.
  
  This commit adds `#[allow(dead_code)]` to the compilation tests, plus a
comment explaining why we do this.

* **attributes: update trybuild output for Rust 1.64.0**

  The error messages for these tests appear to have changed a bit with
  Rust 1.64. This branch runs the tests with `TRYBUILD=overwrite` to
  update for the latest Rust.