### PR TITLE
attributes: document default level for `err`

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -270,6 +270,8 @@ mod expand;
 /// }
 /// ```
 ///
+/// The level of the error value event defaults to `ERROR`.
+///
 /// Similarly, overriding the level of the `err` event :
 ///
 /// ```


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

The current description for the default level of the `err` return value event _strongly implies_ it's the same as the span. However, the implementation actually defaults to `ERROR`.

## Solution

This PR documents that, so future generations don't have to chase down the truth, like I did. 😉 