### PR TITLE
core: Mark DefaultGuard as !Send

### DIFF
--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -143,6 +143,7 @@ use crate::{
 use core::{
     any::Any,
     fmt,
+    marker::PhantomData,
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
@@ -256,12 +257,27 @@ struct State {
 #[cfg(feature = "std")]
 struct Entered<'a>(&'a State);
 
+/// A trait that implements `Sync`, but not `Send`. Used with PhantomData, this
+/// can mark a struct as `!Send`.
+#[cfg(feature = "std")]
+trait NotSend: Sync {}
+
 /// A guard that resets the current default dispatcher to the prior
 /// default dispatcher when dropped.
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[derive(Debug)]
-pub struct DefaultGuard(Option<Dispatch>);
+pub struct DefaultGuard(
+    Option<Dispatch>,
+
+    /// ```compile_fail
+    /// use tracing_core::dispatch::*;
+    /// trait AssertSend: Send {}
+    ///
+    /// impl AssertSend for DefaultGuard {}
+    /// ```
+    PhantomData<dyn NotSend>,
+);
 
 /// Sets this dispatch as the default for the duration of a closure.
 ///
@@ -290,15 +306,24 @@ pub fn with_default<T>(dispatcher: &Dispatch, f: impl FnOnce() -> T) -> T {
     f()
 }
 
-/// Sets the dispatch as the default dispatch for the duration of the lifetime
-/// of the returned DefaultGuard
+/// Sets the dispatch as the current thread's default dispatch for the duration
+/// of the lifetime of the returned DefaultGuard.
 ///
 /// <div class="example-wrap" style="display:inline-block">
 /// <pre class="ignore" style="white-space:normal;font:inherit;">
 ///
 /// **Note**: This function required the Rust standard library.
 /// `no_std` users should use [`set_global_default`] instead.
+/// </pre></div>
 ///
+/// <div class="example-wrap" style="display:inline-block">
+/// <pre class="ignore" style="white-space:normal;font:inherit;">
+///
+/// **Note**: Because this sets the dispatch for the current thread only, the
+/// returned [`DefaultGuard`] does not implement [`Send`]. If the guard was sent
+/// to another thread and dropped there, we'd try to restore the dispatch value
+/// for the wrong thread. Thus, [`DefaultGuard`] should not be sent between
+/// threads.
 /// </pre></div>
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
@@ -1009,7 +1034,7 @@ impl State {
             .ok();
         EXISTS.store(true, Ordering::Release);
         SCOPED_COUNT.fetch_add(1, Ordering::Release);
-        DefaultGuard(prior)
+        DefaultGuard(prior, PhantomData)
     }
 
     #[inline]
@@ -1071,6 +1096,9 @@ mod test {
         collect::Interest,
         metadata::{Kind, Level, Metadata},
     };
+
+    trait AssertSync: Sync {}
+    impl AssertSync for DefaultGuard {}
 
     #[test]
     fn dispatch_is() {


### PR DESCRIPTION
## Motivation

#2482: Dropping `DefaultGuard` in another thread doesn't cause it to get cleaned up properly

The `Drop` impl of `DefaultGuard` modifies the `CURRENT_STATE` thread local, assuming it to be the same thread local it was constructed with.

However, because `DefaultGuard` is `Send`, that may be a different thread local.

## Solution

As discussed in #2482, we should mark `DefaultGuard` as `!Send`. **This is a breaking API change.**

This PR is modeled after #1001, which does the same thing for `Entered`. One notable change is that I use a different trick for marking the struct as `!Send` that doesn't involve `unsafe`.

`Entered` currently uses:

https://github.com/tokio-rs/tracing/blob/a0126b2e2d465e8e6d514acdf128fcef5b863d27/tracing/src/span.rs#L1581-L1591

My PR proposes the following trick instead:

```rust
/// A trait that implements `Sync`, but not `Send`. Used with PhantomData, this
/// can mark a struct as `!Send`.
#[cfg(feature = "std")]
trait NotSend: Sync {}

pub struct DefaultGuard(
    // ...
    PhantomData<dyn NotSend>,
);
```

If accepted:
- I can follow up with a documentation change for 0.1.x that explains the thread safety issue.
- I can follow up with a change to `tracing/src/span.rs` that removes the use of `unsafe` to implement `!Send`.