### PR TITLE
core: record_error uses Debug, not Display

### DIFF
--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -234,7 +234,7 @@ pub trait Visit {
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
-        self.record_debug(field, &DisplayValue(value))
+        self.record_debug(field, &DebugValue(value))
     }
 
     /// Visit a value implementing `fmt::Debug`.
@@ -1122,6 +1122,6 @@ mod test {
             use core::fmt::Write;
             write!(&mut result, "{:?}", value).unwrap();
         });
-        assert_eq!(result, format!("{}", err));
+        assert_eq!(result, format!("{:?}", err));
     }
 }


### PR DESCRIPTION
When receiving a `std::error::Error` in `record_error`, use the `std::fmt::Debug` trait to format the error (which prints more useful information, e.g. the full error context for an `anyhow` style error) rather than `std::fmt::Display`.

`Debug` should print out strictly more information than `Display`, which is generally what people want when logging an error.