### PR TITLE
Add a way to have fixed-width timestamps with a convenience constructor

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -49,7 +49,7 @@ once_cell = { optional = true, version = "1.13.0" }
 # fmt
 tracing-log = { path = "../tracing-log", version = "0.2", optional = true, default-features = false, features = ["log-tracer", "std"] }
 nu-ansi-term = { version = "0.46.0", optional = true }
-time = { version = "0.3.2", features = ["formatting"], optional = true }
+time = { version = "0.3.10", features = ["formatting"], optional = true }
 
 # only required by the json feature
 serde_json = { version = "1.0.82", optional = true }
@@ -73,7 +73,7 @@ regex = { version = "1.6.0", default-features = false, features = ["std"] }
 tracing-futures = { path = "../tracing-futures", version = "0.3", default-features = false, features = ["std-future", "std"] }
 tokio = { version = "1.20.0", features = ["rt", "macros"] }
 # Enable the `time` crate's `macros` feature, for examples.
-time = { version = "0.3.2", features = ["formatting", "macros"] }
+time = { version = "0.3.10", features = ["formatting", "macros"] }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/tracing-subscriber/src/fmt/time/time_crate.rs
+++ b/tracing-subscriber/src/fmt/time/time_crate.rs
@@ -71,6 +71,29 @@ impl LocalTime<well_known::Rfc3339> {
 }
 
 #[cfg(feature = "local-time")]
