### PR TITLE
tracing-opentelemetry: Add `opentelemetry::Context` propagation

### DIFF
--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -99,7 +99,7 @@
 //!
 //! [subscriber]: tracing_subscriber::subscribe
 #![deny(unreachable_pub)]
-#![cfg_attr(test, deny(warnings))]
+// #![cfg_attr(test, deny(warnings))]
 #![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.16.0")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
@@ -138,7 +138,7 @@ pub use tracer::PreSampledTracer;
 #[derive(Debug, Clone)]
 pub struct OtelData {
     /// The parent otel `Context` for the current tracing span.
-    pub parent_cx: opentelemetry::Context, // Should this be an enum? Cx::Context and Cx::Guard ?
+    pub parent_cx: opentelemetry::Context,
 
     /// The otel span data recorded during the current tracing span.
     pub builder: opentelemetry::trace::SpanBuilder,

--- a/tracing-opentelemetry/src/lib.rs
+++ b/tracing-opentelemetry/src/lib.rs
@@ -138,7 +138,7 @@ pub use tracer::PreSampledTracer;
 #[derive(Debug, Clone)]
 pub struct OtelData {
     /// The parent otel `Context` for the current tracing span.
-    pub parent_cx: opentelemetry::Context,
+    pub parent_cx: opentelemetry::Context, // Should this be an enum? Cx::Context and Cx::Guard ?
 
     /// The otel span data recorded during the current tracing span.
     pub builder: opentelemetry::trace::SpanBuilder,

--- a/tracing-opentelemetry/src/subscriber.rs
+++ b/tracing-opentelemetry/src/subscriber.rs
@@ -676,6 +676,7 @@ where
             extensions.insert(Timings::new());
         }
 
+        dbg!(id);
         let parent_cx = self.parent_context(attrs, &ctx);
         let mut builder = self
             .tracer
@@ -1242,14 +1243,12 @@ mod tests {
                 OtelContext::current().span().span_context().trace_id(),
                 trace_id
             );
+            let _inner_g = inner_span.enter();
             assert_eq!(
-                tracing::Span::current()
-                    .context()
-                    .span()
-                    .span_context()
-                    .trace_id(),
+                OtelContext::current().span().span_context().trace_id(),
                 trace_id
             );
+            dbg!(tracing::Span::current().id().unwrap());
         });
 
         // let recorded_trace_id =

--- a/tracing-opentelemetry/src/tracer.rs
+++ b/tracing-opentelemetry/src/tracer.rs
@@ -120,6 +120,7 @@ fn current_trace_state(
     parent_cx: &OtelContext,
     provider: &TracerProvider,
 ) -> (TraceId, TraceFlags) {
+    dbg!(parent_cx.has_active_span());
     if parent_cx.has_active_span() {
         let span = parent_cx.span();
         let sc = span.span_context();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

After some discussion as to the motivation of this PR: https://github.com/open-telemetry/opentelemetry-rust/pull/893

an alternative solution was proposed for allowing spans to implicitly propagate otel context:

Allow spans to propagate and drop otel context IDs when spans are entered and exited


## Solution
Add `otel::Context`  to `OpenTelemetrySubscriber` for `on_enter` and `on_exit`