### PR TITLE
docs: Add reqwest-tracing to related crates in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ are not maintained by the `tokio` project. These include:
 - [`tracing-loki`] provides a layer for shipping logs to [Grafana Loki].
 - [`tracing-logfmt`] provides a layer that formats events and spans into the logfmt format.
 - [`tracing-chrome`] provides a layer that exports trace data that can be viewed in `chrome://tracing`.
+- [`reqwest-tracing`] provides a middleware to trace [`reqwest`] HTTP requests.
 
 (if you're the maintainer of a `tracing` ecosystem crate not in this list,
 please let us know!)
@@ -448,6 +449,8 @@ please let us know!)
 [Grafana Loki]: https://grafana.com/oss/loki/
 [`tracing-logfmt`]: https://crates.io/crates/tracing-logfmt
 [`tracing-chrome`]: https://crates.io/crates/tracing-chrome
+[`reqwest-tracing`]: https://crates.io/crates/reqwest-tracing
+[`reqwest`]: https://crates.io/crates/reqwest
 
 **Note:** that some of the ecosystem crates are currently unreleased and
 undergoing active development. They may be less stable than `tracing` and

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -807,6 +807,7 @@
 //!    grouping together logs from the same spans during writing.
 //!  - [`tracing-loki`] provides a layer for shipping logs to [Grafana Loki].
 //!  - [`tracing-logfmt`] provides a layer that formats events and spans into the logfmt format.
+//!  - [`reqwest-tracing`] provides a middleware to trace [`reqwest`] HTTP requests.
 //!
 //! If you're the maintainer of a `tracing` ecosystem crate not listed above,
 //! please let us know! We'd love to add your project to the list!
@@ -845,6 +846,8 @@
 //! [`tracing-loki`]: https://crates.io/crates/tracing-loki
 //! [Grafana Loki]: https://grafana.com/oss/loki/
 //! [`tracing-logfmt`]: https://crates.io/crates/tracing-logfmt
+//! [`reqwest-tracing`]: https://crates.io/crates/reqwest-tracing
+//! [`reqwest`]: https://crates.io/crates/reqwest
 //!
 //! <div class="example-wrap" style="display:inline-block">
 //! <pre class="ignore" style="white-space:normal;font:inherit;">


### PR DESCRIPTION
Add [`reqwest-tracing`](https://crates.io/crates/reqwest-tracing) to the list of related crates.