### PR TITLE
mock: document public APIs in `subscriber` module

### DIFF
--- a/tracing-mock/src/collector.rs
+++ b/tracing-mock/src/collector.rs
@@ -231,7 +231,7 @@ where
             Some(Expect::Event(mut expected)) => {
                 #[cfg(feature = "tracing-subscriber")]
                 {
-                    if !expected.scope_mut().is_empty() {
+                    if expected.scope_mut().is_some() {
                         unimplemented!(
                             "Expected scope for events is not supported with `MockCollector`."
                         )

--- a/tracing-mock/src/subscriber.rs
+++ b/tracing-mock/src/subscriber.rs
@@ -1,5 +1,5 @@
-//! An implementation of the [`Subscribe`] trait to receive and validate
-//! `tracing` data.
+//! An implementation of the [`Subscribe`] trait which validates that
+//! the `tracing` data it recieves matches  the expected output for a test.
 //!
 //!
 //! The [`MockSubscriber`] is the central component in these tools. The
@@ -206,10 +206,10 @@ pub fn named(name: impl std::fmt::Display) -> MockSubscriberBuilder {
     mock().named(name)
 }
 
-/// A builder for the [`MockSubscriber`].
+/// A builder for constructing [`MockSubscriber`]s.
 ///
-/// Use the methods on this struct to set expectations which are
-/// validated by the [`MockSubscriber`].
+/// The methods on this builder set expectations which are then
+/// validated by the constructed [`MockSubscriber`].
 ///
 /// For a detailed description and examples see the documentation
 /// for the methods and the [`subscriber`] module.
@@ -221,9 +221,9 @@ pub struct MockSubscriberBuilder {
     name: String,
 }
 
-/// A subscriber which can be used to validate received traces.
+/// A subscriber which validates the traces it receives.
 ///
-/// The `MockSubscriber` is constructed with the
+/// A `MockSubscriber` is constructed with a
 /// [`MockSubscriberBuilder`]. For a detailed description and examples,
 /// see the documentation for that struct and for the [`subscriber`]
 /// module.
@@ -245,14 +245,14 @@ impl MockSubscriberBuilder {
     /// (*technically*, the name of the thread where it was created, which is
     /// the name of the test unless tests are run with `--test-threads=1`).
     /// When a test has only one mock subscriber, this is sufficient. However,
-    /// some tests may include multiple subscriber, in order to test
-    /// interactions between multiple subscriber. In that case, it can be
+    /// some tests may include multiple subscribers, in order to test
+    /// interactions between multiple subscribers. In that case, it can be
     /// helpful to give each subscriber a separate name to distinguish where the
     /// debugging output comes from.
     ///
     /// # Examples
     ///
-    /// In the following example, we create 2 subscribers, both
+    /// In the following example, we create two subscribers, both
     /// expecting to receive an event. As we only record a single
     /// event, the test will fail:
     ///
@@ -307,7 +307,7 @@ impl MockSubscriberBuilder {
         self
     }
 
-    /// Adds the expectation that an event matching the [`ExpectedEvent`]
+    /// Adds an expectation that an event matching the [`ExpectedEvent`]
     /// will be recorded next.
     ///
     /// The `event` can be a default mock which will match any event
@@ -362,7 +362,7 @@ impl MockSubscriberBuilder {
         self
     }
 
-    /// Adds the expectation that the creation of a span will be
+    /// Adds an expectation that the creation of a span will be
     /// recorded next.
     ///
     /// This function accepts `Into<NewSpan>` instead of
@@ -431,12 +431,14 @@ impl MockSubscriberBuilder {
         self
     }
 
-    /// Adds the expectation that entering a span matching the
+    /// Adds an expectation that entering a span matching the
     /// [`ExpectedSpan`] will be recorded next.
     ///
     /// This expectation is generally accompanied by a call to
-    /// [`exit`] as well. If used together with [`only`], this
-    /// is necessary.
+    /// [`exit`], since an entered span will typically be exited. If used 
+    /// together with [`only`], this is likely necessary, because the span
+    /// will be dropped before the test completes (except in rare cases,
+    /// such as if [`std::mem::forget`] is used).
     ///
     /// If the span that is entered doesn't match the [`ExpectedSpan`],
     /// or if something else (such as an event) is recorded first,
@@ -505,7 +507,7 @@ impl MockSubscriberBuilder {
         self
     }
 
-    /// Adds the expectation that exiting a span matching the
+    /// Adds an expectation that exiting a span matching the
     /// [`ExpectedSpan`] will be recorded next.
     ///
     /// As a span may be entered and exited multiple times,
@@ -641,7 +643,7 @@ impl MockSubscriberBuilder {
         self
     }
 
-    /// Consume the receiver and return a [`MockSubscriber`] which can
+    /// Consume this builder and return a [`MockSubscriber`] which can
     /// be set as the default subscriber.
     ///
     /// This function is similar to [`run_with_handle`], but it doesn't
@@ -683,7 +685,7 @@ impl MockSubscriberBuilder {
         }
     }
 
-    /// Consume the receiver and return a [`MockSubscriber`] which can
+    /// Consume this builder and return a [`MockSubscriber`] which can
     /// be set as the default subscriber and a [`MockHandle`] which can
     /// be used to validate the provided expectations.
     ///

--- a/tracing-mock/src/subscriber.rs
+++ b/tracing-mock/src/subscriber.rs
@@ -1,9 +1,124 @@
-#![allow(missing_docs, dead_code)]
+//! An implementation of the [`Subscribe`] trait to receive and validate
+//! `tracing` data.
+//!
+//!
+//! The [`MockSubscriber`] is the central component in these tools. The
+//! `MockSubscriber` has expectations set on it which are later
+//! validated as the code under test is run.
+//!
+//! ```
+//! use tracing_mock::{expect, field, subscriber};
+//! use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt, Subscribe};
+//!
+//! let (subscriber, handle) = subscriber::mock()
+//!     // Expect a single event with a specified message
+//!     .event(expect::event().with_fields(field::msg("droids")))
+//!     .run_with_handle();
+//!
+//! // Use `set_default` to apply the `MockSubscriber` until the end
+//! // of the current scope (when the guard `_collect` is dropped).
+//! let _collect = tracing_subscriber::registry()
+//!     .with(subscriber.with_filter(tracing_subscriber::filter::filter_fn(move |_meta| true)))
+//!     .set_default();
+//!
+//! // These *are* the droids we are looking for
+//! tracing::info!("droids");
+//!
+//! // Use the handle to check the assertions. This line will panic if an
+//! // assertion is not met.
+//! handle.assert_finished();
+//! ```
+//!
+//! A more complex example may consider multiple spans and events with
+//! their respective fields:
+//!
+//! ```
+//! use tracing_mock::{expect, field, subscriber};
+//! use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt, Subscribe};
+//!
+//! let span = expect::span()
+//!     .named("my_span");
+//! let (subscriber, handle) = subscriber::mock()
+//!     // Enter a matching span
+//!     .enter(span.clone())
+//!     // Record an event with message "collect parting message"
+//!     .event(expect::event().with_fields(field::msg("say hello")))
+//!     // Exit a matching span
+//!     .exit(span)
+//!     // Expect no further messages to be recorded
+//!     .only()
+//!     // Return the collector and handle
+//!     .run_with_handle();
+//!
+//! // Use `set_default` to apply the `MockSubscriber` until the end
+//! // of the current scope (when the guard `_collect` is dropped).
+//! let _collect = tracing_subscriber::registry()
+//!     .with(subscriber.with_filter(tracing_subscriber::filter::filter_fn(move |_meta| true)))
+//!     .set_default();
+//!
+//! {
+//!     let span = tracing::trace_span!(
+//!         "my_span",
+//!         greeting = "hello world",
+//!     );
+//!
+//!     let _guard = span.enter();
+//!     tracing::info!("say hello");
+//! }
+//!
+//! // Use the handle to check the assertions. This line will panic if an
+//! // assertion is not met.
+//! handle.assert_finished();
+//! ```
+//!
+//! If we modify the previous example so that we **don't** enter the
+//! span before recording an event, the test will fail:
+//!
+//! ```should_panic
+//! use tracing_mock::{expect, field, subscriber};
+//! use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt, Subscribe};
+//!
+//! let span = expect::span()
+//!     .named("my_span");
+//! let (subscriber, handle) = subscriber::mock()
+//!     // Enter a matching span
+//!     .enter(span.clone())
+//!     // Record an event with message "collect parting message"
+//!     .event(expect::event().with_fields(field::msg("say hello")))
+//!     // Exit a matching span
+//!     .exit(span)
+//!     // Expect no further messages to be recorded
+//!     .only()
+//!     // Return the collector and handle
+//!     .run_with_handle();
+//!
+//! // Use `set_default` to apply the `MockSubscriber` until the end
+//! // of the current scope (when the guard `_collect` is dropped).
+//! let _collect = tracing_subscriber::registry()
+//!     .with(subscriber.with_filter(tracing_subscriber::filter::filter_fn(move |_meta| true)))
+//!     .set_default();
+//!
+//! {
+//!     let span = tracing::trace_span!(
+//!         "my_span",
+//!         greeting = "hello world",
+//!     );
+//!
+//!     // Don't enter the span.
+//!     // let _guard = span.enter();
+//!     tracing::info!("say hello");
+//! }
+//!
+//! // Use the handle to check the assertions. This line will panic if an
+//! // assertion is not met.
+//! handle.assert_finished();
+//! ```
+//!
+//! [`Subscribe`]: trait@tracing_subscriber::subscribe::Subscribe
 use crate::{
     collector::MockHandle,
     event::ExpectedEvent,
     expect::Expect,
-    field::ExpectedFields,
     span::{ExpectedSpan, NewSpan},
 };
 use tracing_core::{
@@ -21,6 +136,54 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+/// Create a [`MockSubscriberBuilder`] used to construct a
+/// [`MockSubscriber`].
+///
+/// For additional information and examples, see the [`subscriber`]
+/// module and [`MockSubscriberBuilder`] documentation.
+///
+/// # Examples
+///
+/// ```
+/// use tracing_mock::{expect, field, subscriber};
+/// use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt, Subscribe};
+///
+/// let span = expect::span()
+///     .named("my_span");
+/// let (subscriber, handle) = subscriber::mock()
+///     // Enter a matching span
+///     .enter(span.clone())
+///     // Record an event with message "collect parting message"
+///     .event(expect::event().with_fields(field::msg("say hello")))
+///     // Exit a matching span
+///     .exit(span)
+///     // Expect no further messages to be recorded
+///     .only()
+///     // Return the collector and handle
+///     .run_with_handle();
+///
+/// // Use `set_default` to apply the `MockSubscriber` until the end
+/// // of the current scope (when the guard `_collect` is dropped).
+/// let _collect = tracing_subscriber::registry()
+///     .with(subscriber.with_filter(tracing_subscriber::filter::filter_fn(move |_meta| true)))
+///     .set_default();
+///
+/// {
+///     let span = tracing::trace_span!(
+///         "my_span",
+///         greeting = "hello world",
+///     );
+///
+///     let _guard = span.enter();
+///     tracing::info!("say hello");
+/// }
+///
+/// // Use the handle to check the assertions. This line will panic if an
+/// // assertion is not met.
+/// handle.assert_finished();
+/// ```
+///
+/// [`subscriber`]: mod@crate::subscriber
 pub fn mock() -> MockSubscriberBuilder {
     MockSubscriberBuilder {
         expected: Default::default(),
@@ -31,15 +194,41 @@ pub fn mock() -> MockSubscriberBuilder {
     }
 }
 
+/// Create a [`MockSubscriberBuilder`] with a name already set.
+///
+/// This constructor is equivalent to `subscriber::mock().named(name)`.
+///
+/// For additional information and examples, see the [`subscriber`]
+/// module and [`MockSubscriberBuilder`] documentation.
+///
+/// [`subscriber`]: mod@crate::subscriber
 pub fn named(name: impl std::fmt::Display) -> MockSubscriberBuilder {
     mock().named(name)
 }
+
+/// A builder for the [`MockSubscriber`].
+///
+/// Use the methods on this struct to set expectations which are
+/// validated by the [`MockSubscriber`].
+///
+/// For a detailed description and examples see the documentation
+/// for the methods and the [`subscriber`] module.
+///
+/// [`subscriber`]: mod@crate::subscriber
 
 pub struct MockSubscriberBuilder {
     expected: VecDeque<Expect>,
     name: String,
 }
 
+/// A subscriber which can be used to validate received traces.
+///
+/// The `MockSubscriber` is constructed with the
+/// [`MockSubscriberBuilder`]. For a detailed description and examples,
+/// see the documentation for that struct and for the [`subscriber`]
+/// module.
+///
+/// [`subscriber`]: mod@crate::subscriber
 pub struct MockSubscriber {
     expected: Arc<Mutex<VecDeque<Expect>>>,
     current: Mutex<Vec<Id>>,
@@ -56,10 +245,58 @@ impl MockSubscriberBuilder {
     /// (*technically*, the name of the thread where it was created, which is
     /// the name of the test unless tests are run with `--test-threads=1`).
     /// When a test has only one mock subscriber, this is sufficient. However,
-    /// some tests may include multiple subscribers, in order to test
-    /// interactions between multiple subscribers. In that case, it can be
+    /// some tests may include multiple subscriber, in order to test
+    /// interactions between multiple subscriber. In that case, it can be
     /// helpful to give each subscriber a separate name to distinguish where the
     /// debugging output comes from.
+    ///
+    /// # Examples
+    ///
+    /// In the following example, we create 2 subscribers, both
+    /// expecting to receive an event. As we only record a single
+    /// event, the test will fail:
+    ///
+    /// ```should_panic
+    /// use tracing_mock::{subscriber, expect};
+    /// use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt, Subscribe};
+    ///
+    /// let (subscriber_1, handle_1) = subscriber::mock()
+    ///     .named("subscriber-1")
+    ///     .event(expect::event())
+    ///     .run_with_handle();
+    ///
+    /// let (subscriber_2, handle_2) = subscriber::mock()
+    ///     .named("subscriber-2")
+    ///     .event(expect::event())
+    ///     .run_with_handle();
+    ///
+    /// let _collect = tracing_subscriber::registry()
+    ///     .with(subscriber_2.with_filter(tracing_subscriber::filter::filter_fn(move |_meta| true)))
+    ///     .set_default();
+    /// {
+    ///     let _collect = tracing_subscriber::registry()
+    ///         .with(subscriber_1.with_filter(tracing_subscriber::filter::filter_fn(move |_meta| true)))
+    ///         .set_default();
+    ///
+    ///     tracing::info!("a");
+    /// }
+    ///
+    /// handle_1.assert_finished();
+    /// handle_2.assert_finished();
+    /// ```
+    ///
+    /// In the test output, we see that the subscriber which didn't
+    /// received the event was the one named `subscriber-2`, which is
+    /// correct as the subscriber named `subscriber-1` was the default
+    /// when the event was recorded:
+    ///
+    /// ```text
+    /// [main::subscriber-2] more notifications expected: [
+    ///     Event(
+    ///         MockEvent,
+    ///     ),
+    /// ]', tracing-mock/src/collector.rs:472:13
+    /// ```
     pub fn named(mut self, name: impl fmt::Display) -> Self {
         use std::fmt::Write;
         if !self.name.is_empty() {
@@ -70,34 +307,122 @@ impl MockSubscriberBuilder {
         self
     }
 
-    pub fn enter(mut self, span: ExpectedSpan) -> Self {
-        self.expected.push_back(Expect::Enter(span));
-        self
-    }
-
+    /// Adds the expectation that an event matching the [`ExpectedEvent`]
+    /// will be recorded next.
+    ///
+    /// The `event` can be a default mock which will match any event
+    /// (`expect::event()`) or can include additional expectations.
+    /// See the [`ExpectedEvent`] documentation for more details.
+    ///
+    /// If an event is recorded that doesn't match the `ExpectedEvent`,
+    /// or if something else (such as entering a span) is recorded
+    /// first, then the expectation will fail.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tracing_mock::{expect, subscriber};
+    /// use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt, Subscribe};
+    ///
+    /// let (subscriber, handle) = subscriber::mock()
+    ///     .event(expect::event())
+    ///     .run_with_handle();
+    ///
+    /// let _collect = tracing_subscriber::registry()
+    ///     .with(subscriber.with_filter(tracing_subscriber::filter::filter_fn(move |_meta| true)))
+    ///     .set_default();
+    ///
+    /// tracing::info!("event");
+    ///
+    /// handle.assert_finished();
+    /// ```
+    ///
+    /// A span is entered before the event, causing the test to fail:
+    ///
+    /// ```should_panic
+    /// use tracing_mock::{expect, subscriber};
+    /// use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt, Subscribe};
+    ///
+    /// let (subscriber, handle) = subscriber::mock()
+    ///     .event(expect::event())
+    ///     .run_with_handle();
+    ///
+    /// let _collect = tracing_subscriber::registry()
+    ///     .with(subscriber.with_filter(tracing_subscriber::filter::filter_fn(move |_meta| true)))
+    ///     .set_default();
+    ///
+    /// let span = tracing::info_span!("span");
+    /// let _guard = span.enter();
+    /// tracing::info!("event");
+    ///
+    /// handle.assert_finished();
+    /// ```
     pub fn event(mut self, event: ExpectedEvent) -> Self {
         self.expected.push_back(Expect::Event(event));
         self
     }
 
-    pub fn exit(mut self, span: ExpectedSpan) -> Self {
-        self.expected.push_back(Expect::Exit(span));
-        self
-    }
-
-    pub fn only(mut self) -> Self {
-        self.expected.push_back(Expect::Nothing);
-        self
-    }
-
-    pub fn record<I>(mut self, span: ExpectedSpan, fields: I) -> Self
-    where
-        I: Into<ExpectedFields>,
-    {
-        self.expected.push_back(Expect::Visit(span, fields.into()));
-        self
-    }
-
+    /// Adds the expectation that the creation of a span will be
+    /// recorded next.
+    ///
+    /// This function accepts `Into<NewSpan>` instead of
+    /// [`ExpectedSpan`] directly, so it can be used to test
+    /// span fields and the span parent.
+    ///
+    /// The new span doesn't need to be entered for this expectation
+    /// to succeed.
+    ///
+    /// If a span is recorded that doesn't match the `ExpectedSpan`,
+    /// or if something else (such as an event) is recorded first,
+    /// then the expectation will fail.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tracing_mock::{expect, subscriber};
+    /// use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt, Subscribe};
+    ///
+    /// let span = expect::span()
+    ///     .at_level(tracing::Level::INFO)
+    ///     .named("the span we're testing")
+    ///     .with_field(expect::field("testing").with_value(&"yes"));
+    /// let (subscriber, handle) = subscriber::mock()
+    ///     .new_span(span)
+    ///     .run_with_handle();
+    ///
+    /// let _collect = tracing_subscriber::registry()
+    ///     .with(subscriber.with_filter(tracing_subscriber::filter::filter_fn(move |_meta| true)))
+    ///     .set_default();
+    ///
+    /// _ = tracing::info_span!("the span we're testing", testing = "yes");
+    ///
+    /// handle.assert_finished();
+    /// ```
+    ///
+    /// An event is recorded before the span is created, causing the
+    /// test to fail:
+    ///
+    /// ```should_panic
+    /// use tracing_mock::{expect, subscriber};
+    /// use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt, Subscribe};
+    ///
+    /// let span = expect::span()
+    ///     .at_level(tracing::Level::INFO)
+    ///     .named("the span we're testing")
+    ///     .with_field(expect::field("testing").with_value(&"yes"));
+    /// let (subscriber, handle) = subscriber::mock()
+    ///     .new_span(span)
+    ///     .run_with_handle();
+    ///
+    /// let _collect = tracing_subscriber::registry()
+    ///     .with(subscriber.with_filter(tracing_subscriber::filter::filter_fn(move |_meta| true)))
+    ///     .set_default();
+    ///
+    /// tracing::info!("an event");
+    /// _ = tracing::info_span!("the span we're testing", testing = "yes");
+    ///
+    /// handle.assert_finished();
+    /// ```
     pub fn new_span<I>(mut self, new_span: I) -> Self
     where
         I: Into<NewSpan>,
@@ -106,6 +431,250 @@ impl MockSubscriberBuilder {
         self
     }
 
+    /// Adds the expectation that entering a span matching the
+    /// [`ExpectedSpan`] will be recorded next.
+    ///
+    /// This expectation is generally accompanied by a call to
+    /// [`exit`] as well. If used together with [`only`], this
+    /// is necessary.
+    ///
+    /// If the span that is entered doesn't match the [`ExpectedSpan`],
+    /// or if something else (such as an event) is recorded first,
+    /// then the expectation will fail.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tracing_mock::{expect, subscriber};
+    /// use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt, Subscribe};
+    ///
+    /// let span = expect::span()
+    ///     .at_level(tracing::Level::INFO)
+    ///     .named("the span we're testing");
+    /// let (subscriber, handle) = subscriber::mock()
+    ///     .enter(span.clone())
+    ///     .exit(span)
+    ///     .only()
+    ///     .run_with_handle();
+    ///
+    /// let _collect = tracing_subscriber::registry()
+    ///     .with(subscriber.with_filter(tracing_subscriber::filter::filter_fn(move |_meta| true)))
+    ///     .set_default();
+    ///
+    /// {
+    ///     let span = tracing::info_span!("the span we're testing");
+    ///     let _entered = span.enter();
+    /// }
+    ///
+    /// handle.assert_finished();
+    /// ```
+    ///
+    /// An event is recorded before the span is entered, causing the
+    /// test to fail:
+    ///
+    /// ```should_panic
+    /// use tracing_mock::{expect, subscriber};
+    /// use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt, Subscribe};
+    ///
+    /// let span = expect::span()
+    ///     .at_level(tracing::Level::INFO)
+    ///     .named("the span we're testing");
+    /// let (subscriber, handle) = subscriber::mock()
+    ///     .enter(span.clone())
+    ///     .exit(span)
+    ///     .only()
+    ///     .run_with_handle();
+    ///
+    /// let _collect = tracing_subscriber::registry()
+    ///     .with(subscriber.with_filter(tracing_subscriber::filter::filter_fn(move |_meta| true)))
+    ///     .set_default();
+    ///
+    /// {
+    ///     tracing::info!("an event");
+    ///     let span = tracing::info_span!("the span we're testing");
+    ///     let _entered = span.enter();
+    /// }
+    ///
+    /// handle.assert_finished();
+    /// ```
+    ///
+    /// [`exit`]: fn@Self::exit
+    /// [`only`]: fn@Self::only
+    pub fn enter(mut self, span: ExpectedSpan) -> Self {
+        self.expected.push_back(Expect::Enter(span));
+        self
+    }
+
+    /// Adds the expectation that exiting a span matching the
+    /// [`ExpectedSpan`] will be recorded next.
+    ///
+    /// As a span may be entered and exited multiple times,
+    /// this is different from the span being closed. In
+    /// general [`enter`] and `exit` should be paired.
+    ///
+    /// If the span that is exited doesn't match the [`ExpectedSpan`],
+    /// or if something else (such as an event) is recorded first,
+    /// then the expectation will fail.
+    ///
+    /// **Note**: Ensure that the guard returned by [`Span::enter`]
+    /// is dropped before calling [`MockHandle::assert_finished`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tracing_mock::{expect, subscriber};
+    /// use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt, Subscribe};
+    ///
+    /// let span = expect::span()
+    ///     .at_level(tracing::Level::INFO)
+    ///     .named("the span we're testing");
+    /// let (subscriber, handle) = subscriber::mock()
+    ///     .enter(span.clone())
+    ///     .exit(span)
+    ///     .only()
+    ///     .run_with_handle();
+    ///
+    /// let _collect = tracing_subscriber::registry()
+    ///     .with(subscriber.with_filter(tracing_subscriber::filter::filter_fn(move |_meta| true)))
+    ///     .set_default();
+    /// {
+    ///     let span = tracing::info_span!("the span we're testing");
+    ///     let _entered = span.enter();
+    /// }
+    ///
+    /// handle.assert_finished();
+    /// ```
+    ///
+    /// An event is recorded before the span is exited, causing the
+    /// test to fail:
+    ///
+    /// ```should_panic
+    /// use tracing_mock::{expect, subscriber};
+    /// use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt, Subscribe};
+    ///
+    /// let span = expect::span()
+    ///     .at_level(tracing::Level::INFO)
+    ///     .named("the span we're testing");
+    /// let (subscriber, handle) = subscriber::mock()
+    ///     .enter(span.clone())
+    ///     .exit(span)
+    ///     .only()
+    ///     .run_with_handle();
+    ///
+    /// let _collect = tracing_subscriber::registry()
+    ///     .with(subscriber.with_filter(tracing_subscriber::filter::filter_fn(move |_meta| true)))
+    ///     .set_default();
+    ///
+    /// {
+    ///     let span = tracing::info_span!("the span we're testing");
+    ///     let _entered = span.enter();
+    ///     tracing::info!("an event");
+    /// }
+    ///
+    /// handle.assert_finished();
+    /// ```
+    ///
+    /// [`enter`]: fn@Self::enter
+    /// [`MockHandle::assert_finished`]: fn@crate::collector::MockHandle::assert_finished
+    /// [`Span::enter`]: fn@tracing::Span::enter
+    pub fn exit(mut self, span: ExpectedSpan) -> Self {
+        self.expected.push_back(Expect::Exit(span));
+        self
+    }
+
+    /// Expects that no further traces are received.
+    ///
+    /// The call to `only` should appear immediately before the final
+    /// call to [`run`] or [`run_with_handle`], as any expectations which
+    /// are added after `only` will not be considered.
+    ///
+    /// # Examples
+    ///
+    /// Consider this simple test. It passes even though we only
+    /// expect a single event, but receive three:
+    ///
+    /// ```
+    /// use tracing_mock::{expect, subscriber};
+    /// use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt, Subscribe};
+    ///
+    /// let (subscriber, handle) = subscriber::mock()
+    ///     .event(expect::event())
+    ///     .run_with_handle();
+    ///
+    /// let _collect = tracing_subscriber::registry()
+    ///     .with(subscriber.with_filter(tracing_subscriber::filter::filter_fn(move |_meta| true)))
+    ///     .set_default();
+    ///
+    /// tracing::info!("a");
+    /// tracing::info!("b");
+    /// tracing::info!("c");
+    ///
+    /// handle.assert_finished();
+    /// ```
+    ///
+    /// After including `only`, the test will fail:
+    ///
+    /// ```should_panic
+    /// use tracing_mock::{expect, subscriber};
+    /// use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt, Subscribe};
+    ///
+    /// let (subscriber, handle) = subscriber::mock()
+    ///     .event(expect::event())
+    ///     .only()
+    ///     .run_with_handle();
+    ///
+    /// let _collect = tracing_subscriber::registry()
+    ///     .with(subscriber.with_filter(tracing_subscriber::filter::filter_fn(move |_meta| true)))
+    ///     .set_default();
+    ///
+    /// tracing::info!("a");
+    /// tracing::info!("b");
+    /// tracing::info!("c");
+    ///
+    /// handle.assert_finished();
+    /// ```
+    ///
+    /// [`run`]: fn@Self::run
+    /// [`run_with_handle`]: fn@Self::run_with_handle
+    pub fn only(mut self) -> Self {
+        self.expected.push_back(Expect::Nothing);
+        self
+    }
+
+    /// Consume the receiver and return a [`MockSubscriber`] which can
+    /// be set as the default subscriber.
+    ///
+    /// This function is similar to [`run_with_handle`], but it doesn't
+    /// return a [`MockHandle`]. This is useful if the desired
+    /// assertions can be checked externally to the subscriber.
+    ///
+    /// # Examples
+    ///
+    /// The following test is used within the `tracing-subscriber`
+    /// codebase:
+    ///
+    /// ```
+    /// use tracing::Collect;
+    /// use tracing_mock::subscriber;
+    /// use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt, Subscribe};
+    ///
+    /// let unfiltered = subscriber::named("unfiltered").run().boxed();
+    /// let info = subscriber::named("info")
+    ///     .run()
+    ///     .with_filter(tracing_core::LevelFilter::INFO)
+    ///     .boxed();
+    /// let debug = subscriber::named("debug")
+    ///     .run()
+    ///     .with_filter(tracing_core::LevelFilter::DEBUG)
+    ///     .boxed();
+    ///
+    /// let collector = tracing_subscriber::registry().with(vec![unfiltered, info, debug]);
+    ///
+    /// assert_eq!(collector.max_level_hint(), None);
+    /// ```
+    ///
+    /// [`MockHandle`]: struct@crate::collector::MockHandle
+    /// [`run_with_handle`]: fn@Self::run_with_handle
     pub fn run(self) -> MockSubscriber {
         MockSubscriber {
             expected: Arc::new(Mutex::new(self.expected)),
@@ -114,6 +683,31 @@ impl MockSubscriberBuilder {
         }
     }
 
+    /// Consume the receiver and return a [`MockSubscriber`] which can
+    /// be set as the default subscriber and a [`MockHandle`] which can
+    /// be used to validate the provided expectations.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tracing_mock::{expect, subscriber};
+    /// use tracing_subscriber::{subscribe::CollectExt, util::SubscriberInitExt, Subscribe};
+    ///
+    /// let (subscriber, handle) = subscriber::mock()
+    ///     .event(expect::event())
+    ///     .run_with_handle();
+    ///
+    /// let _collect = tracing_subscriber::registry()
+    ///     .with(subscriber.with_filter(tracing_subscriber::filter::filter_fn(move |_meta| true)))
+    ///     .set_default();
+    ///
+    /// tracing::info!("event");
+    ///
+    /// handle.assert_finished();
+    /// ```
+    ///
+    /// [`MockHandle`]: struct@crate::collector::MockHandle
+    /// [`MockSubscriber`]: struct@crate::subscriber::MockSubscriber
     pub fn run_with_handle(self) -> (MockSubscriber, MockHandle) {
         let expected = Arc::new(Mutex::new(self.expected));
         let handle = MockHandle::new(expected.clone(), self.name.clone());
@@ -185,6 +779,46 @@ impl MockSubscriber {
             );
         }
     }
+
+    fn check_event_scope<C>(
+        &self,
+        current_scope: Option<tracing_subscriber::registry::Scope<'_, C>>,
+        expected_scope: &mut [ExpectedSpan],
+    ) where
+        C: for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>,
+    {
+        let mut current_scope = current_scope.into_iter().flatten();
+        let mut i = 0;
+        for (expected, actual) in expected_scope.iter_mut().zip(&mut current_scope) {
+            println!(
+                "[{}] event_scope[{}] actual={} ({:?}); expected={}",
+                self.name,
+                i,
+                actual.name(),
+                actual.id(),
+                expected
+            );
+            self.check_span_ref(
+                expected,
+                &actual,
+                format_args!("the {}th span in the event's scope to be", i),
+            );
+            i += 1;
+        }
+        let remaining_expected = &expected_scope[i..];
+        assert!(
+            remaining_expected.is_empty(),
+            "\n[{}] did not observe all expected spans in event scope!\n[{}] missing: {:#?}",
+            self.name,
+            self.name,
+            remaining_expected,
+        );
+        assert!(
+            current_scope.next().is_none(),
+            "\n[{}] did not expect all spans in the actual event scope!",
+            self.name,
+        );
+    }
 }
 
 impl<C> Subscribe<C> for MockSubscriber
@@ -221,45 +855,21 @@ where
             Some(Expect::Event(mut expected)) => {
                 let get_parent_name = || cx.event_span(event).map(|span| span.name().to_string());
                 expected.check(event, get_parent_name, &self.name);
-                let mut current_scope = cx.event_scope(event).into_iter().flatten();
-                let expected_scope = expected.scope_mut();
-                let mut i = 0;
-                for (expected, actual) in expected_scope.iter_mut().zip(&mut current_scope) {
-                    println!(
-                        "[{}] event_scope[{}] actual={} ({:?}); expected={}",
-                        self.name,
-                        i,
-                        actual.name(),
-                        actual.id(),
-                        expected
-                    );
-                    self.check_span_ref(
-                        expected,
-                        &actual,
-                        format_args!("the {}th span in the event's scope to be", i),
-                    );
-                    i += 1;
+
+                if let Some(expected_scope) = expected.scope_mut() {
+                    self.check_event_scope(cx.event_scope(event), expected_scope);
                 }
-                let remaining_expected = &expected_scope[i..];
-                assert!(
-                    remaining_expected.is_empty(),
-                    "\n[{}] did not observe all expected spans in event scope!\n[{}] missing: {:#?}",
-                    self.name,
-                    self.name,
-                    remaining_expected,
-                );
-                assert!(
-                    current_scope.next().is_none(),
-                    "\n[{}] did not expect all spans in the actual event scope!",
-                    self.name,
-                );
             }
             Some(ex) => ex.bad(&self.name, format_args!("observed event {:#?}", event)),
         }
     }
 
     fn on_follows_from(&self, _span: &Id, _follows: &Id, _: Context<'_, C>) {
-        // TODO: it should be possible to expect spans to follow from other spans
+        unimplemented!(
+            "so far, we don't have any tests that need an `on_follows_from` \
+            implementation.\nif you just wrote one that does, feel free to \
+            implement it!"
+        );
     }
 
     fn on_new_span(&self, span: &Attributes<'_>, id: &Id, cx: Context<'_, C>) {


### PR DESCRIPTION
## Motivation

There has been interest around publishing `tracing-mock` to crates.io
for some time. In order to make this possible, documentation and some
code clean up is needed.

The `subscriber` module needs documentation and examples.

## Solution

This change adds documentation to the `subscriber` module and all the public
APIs within it. This includes doctests on all the methods which serve as
examples.

The `MockSubscriberBuilder::record` method was removed as its
functionality is not implemented.

Previously, the `MockSubscriber` would verify the scope of an
`ExpectedEvent`, even if `in_scope` hadn't been called. In this case,
that would check that an event was not in a span if `in_scope` had not
been called. `tracing-subscriber` all adhere to this pattern. However it
is different to the behavior of all other expectation methods, where an
explicit call is needed to expect something, otherwise nothing is
checked. As such, the behavior has been modified to align with the rest
of the crate. The previous behavior can be achieved by calling
`in_scope(None)` to verify that an event has no scope. The documentation
for `in_scope` has been updated with an example for this case.

The tests in `tracing-subscriber` which previously verified *implicitly*
that an event had no scope (by not calling `in_scope` at all) have *not*
been modified. It is my opinion that this implicit behavior was never
required.

Refs: #539