### PR TITLE
chore: allow renamed and removed lints on docs build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,7 @@
 [build.environment]
   RUSTDOCFLAGS="""
     -D warnings \
+    --force-warn renamed-and-removed-lints` \
     --cfg docsrs \
     --html-before-content /opt/build/repo/assets/warning.html \
     --html-in-header /opt/build/repo/assets/noindex.html \

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@
 [build.environment]
   RUSTDOCFLAGS="""
     -D warnings \
-    --force-warn renamed-and-removed-lints` \
+    --force-warn renamed-and-removed-lints \
     --cfg docsrs \
     --html-before-content /opt/build/repo/assets/warning.html \
     --html-in-header /opt/build/repo/assets/noindex.html \


### PR DESCRIPTION
Currently, the Netlify docs are failing because of a warning that one of the lints we explicitly enable is no longer a warning on nightly but becoming a hard error. This is because the docs are built on nightly with `-D warnings`, which denies all warnings...which seems not ideal.

For now, let's not remove that lint from the `deny` list, as it's still a valid lint on stable. Instead, this PR explicitly allows that lint on the docs build.