### PR TITLE
max_log_files_feature

### DIFF
--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -22,7 +22,7 @@ rust-version = "1.53.0"
 
 [dependencies]
 crossbeam-channel = "0.5.5"
-time = { version = "0.3.2", default-features = false, features = ["formatting"] }
+time = { version = "0.3.2", default-features = false, features = ["formatting", "parsing"] }
 parking_lot = { optional = true, version = "0.12.1" }
 thiserror = "1.0.31"
 

--- a/tracing-appender/src/rolling/builder.rs
+++ b/tracing-appender/src/rolling/builder.rs
@@ -10,6 +10,7 @@ pub struct Builder {
     pub(super) rotation: Rotation,
     pub(super) prefix: Option<String>,
     pub(super) suffix: Option<String>,
+    pub(super) max_files: Option<usize>,
 }
 
 /// Errors returned by [`Builder::build`].
@@ -38,16 +39,21 @@ impl Builder {
     /// | Parameter | Default Value | Notes |
     /// | :-------- | :------------ | :---- |
     /// | [`rotation`] | [`Rotation::NEVER`] | By default, log files will never be rotated. |
-    /// | [`filename_prefix`] | `""` | By default, log file names will not have a prefix. |
+    /// | [`prefix`] | `""` | By default, log file names will not have a prefix. |
+    /// | [`suffix`] | `""` | By default, log file names will not have a suffix. |
+    /// | [`max_files`] | `None` | By default, there is no limit for maximum log file count. |
     ///
     /// [`rotation`]: Self::rotation
     /// [`filename_prefix`]: Self::filename_prefix
+    /// [`filename_suffix`]: Self::filename_suffix
+    /// [`max_log_files`]: Self::max_log_files
     #[must_use]
     pub const fn new() -> Self {
         Self {
             rotation: Rotation::NEVER,
             prefix: None,
             suffix: None,
+            max_files: None,
         }
     }
 
@@ -179,6 +185,52 @@ impl Builder {
             Some(suffix)
         };
         Self { suffix, ..self }
+    }
+
+    /// Keeps the last `n` log files on disk.
+    ///
+    /// When a new log file is created, if there are `n` or more
+    /// existing log files in the directory, the oldest will be deleted.
+    /// If no value is supplied, the `RollingAppender` will not remove any files.
+    ///
+    /// Files are considered candidates for deletion based on the following
+    /// criteria:
+    ///
+    /// * The file must not be a directory or symbolic link.
+    /// * If the appender is configured with a [`filename_prefix`], the file
+    ///   name must start with that prefix.
+    /// * If the appender is configured with a [`filename_suffix`], the file
+    ///   name must end with that suffix.
+    /// * If the appender has neither a filename prefix nor a suffix, then the
+    ///   file name must parse as a valid date based on the appender's date
+    ///   format.
+    ///
+    /// Files matching these criteria may be deleted if the maximum number of
+    /// log files in the directory has been reached.
+    ///
+    /// [`filename_prefix`]: Self::filename_prefix
+    /// [`filename_suffix`]: Self::filename_suffix
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tracing_appender::rolling::RollingFileAppender;
+    ///
+    /// # fn docs() {
+    /// let appender = RollingFileAppender::builder()
+    ///     .max_log_files(5) // only the most recent 5 log files will be kept
+    ///     // ...
+    ///     .build("/var/log")
+    ///     .expect("failed to initialize rolling file appender");
+    /// # drop(appender)
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn max_log_files(self, n: usize) -> Self {
+        Self {
+            max_files: Some(n),
+            ..self
+        }
     }
 
     /// Builds a new [`RollingFileAppender`] with the configured parameters,

--- a/tracing-appender/src/rolling/builder.rs
+++ b/tracing-appender/src/rolling/builder.rs
@@ -39,9 +39,9 @@ impl Builder {
     /// | Parameter | Default Value | Notes |
     /// | :-------- | :------------ | :---- |
     /// | [`rotation`] | [`Rotation::NEVER`] | By default, log files will never be rotated. |
-    /// | [`prefix`] | `""` | By default, log file names will not have a prefix. |
-    /// | [`suffix`] | `""` | By default, log file names will not have a suffix. |
-    /// | [`max_files`] | `None` | By default, there is no limit for maximum log file count. |
+    /// | [`filename_prefix`] | `""` | By default, log file names will not have a prefix. |
+    /// | [`filename_suffix`] | `""` | By default, log file names will not have a suffix. |
+    /// | [`max_log_files`] | `None` | By default, there is no limit for maximum log file count. |
     ///
     /// [`rotation`]: Self::rotation
     /// [`filename_prefix`]: Self::filename_prefix


### PR DESCRIPTION
## Motivation

`tracing-appender` does not have `Rotation` based on size yet.
Also, it doesn't have the feature of **keeping the most recent `N` log files**

I believe the second feature is more easy to implement, and also will partially solve the `Rotation` based on size problem. Because people may choose `hourly` or `daily` rotation based on their needs, and put an extra boundary of `keep the last 5 files` for example. Of course it won't handle all the edge cases for `Rotation` based on size. But it will cover most of the scenarios. And also, it is a good feature to have on its own :)

## Solution

Introduce another field called `keep_last: Option<usize>` to the `Inner` of `RollingFileAppender` struct.
I managed to did not touch any of the existing functions, so it **WON'T BE A BREAKING CHANGE**. Yay :)

The solution is, whenever the rotation should happen, the `refresh_writer()` is called. So I embed the following logic into that function:

1- check the log folder and detect the log files
2- if there are more log files than the `last_keep` amount
3- store the filenames in a vector, and sort them by their dates (dates are already present in the filename)
4- keep deleting the oldest ones, till we have desired amount of log files in the log folder

P.S. this PR was opened before, but got closed since it would be easier for the maintainers to target `master` branch instead of `v0.1.x`
Also, @CBenoit contributed to this PR, it would be great to give credit to him :)
