### PR TITLE
Add parameter to track thread name for padding

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -492,6 +492,22 @@ where
         }
     }
 
+    /// Sets whether or not the length of the [name] of the current thread is
+    /// tracked for padding.
+    ///
+    /// [name]: std::thread#naming-threads
+    pub fn with_thread_names_length_tracking(
+        self,
+        track_thread_name_length: bool,
+    ) -> Layer<S, N, format::Format<L, T>, W> {
+        Layer {
+            fmt_event: self
+                .fmt_event
+                .with_thread_names_length_tracking(track_thread_name_length),
+            ..self
+        }
+    }
+
     /// Sets the layer being built to use a [less verbose formatter][super::format::Compact].
     pub fn compact(self) -> Layer<S, N, format::Format<format::Compact, T>, W>
     where


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
Closes #2465 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Added a new parameter to disable the padding. Let me know if the name is ok or not.
I made sure the default behaviour remains the same.
