### PR TITLE
Add span IDs

### DIFF
--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -188,6 +188,7 @@ where
             // that the fields are not supposed to be missing.
             Err(e) => serializer.serialize_entry("field_error", &format!("{}", e))?,
         };
+        serializer.serialize_entry("id", &self.0.id().into_u64())?;
         serializer.serialize_entry("name", self.0.metadata().name())?;
         serializer.end()
     }


### PR DESCRIPTION
## Motivation

I think this will address [#1481](https://github.com/tokio-rs/tracing/issues/1481)

Having a general way to add span ID information to events being output as logs will enable trace-to-log linking in various tracing services.
