### PR TITLE
subscriber: fix wrong `doc_cfg` attribute

### DIFF
--- a/tracing-subscriber/src/fmt/time/mod.rs
+++ b/tracing-subscriber/src/fmt/time/mod.rs
@@ -12,7 +12,7 @@ mod time_crate;
 pub use time_crate::UtcTime;
 
 #[cfg(feature = "local-time")]
-#[cfg_attr(docsrs, doc(cfg(unsound_local_offset, feature = "local-time")))]
+#[cfg_attr(docsrs, doc(cfg(all(unsound_local_offset, feature = "local-time"))))]
 pub use time_crate::LocalTime;
 
 /// A type that can measure and format the current time.


### PR DESCRIPTION
This `doc_cfg` attribute's `cfg` part has multiple predicates without an `all`, which iis what's breaking the netlify build. I'm...kind of surprised this ever succeeded, since the cfg is malformed...