### PR TITLE
Fix typo in RollingFileAppender docs

### DIFF
--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -46,7 +46,7 @@ pub use builder::{Builder, InitError};
 /// writes without blocking the current thread.
 ///
 /// Additionally, `RollingFileAppender` also implements the [`MakeWriter`]
-/// trait from `tracing-appender`, so it may also be used
+/// trait from `tracing-subscriber`, so it may also be used
 /// directly, without [`NonBlocking`].
 ///
 /// [write]: std::io::Write


### PR DESCRIPTION
The `MakeWriter` trait comes from the `tracing-subscriber` crate, not `tracing-appender`.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
