### PR TITLE
attributes: update `async_instrument` error text for Rust 1.66

### DIFF
--- a/tracing-attributes/tests/ui/async_instrument.stderr
+++ b/tracing-attributes/tests/ui/async_instrument.stderr
@@ -93,6 +93,6 @@ error[E0308]: mismatched types
 42 |   async fn extra_semicolon() -> i32 {
    |  ___________________________________^
 43 | |     1;
-   | |      - help: remove this semicolon
+   | |      - help: remove this semicolon to return this value
 44 | | }
    | |_^ expected `i32`, found `()`


### PR DESCRIPTION
## Motivation

There is a broken test in `tracing-attributes/tests/ui/async_instrument.rs`
caused by a change in an error message in `rustc`.

## Solution

The error message suggesting that you remove a semicolon to return a
value (instead of unit) was updated slightly in rust-lang/rust#102650,
which was included in Rust 1.66.0.

This causes one of the tests in tracing-attributes to fail. We fix it by
using the updated error message.
