### PR TITLE
feat(appender): size-based rotation

### DIFF
--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -103,7 +103,7 @@ pub struct RollingFileAppender {
 #[derive(Debug)]
 pub struct RollingWriter<'a> {
     inner: RwLockReadGuard<'a, File>,
-    current_size: Arc<AtomicU64>,
+    current_size: &'a AtomicU64,
 }
 
 #[derive(Debug)]
@@ -269,7 +269,7 @@ impl<'a> tracing_subscriber::fmt::writer::MakeWriter<'a> for RollingFileAppender
 
         RollingWriter {
             inner: self.writer.read(),
-            current_size: Arc::clone(&self.state.current_size),
+            current_size: &self.state.current_size,
         }
     }
 }
@@ -542,6 +542,22 @@ impl Rotation {
     pub const fn max_bytes(number_of_bytes: u64) -> Self {
         Self {
             timed: Timed::Never,
+            max_bytes: Some(number_of_bytes),
+        }
+    }
+
+    /// Provides a minutely and size-based rotation.
+    pub const fn minutely_with_max_bytes(number_of_bytes: u64) -> Self {
+        Self {
+            timed: Timed::Minutely,
+            max_bytes: Some(number_of_bytes),
+        }
+    }
+
+    /// Provides a hourly and size-based rotation.
+    pub const fn hourly_with_max_bytes(number_of_bytes: u64) -> Self {
+        Self {
+            timed: Timed::Hourly,
             max_bytes: Some(number_of_bytes),
         }
     }

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -971,19 +971,18 @@ impl Inner {
             .compare_exchange(current, next_date, Ordering::AcqRel, Ordering::Acquire)
             .is_ok();
 
-        if next_date_updated {
-            if let Some(index) = &self.log_filename_index {
+        match &self.log_filename_index {
+            Some(index) if next_date_updated => {
                 if current == next_date {
                     index.fetch_add(1, Ordering::SeqCst);
                 } else {
                     index.store(0, Ordering::Release);
                 }
             }
-
-            true
-        } else {
-            false
+            _ => {}
         }
+
+        next_date_updated
     }
 }
 

--- a/tracing-appender/src/rolling/builder.rs
+++ b/tracing-appender/src/rolling/builder.rs
@@ -264,6 +264,15 @@ impl Builder {
     pub fn build(&self, directory: impl AsRef<Path>) -> Result<RollingFileAppender, InitError> {
         RollingFileAppender::from_builder(self, directory)
     }
+
+    #[cfg(test)]
+    pub(super) fn build_with_now(
+        &self,
+        directory: impl AsRef<Path>,
+        now: Box<dyn Fn() -> time::OffsetDateTime + Send + Sync>,
+    ) -> Result<RollingFileAppender, InitError> {
+        RollingFileAppender::from_builder_with_custom_now(self, directory, now)
+    }
 }
 
 impl Default for Builder {


### PR DESCRIPTION
This patch adds size-based rotation to tracing-appender.

Closes https://github.com/tokio-rs/tracing/issues/1940
Closes https://github.com/tokio-rs/tracing/issues/858

cc @hawkw @IniterWorker @CfirTsabari 

## Motivation

In a constrained environment, we should be able to contain the logging size and period.

## Solution

Maximum bytes per log file may be specified in the `Rotation` struct.
Written bytes are counted and when the specified maximum number of bytes is exceeded, log file is rolled over.
