### PR TITLE
Implement `layer::Filter` for `Option<Filter>`

### DIFF
--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -134,7 +134,7 @@ fn gen_block<B: ToTokens>(
             .into_iter()
             .flat_map(|param| match param {
                 FnArg::Typed(PatType { pat, ty, .. }) => {
-                    param_names(*pat, RecordType::parse_from_ty(&*ty))
+                    param_names(*pat, RecordType::parse_from_ty(&ty))
                 }
                 FnArg::Receiver(_) => Box::new(iter::once((
                     Ident::new("self", param.span()),

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -368,7 +368,7 @@ where
     CURRENT_STATE
         .try_with(|state| {
             if let Some(entered) = state.enter() {
-                return f(&*entered.current());
+                return f(&entered.current());
             }
 
             f(&Dispatch::none())
@@ -390,7 +390,7 @@ pub fn get_current<T>(f: impl FnOnce(&Dispatch) -> T) -> Option<T> {
     CURRENT_STATE
         .try_with(|state| {
             let entered = state.enter()?;
-            Some(f(&*entered.current()))
+            Some(f(&entered.current()))
         })
         .ok()?
 }

--- a/tracing-futures/src/executor/mod.rs
+++ b/tracing-futures/src/executor/mod.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "futures-01")]
 mod futures_01;
-#[cfg(feature = "futures-01")]
-pub use self::futures_01::*;
 
 #[cfg(feature = "futures_preview")]
 mod futures_preview;

--- a/tracing-subscriber/benches/support/mod.rs
+++ b/tracing-subscriber/benches/support/mod.rs
@@ -33,7 +33,7 @@ impl MultithreadedBench {
         thread::spawn(move || {
             let dispatch = this.dispatch.clone();
             tracing::dispatcher::with_default(&dispatch, move || {
-                f(&*this.start);
+                f(&this.start);
                 this.end.wait();
             })
         });

--- a/tracing-subscriber/src/filter/layer_filters/mod.rs
+++ b/tracing-subscriber/src/filter/layer_filters/mod.rs
@@ -523,6 +523,75 @@ impl<S> layer::Filter<S> for Box<dyn layer::Filter<S> + Send + Sync + 'static> {
     filter_impl_body!();
 }
 
+// Implement Filter for Option<Filter> where None => allow
+#[cfg(feature = "registry")]
+#[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
+impl<F, S> layer::Filter<S> for Option<F>
+where
+    F: layer::Filter<S>,
+{
+    #[inline]
+    fn enabled(&self, meta: &Metadata<'_>, ctx: &Context<'_, S>) -> bool {
+        self.as_ref()
+            .map(|inner| inner.enabled(meta, ctx))
+            .unwrap_or(true)
+    }
+
+    #[inline]
+    fn callsite_enabled(&self, meta: &'static Metadata<'static>) -> Interest {
+        self.as_ref()
+            .map(|inner| inner.callsite_enabled(meta))
+            .unwrap_or_else(Interest::sometimes)
+    }
+
+    #[inline]
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        self.as_ref().and_then(|inner| inner.max_level_hint())
+    }
+
+    #[inline]
+    fn event_enabled(&self, event: &Event<'_>, ctx: &Context<'_, S>) -> bool {
+        self.as_ref()
+            .map(|inner| inner.event_enabled(event, ctx))
+            .unwrap_or(true)
+    }
+
+    #[inline]
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        if let Some(inner) = self {
+            inner.on_new_span(attrs, id, ctx)
+        }
+    }
+
+    #[inline]
+    fn on_record(&self, id: &span::Id, values: &span::Record<'_>, ctx: Context<'_, S>) {
+        if let Some(inner) = self {
+            inner.on_record(id, values, ctx)
+        }
+    }
+
+    #[inline]
+    fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
+        if let Some(inner) = self {
+            inner.on_enter(id, ctx)
+        }
+    }
+
+    #[inline]
+    fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
+        if let Some(inner) = self {
+            inner.on_exit(id, ctx)
+        }
+    }
+
+    #[inline]
+    fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
+        if let Some(inner) = self {
+            inner.on_close(id, ctx)
+        }
+    }
+}
+
 // === impl Filtered ===
 
 impl<L, F, S> Filtered<L, F, S> {

--- a/tracing-subscriber/src/filter/layer_filters/mod.rs
+++ b/tracing-subscriber/src/filter/layer_filters/mod.rs
@@ -478,6 +478,36 @@ macro_rules! filter_impl_body {
         fn max_level_hint(&self) -> Option<LevelFilter> {
             self.deref().max_level_hint()
         }
+
+        #[inline]
+        fn event_enabled(&self, event: &Event<'_>, cx: &Context<'_, S>) -> bool {
+            self.deref().event_enabled(event, cx)
+        }
+
+        #[inline]
+        fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+            self.deref().on_new_span(attrs, id, ctx)
+        }
+
+        #[inline]
+        fn on_record(&self, id: &span::Id, values: &span::Record<'_>, ctx: Context<'_, S>) {
+            self.deref().on_record(id, values, ctx)
+        }
+
+        #[inline]
+        fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
+            self.deref().on_enter(id, ctx)
+        }
+
+        #[inline]
+        fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
+            self.deref().on_exit(id, ctx)
+        }
+
+        #[inline]
+        fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
+            self.deref().on_close(id, ctx)
+        }
     };
 }
 

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -720,7 +720,7 @@ mod test {
             );
 
             let span = tracing::info_span!("the span", na = tracing::field::Empty);
