### PR TITLE
Add compile error on const fn instrumentation

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -79,7 +79,7 @@
 )]
 
 use proc_macro2::TokenStream;
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 use syn::parse::{Parse, ParseStream};
 use syn::{Attribute, ItemFn, Signature, Visibility};
 
@@ -342,6 +342,14 @@ mod expand;
 /// }
 /// ```
 ///
+/// `const fn` cannot be instrumented, and will result in a compilation failure:
+///
+/// ```compile_fail
+/// # use tracing_attributes::instrument;
+/// #[instrument]
+/// const fn my_const_function() {}
+/// ```
+///
 /// [span]: https://docs.rs/tracing/latest/tracing/span/index.html
 /// [`follows_from`]: https://docs.rs/tracing/latest/tracing/struct.Span.html#method.follows_from
 /// [`tracing`]: https://github.com/tokio-rs/tracing
@@ -384,6 +392,13 @@ fn instrument_precise(
 ) -> Result<proc_macro::TokenStream, syn::Error> {
     let input = syn::parse::<ItemFn>(item)?;
     let instrumented_function_name = input.sig.ident.to_string();
+
+    if input.sig.constness.is_some() {
+        return Ok(quote! {
+            compile_error!("instrumenting const fn not supported")
+        }
+        .into());
+    }
 
     // check for async_trait-like patterns in the block, and instrument
     // the future instead of the wrapper

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -395,7 +395,7 @@ fn instrument_precise(
 
     if input.sig.constness.is_some() {
         return Ok(quote! {
-            compile_error!("instrumenting const fn not supported")
+            compile_error!("the `#[instrument]` attribute may not be used with `const fn`s")
         }
         .into());
     }

--- a/tracing-attributes/tests/ui.rs
+++ b/tracing-attributes/tests/ui.rs
@@ -5,3 +5,10 @@ fn async_instrument() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/async_instrument.rs");
 }
+
+#[rustversion::stable]
+#[test]
+fn const_instrument() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/const_instrument.rs");
+}

--- a/tracing-attributes/tests/ui/const_instrument.rs
+++ b/tracing-attributes/tests/ui/const_instrument.rs
@@ -1,0 +1,8 @@
+#![allow(unreachable_code)]
+
+#[tracing::instrument]
+const fn unit() {
+    ""
+}
+
+fn main() {}

--- a/tracing-attributes/tests/ui/const_instrument.stderr
+++ b/tracing-attributes/tests/ui/const_instrument.stderr
@@ -1,0 +1,15 @@
+error: macros that expand to items must be delimited with braces or followed by a semicolon
+ --> tests/ui/async_instrument.rs:3:1
+  |
+3 | #[tracing::instrument]
+  | ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `tracing::instrument` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: instrumenting const fn not supported
+ --> tests/ui/async_instrument.rs:3:1
+  |
+3 | #[tracing::instrument]
+  | ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `tracing::instrument` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tracing-attributes/tests/ui/const_instrument.stderr
+++ b/tracing-attributes/tests/ui/const_instrument.stderr
@@ -6,7 +6,7 @@ error: macros that expand to items must be delimited with braces or followed by 
   |
   = note: this error originates in the attribute macro `tracing::instrument` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: instrumenting const fn not supported
+error: the `#[instrument]` attribute may not be used with `const fn`s
  --> tests/ui/async_instrument.rs:3:1
   |
 3 | #[tracing::instrument]

--- a/tracing-attributes/tests/ui/const_instrument.stderr
+++ b/tracing-attributes/tests/ui/const_instrument.stderr
@@ -1,5 +1,5 @@
 error: macros that expand to items must be delimited with braces or followed by a semicolon
- --> tests/ui/async_instrument.rs:3:1
+ --> tests/ui/const_instrument.rs:3:1
   |
 3 | #[tracing::instrument]
   | ^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ error: macros that expand to items must be delimited with braces or followed by 
   = note: this error originates in the attribute macro `tracing::instrument` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the `#[instrument]` attribute may not be used with `const fn`s
- --> tests/ui/async_instrument.rs:3:1
+ --> tests/ui/const_instrument.rs:3:1
   |
 3 | #[tracing::instrument]
   | ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes: #2414

I'm newer to using macro expansions to enforce `compile_error!` calls, and this is my interpretation on how to approach it.  Unfortunately, the `compile_error!` is triggering regardless of whether I'm instrumenting a function or not, which makes me think I'm not approaching the code generation portion correctly.

Should I be forming this as a `proc_macro` instead of a `macro_rules`?