### PR TITLE
chore: track Rust 1.65 clippy lints

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
-blacklisted-names = []
+disallowed-names = []
 cognitive-complexity-threshold = 100
 too-many-arguments-threshold = 8
 type-complexity-threshold = 375

--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -135,7 +135,7 @@ fn gen_block<B: ToTokens>(
             .into_iter()
             .flat_map(|param| match param {
                 FnArg::Typed(PatType { pat, ty, .. }) => {
-                    param_names(*pat, RecordType::parse_from_ty(&*ty))
+                    param_names(*pat, RecordType::parse_from_ty(&ty))
                 }
                 FnArg::Receiver(_) => Box::new(iter::once((
                     Ident::new("self", param.span()),

--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -475,7 +475,7 @@ pub fn get_current<T>(f: impl FnOnce(&Dispatch) -> T) -> Option<T> {
     CURRENT_STATE
         .try_with(|state| {
             let entered = state.enter()?;
-            Some(f(&*entered.current()))
+            Some(f(&entered.current()))
         })
         .ok()?
 }

--- a/tracing-subscriber/benches/support/mod.rs
+++ b/tracing-subscriber/benches/support/mod.rs
@@ -35,7 +35,7 @@ impl MultithreadedBench {
         thread::spawn(move || {
             let dispatch = this.dispatch.clone();
             tracing::dispatch::with_default(&dispatch, move || {
-                f(&*this.start);
+                f(&this.start);
                 this.end.wait();
             })
         });

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -681,7 +681,7 @@ mod test {
             );
 
             let span = tracing::info_span!("the span", na = tracing::field::Empty);
-            span.record("na", &"value");
+            span.record("na", "value");
             let _enter = span.enter();
 
             tracing::info!("an event inside the root span");

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -418,7 +418,7 @@ impl<'a> SpanData<'a> for Data<'a> {
     }
 
     fn metadata(&self) -> &'static Metadata<'static> {
-        (*self).inner.metadata
+        self.inner.metadata
     }
 
     fn parent(&self) -> Option<&Id> {
@@ -898,7 +898,7 @@ mod tests {
 
             drop(span3);
 
-            state.assert_closed_in_order(&["child", "parent", "grandparent"]);
+            state.assert_closed_in_order(["child", "parent", "grandparent"]);
         });
     }
 }

--- a/tracing-subscriber/tests/field_filter.rs
+++ b/tracing-subscriber/tests/field_filter.rs
@@ -103,7 +103,7 @@ fn record_after_created() {
             tracing::debug!("i'm disabled!");
         });
 
-        span.record("enabled", &true);
+        span.record("enabled", true);
         span.in_scope(|| {
             tracing::debug!("i'm enabled!");
         });

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -1604,7 +1604,7 @@ mod test {
 
     #[test]
     fn test_record_backwards_compat() {
-        Span::current().record("some-key", &"some text");
-        Span::current().record("some-key", &false);
+        Span::current().record("some-key", "some text");
+        Span::current().record("some-key", false);
     }
 }

--- a/tracing/tests/span.rs
+++ b/tracing/tests/span.rs
@@ -563,7 +563,7 @@ fn record_new_value_for_field() {
 
     with_default(collector, || {
         let span = tracing::span!(Level::TRACE, "foo", bar = 5, baz = false);
-        span.record("baz", &true);
+        span.record("baz", true);
         span.in_scope(|| {})
     });
 
@@ -598,8 +598,8 @@ fn record_new_values_for_fields() {
 
     with_default(collector, || {
         let span = tracing::span!(Level::TRACE, "foo", bar = 4, baz = false);
-        span.record("bar", &5);
-        span.record("baz", &true);
+        span.record("bar", 5);
+        span.record("baz", true);
         span.in_scope(|| {})
     });
 


### PR DESCRIPTION
This commit fixes some new Clippy lints that landed in Rust 1.65.0, and removes a deprecated config key in `clippy.toml` in favor of its new name.

This should fix warnings on CI.