+impl LocalTime<well_known::Iso8601> {
+    /// Returns a formatter that formats the current [local time] in the
+    /// [RFC 3339] format (a subset of the [ISO 8601] timestamp format).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tracing_subscriber::fmt::{self, time};
+    ///
+    /// let collector = tracing_subscriber::fmt()
+    ///     .with_timer(time::LocalTime::iso_8601());
+    /// # drop(collector);
+    /// ```
+    ///
+    /// [local time]: https://docs.rs/time/0.3/time/struct.OffsetDateTime.html#method.now_local
+    /// [RFC 3339]: https://datatracker.ietf.org/doc/html/rfc3339
+    /// [ISO 8601]: https://en.wikipedia.org/wiki/ISO_8601
+    pub fn iso_8601() -> Self {
+        Self::new(well_known::Iso8601::DEFAULT)
+    }
+}
+
+#[cfg(feature = "local-time")]
 impl<F: Formattable> LocalTime<F> {
     /// Returns a formatter that formats the current [local time] using the
     /// [`time` crate] with the provided provided format. The format may be any
@@ -133,12 +156,12 @@ impl<F: Formattable> LocalTime<F> {
     /// crate's "macros" feature flag.
     ///
     /// Using a [well-known format][well-known formats] (this is equivalent to
-    /// [`LocalTime::rfc_3339`]):
+    /// [`LocalTime::iso_8601`]):
     ///
     /// ```
     /// use tracing_subscriber::fmt::{self, time::LocalTime};
     ///
-    /// let timer = LocalTime::new(time::format_description::well_known::Rfc3339);
+    /// let timer = LocalTime::new(time::format_description::well_known::Iso8601::DEFAULT);
     /// let collector = tracing_subscriber::fmt()
     ///     .with_timer(timer);
     /// # drop(collector);
@@ -201,6 +224,28 @@ impl UtcTime<well_known::Rfc3339> {
     }
 }
 
+impl UtcTime<well_known::Iso8601> {
+    /// Returns a formatter that formats the current [UTC time] in the
+    /// [RFC 3339] format, which is a subset of the [ISO 8601] timestamp format.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tracing_subscriber::fmt::{self, time};
+    ///
+    /// let collector = tracing_subscriber::fmt()
+    ///     .with_timer(time::UtcTime::iso_8601());
+    /// # drop(collector);
+    /// ```
+    ///
+    /// [local time]: https://docs.rs/time/0.3/time/struct.OffsetDateTime.html#method.now_utc
+    /// [RFC 3339]: https://datatracker.ietf.org/doc/html/rfc3339
+    /// [ISO 8601]: https://en.wikipedia.org/wiki/ISO_8601
+    pub fn iso_8601() -> Self {
+        Self::new(well_known::Iso8601::DEFAULT)
+    }
+}
+
 impl<F: Formattable> UtcTime<F> {
     /// Returns a formatter that formats the current [UTC time] using the
     /// [`time` crate], with the provided provided format. The format may be any
@@ -250,12 +295,12 @@ impl<F: Formattable> UtcTime<F> {
     /// ```
     ///
     /// Using a [well-known format][well-known formats] (this is equivalent to
-    /// [`UtcTime::rfc_3339`]):
+    /// [`UtcTime::iso_8601`]):
     ///
     /// ```
     /// use tracing_subscriber::fmt::{self, time::UtcTime};
     ///
-    /// let timer = UtcTime::new(time::format_description::well_known::Rfc3339);
+    /// let timer = UtcTime::new(time::format_description::well_known::Iso8601::DEFAULT);
     /// let collector = tracing_subscriber::fmt()
     ///     .with_timer(timer);
     /// # drop(collector);

--- a/tracing-subscriber/src/fmt/time/time_crate.rs
+++ b/tracing-subscriber/src/fmt/time/time_crate.rs
@@ -50,21 +50,15 @@ pub struct UtcTime<F> {
 #[cfg(feature = "local-time")]
 impl LocalTime<well_known::Rfc3339> {
     /// Returns a formatter that formats the current [local time] in the
-    /// [RFC 3339] format (a subset of the [ISO 8601] timestamp format).
+    /// [RFC 3339] format (a subset of the [ISO 8601] timestamp format),
+    /// but with a variable number of decimal digits.
     ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tracing_subscriber::fmt::{self, time};
-    ///
-    /// let collector = tracing_subscriber::fmt()
-    ///     .with_timer(time::LocalTime::rfc_3339());
-    /// # drop(collector);
-    /// ```
+    /// Use [`LocalTime::iso_8601`] instead.
     ///
     /// [local time]: https://docs.rs/time/0.3/time/struct.OffsetDateTime.html#method.now_local
     /// [RFC 3339]: https://datatracker.ietf.org/doc/html/rfc3339
     /// [ISO 8601]: https://en.wikipedia.org/wiki/ISO_8601
+    #[deprecated(note = "this has a variable number of decimal digits, use `LocalTime::iso_8601()` instead")]
     pub fn rfc_3339() -> Self {
         Self::new(well_known::Rfc3339)
     }
@@ -204,21 +198,15 @@ where
 
 impl UtcTime<well_known::Rfc3339> {
     /// Returns a formatter that formats the current [UTC time] in the
-    /// [RFC 3339] format, which is a subset of the [ISO 8601] timestamp format.
+    /// [RFC 3339] format, which is a subset of the [ISO 8601] timestamp format,
+    /// but with a variable number of decimal digits.
     ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tracing_subscriber::fmt::{self, time};
-    ///
-    /// let collector = tracing_subscriber::fmt()
-    ///     .with_timer(time::UtcTime::rfc_3339());
-    /// # drop(collector);
-    /// ```
+    /// Use [`UtcTime::iso_8601`] instead.
     ///
     /// [local time]: https://docs.rs/time/0.3/time/struct.OffsetDateTime.html#method.now_utc
     /// [RFC 3339]: https://datatracker.ietf.org/doc/html/rfc3339
     /// [ISO 8601]: https://en.wikipedia.org/wiki/ISO_8601
+    #[deprecated(note = "this has a variable number of decimal digits, use `UtcTime::iso_8601()` instead")]
     pub fn rfc_3339() -> Self {
         Self::new(well_known::Rfc3339)
     }


### PR DESCRIPTION
Add `{LocalTime,UtcTime}::iso_8601` that implements the same format as `{LocalTime,UtcTime}::rfc_3339`, but with a fixed width for timestamps.

Fixes https://github.com/tokio-rs/tracing/issues/1729.