### PR TITLE
tracing-subscriber: implement Clone for EnvFilter

### DIFF
--- a/tracing-subscriber/src/filter/env/builder.rs
+++ b/tracing-subscriber/src/filter/env/builder.rs
@@ -2,9 +2,7 @@ use super::{
     directive::{self, Directive},
     EnvFilter, FromEnvError,
 };
-use crate::sync::RwLock;
 use std::env;
-use thread_local::ThreadLocal;
 use tracing::level_filters::STATIC_MAX_LEVEL;
 
 /// A [builder] for constructing new [`EnvFilter`]s.
@@ -294,9 +292,7 @@ impl Builder {
             statics,
             dynamics,
             has_dynamics,
-            by_id: RwLock::new(Default::default()),
-            by_cs: RwLock::new(Default::default()),
-            scope: ThreadLocal::new(),
+            inner: Default::default(),
             regex: self.regex,
         };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

As of `clap` `v4`, there's `Clone` bound, thus making it impossible for `EnvFilter` to be a `clap` command line argument.

## Solution

Implement `Clone` for `EnvFilter`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
