### PR TITLE
doc(opentelemetry): use histogram for metrics

### DIFF
--- a/tracing-opentelemetry/src/metrics.rs
+++ b/tracing-opentelemetry/src/metrics.rs
@@ -263,7 +263,7 @@ impl<'a> Visit for MetricVisitor<'a> {
 /// - `monotonic_counter.` (non-negative numbers): Used when the counter should
 ///   only ever increase
 /// - `counter.`: Used when the counter can go up or down
-/// - `value.`: Used for discrete data points (i.e., summing them does not make
+/// - `histogram.`: Used for discrete data points (i.e., summing them does not make
 ///   semantic sense)
 ///
 /// Examples:
@@ -276,9 +276,9 @@ impl<'a> Visit for MetricVisitor<'a> {
 /// info!(counter.baz = -1);
 /// info!(counter.xyz = 1.1);
 ///
-/// info!(value.qux = 1);
-/// info!(value.abc = -1);
-/// info!(value.def = 1.1);
+/// info!(histogram.qux = 1);
+/// info!(histogram.abc = -1);
+/// info!(histogram.def = 1.1);
 /// ```
 ///
 /// # Mixing data types

--- a/tracing-opentelemetry/tests/metrics_publishing.rs
+++ b/tracing-opentelemetry/tests/metrics_publishing.rs
@@ -129,7 +129,7 @@ async fn u64_histogram_is_exported() {
     );
 
     tracing::collect::with_default(subscriber, || {
-        tracing::info!(value.abcdefg = 9_u64);
+        tracing::info!(histogram.abcdefg = 9_u64);
     });
 
     exporter.export().unwrap();
@@ -145,7 +145,7 @@ async fn i64_histogram_is_exported() {
     );
 
     tracing::collect::with_default(subscriber, || {
-        tracing::info!(value.abcdefg_auenatsou = -19_i64);
+        tracing::info!(histogram.abcdefg_auenatsou = -19_i64);
     });
 
     exporter.export().unwrap();
@@ -161,7 +161,7 @@ async fn f64_histogram_is_exported() {
     );
 
     tracing::collect::with_default(subscriber, || {
-        tracing::info!(value.abcdefg_racecar = 777.0012_f64);
+        tracing::info!(histogram.abcdefg_racecar = 777.0012_f64);
     });
 
     exporter.export().unwrap();


### PR DESCRIPTION
## Motivation

This fixes a discrepancy in the `tracing-opentelemetry` docs for the new MetricsLayer. The docs refer to `value.` as a way to collect discrete data point, but this doesn't match any of the prefix constant mentioned in the same file.

```rust
const METRIC_PREFIX_MONOTONIC_COUNTER: &str = "monotonic_counter.";
const METRIC_PREFIX_COUNTER: &str = "counter.";
const METRIC_PREFIX_HISTOGRAM: &str = "histogram.";
```

## Solution

This fixes the documentation and test by referring to `histogram.` instead of `value.`.
