### PR TITLE
Move #1055 onto v0.1.x: TracedError::err_into

### DIFF
--- a/examples/examples/map-traced-error.rs
+++ b/examples/examples/map-traced-error.rs
@@ -1,0 +1,82 @@
+//! An example on composing errors inside of a `TracedError`, such that the
+//! SpanTrace captured is captured when creating the inner error, but still wraps
+//! the outer error.
+#![deny(rust_2018_idioms)]
+#![allow(clippy::try_err)]
+use std::error::Error;
+use std::fmt;
+use tracing_error::{prelude::*, ErrorSubscriber, TracedError};
+use tracing_subscriber::prelude::*;
+
+fn main() {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::subscriber())
+        // The `ErrorSubscriber` subscriber enables the use of `SpanTrace`.
+        .with(ErrorSubscriber::default())
+        .init();
+
+    let e = do_something().unwrap_err();
+    print_extracted_spantraces(&e);
+}
+
+// Iterate through the source errors and check if each error is actually the attached `SpanTrace`
+// before printing it
+fn print_extracted_spantraces(error: &(dyn Error + 'static)) {
+    let mut error = Some(error);
+    let mut ind = 0;
+
+    while let Some(err) = error {
+        if let Some(spantrace) = err.span_trace() {
+            eprintln!("Span Backtrace:\n{}", spantrace);
+        } else {
+            eprintln!("Error {}: {}", ind, err);
+        }
+
+        error = err.source();
+        ind += 1;
+    }
+}
+
+#[tracing::instrument]
+fn do_something() -> Result<(), TracedError<OuterError>> {
+    do_the_real_stuff().map_err(TracedError::err_into)
+}
+
+#[tracing::instrument]
+fn do_the_real_stuff() -> Result<(), TracedError<InnerError>> {
+    Err(InnerError).map_err(TracedError::from)
+}
+
+#[derive(Debug)]
+struct OuterError {
+    source: InnerError,
+}
+
+impl Error for OuterError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+impl fmt::Display for OuterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "outer error message")
+    }
+}
+
+impl From<InnerError> for OuterError {
+    fn from(source: InnerError) -> Self {
+        Self { source }
+    }
+}
+
+#[derive(Debug)]
+struct InnerError;
+
+impl Error for InnerError {}
+
+impl fmt::Display for InnerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "inner error message")
+    }
+}

--- a/examples/examples/map-traced-error.rs
+++ b/examples/examples/map-traced-error.rs
@@ -5,14 +5,14 @@
 #![allow(clippy::try_err)]
 use std::error::Error;
 use std::fmt;
-use tracing_error::{prelude::*, ErrorSubscriber, TracedError};
+use tracing_error::{prelude::*, ErrorLayer, TracedError};
 use tracing_subscriber::prelude::*;
 
 fn main() {
     tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::subscriber())
-        // The `ErrorSubscriber` subscriber enables the use of `SpanTrace`.
-        .with(ErrorSubscriber::default())
+        .with(tracing_subscriber::fmt::layer())
+        // The `ErrorLayer` subscriber enables the use of `SpanTrace`.
+        .with(ErrorLayer::default())
         .init();
 
     let e = do_something().unwrap_err();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation


This change is effectively required for users who follow a common pattern in error management, such as that supported by `thiserror`:

```rust
#[derive(thiserror::Error)
enum InnerError {
  #[error("it broke")]
  ItBroke
}

#[derive(thiserror::Error)
enum OuterError {
    #[error("inner error")]
    InnerError(#[from] InnerError)
}
```

`thiserror` implements `From<InnerError> for OuterError` which jives with `?`, but the `TracedError` wrapper blocks access to that.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution


This brings https://github.com/tokio-rs/tracing/pull/1055 over to the `v0.1.x` branch to support release, credit to @yaahc

It renames `ErrorSubscriber` -> `ErrorLayer` in the example to match the target branch.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
