### PR TITLE
appender: allow worker thread name to be configured (#2364)

### DIFF
--- a/tracing-appender/src/worker.rs
+++ b/tracing-appender/src/worker.rs
@@ -67,9 +67,9 @@ impl<T: Write + Send + Sync + 'static> Worker<T> {
     }
 
     /// Creates a worker thread that processes a channel until it's disconnected
-    pub(crate) fn worker_thread(mut self) -> std::thread::JoinHandle<()> {
+    pub(crate) fn worker_thread(mut self, name: String) -> std::thread::JoinHandle<()> {
         thread::Builder::new()
-            .name("tracing-appender".to_string())
+            .name(name)
             .spawn(move || {
                 loop {
                     match self.work() {


### PR DESCRIPTION
## Motivation

The worker thread name in non blocking mode is always "tracing-appender".
It can be convenient to quickly identify the appender threads for
audit reasons or affinity pinning.

## Solution

This patch adds a new setter to the builder and propagates the info to
the thread initialization.
