### PR TITLE
subscriber: Add docs for json event_format

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -114,7 +114,7 @@ where
     ///
     /// Make sure `fmt_fields` is compatible with `event_fmt`:
     ///
-    /// ```rust
+    /// ```no_build
     /// use tracing_subscriber::fmt::{self, format};
     ///
     /// let fmt_subscriber = fmt::subscriber()

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -93,9 +93,15 @@ where
     /// trait, which is implemented for all functions taking a [`FmtContext`], a
     /// [`Writer`], and an [`Event`].
     ///
+    /// # Notes
+    ///
+    /// `fmt_fields` should also be updated to compatible FormatFields.
+    /// For example, useing `JsonFields` for `Json` format.
+    ///
     /// # Examples
     ///
     /// Setting a type implementing [`FormatEvent`] as the formatter:
+    ///
     /// ```rust
     /// use tracing_subscriber::fmt::{self, format};
     ///
@@ -105,6 +111,20 @@ where
     /// # use tracing_subscriber::Subscribe as _;
     /// # let _ = fmt_subscriber.with_collector(tracing_subscriber::registry::Registry::default());
     /// ```
+    ///
+    /// Make sure `fmt_fields` is compatible with `event_fmt`:
+    ///
+    /// ```rust
+    /// use tracing_subscriber::fmt::{self, format};
+    ///
+    /// let fmt_subscriber = fmt::subscriber()
+    ///     .event_format(format().json())
+    ///     .fmt_fields(format::JsonFields::new());
+    /// # // this is necessary for type inference.
+    /// # use tracing_subscriber::Subscribe as _;
+    /// # let _ = fmt_subscriber.with_collector(tracing_subscriber::registry::Registry::default());
+    /// ```
+    ///
     /// [`FormatEvent`]: format::FormatEvent
     /// [`Event`]: tracing::Event
     /// [`Writer`]: format::Writer


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>


## Motivation

Add docs for `event_format`.

`fmt_fields` should also be updated while setting event_format (especially for structural logging formats like `json`).

I've been confused by this mistake for a whole day. Adding this in `event_format`'s docs will prevent others from this mistake.

## Solution

Docs added.