### PR TITLE
fix new clippy lints from 1.67.0

### DIFF
--- a/tracing-error/src/subscriber.rs
+++ b/tracing-error/src/subscriber.rs
@@ -111,9 +111,9 @@ where
 }
 
 impl WithContext {
-    pub(crate) fn with_context<'a>(
+    pub(crate) fn with_context(
         &self,
-        dispatch: &'a Dispatch,
+        dispatch: &Dispatch,
         id: &span::Id,
         mut f: impl FnMut(&'static Metadata<'static>, &str) -> bool,
     ) {

--- a/tracing-opentelemetry/src/subscriber.rs
+++ b/tracing-opentelemetry/src/subscriber.rs
@@ -83,9 +83,9 @@ pub(crate) struct WithContext(
 impl WithContext {
     // This function allows a function to be called in the context of the
     // "remembered" subscriber.
-    pub(crate) fn with_context<'a>(
+    pub(crate) fn with_context(
         &self,
-        dispatch: &'a tracing::Dispatch,
+        dispatch: &tracing::Dispatch,
         id: &span::Id,
         mut f: impl FnMut(&mut OtelData, &dyn PreSampledTracer),
     ) {


### PR DESCRIPTION
## Motivation

New clippy lints in Rust 1.67.0 are causing pipelines to fail with
existing code, this should be fixed so that pipelines pass again.

## Solution

There are new warnings as errors reported by clippy in Rust 1.67.0.

This are causing builds to fail, e.g.:
https://github.com/tokio-rs/tracing/actions/runs/4027112923/jobs/6922513360

In both cases they are reports of lifetimes that can be elided. This
change removes the unnecessary lifetime annotations to make clippy
happy.
