### PR TITLE
error: impl<E> Clone for TracedError where E: Clone

### DIFF
--- a/tracing-error/src/error.rs
+++ b/tracing-error/src/error.rs
@@ -181,6 +181,12 @@ where
     }
 }
 
+impl<E> std::clone::Clone for TracedError<E> where E: Clone {
+    fn clone(&self) -> Self {
+        Self { inner: self.inner.clone() }
+    }
+}
+
 impl<E> From<E> for TracedError<E>
 where
     E: Error + Send + Sync + 'static,
@@ -210,6 +216,12 @@ impl ErrorImpl<Erased> {
         // the function pointer we construct here will also retain the original type. therefore,
         // when this is consumed by the `error` method, it will be safe to call.
         unsafe { (self.vtable.object_ref)(self) }
+    }
+}
+
+impl<E> Clone for ErrorImpl<E> where E: Clone {
+    fn clone(&self) -> Self {
+        Self { vtable: self.vtable, span_trace: self.span_trace.clone(), error: self.error.clone() }
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

As a user of `TracedError`, I'd like to be able to clone it if I was previous able to clone
the error within.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

`impl<E> Clone for TracedError where E: Clone` clones inner data and copies
the `& 'static` vtable ref

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
