### PR TITLE
Make newlines configurable for tracing_subscriber::fmt::format::Json

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -604,6 +604,21 @@ impl<C, T, W> Subscriber<C, format::JsonFields, format::Format<format::Json, T>,
             ..self
         }
     }
+
+    /// Sets whether or not the formatter will include newline characters after
+    /// formatting a log event.
+    ///
+    /// See [`format::Json`]
+    pub fn with_newlines(
+        self,
+        print_newlines: bool,
+    ) -> Subscriber<C, format::JsonFields, format::Format<format::Json, T>, W> {
+        Subscriber {
+            fmt_event: self.fmt_event.with_newlines(print_newlines),
+            fmt_fields: format::JsonFields::new(),
+            ..self
+        }
+    }
 }
 
 impl<C, N, E, W> Subscriber<C, N, E, W> {

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -65,6 +65,8 @@ use tracing_log::NormalizeEvent;
 /// span
 /// - [`Json::with_span_list`] can be used to control logging of the span list
 /// object.
+/// - [`Json::with_newlines`] can be used to disable newlines in the log event
+/// format.
 ///
 /// By default, event fields are not flattened, and both current span and span
 /// list are logged.
@@ -74,6 +76,7 @@ pub struct Json {
     pub(crate) flatten_event: bool,
     pub(crate) display_current_span: bool,
     pub(crate) display_span_list: bool,
+    pub(crate) print_newlines: bool,
 }
 
 impl Json {
@@ -91,6 +94,13 @@ impl Json {
     /// entered spans. Spans are logged in a list from root to leaf.
     pub fn with_span_list(&mut self, display_span_list: bool) {
         self.display_span_list = display_span_list;
+    }
+
+    /// If set to `false`, formatted events won't be followed by a newline.
+    /// This option is mainly useful for logic that is supposed to expand logged
+    /// JSON values by embedding them in a wrapping JSON structure.
+    pub fn with_newlines(&mut self, print_newlines: bool) {
+        self.print_newlines = print_newlines;
     }
 }
 
@@ -318,6 +328,7 @@ impl Default for Json {
             flatten_event: false,
             display_current_span: true,
             display_span_list: true,
+            print_newlines: true,
         }
     }
 }

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -850,6 +850,25 @@ mod test {
         });
     }
 
+    #[test]
+    fn json_without_newlines() {
+        let buffer = MockMakeWriter::default();
+        let subscriber = collector()
+            .with_writer(buffer.clone())
+            .json()
+            .with_newlines(false)
+            .finish();
+
+        with_default(subscriber, || {
+            tracing::info!("Log message 1");
+            tracing::info!("Log message 2");
+            tracing::info!("Log message 3");
+
+            let buf = String::from_utf8(buffer.buf().to_vec()).unwrap();
+            assert_eq!(1, buf.lines().count());
+        });
+    }
+
     fn parse_as_json(buffer: &MockMakeWriter) -> serde_json::Value {
         let buf = String::from_utf8(buffer.buf().to_vec()).unwrap();
         let json = buf

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -318,7 +318,12 @@ where
         };
 
         visit().map_err(|_| fmt::Error)?;
-        writeln!(writer)
+
+        if self.format.print_newlines {
+            writeln!(writer)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -908,6 +908,17 @@ impl<T> Format<Json, T> {
         self.format.with_span_list(display_span_list);
         self
     }
+
+    /// Sets whether or not the formatter will include newline characters after
+    /// formatting a log event.
+    ///
+    /// See [`Json`]
+    #[cfg(feature = "json")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
+    pub fn with_newlines(mut self, print_newlines: bool) -> Format<Json, T> {
+        self.format.with_newlines(print_newlines);
+        self
+    }
 }
 
 impl<C, N, T> FormatEvent<C, N> for Format<Full, T>

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -803,6 +803,20 @@ impl<T, F, W> CollectorBuilder<format::JsonFields, format::Format<format::Json, 
             inner: self.inner.with_span_list(display_span_list),
         }
     }
+
+    /// Sets whether or not the formatter will include newline characters after
+    /// formatting a log event.
+    ///
+    /// See [`format::Json`](super::fmt::format::Json)
+    pub fn with_newlines(
+        self,
+        print_newlines: bool,
+    ) -> CollectorBuilder<format::JsonFields, format::Format<format::Json, T>, F, W> {
+        CollectorBuilder {
+            filter: self.filter,
+            inner: self.inner.with_newlines(print_newlines),
+        }
+    }
 }
 
 impl<N, E, F, W> CollectorBuilder<N, E, reload::Subscriber<F>, W>


### PR DESCRIPTION
This PR implements the changes outlined in #2372

## Motivation

By providing a way to suppress the inclusion of newline characters in the JSON log format, wrapping and extending the existing JSON formatter becomes much easier without the need to re-implement big parts of it.

Example from #2372:

```
#[derive(Clone)]
pub struct JsonLogFormat(Format<Json, SystemTime>);

impl Default for JsonLogFormat {
    fn default() -> Self {
        Self(Format::default().json().with_newlines(false))
    }
}

impl<S, N> FormatEvent<S, N> for JsonLogFormat
where
    S: Subscriber+for<'a> LookupSpan<'a>,
    N: for<'a> FormatFields<'a>+'static,
{
    fn format_event(
        &self,
        ctx: &tracing_subscriber::fmt::FmtContext<'_, S, N>,
        mut writer: tracing_subscriber::fmt::format::Writer<'_>,
        event: &tracing::Event<'_>,
    ) -> std::fmt::Result {
        write!(&mut writer, "{{\"log\":")?;
        self.0.format_event(ctx, writer.by_ref(), event)?;
        writeln!(&mut writer, "}}")
    }
}
```
