### PR TITLE
fix(doc): warning styles in html-in-header

### DIFF
--- a/assets/warning-css.html
+++ b/assets/warning-css.html
@@ -1,4 +1,5 @@
-#tracing-warning-header {
+<style>
+  #tracing-warning-header {
     z-index: 400;
     position: fixed;
     background-color: orange;
@@ -12,14 +13,15 @@
     line-height: 0.6;
     padding-top: 10px;
     padding-left: 230px;
-}
+  }
 
-body {
+  body {
     /* add top padding to fit the warning header */
     padding-top: 50px !important;
-}
+  }
 
-.sidebar {
+  .sidebar {
     /* add top padding to fit the warning header */
     margin-top: 50px !important;
-}
+  }
+</style>

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,7 @@
     --cfg docsrs \
     --html-before-content /opt/build/repo/assets/warning.html \
     --html-in-header /opt/build/repo/assets/noindex.html \
-    --extend-css /opt/build/repo/assets/warning.css \
+    --html-in-header /opt/build/repo/assets/warning-css.html \
     """
 
 [[redirects]]


### PR DESCRIPTION
## Motivation

The documentation under https://tracing.rs/tracing/ is missing CSS styles.
Fixes #2444 

## Solution

Used the `--html-in-header` rustdoc flag instead of `--extend-css`. Converted the css file into an html file.
