### PR TITLE
mock: move subscriber mock from tracing-subscriber tests

### DIFF
--- a/tracing-mock/Cargo.toml
+++ b/tracing-mock/Cargo.toml
@@ -17,10 +17,6 @@ edition = "2018"
 rust-version = "1.49.0"
 publish = false
 
-[features]
-default = []
-subscriber = ["tracing-subscriber"]
-
 [dependencies]
 tracing = { path = "../tracing", version = "0.2", default-features = false }
 tracing-core = { path = "../tracing-core", version = "0.2", default-features = false }

--- a/tracing-mock/Cargo.toml
+++ b/tracing-mock/Cargo.toml
@@ -17,9 +17,14 @@ edition = "2018"
 rust-version = "1.49.0"
 publish = false
 
+[features]
+default = []
+subscriber = ["tracing-subscriber"]
+
 [dependencies]
 tracing = { path = "../tracing", version = "0.2", default-features = false }
 tracing-core = { path = "../tracing-core", version = "0.2", default-features = false }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, optional = true }
 tokio-test = { version = "0.4.2", optional = true }
 
 # Fix minimal-versions; tokio-test fails with otherwise acceptable 0.1.0

--- a/tracing-mock/src/collector.rs
+++ b/tracing-mock/src/collector.rs
@@ -1,6 +1,7 @@
 #![allow(missing_docs)]
