### PR TITLE
tracing-attributes: allow warning clippy unreachable

### DIFF
--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -64,7 +64,7 @@ pub(crate) fn gen_function<'a, B: ToTokens + 'a>(
     // unreachable, but does affect inference, so it needs to be written
     // exactly that way for it to do its magic.
     let fake_return_edge = quote_spanned! {return_span=>
-        #[allow(unreachable_code, clippy::diverging_sub_expression, clippy::let_unit_value)]
+        #[allow(unreachable_code, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::unreachable)]
         if false {
             let __tracing_attr_fake_return: #return_type =
                 unreachable!("this is just for type inference, and is unreachable code");


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation
Getting clippy warnings when using the macro https://github.com/tokio-rs/tracing/pull/2270#issuecomment-1282881008
 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Adding the clippy lint warning as discussed here https://github.com/tokio-rs/tracing/pull/2270#issuecomment-1282887973
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
