### PR TITLE
fix: %<ident> fields in info! macro

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -1573,7 +1573,7 @@ macro_rules! info {
         $crate::event!(target: $target, $crate::Level::INFO, { ?$($k).+ $($field)* })
     );
     (target: $target:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(target: $target, $crate::Level::INFO, { $($k).+ $($field)* })
+        $crate::event!(target: $target, $crate::Level::INFO, { %$($k).+ $($field)* })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
         $crate::event!(target: $target, $crate::Level::INFO, {}, $($arg)+)

--- a/tracing/tests/macros.rs
+++ b/tracing/tests/macros.rs
@@ -10,10 +10,26 @@ use tracing::{
 // they're compile-time tests, so I want to get line numbers etc out of
 // failures, and producing them with a macro would muddy the waters a bit.
 
+struct DebugValue;
+impl std::fmt::Debug for DebugValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DebugOnly")
+    }
+}
+const DEBUG_VALUE: DebugValue = DebugValue;
+
+struct DisplayValue;
+impl std::fmt::Display for DisplayValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DisplayOnly")
+    }
+}
+const DISPLAY_VALUE: DisplayValue = DisplayValue;
+
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn span() {
-    span!(target: "foo_events", Level::DEBUG, "foo", bar.baz = ?2, quux = %3, quuux = 4);
+    span!(target: "foo_events", Level::DEBUG, "foo", bar.baz = ?DEBUG_VALUE, quux = %DISPLAY_VALUE, quuux = 4);
     span!(target: "foo_events", Level::DEBUG, "foo", bar.baz = 2, quux = 3);
     span!(target: "foo_events", Level::DEBUG, "foo", bar.baz = 2, quux = 4,);
     span!(target: "foo_events", Level::DEBUG, "foo");
@@ -22,8 +38,8 @@ fn span() {
     span!(Level::DEBUG, "foo", bar.baz = 2, quux = 4,);
     span!(Level::DEBUG, "foo", bar.baz = 2, quux = 3);
     span!(Level::DEBUG, "foo", bar.baz = 2, quux = 4,);
-    span!(Level::DEBUG, "foo", bar.baz = ?2);
-    span!(Level::DEBUG, "foo", bar.baz = %2);
+    span!(Level::DEBUG, "foo", bar.baz = ?DEBUG_VALUE);
+    span!(Level::DEBUG, "foo", bar.baz = %DISPLAY_VALUE);
     span!(Level::DEBUG, "foo");
     span!(Level::DEBUG, "bar",);
 }
@@ -31,15 +47,15 @@ fn span() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn trace_span() {
-    trace_span!(target: "foo_events", "foo", bar.baz = ?2, quux = %3, quuux = 4);
+    trace_span!(target: "foo_events", "foo", bar.baz = ?DEBUG_VALUE, quux = %DISPLAY_VALUE, quuux = 4);
     trace_span!(target: "foo_events", "foo", bar.baz = 2, quux = 3);
     trace_span!(target: "foo_events", "foo", bar.baz = 2, quux = 4,);
     trace_span!(target: "foo_events", "foo");
     trace_span!(target: "foo_events", "bar",);
     trace_span!("foo", bar.baz = 2, quux = 3);
     trace_span!("foo", bar.baz = 2, quux = 4,);
-    trace_span!("foo", bar.baz = ?2);
-    trace_span!("foo", bar.baz = %2);
+    trace_span!("foo", bar.baz = ?DEBUG_VALUE);
+    trace_span!("foo", bar.baz = %DISPLAY_VALUE);
     trace_span!("bar");
     trace_span!("bar",);
 }
@@ -47,15 +63,15 @@ fn trace_span() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn debug_span() {
-    debug_span!(target: "foo_events", "foo", bar.baz = ?2, quux = %3, quuux = 4);
+    debug_span!(target: "foo_events", "foo", bar.baz = ?DEBUG_VALUE, quux = %DISPLAY_VALUE, quuux = 4);
     debug_span!(target: "foo_events", "foo", bar.baz = 2, quux = 3);
     debug_span!(target: "foo_events", "foo", bar.baz = 2, quux = 4,);
     debug_span!(target: "foo_events", "foo");
     debug_span!(target: "foo_events", "bar",);
     debug_span!("foo", bar.baz = 2, quux = 3);
     debug_span!("foo", bar.baz = 2, quux = 4,);
-    debug_span!("foo", bar.baz = ?2);
-    debug_span!("foo", bar.baz = %2);
+    debug_span!("foo", bar.baz = ?DEBUG_VALUE);
+    debug_span!("foo", bar.baz = %DISPLAY_VALUE);
     debug_span!("bar");
     debug_span!("bar",);
 }
@@ -63,15 +79,15 @@ fn debug_span() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn info_span() {
-    info_span!(target: "foo_events", "foo", bar.baz = ?2, quux = %3, quuux = 4);
+    info_span!(target: "foo_events", "foo", bar.baz = ?DEBUG_VALUE, quux = %DISPLAY_VALUE, quuux = 4);
     info_span!(target: "foo_events", "foo", bar.baz = 2, quux = 3);
     info_span!(target: "foo_events", "foo", bar.baz = 2, quux = 4,);
     info_span!(target: "foo_events", "foo");
     info_span!(target: "foo_events", "bar",);
     info_span!("foo", bar.baz = 2, quux = 3);
     info_span!("foo", bar.baz = 2, quux = 4,);
-    info_span!("foo", bar.baz = ?2);
-    info_span!("foo", bar.baz = %2);
+    info_span!("foo", bar.baz = ?DEBUG_VALUE);
+    info_span!("foo", bar.baz = %DISPLAY_VALUE);
     info_span!("bar");
     info_span!("bar",);
 }
@@ -79,15 +95,15 @@ fn info_span() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn warn_span() {
-    warn_span!(target: "foo_events", "foo", bar.baz = ?2, quux = %3, quuux = 4);
+    warn_span!(target: "foo_events", "foo", bar.baz = ?DEBUG_VALUE, quux = %DISPLAY_VALUE, quuux = 4);
     warn_span!(target: "foo_events", "foo", bar.baz = 2, quux = 3);
     warn_span!(target: "foo_events", "foo", bar.baz = 2, quux = 4,);
     warn_span!(target: "foo_events", "foo");
     warn_span!(target: "foo_events", "bar",);
     warn_span!("foo", bar.baz = 2, quux = 3);
     warn_span!("foo", bar.baz = 2, quux = 4,);
-    warn_span!("foo", bar.baz = ?2);
-    warn_span!("foo", bar.baz = %2);
+    warn_span!("foo", bar.baz = ?DEBUG_VALUE);
+    warn_span!("foo", bar.baz = %DISPLAY_VALUE);
     warn_span!("bar");
     warn_span!("bar",);
 }
@@ -95,15 +111,15 @@ fn warn_span() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn error_span() {
-    error_span!(target: "foo_events", "foo", bar.baz = ?2, quux = %3, quuux = 4);
+    error_span!(target: "foo_events", "foo", bar.baz = ?DEBUG_VALUE, quux = %DISPLAY_VALUE, quuux = 4);
     error_span!(target: "foo_events", "foo", bar.baz = 2, quux = 3);
     error_span!(target: "foo_events", "foo", bar.baz = 2, quux = 4,);
     error_span!(target: "foo_events", "foo");
     error_span!(target: "foo_events", "bar",);
     error_span!("foo", bar.baz = 2, quux = 3);
     error_span!("foo", bar.baz = 2, quux = 4,);
-    error_span!("foo", bar.baz = ?2);
-    error_span!("foo", bar.baz = %2);
+    error_span!("foo", bar.baz = ?DEBUG_VALUE);
+    error_span!("foo", bar.baz = %DISPLAY_VALUE);
     error_span!("bar");
     error_span!("bar",);
 }
@@ -284,8 +300,8 @@ fn error_span_with_parent() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn span_with_non_rust_symbol() {
-    span!(Level::TRACE, "non-rust", "guid:x-request-id" = ?"abcdef", "more {}", 42);
-    span!(Level::TRACE, "non-rust", "guid:x-request-id" = %"abcdef", "more {}", 51);
+    span!(Level::TRACE, "non-rust", "guid:x-request-id" = ?DEBUG_VALUE, "more {}", 42);
+    span!(Level::TRACE, "non-rust", "guid:x-request-id" = %DISPLAY_VALUE, "more {}", 51);
     span!(
         Level::TRACE,
         "non-rust",
@@ -293,20 +309,20 @@ fn span_with_non_rust_symbol() {
         "more {}",
         60
     );
-    span!(Level::TRACE, "non-rust", "guid:x-request-id" = ?"abcdef");
-    span!(Level::TRACE, "non-rust", "guid:x-request-id" = %"abcdef");
+    span!(Level::TRACE, "non-rust", "guid:x-request-id" = ?DEBUG_VALUE);
+    span!(Level::TRACE, "non-rust", "guid:x-request-id" = %DISPLAY_VALUE);
     span!(Level::TRACE, "non-rust", "guid:x-request-id" = "abcdef");
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn event() {
-    event!(Level::DEBUG, foo = ?3, bar.baz = %2, quux = false);
+    event!(Level::DEBUG, foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false);
     event!(Level::DEBUG, foo = 3, bar.baz = 2, quux = false);
     event!(Level::DEBUG, foo = 3, bar.baz = 3,);
     event!(Level::DEBUG, "foo");
     event!(Level::DEBUG, "foo: {}", 3);
-    event!(Level::INFO, foo = ?3, bar.baz = %2, quux = false, "hello world {:?}", 42);
+    event!(Level::INFO, foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false, "hello world {:?}", 42);
     event!(
         Level::INFO,
         foo = 3,
@@ -319,7 +335,7 @@ fn event() {
     event!(Level::DEBUG, { foo = 3, bar.baz = 80 }, "quux");
     event!(Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     event!(Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    event!(Level::DEBUG, { foo = ?2, bar.baz = %78 }, "quux");
+    event!(Level::DEBUG, { foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE }, "quux");
     event!(target: "foo_events", Level::DEBUG, foo = 3, bar.baz = 2, quux = false);
     event!(target: "foo_events", Level::DEBUG, foo = 3, bar.baz = 3,);
     event!(target: "foo_events", Level::DEBUG, "foo");
@@ -328,9 +344,11 @@ fn event() {
     event!(target: "foo_events", Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     event!(target: "foo_events", Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     event!(target: "foo_events", Level::DEBUG, { foo = 2, bar.baz = 78, }, "quux");
+    let debug_foo = DEBUG_VALUE;
+    let display_foo = DISPLAY_VALUE;
     let foo = 1;
-    event!(Level::DEBUG, ?foo);
-    event!(Level::DEBUG, %foo);
+    event!(Level::DEBUG, ?debug_foo);
+    event!(Level::DEBUG, %display_foo);
     event!(Level::DEBUG, foo);
 }
 
@@ -381,7 +399,7 @@ fn event_enabled() {
 fn locals_with_message() {
     let data = (42, "forty-two");
     let private_data = "private";
-    let error = "a bad error";
+    let error = DISPLAY_VALUE;
     event!(Level::ERROR, %error, "Received error");
     event!(
         target: "app_events",
@@ -425,19 +443,19 @@ fn locals_no_message() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn trace() {
-    trace!(foo = ?3, bar.baz = %2, quux = false);
+    trace!(foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false);
     trace!(foo = 3, bar.baz = 2, quux = false);
     trace!(foo = 3, bar.baz = 3,);
     trace!("foo");
     trace!("foo: {}", 3);
-    trace!(foo = ?3, bar.baz = %2, quux = false, "hello world {:?}", 42);
+    trace!(foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false, "hello world {:?}", 42);
     trace!(foo = 3, bar.baz = 2, quux = false, "hello world {:?}", 42);
     trace!(foo = 3, bar.baz = 3, "hello world {:?}", 42,);
     trace!({ foo = 3, bar.baz = 80 }, "quux");
     trace!({ foo = 2, bar.baz = 79 }, "quux {:?}", true);
     trace!({ foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     trace!({ foo = 2, bar.baz = 78 }, "quux");
-    trace!({ foo = ?2, bar.baz = %78 }, "quux");
+    trace!({ foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE }, "quux");
     trace!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     trace!(target: "foo_events", foo = 3, bar.baz = 3,);
     trace!(target: "foo_events", "foo");
@@ -446,34 +464,36 @@ fn trace() {
     trace!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     trace!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     trace!(target: "foo_events", { foo = 2, bar.baz = 78, }, "quux");
+    let debug_foo = DEBUG_VALUE;
+    let display_foo = DISPLAY_VALUE;
     let foo = 1;
-    trace!(?foo);
-    trace!(%foo);
+    trace!(?debug_foo);
+    trace!(%display_foo);
     trace!(foo);
-    trace!(target: "foo_events", ?foo);
-    trace!(target: "foo_events", %foo);
+    trace!(target: "foo_events", ?debug_foo);
+    trace!(target: "foo_events", %display_foo);
     trace!(target: "foo_events", foo);
-    trace!(target: "foo_events", ?foo, true, "message");
-    trace!(target: "foo_events", %foo, true, "message");
+    trace!(target: "foo_events", ?debug_foo, true, "message");
+    trace!(target: "foo_events", %display_foo, true, "message");
     trace!(target: "foo_events", foo, true, "message");
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn debug() {
-    debug!(foo = ?3, bar.baz = %2, quux = false);
+    debug!(foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false);
     debug!(foo = 3, bar.baz = 2, quux = false);
     debug!(foo = 3, bar.baz = 3,);
     debug!("foo");
     debug!("foo: {}", 3);
-    debug!(foo = ?3, bar.baz = %2, quux = false, "hello world {:?}", 42);
+    debug!(foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false, "hello world {:?}", 42);
     debug!(foo = 3, bar.baz = 2, quux = false, "hello world {:?}", 42);
     debug!(foo = 3, bar.baz = 3, "hello world {:?}", 42,);
     debug!({ foo = 3, bar.baz = 80 }, "quux");
     debug!({ foo = 2, bar.baz = 79 }, "quux {:?}", true);
     debug!({ foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     debug!({ foo = 2, bar.baz = 78 }, "quux");
-    debug!({ foo = ?2, bar.baz = %78 }, "quux");
+    debug!({ foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE }, "quux");
     debug!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     debug!(target: "foo_events", foo = 3, bar.baz = 3,);
     debug!(target: "foo_events", "foo");
@@ -482,34 +502,36 @@ fn debug() {
     debug!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     debug!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     debug!(target: "foo_events", { foo = 2, bar.baz = 78, }, "quux");
+    let debug_foo = DEBUG_VALUE;
+    let display_foo = DISPLAY_VALUE;
     let foo = 1;
-    debug!(?foo);
-    debug!(%foo);
+    debug!(?debug_foo);
+    debug!(%display_foo);
     debug!(foo);
-    debug!(target: "foo_events", ?foo);
-    debug!(target: "foo_events", %foo);
+    debug!(target: "foo_events", ?debug_foo);
+    debug!(target: "foo_events", %display_foo);
     debug!(target: "foo_events", foo);
-    debug!(target: "foo_events", ?foo, true, "message");
-    debug!(target: "foo_events", %foo, true, "message");
+    debug!(target: "foo_events", ?debug_foo, true, "message");
+    debug!(target: "foo_events", %display_foo, true, "message");
     debug!(target: "foo_events", foo, true, "message");
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn info() {
-    info!(foo = ?3, bar.baz = %2, quux = false);
+    info!(foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false);
     info!(foo = 3, bar.baz = 2, quux = false);
     info!(foo = 3, bar.baz = 3,);
     info!("foo");
     info!("foo: {}", 3);
-    info!(foo = ?3, bar.baz = %2, quux = false, "hello world {:?}", 42);
+    info!(foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false, "hello world {:?}", 42);
     info!(foo = 3, bar.baz = 2, quux = false, "hello world {:?}", 42);
     info!(foo = 3, bar.baz = 3, "hello world {:?}", 42,);
     info!({ foo = 3, bar.baz = 80 }, "quux");
     info!({ foo = 2, bar.baz = 79 }, "quux {:?}", true);
     info!({ foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     info!({ foo = 2, bar.baz = 78 }, "quux");
-    info!({ foo = ?2, bar.baz = %78 }, "quux");
+    info!({ foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE }, "quux");
     info!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     info!(target: "foo_events", foo = 3, bar.baz = 3,);
     info!(target: "foo_events", "foo");
@@ -518,34 +540,36 @@ fn info() {
     info!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     info!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     info!(target: "foo_events", { foo = 2, bar.baz = 78, }, "quux");
+    let debug_foo = DEBUG_VALUE;
+    let display_foo = DISPLAY_VALUE;
     let foo = 1;
-    info!(?foo);
-    info!(%foo);
+    info!(?debug_foo);
+    info!(%display_foo);
     info!(foo);
-    info!(target: "foo_events", ?foo);
-    info!(target: "foo_events", %foo);
+    info!(target: "foo_events", ?debug_foo);
+    info!(target: "foo_events", %display_foo);
     info!(target: "foo_events", foo);
-    info!(target: "foo_events", ?foo, true, "message");
-    info!(target: "foo_events", %foo, true, "message");
+    info!(target: "foo_events", ?debug_foo, true, "message");
+    info!(target: "foo_events", %display_foo, true, "message");
     info!(target: "foo_events", foo, true, "message");
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn warn() {
-    warn!(foo = ?3, bar.baz = %2, quux = false);
+    warn!(foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false);
     warn!(foo = 3, bar.baz = 2, quux = false);
     warn!(foo = 3, bar.baz = 3,);
     warn!("foo");
     warn!("foo: {}", 3);
-    warn!(foo = ?3, bar.baz = %2, quux = false, "hello world {:?}", 42);
+    warn!(foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false, "hello world {:?}", 42);
     warn!(foo = 3, bar.baz = 2, quux = false, "hello world {:?}", 42);
     warn!(foo = 3, bar.baz = 3, "hello world {:?}", 42,);
     warn!({ foo = 3, bar.baz = 80 }, "quux");
     warn!({ foo = 2, bar.baz = 79 }, "quux {:?}", true);
     warn!({ foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     warn!({ foo = 2, bar.baz = 78 }, "quux");
-    warn!({ foo = ?2, bar.baz = %78 }, "quux");
+    warn!({ foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE }, "quux");
     warn!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     warn!(target: "foo_events", foo = 3, bar.baz = 3,);
     warn!(target: "foo_events", "foo");
@@ -554,34 +578,36 @@ fn warn() {
     warn!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     warn!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     warn!(target: "foo_events", { foo = 2, bar.baz = 78, }, "quux");
+    let debug_foo = DEBUG_VALUE;
+    let display_foo = DISPLAY_VALUE;
     let foo = 1;
-    warn!(?foo);
-    warn!(%foo);
+    warn!(?debug_foo);
+    warn!(%display_foo);
     warn!(foo);
-    warn!(target: "foo_events", ?foo);
-    warn!(target: "foo_events", %foo);
+    warn!(target: "foo_events", ?debug_foo);
+    warn!(target: "foo_events", %display_foo);
     warn!(target: "foo_events", foo);
-    warn!(target: "foo_events", ?foo, true, "message");
-    warn!(target: "foo_events", %foo, true, "message");
+    warn!(target: "foo_events", ?debug_foo, true, "message");
+    warn!(target: "foo_events", %display_foo, true, "message");
     warn!(target: "foo_events", foo, true, "message");
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn error() {
-    error!(foo = ?3, bar.baz = %2, quux = false);
+    error!(foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false);
     error!(foo = 3, bar.baz = 2, quux = false);
     error!(foo = 3, bar.baz = 3,);
     error!("foo");
     error!("foo: {}", 3);
-    error!(foo = ?3, bar.baz = %2, quux = false, "hello world {:?}", 42);
+    error!(foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false, "hello world {:?}", 42);
     error!(foo = 3, bar.baz = 2, quux = false, "hello world {:?}", 42);
     error!(foo = 3, bar.baz = 3, "hello world {:?}", 42,);
     error!({ foo = 3, bar.baz = 80 }, "quux");
     error!({ foo = 2, bar.baz = 79 }, "quux {:?}", true);
     error!({ foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     error!({ foo = 2, bar.baz = 78, }, "quux");
-    error!({ foo = ?2, bar.baz = %78 }, "quux");
+    error!({ foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE }, "quux");
     error!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     error!(target: "foo_events", foo = 3, bar.baz = 3,);
     error!(target: "foo_events", "foo");
@@ -590,22 +616,24 @@ fn error() {
     error!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     error!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     error!(target: "foo_events", { foo = 2, bar.baz = 78, }, "quux");
+    let debug_foo = DEBUG_VALUE;
+    let display_foo = DISPLAY_VALUE;
     let foo = 1;
-    error!(?foo);
-    error!(%foo);
+    error!(?debug_foo);
+    error!(%display_foo);
     error!(foo);
-    error!(target: "foo_events", ?foo);
-    error!(target: "foo_events", %foo);
+    error!(target: "foo_events", ?debug_foo);
+    error!(target: "foo_events", %display_foo);
     error!(target: "foo_events", foo);
-    error!(target: "foo_events", ?foo, true, "message");
-    error!(target: "foo_events", %foo, true, "message");
+    error!(target: "foo_events", ?debug_foo, true, "message");
+    error!(target: "foo_events", %display_foo, true, "message");
     error!(target: "foo_events", foo, true, "message");
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn event_root() {
-    event!(parent: None, Level::DEBUG, foo = ?3, bar.baz = %2, quux = false);
+    event!(parent: None, Level::DEBUG, foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false);
     event!(
         parent: None,
         Level::DEBUG,
@@ -619,7 +647,7 @@ fn event_root() {
     event!(parent: None, Level::DEBUG, { foo = 3, bar.baz = 80 }, "quux");
     event!(parent: None, Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     event!(parent: None, Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    event!(parent: None, Level::DEBUG, { foo = ?2, bar.baz = %78 }, "quux");
+    event!(parent: None, Level::DEBUG, { foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE }, "quux");
     event!(target: "foo_events", parent: None, Level::DEBUG, foo = 3, bar.baz = 2, quux = false);
     event!(target: "foo_events", parent: None, Level::DEBUG, foo = 3, bar.baz = 3,);
     event!(target: "foo_events", parent: None, Level::DEBUG, "foo");
@@ -633,7 +661,7 @@ fn event_root() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn trace_root() {
-    trace!(parent: None, foo = ?3, bar.baz = %2, quux = false);
+    trace!(parent: None, foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false);
     trace!(parent: None, foo = 3, bar.baz = 2, quux = false);
     trace!(parent: None, foo = 3, bar.baz = 3,);
     trace!(parent: None, "foo");
@@ -642,7 +670,7 @@ fn trace_root() {
     trace!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     trace!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     trace!(parent: None, { foo = 2, bar.baz = 78 }, "quux");
-    trace!(parent: None, { foo = ?2, bar.baz = %78 }, "quux");
+    trace!(parent: None, { foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE }, "quux");
     trace!(target: "foo_events", parent: None, foo = 3, bar.baz = 2, quux = false);
     trace!(target: "foo_events", parent: None, foo = 3, bar.baz = 3,);
     trace!(target: "foo_events", parent: None, "foo");
@@ -656,7 +684,7 @@ fn trace_root() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn debug_root() {
-    debug!(parent: None, foo = ?3, bar.baz = %2, quux = false);
+    debug!(parent: None, foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false);
     debug!(parent: None, foo = 3, bar.baz = 2, quux = false);
     debug!(parent: None, foo = 3, bar.baz = 3,);
     debug!(parent: None, "foo");
@@ -665,7 +693,7 @@ fn debug_root() {
     debug!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     debug!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     debug!(parent: None, { foo = 2, bar.baz = 78 }, "quux");
-    debug!(parent: None, { foo = ?2, bar.baz = %78 }, "quux");
+    debug!(parent: None, { foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE }, "quux");
     debug!(target: "foo_events", parent: None, foo = 3, bar.baz = 2, quux = false);
     debug!(target: "foo_events", parent: None, foo = 3, bar.baz = 3,);
     debug!(target: "foo_events", parent: None, "foo");
@@ -679,7 +707,7 @@ fn debug_root() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn info_root() {
-    info!(parent: None, foo = ?3, bar.baz = %2, quux = false);
+    info!(parent: None, foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false);
     info!(parent: None, foo = 3, bar.baz = 2, quux = false);
     info!(parent: None, foo = 3, bar.baz = 3,);
     info!(parent: None, "foo");
@@ -688,7 +716,7 @@ fn info_root() {
     info!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     info!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     info!(parent: None, { foo = 2, bar.baz = 78 }, "quux");
-    info!(parent: None, { foo = ?2, bar.baz = %78 }, "quux");
+    info!(parent: None, { foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE }, "quux");
     info!(target: "foo_events", parent: None, foo = 3, bar.baz = 2, quux = false);
     info!(target: "foo_events", parent: None, foo = 3, bar.baz = 3,);
     info!(target: "foo_events", parent: None, "foo");
@@ -702,7 +730,7 @@ fn info_root() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn warn_root() {
-    warn!(parent: None, foo = ?3, bar.baz = %2, quux = false);
+    warn!(parent: None, foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false);
     warn!(parent: None, foo = 3, bar.baz = 2, quux = false);
     warn!(parent: None, foo = 3, bar.baz = 3,);
     warn!(parent: None, "foo");
@@ -711,7 +739,7 @@ fn warn_root() {
     warn!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     warn!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     warn!(parent: None, { foo = 2, bar.baz = 78 }, "quux");
-    warn!(parent: None, { foo = ?2, bar.baz = %78 }, "quux");
+    warn!(parent: None, { foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE }, "quux");
     warn!(target: "foo_events", parent: None, foo = 3, bar.baz = 2, quux = false);
     warn!(target: "foo_events", parent: None, foo = 3, bar.baz = 3,);
     warn!(target: "foo_events", parent: None, "foo");
@@ -725,7 +753,7 @@ fn warn_root() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn error_root() {
-    error!(parent: None, foo = ?3, bar.baz = %2, quux = false);
+    error!(parent: None, foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false);
     error!(parent: None, foo = 3, bar.baz = 2, quux = false);
     error!(parent: None, foo = 3, bar.baz = 3,);
     error!(parent: None, "foo");
@@ -734,7 +762,7 @@ fn error_root() {
     error!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     error!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     error!(parent: None, { foo = 2, bar.baz = 78 }, "quux");
-    error!(parent: None, { foo = ?2, bar.baz = %78 }, "quux");
+    error!(parent: None, { foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE }, "quux");
     error!(target: "foo_events", parent: None, foo = 3, bar.baz = 2, quux = false);
     error!(target: "foo_events", parent: None, foo = 3, bar.baz = 3,);
     error!(target: "foo_events", parent: None, "foo");
@@ -749,7 +777,7 @@ fn error_root() {
 #[test]
 fn event_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
-    event!(parent: &p, Level::DEBUG, foo = ?3, bar.baz = %2, quux = false);
+    event!(parent: &p, Level::DEBUG, foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false);
     event!(parent: &p, Level::DEBUG, foo = 3, bar.baz = 2, quux = false);
     event!(parent: &p, Level::DEBUG, foo = 3, bar.baz = 3,);
     event!(parent: &p, Level::DEBUG, "foo");
@@ -757,7 +785,7 @@ fn event_with_parent() {
     event!(parent: &p, Level::DEBUG, { foo = 3, bar.baz = 80 }, "quux");
     event!(parent: &p, Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     event!(parent: &p, Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    event!(parent: &p, Level::DEBUG, { foo = ?2, bar.baz = %78 }, "quux");
+    event!(parent: &p, Level::DEBUG, { foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE }, "quux");
     event!(target: "foo_events", parent: &p, Level::DEBUG, foo = 3, bar.baz = 2, quux = false);
     event!(target: "foo_events", parent: &p, Level::DEBUG, foo = 3, bar.baz = 3,);
     event!(target: "foo_events", parent: &p, Level::DEBUG, "foo");
@@ -772,7 +800,7 @@ fn event_with_parent() {
 #[test]
 fn trace_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
-    trace!(parent: &p, foo = ?3, bar.baz = %2, quux = false);
+    trace!(parent: &p, foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false);
     trace!(parent: &p, foo = 3, bar.baz = 2, quux = false);
     trace!(parent: &p, foo = 3, bar.baz = 3,);
     trace!(parent: &p, "foo");
@@ -781,7 +809,7 @@ fn trace_with_parent() {
     trace!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     trace!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     trace!(parent: &p, { foo = 2, bar.baz = 78 }, "quux");
-    trace!(parent: &p, { foo = ?2, bar.baz = %78 }, "quux");
+    trace!(parent: &p, { foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE }, "quux");
     trace!(target: "foo_events", parent: &p, foo = 3, bar.baz = 2, quux = false);
     trace!(target: "foo_events", parent: &p, foo = 3, bar.baz = 3,);
     trace!(target: "foo_events", parent: &p, "foo");
@@ -796,7 +824,7 @@ fn trace_with_parent() {
 #[test]
 fn debug_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
-    debug!(parent: &p, foo = ?3, bar.baz = %2, quux = false);
+    debug!(parent: &p, foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false);
     debug!(parent: &p, foo = 3, bar.baz = 2, quux = false);
     debug!(parent: &p, foo = 3, bar.baz = 3,);
     debug!(parent: &p, "foo");
@@ -805,7 +833,7 @@ fn debug_with_parent() {
     debug!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     debug!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     debug!(parent: &p, { foo = 2, bar.baz = 78 }, "quux");
-    debug!(parent: &p, { foo = ?2, bar.baz = %78 }, "quux");
+    debug!(parent: &p, { foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE }, "quux");
     debug!(target: "foo_events", parent: &p, foo = 3, bar.baz = 2, quux = false);
     debug!(target: "foo_events", parent: &p, foo = 3, bar.baz = 3,);
     debug!(target: "foo_events", parent: &p, "foo");
@@ -820,7 +848,7 @@ fn debug_with_parent() {
 #[test]
 fn info_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
-    info!(parent: &p, foo = ?3, bar.baz = %2, quux = false);
+    info!(parent: &p, foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false);
     info!(parent: &p, foo = 3, bar.baz = 2, quux = false);
     info!(parent: &p, foo = 3, bar.baz = 3,);
     info!(parent: &p, "foo");
@@ -829,7 +857,7 @@ fn info_with_parent() {
     info!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     info!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     info!(parent: &p, { foo = 2, bar.baz = 78 }, "quux");
-    info!(parent: &p, { foo = ?2, bar.baz = %78 }, "quux");
+    info!(parent: &p, { foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE }, "quux");
     info!(target: "foo_events", parent: &p, foo = 3, bar.baz = 2, quux = false);
     info!(target: "foo_events", parent: &p, foo = 3, bar.baz = 3,);
     info!(target: "foo_events", parent: &p, "foo");
@@ -844,7 +872,7 @@ fn info_with_parent() {
 #[test]
 fn warn_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
-    warn!(parent: &p, foo = ?3, bar.baz = %2, quux = false);
+    warn!(parent: &p, foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false);
     warn!(parent: &p, foo = 3, bar.baz = 2, quux = false);
     warn!(parent: &p, foo = 3, bar.baz = 3,);
     warn!(parent: &p, "foo");
@@ -853,7 +881,7 @@ fn warn_with_parent() {
     warn!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     warn!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     warn!(parent: &p, { foo = 2, bar.baz = 78 }, "quux");
-    warn!(parent: &p, { foo = ?2, bar.baz = %78 }, "quux");
+    warn!(parent: &p, { foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE }, "quux");
     warn!(target: "foo_events", parent: &p, foo = 3, bar.baz = 2, quux = false);
     warn!(target: "foo_events", parent: &p, foo = 3, bar.baz = 3,);
     warn!(target: "foo_events", parent: &p, "foo");
@@ -868,7 +896,7 @@ fn warn_with_parent() {
 #[test]
 fn error_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
-    error!(parent: &p, foo = ?3, bar.baz = %2, quux = false);
+    error!(parent: &p, foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE, quux = false);
     error!(parent: &p, foo = 3, bar.baz = 2, quux = false);
     error!(parent: &p, foo = 3, bar.baz = 3,);
     error!(parent: &p, "foo");
@@ -877,7 +905,7 @@ fn error_with_parent() {
     error!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     error!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     error!(parent: &p, { foo = 2, bar.baz = 78 }, "quux");
-    error!(parent: &p, { foo = ?2, bar.baz = %78 }, "quux");
+    error!(parent: &p, { foo = ?DEBUG_VALUE, bar.baz = %DISPLAY_VALUE }, "quux");
     error!(target: "foo_events", parent: &p, foo = 3, bar.baz = 2, quux = false);
     error!(target: "foo_events", parent: &p, foo = 3, bar.baz = 3,);
     error!(target: "foo_events", parent: &p, "foo");


### PR DESCRIPTION
Previously `info!(target: "foo", %display_only_value)` would not work,
because due to a bug display_only_value required an implementation of
`tracing::Value`. This commit fixes this bug, and makes the macro test
suite more robust for the debug & display macro shorthands.

The improved tests fail on master, but pass with the fix.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
