### PR TITLE
format: dim compact targets, matching the default formatter

### DIFF
--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1065,15 +1065,14 @@ where
             write!(writer, "{:0>2?} ", std::thread::current().id())?;
         }
 
-        let bold = writer.bold();
         let dimmed = writer.dimmed();
         if self.display_target {
-            write!(writer, "{}{}", bold.paint(meta.target()), dimmed.paint(":"))?;
+            write!(writer, "{}{}", dimmed.paint(meta.target()), dimmed.paint(":"))?;
         }
 
         if self.display_filename {
             if let Some(filename) = meta.file() {
-                write!(writer, "{}{}", bold.paint(filename), dimmed.paint(":"))?;
+                write!(writer, "{}{}", dimmed.paint(filename), dimmed.paint(":"))?;
             }
         }
 
@@ -1082,9 +1081,9 @@ where
                 write!(
                     writer,
                     "{}{}{}{}",
-                    bold.prefix(),
+                    dimmed.prefix(),
                     line_number,
-                    bold.suffix(),
+                    dimmed.suffix(),
                     dimmed.paint(":")
                 )?;
             }


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/tracing/issues/2408



## Motivation

Fixes https://github.com/tokio-rs/tracing/issues/2408

## Solution

Just switch to use `dim`

Before:
![2022-12-08_13-58-40](https://user-images.githubusercontent.com/623453/206576169-63ee4e20-b56f-4c63-a9b3-80ba2e97eec9.png)
After:
![2022-12-08_13-55-36](https://user-images.githubusercontent.com/623453/206576055-878d360f-7b95-4e18-bc31-4fb6f1b71a3a.png)
Full mode for comparison:
![2022-12-08_13-55-48](https://user-images.githubusercontent.com/623453/206576054-6e38852c-cb3a-4b84-98e5-50463cdb5073.png)

