### PR TITLE
tracing: prepare to release v0.1.37

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,55 @@
+'# 0.1.37 (October 6, 2022)
+
+This release of `tracing` incorporates changes from `tracing-core`
+[v0.1.30][core-0.1.30] and `tracing-attributes` [v0.1.23][0.1.23], including the
+new `Subscriber::on_register_dispatch` method for performing late initialization
+after a `Subscriber` is registered as a `Dispatch`, and bugfixes for the
+`#[instrument]` attribute. Additionally, it fixes instances of the
+`bare_trait_objects` lint, which is now a warning on `tracing`'s MSRV and will
+become an error in the next edition.
+
+### Fixed
+
+- **attributes**: Incorrect handling of inner attributes in `#[instrument]`ed
+  functions ([#2307])
+- **attributes**: Incorrect location of compiler diagnostic spans generated for
+  type errors in `#[instrument]`ed `async fn`s ([#2270])
+- **attributes**: Updated `syn` dependency to fix compilation with `-Z
+  minimal-versions` ([#2246])
+- `bare_trait_objects` warning in `valueset!` macro expansion ([#2308])
+
+### Added
+
+- **core**: `Subscriber::on_register_dispatch` method ([#2269])
+- **core**: `WeakDispatch` type and `Dispatch::downgrade()` function ([#2293])
+
+### Changed
+
+- `tracing-core`: updated to [0.1.30][core-0.1.30]
+- `tracing-attributes`: updated to [0.1.23][attrs-0.1.23]
+
+### Documented
+
+- Added [`tracing-web`] and [`reqwest-tracing`] to related crates ([#2283],
+  [#2331])
+
+Thanks to new contributors @compiler-errors, @e-nomem, @WorldSEnder, @Xiami2012,
+and @tl-rodrigo-gryzinski, as well as @jswrenn and @CAD97, for contributing to
+this release!
+
+[core-0.1.30]: https://github.com/tokio-rs/tracing/releases/tag/tracing-core-0.1.30
+[attrs-0.1.23]: https://github.com/tokio-rs/tracing/releases/tag/tracing-attributes-0.1.23
+[`tracing-web`]: https://crates.io/crates/tracing-web/
+[`reqwest-tracing`]: https://crates.io/crates/reqwest-tracing/
+[#2246]: https://github.com/tokio-rs/tracing/pull/2246
+[#2269]: https://github.com/tokio-rs/tracing/pull/2269
+[#2283]: https://github.com/tokio-rs/tracing/pull/2283
+[#2270]: https://github.com/tokio-rs/tracing/pull/2270
+[#2293]: https://github.com/tokio-rs/tracing/pull/2293
+[#2307]: https://github.com/tokio-rs/tracing/pull/2307
+[#2308]: https://github.com/tokio-rs/tracing/pull/2308
+[#2331]: https://github.com/tokio-rs/tracing/pull/2331
+'
 # 0.1.36 (July 29, 2022)
 
 This release adds support for owned values and fat pointers as arguments to the

--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,10 +1,10 @@
-'# 0.1.37 (October 6, 2022)
+# 0.1.37 (October 6, 2022)
 
 This release of `tracing` incorporates changes from `tracing-core`
-[v0.1.30][core-0.1.30] and `tracing-attributes` [v0.1.23][0.1.23], including the
-new `Subscriber::on_register_dispatch` method for performing late initialization
-after a `Subscriber` is registered as a `Dispatch`, and bugfixes for the
-`#[instrument]` attribute. Additionally, it fixes instances of the
+[v0.1.30][core-0.1.30] and `tracing-attributes` [v0.1.23][attrs-0.1.23],
+including the new `Subscriber::on_register_dispatch` method for performing late
+initialization after a `Subscriber` is registered as a `Dispatch`, and bugfixes
+for the `#[instrument]` attribute. Additionally, it fixes instances of the
 `bare_trait_objects` lint, which is now a warning on `tracing`'s MSRV and will
 become an error in the next edition.
 
@@ -49,7 +49,7 @@ this release!
 [#2307]: https://github.com/tokio-rs/tracing/pull/2307
 [#2308]: https://github.com/tokio-rs/tracing/pull/2308
 [#2331]: https://github.com/tokio-rs/tracing/pull/2331
-'
+
 # 0.1.36 (July 29, 2022)
 
 This release adds support for owned values and fat pointers as arguments to the

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -28,9 +28,9 @@ edition = "2018"
 rust-version = "1.49.0"
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.29", default-features = false }
+tracing-core = { path = "../tracing-core", version = "0.1.30", default-features = false }
 log = { version = "0.4.17", optional = true }
-tracing-attributes = { path = "../tracing-attributes", version = "0.1.22", optional = true }
+tracing-attributes = { path = "../tracing-attributes", version = "0.1.23", optional = true }
 cfg-if = "1.0.0"
 pin-project-lite = "0.2.9"
 

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.36"
+version = "0.1.37"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -250,7 +250,7 @@ my_future
 is as long as the future's.
 
 The second, and preferred, option is through the
-[`#[instrument]`](https://docs.rs/tracing/0.1.36/tracing/attr.instrument.html)
+[`#[instrument]`](https://docs.rs/tracing/0.1.37/tracing/attr.instrument.html)
 attribute:
 
 ```rust
@@ -297,7 +297,7 @@ span.in_scope(|| {
 // Dropping the span will close it, indicating that it has ended.
 ```
 
-The [`#[instrument]`](https://docs.rs/tracing/0.1.36/tracing/attr.instrument.html) attribute macro
+The [`#[instrument]`](https://docs.rs/tracing/0.1.37/tracing/attr.instrument.html) attribute macro
 can reduce some of this boilerplate:
 
 ```rust

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -817,7 +817,7 @@
 //!
 //!   ```toml
 //!   [dependencies]
-//!   tracing = { version = "0.1.36", default-features = false }
+//!   tracing = { version = "0.1.37", default-features = false }
 //!   ```
 //!
 //! <pre class="ignore" style="white-space:normal;font:inherit;">
@@ -900,7 +900,7 @@
 //! [flags]: #crate-feature-flags
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
-#![doc(html_root_url = "https://docs.rs/tracing/0.1.36")]
+#![doc(html_root_url = "https://docs.rs/tracing/0.1.37")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"


### PR DESCRIPTION
# 0.1.37 (October 6, 2022)

This release of `tracing` incorporates changes from `tracing-core`
[v0.1.30][core-0.1.30] and `tracing-attributes` [v0.1.23][attrs-0.1.23],
including the new `Subscriber::on_register_dispatch` method for
performing late initialization after a `Subscriber` is registered as a
`Dispatch`, and bugfixes for the `#[instrument]` attribute.
Additionally, it fixes instances of the `bare_trait_objects` lint, which
is now a warning on `tracing`'s MSRV and will become an error in the
next edition.

### Fixed

- **attributes**: Incorrect handling of inner attributes in
  `#[instrument]`ed functions (https://github.com/tokio-rs/tracing/pull/2307)
- **attributes**: Incorrect location of compiler diagnostic spans
  generated for type errors in `#[instrument]`ed `async fn`s (https://github.com/tokio-rs/tracing/pull/2270)
- **attributes**: Updated `syn` dependency to fix compilation with `-Z
  minimal-versions` (https://github.com/tokio-rs/tracing/pull/2246)
- `bare_trait_objects` warning in `valueset!` macro expansion (https://github.com/tokio-rs/tracing/pull/2308)

### Added

- **core**: `Subscriber::on_register_dispatch` method (https://github.com/tokio-rs/tracing/pull/2269)
- **core**: `WeakDispatch` type and `Dispatch::downgrade()` function
  (https://github.com/tokio-rs/tracing/pull/2293)

### Changed

- `tracing-core`: updated to [0.1.30][core-0.1.30]
- `tracing-attributes`: updated to [0.1.23][attrs-0.1.23]

### Documented

- Added [`tracing-web`] and [`reqwest-tracing`] to related crates
  (#2283, #2331)

Thanks to new contributors @compiler-errors, @e-nomem, @WorldSEnder,
@Xiami2012, and @tl-rodrigo-gryzinski, as well as @jswrenn and @CAD97,
for contributing to this release!

[core-0.1.30]:
    https://github.com/tokio-rs/tracing/releases/tag/tracing-core-0.1.30
[attrs-0.1.23]:
    https://github.com/tokio-rs/tracing/releases/tag/tracing-attributes-0.1.23
[`tracing-web`]: https://crates.io/crates/tracing-web/
[`reqwest-tracing`]: https://crates.io/crates/reqwest-tracing/