### PR TITLE
Add a way to filter format event

### DIFF
--- a/tracing-subscriber/src/fmt/format/filter.rs
+++ b/tracing-subscriber/src/fmt/format/filter.rs
@@ -1,0 +1,56 @@
+use core::fmt;
+
+use tracing_core::{Collect, Event};
+
+use crate::{fmt::FmtContext, registry::LookupSpan};
+
+use super::{FormatEvent, FormatFields, Writer};
+
+/// `FilteringFormatter` is useful if you want to not filter the entire event but only want to not display it
+/// ```
+/// use tracing_core::Event;
+/// use tracing_subscriber::fmt::format::{FilteringFormatter, Format};
+/// tracing_subscriber::fmt::fmt()
+/// .event_format(FilteringFormatter::new(
+///     Format::default().pretty(),
+///     // Do not display the event if an attribute name starts with "counter"
+///     |event: &Event| !event.metadata().fields().iter().any(|f| f.name().starts_with("counter")),
+/// ))
+/// .finish();
+/// ```
+#[derive(Debug)]
+pub struct FilteringFormatter<T, F> {
+    inner: T,
+    filter_fn: F,
+}
+
+impl<T, F> FilteringFormatter<T, F>
+where
+    F: Fn(&Event<'_>) -> bool,
+{
+    /// Creates a new FilteringFormatter
+    pub fn new(inner: T, filter_fn: F) -> Self {
+        Self { inner, filter_fn }
+    }
+}
+
+impl<T, F, S, N> FormatEvent<S, N> for FilteringFormatter<T, F>
+where
+    T: FormatEvent<S, N>,
+    F: Fn(&Event<'_>) -> bool,
+    S: Collect + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        if (self.filter_fn)(event) {
+            self.inner.format_event(ctx, writer, event)
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -60,6 +60,9 @@ mod pretty;
 #[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
 pub use pretty::*;
 
+mod filter;
+pub use filter::*;
+
 use fmt::{Debug, Display};
 
 /// A type that can format a tracing [`Event`] to a [`Writer`].


### PR DESCRIPTION
## Motivation

Now we can create metrics and increments it directly using tracing macros I'm using it thanks to [`MetricsSubscriber`](https://tracing.rs/tracing_opentelemetry/struct.metricssubscriber). But I don't want to display the event in my logs.

## Solution

So I created a wrapper around `FormatEvent` to wrap an existing `FormatEvent` impl and takes a filtering function to filter event we don't want to display.

example:

```rust
use tracing_core::Event;
use tracing_subscriber::fmt::format::{FilteringFormatter, Format};
tracing_subscriber::fmt::fmt()
    .event_format(FilteringFormatter::new(
        Format::default().pretty(),
        // Do not display the event if an attribute name starts with "counter"
        |event: &Event| !event.metadata().fields().iter().any(|f| f.name().starts_with("counter")),
    ))
    .finish();
```

DISCLAIMER: it might be the wrong way to solve this but I didn't find another way. Let me know if I'm wrong. It's ok if it's not something you want in your codebase, I'm opening this PR because I already wrote it.
