### PR TITLE
attributes: prepare to release v0.1.23

### DIFF
--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.1.23 (October 6, 2022)
 
 This release of `tracing-attributes` fixes a bug where compiler diagnostic spans
-for type errorsin `#[instrument]`ed `async fn`s have the location of the
+for type errors in `#[instrument]`ed `async fn`s have the location of the
 `#[instrument]` attribute rather than the location of the actual error, and a
 bug where inner attributes in `#[instrument]`ed functions would cause a compiler
 error.

--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 0.1.23 (October 6, 2022)
+
+This release of `tracing-attributes` fixes a bug where compiler diagnostic spans
+for type errorsin `#[instrument]`ed `async fn`s have the location of the
+`#[instrument]` attribute rather than the location of the actual error, and a
+bug where inner attributes in `#[instrument]`ed functions would cause a compiler
+error.
+### Fixed
+
+- Fix incorrect handling of inner attributes in `#[instrument]`ed functions ([#2307])
+- Add fake return to improve spans generated for type errors in `async fn`s ([#2270])
+- Updated `syn` dependency to fix compilation with `-Z minimal-versions`
+  ([#2246])
+
+Thanks to new contributors @compiler-errors and @e-nomem, as well as @CAD97, for
+contributing to this release!
+
+[#2307]: https://github.com/tokio-rs/tracing/pull/2307
+[#2270]: https://github.com/tokio-rs/tracing/pull/2270
+[#2246]: https://github.com/tokio-rs/tracing/pull/2246
+
 # 0.1.22 (July 1, 2022)
 
 This release fixes an issue where using the `err` or `ret` arguments to

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-attributes"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.22"
+version = "0.1.23"
 authors = [
     "Tokio Contributors <team@tokio.rs>",
     "Eliza Weisman <eliza@buoyant.io>",

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -18,7 +18,7 @@ Macro attributes for application-level tracing.
 [crates-badge]: https://img.shields.io/crates/v/tracing-attributes.svg
 [crates-url]: https://crates.io/crates/tracing-attributes
 [docs-badge]: https://docs.rs/tracing-attributes/badge.svg
-[docs-url]: https://docs.rs/tracing-attributes/0.1.22
+[docs-url]: https://docs.rs/tracing-attributes/0.1.23
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_attributes
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -47,7 +47,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing-attributes = "0.1.22"
+tracing-attributes = "0.1.23"
 ```
 
 

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tracing-attributes = "0.1.22"
+//! tracing-attributes = "0.1.23"
 //! ```
 //!
 //! The [`#[instrument]`][instrument] attribute can now be added to a function
@@ -52,7 +52,7 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
-#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.22")]
+#![doc(html_root_url = "https://docs.rs/tracing-attributes/0.1.23")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.1.23 (October 6, 2022)

This release of `tracing-attributes` fixes a bug where compiler diagnostic spans for type error sin `#[instrument]`ed `async fn`s have the location of the `#[instrument]` attribute rather than the location of the actual error, and a bug where inner attributes in `#[instrument]`ed functions would cause a compiler error. ### Fixed

- Fix incorrect handling of inner attributes in `#[instrument]`ed functions ([#2307])
- Add fake return to improve spans generated for type errors in `async fn`s ([#2270])
- Updated `syn` dependency to fix compilation with `-Z minimal-versions` ([#2246])

Thanks to new contributors @compiler-errors and @e-nomem, as well as @CAD97, for contributing to this release!

[#2307]: https://github.com/tokio-rs/tracing/pull/2307
[#2270]: https://github.com/tokio-rs/tracing/pull/2270
[#2246]: https://github.com/tokio-rs/tracing/pull/2246