-use super::{
+use crate::{
     event::MockEvent,
+    expectation::Expect,
     field as mock_field,
     span::{MockSpan, NewSpan},
 };
@@ -19,22 +20,6 @@ use tracing::{
     span::{self, Attributes, Id},
     Collect, Event, Metadata,
 };
-
-#[derive(Debug, Eq, PartialEq)]
-pub enum Expect {
-    Event(MockEvent),
-    FollowsFrom {
-        consequence: MockSpan,
-        cause: MockSpan,
-    },
-    Enter(MockSpan),
-    Exit(MockSpan),
-    CloneSpan(MockSpan),
-    DropSpan(MockSpan),
-    Visit(MockSpan, mock_field::Expect),
-    NewSpan(NewSpan),
-    Nothing,
-}
 
 struct SpanState {
     name: &'static str,
@@ -469,7 +454,7 @@ where
 }
 
 impl MockHandle {
-    pub fn new(expected: Arc<Mutex<VecDeque<Expect>>>, name: String) -> Self {
+    pub(crate) fn new(expected: Arc<Mutex<VecDeque<Expect>>>, name: String) -> Self {
         Self(expected, name)
     }
 

--- a/tracing-mock/src/expectation.rs
+++ b/tracing-mock/src/expectation.rs
@@ -1,0 +1,21 @@
+use crate::{
+    event::MockEvent,
+    field,
+    span::{MockSpan, NewSpan},
+};
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum Expect {
+    Event(MockEvent),
+    FollowsFrom {
+        consequence: MockSpan,
+        cause: MockSpan,
+    },
+    Enter(MockSpan),
+    Exit(MockSpan),
+    CloneSpan(MockSpan),
+    DropSpan(MockSpan),
+    Visit(MockSpan, field::Expect),
+    NewSpan(NewSpan),
+    Nothing,
+}

--- a/tracing-mock/src/lib.rs
+++ b/tracing-mock/src/lib.rs
@@ -5,9 +5,14 @@ use std::{
 
 pub mod collector;
 pub mod event;
+mod expectation;
 pub mod field;
 mod metadata;
 pub mod span;
+
+#[cfg(feature = "subscriber")]
+#[doc(hidden)]
+pub mod subscriber;
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum Parent {

--- a/tracing-mock/src/lib.rs
+++ b/tracing-mock/src/lib.rs
@@ -10,8 +10,7 @@ pub mod field;
 mod metadata;
 pub mod span;
 
-#[cfg(feature = "subscriber")]
-#[doc(hidden)]
+#[cfg(feature = "tracing-subscriber")]
 pub mod subscriber;
 
 #[derive(Debug, Eq, PartialEq)]

--- a/tracing-mock/src/subscriber.rs
+++ b/tracing-mock/src/subscriber.rs
@@ -1,9 +1,9 @@
 #![allow(missing_docs, dead_code)]
-pub use tracing_mock::{collector, event, field, span};
-
-use self::{
-    collector::{Expect, MockHandle},
+use crate::{
+    collector::MockHandle,
     event::MockEvent,
+    expectation::Expect,
+    field,
     span::{MockSpan, NewSpan},
 };
 use tracing_core::{
@@ -21,22 +21,18 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-pub mod subscriber {
-    use super::ExpectSubscriberBuilder;
-
-    pub fn mock() -> ExpectSubscriberBuilder {
-        ExpectSubscriberBuilder {
-            expected: Default::default(),
-            name: std::thread::current()
-                .name()
-                .map(String::from)
-                .unwrap_or_default(),
-        }
+pub fn mock() -> ExpectSubscriberBuilder {
+    ExpectSubscriberBuilder {
+        expected: Default::default(),
+        name: std::thread::current()
+            .name()
+            .map(String::from)
+            .unwrap_or_default(),
     }
+}
 
-    pub fn named(name: impl std::fmt::Display) -> ExpectSubscriberBuilder {
-        mock().named(name)
-    }
+pub fn named(name: impl std::fmt::Display) -> ExpectSubscriberBuilder {
+    mock().named(name)
 }
 
 pub struct ExpectSubscriberBuilder {

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -65,7 +65,7 @@ thread_local = { version = "1.1.4", optional = true }
 
 [dev-dependencies]
 tracing = { path = "../tracing", version = "0.2" }
-tracing-mock = { path = "../tracing-mock" }
+tracing-mock = { path = "../tracing-mock", features = ["subscriber"] }
 log = "0.4.17"
 tracing-log = { path = "../tracing-log", version = "0.2" }
 criterion = { version = "0.3.6", default_features = false }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -65,7 +65,7 @@ thread_local = { version = "1.1.4", optional = true }
 
 [dev-dependencies]
 tracing = { path = "../tracing", version = "0.2" }
-tracing-mock = { path = "../tracing-mock", features = ["subscriber"] }
+tracing-mock = { path = "../tracing-mock", features = ["tracing-subscriber"] }
 log = "0.4.17"
 tracing-log = { path = "../tracing-log", version = "0.2" }
 criterion = { version = "0.3.6", default_features = false }

--- a/tracing-subscriber/tests/cached_subscriber_filters_dont_break_other_subscribers.rs
+++ b/tracing-subscriber/tests/cached_subscriber_filters_dont_break_other_subscribers.rs
@@ -1,7 +1,9 @@
 #![cfg(feature = "registry")]
-mod support;
-use self::support::*;
 use tracing::Level;
+use tracing_mock::{
+    collector, event,
+    subscriber::{self, ExpectSubscriber},
+};
 use tracing_subscriber::{filter::LevelFilter, prelude::*};
 
 #[test]

--- a/tracing-subscriber/tests/env_filter/main.rs
+++ b/tracing-subscriber/tests/env_filter/main.rs
@@ -1,12 +1,9 @@
 #![cfg(feature = "env-filter")]
 
-#[path = "../support.rs"]
-mod support;
-use self::support::*;
-
 mod per_subscriber;
 
 use tracing::{self, collect::with_default, Level};
+use tracing_mock::{collector, event, field, span};
 use tracing_subscriber::{
     filter::{EnvFilter, LevelFilter},
     prelude::*,

--- a/tracing-subscriber/tests/env_filter/per_subscriber.rs
+++ b/tracing-subscriber/tests/env_filter/per_subscriber.rs
@@ -2,6 +2,7 @@
 //! `subscriber` filter).
 #![cfg(feature = "registry")]
 use super::*;
+use tracing_mock::{event, field, span, subscriber};
 
 #[test]
 fn level_filter_event() {

--- a/tracing-subscriber/tests/hinted_subscriber_filters_dont_break_other_subscribers.rs
+++ b/tracing-subscriber/tests/hinted_subscriber_filters_dont_break_other_subscribers.rs
@@ -1,7 +1,9 @@
 #![cfg(feature = "registry")]
-mod support;
-use self::support::*;
 use tracing::{Collect, Level, Metadata};
+use tracing_mock::{
+    collector, event,
+    subscriber::{self, ExpectSubscriber},
+};
 use tracing_subscriber::{filter::DynFilterFn, prelude::*, subscribe::Context};
 
 #[test]

--- a/tracing-subscriber/tests/multiple_subscriber_filter_interests_cached.rs
+++ b/tracing-subscriber/tests/multiple_subscriber_filter_interests_cached.rs
@@ -1,12 +1,10 @@
 #![cfg(feature = "registry")]
-mod support;
-use self::support::*;
-
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
 };
 use tracing::{Collect, Level};
+use tracing_mock::{event, subscriber};
 use tracing_subscriber::{filter, prelude::*};
 
 #[test]

--- a/tracing-subscriber/tests/subscriber_filter_interests_are_cached.rs
+++ b/tracing-subscriber/tests/subscriber_filter_interests_are_cached.rs
@@ -1,12 +1,10 @@
 #![cfg(feature = "registry")]
-mod support;
-use self::support::*;
-
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
 };
 use tracing::{Collect, Level};
+use tracing_mock::{event, subscriber};
 use tracing_subscriber::{filter, prelude::*};
 
 #[test]

--- a/tracing-subscriber/tests/subscriber_filters/filter_scopes.rs
+++ b/tracing-subscriber/tests/subscriber_filters/filter_scopes.rs
@@ -1,4 +1,5 @@
 use super::*;
+use tracing_mock::subscriber::ExpectSubscriber;
 
 #[test]
 fn filters_span_scopes() {

--- a/tracing-subscriber/tests/subscriber_filters/main.rs
+++ b/tracing-subscriber/tests/subscriber_filters/main.rs
@@ -1,7 +1,4 @@
 #![cfg(feature = "registry")]
-#[path = "../support.rs"]
-mod support;
-use self::support::*;
 mod filter_scopes;
 mod per_event;
 mod targets;
@@ -9,6 +6,7 @@ mod trees;
 mod vec;
 
 use tracing::{level_filters::LevelFilter, Level};
+use tracing_mock::{collector, event, span, subscriber};
 use tracing_subscriber::{filter, prelude::*, Subscribe};
 
 #[test]

--- a/tracing-subscriber/tests/subscriber_filters/per_event.rs
+++ b/tracing-subscriber/tests/subscriber_filters/per_event.rs
@@ -1,5 +1,5 @@
-use crate::support::*;
 use tracing::Level;
+use tracing_mock::{event, subscriber};
 use tracing_subscriber::{field::Visit, prelude::*, subscribe::Filter};
 
 struct FilterEvent;

--- a/tracing-subscriber/tests/subscriber_filters/trees.rs
+++ b/tracing-subscriber/tests/subscriber_filters/trees.rs
@@ -1,4 +1,5 @@
 use super::*;
+use tracing_mock::subscriber::ExpectSubscriber;
 
 #[test]
 fn basic_trees() {

--- a/tracing-subscriber/tests/subscriber_filters/vec.rs
+++ b/tracing-subscriber/tests/subscriber_filters/vec.rs
@@ -1,5 +1,6 @@
 use super::*;
 use tracing::Collect;
+use tracing_mock::subscriber::ExpectSubscriber;
 
 #[test]
 fn with_filters_unboxed() {

--- a/tracing-subscriber/tests/unhinted_subscriber_filters_dont_break_other_subscribers.rs
+++ b/tracing-subscriber/tests/unhinted_subscriber_filters_dont_break_other_subscribers.rs
@@ -1,7 +1,9 @@
 #![cfg(feature = "registry")]
-mod support;
-use self::support::*;
 use tracing::Level;
+use tracing_mock::{
+    collector, event,
+    subscriber::{self, ExpectSubscriber},
+};
 use tracing_subscriber::{filter::DynFilterFn, prelude::*};
 
 #[test]

--- a/tracing-subscriber/tests/vec_subscriber_filter_interests_cached.rs
+++ b/tracing-subscriber/tests/vec_subscriber_filter_interests_cached.rs
@@ -1,12 +1,13 @@
 #![cfg(feature = "registry")]
-mod support;
-use self::support::*;
-
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
 };
 use tracing::{Collect, Level};
+use tracing_mock::{
+    event,
+    subscriber::{self, ExpectSubscriber},
+};
 use tracing_subscriber::{filter, prelude::*};
 
 #[test]


### PR DESCRIPTION
## Motivation

The `tracing-subscriber` module `tests::support` included functionality to mock a subscriber (via the `Subscribe` trait). This code depends on some items from `tracing_mock::collector` which should otherwise not be public.

## Solution

This change moves the mocking functionality inside `tracing-mock` behind a feature flag. Allowing the `Expect` enum and `MockHandle::new` from `tracing_mock::collector` to be made `pub(crate)` instead of `pub`. Since it's now used from two different modules, the `Expect` enum has been moved to its own module.

This requires a lot of modifications to imports so that we're not doing wildcard imports from another crate (i.e. in `tracing-subscriber` importing wildcards from `tracing-mock`).

Closes: #2359