### PR TITLE
error: provide access to inner error within TracedError

### DIFF
--- a/tracing-error/src/error.rs
+++ b/tracing-error/src/error.rs
@@ -179,6 +179,50 @@ where
     {
         self.map(Into::into)
     }
+
+    /// Return a reference to the original error stored within this [`TracedError`].
+    ///
+    /// ```rust
+    /// use tracing_error::TracedError;
+    /// # #[derive(Clone, Debug, PartialEq)]
+    /// # struct MyError(u64);
+    /// # impl std::fmt::Display for MyError {
+    /// #     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    /// #         write!(f, "Inner Error")
+    /// #     }
+    /// # }
+    /// # impl std::error::Error for InnerError {}
+    ///
+    /// let original_err = MyError(42);
+    ///
+    /// let traced_err: TracedError<MyError> = TracedError::from(original_err.clone())
+    /// assert_eq!(traced_err.get_inner_error(), &original_err)
+    /// ```
+    pub fn get_inner_error(&self) -> &E {
+        &self.inner.error
+    }
+
+    /// Consume the [`TracedError`] and return the original error stored within.
+    ///
+    /// ```rust
+    /// use tracing_error::TracedError;
+    /// # #[derive(Clone, Debug, PartialEq)]
+    /// # struct MyError(u64);
+    /// # impl std::fmt::Display for MyError {
+    /// #     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    /// #         write!(f, "Inner Error")
+    /// #     }
+    /// # }
+    /// # impl std::error::Error for InnerError {}
+    ///
+    /// let original_err = MyError(42);
+    ///
+    /// let traced_err: TracedError<MyError> = TracedError::from(original_err.clone())
+    /// assert_eq!(traced_err.to_inner_error(), original_err)
+    /// ```
+    pub fn to_inner_error(self) -> E {
+        self.inner.error
+    }
 }
 
 impl<E> From<E> for TracedError<E>


### PR DESCRIPTION
## Motivation

This change makes `TracedError` a two-way door, making it easier to adopt in a larger codebase.

This change provides an "escape hatch" to be able to read and extract error stored within a TracedError. Among other things, this will help adoption of TracedError by:

* allowing onboarding users to still match against error variants,
  as might be common in test cases

* allowing crate users to bypass missing or unreleased features

* allowing for partial migration of a codebase, so that TracedError
  can be used in one portion, and then the original error extracted
  at some interface above which TracedError is not yet used or wanted.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Add `TracedError::get_inner_error` to get a ref, and `TracedError::to_inner_error` to extract the error entirely.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->