-            span.record("na", &"value");
+            span.record("na", "value");
             let _enter = span.enter();
 
             tracing::info!("an event inside the root span");

--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -462,11 +462,13 @@
 //!
 //! This crate's [`filter`] module provides a number of types which implement
 //! the [`Filter`] trait, such as [`LevelFilter`], [`Targets`], and
-//! [`FilterFn`]. These [`Filter`]s provide ready-made implementations of
-//! common forms of filtering. For custom filtering policies, the [`FilterFn`]
-//! and [`DynFilterFn`] types allow implementing a [`Filter`] with a closure or
+//! [`FilterFn`]. These [`Filter`]s provide ready-made implementations of common
+//! forms of filtering. For custom filtering policies, the [`FilterFn`] and
+//! [`DynFilterFn`] types allow implementing a [`Filter`] with a closure or
 //! function pointer. In addition, when more control is required, the [`Filter`]
-//! trait may also be implemented for user-defined types.
+//! trait may also be implemented for user-defined types. [`Option<Filter>`]
+//! also implements [`Filter`], where [`None`](Option::None) doesn't filter
+//! anything (that is, it allows everything).
 //!
 //! <pre class="compile_fail" style="white-space:normal;font:inherit;">
 //!     <strong>Warning</strong>: Currently, the <a href="../struct.Registry.html">

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -902,7 +902,7 @@ mod tests {
 
             drop(span3);
 
-            state.assert_closed_in_order(&["child", "parent", "grandparent"]);
+            state.assert_closed_in_order(["child", "parent", "grandparent"]);
         });
     }
 }

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -422,7 +422,7 @@ impl<'a> SpanData<'a> for Data<'a> {
     }
 
     fn metadata(&self) -> &'static Metadata<'static> {
-        (*self).inner.metadata
+        self.inner.metadata
     }
 
     fn parent(&self) -> Option<&Id> {

--- a/tracing-subscriber/tests/field_filter.rs
+++ b/tracing-subscriber/tests/field_filter.rs
@@ -103,7 +103,7 @@ fn record_after_created() {
             tracing::debug!("i'm disabled!");
         });
 
-        span.record("enabled", &true);
+        span.record("enabled", true);
         span.in_scope(|| {
             tracing::debug!("i'm enabled!");
         });

--- a/tracing-subscriber/tests/layer_filters/main.rs
+++ b/tracing-subscriber/tests/layer_filters/main.rs
@@ -5,6 +5,7 @@ use self::support::*;
 mod boxed;
 mod downcast_raw;
 mod filter_scopes;
+mod option;
 mod per_event;
 mod targets;
 mod trees;

--- a/tracing-subscriber/tests/layer_filters/option.rs
+++ b/tracing-subscriber/tests/layer_filters/option.rs
@@ -1,0 +1,40 @@
+use super::*;
+use tracing_subscriber::{filter, prelude::*, Layer};
+
+fn filter<S>() -> filter::DynFilterFn<S> {
+    // Use dynamic filter fn to disable interest caching and max-level hints,
+    // allowing us to put all of these tests in the same file.
+    filter::dynamic_filter_fn(|_, _| false)
+}
+
+#[test]
+fn option_some() {
+    let (layer, handle) = layer::mock().done().run_with_handle();
+    let layer = Box::new(layer.with_filter(Some(filter())));
+
+    let _guard = tracing_subscriber::registry().with(layer).set_default();
+
+    for i in 0..2 {
+        tracing::info!(i);
+    }
+
+    handle.assert_finished();
+}
+
+#[test]
+fn option_none() {
+    let (layer, handle) = layer::mock()
+        .event(event::mock())
+        .event(event::mock())
+        .done()
+        .run_with_handle();
+    let layer = Box::new(layer.with_filter(None::<filter::DynFilterFn<_>>));
+
+    let _guard = tracing_subscriber::registry().with(layer).set_default();
+
+    for i in 0..2 {
+        tracing::info!(i);
+    }
+
+    handle.assert_finished();
+}

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -1617,7 +1617,7 @@ mod test {
 
     #[test]
     fn test_record_backwards_compat() {
-        Span::current().record("some-key", &"some text");
-        Span::current().record("some-key", &false);
+        Span::current().record("some-key", "some text");
+        Span::current().record("some-key", false);
     }
 }

--- a/tracing/tests/span.rs
+++ b/tracing/tests/span.rs
@@ -563,7 +563,7 @@ fn record_new_value_for_field() {
 
     with_default(subscriber, || {
         let span = tracing::span!(Level::TRACE, "foo", bar = 5, baz = false);
-        span.record("baz", &true);
+        span.record("baz", true);
         span.in_scope(|| {})
     });
 
@@ -598,8 +598,8 @@ fn record_new_values_for_fields() {
 
     with_default(subscriber, || {
         let span = tracing::span!(Level::TRACE, "foo", bar = 4, baz = false);
-        span.record("bar", &5);
-        span.record("baz", &true);
+        span.record("bar", 5);
+        span.record("baz", true);
         span.in_scope(|| {})
     });
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

It's currently awkward to have an optional layer filter.

## Solution

Implement `Filter<S>` for `Option<F> where F: Filter<S>`, following the example of `Layer`. A `None` layer filter passes everything through.

Also, it looks like Filter for Arc/Box doesn't pass through all the methods, so extend the `filter_impl_body` macro to include them.