### PR TITLE
add tracing-indicatif as a related crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ are not maintained by the `tokio` project. These include:
 - [`tracing-logfmt`] provides a layer that formats events and spans into the logfmt format.
 - [`tracing-chrome`] provides a layer that exports trace data that can be viewed in `chrome://tracing`.
 - [`reqwest-tracing`] provides a middleware to trace [`reqwest`] HTTP requests.
+- [`tracing-indicatif`] provides a layer to show [`indicatif`] CLI progress bars for active spans.
 
 (if you're the maintainer of a `tracing` ecosystem crate not in this list,
 please let us know!)
@@ -451,6 +452,8 @@ please let us know!)
 [`tracing-chrome`]: https://crates.io/crates/tracing-chrome
 [`reqwest-tracing`]: https://crates.io/crates/reqwest-tracing
 [`reqwest`]: https://crates.io/crates/reqwest
+[`tracing-indicatif`]: https://crates.io/crates/tracing-indicatif
+[`indicatif`]: https://crates.io/crates/indicatif
 
 **Note:** that some of the ecosystem crates are currently unreleased and
 undergoing active development. They may be less stable than `tracing` and

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -808,6 +808,8 @@
 //!  - [`tracing-loki`] provides a layer for shipping logs to [Grafana Loki].
 //!  - [`tracing-logfmt`] provides a layer that formats events and spans into the logfmt format.
 //!  - [`reqwest-tracing`] provides a middleware to trace [`reqwest`] HTTP requests.
+//!  - [`reqwest-tracing`] provides a middleware to trace [`reqwest`] HTTP requests.
+//!  - [`tracing-indicatif`] provides a layer to show [`indicatif`] CLI progress bars for active spans.
 //!
 //! If you're the maintainer of a `tracing` ecosystem crate not listed above,
 //! please let us know! We'd love to add your project to the list!
@@ -848,6 +850,8 @@
 //! [`tracing-logfmt`]: https://crates.io/crates/tracing-logfmt
 //! [`reqwest-tracing`]: https://crates.io/crates/reqwest-tracing
 //! [`reqwest`]: https://crates.io/crates/reqwest
+//! [`tracing-indicatif`]: https://crates.io/crates/tracing-indicatif
+//! [`indicatif`]: https://crates.io/crates/indicatif
 //!
 //! <div class="example-wrap" style="display:inline-block">
 //! <pre class="ignore" style="white-space:normal;font:inherit;">


### PR DESCRIPTION
I published the first release of the [tracing-indicatif](https://crates.io/crates/tracing-indicatif) crate that provides a tracing layer to show indicatif progress bars for active spans. @davidbarsky recommended I add this as a related crate to tracing given its potential usefulness to other Rust CLI developers.

Test Plan:
tested with `cargo doc --open` and the entries are formatted as expected.