### PR TITLE
subscriber: add ability to disable ANSI without crate feature

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -274,12 +274,26 @@ impl<C, N, E, W> Subscriber<C, N, E, W> {
         }
     }
 
-    /// Enable ANSI terminal colors for formatted output.
+    /// Sets whether or not the formatter emits ANSI terminal escape codes
+    /// for colors and other text formatting.
+    ///
+    /// Enabling ANSI escapes (calling `with_ansi(true)`) requires the "ansi"
+    /// crate feature flag. Calling `with_ansi(true)` without the "ansi"
+    /// feature flag enabled will panic if debug assertions are enabled, or
+    /// print a warning otherwise.
+    ///
+    /// This method itself is still available without the feature flag. This
+    /// is to allow ANSI escape codes to be explicitly *disabled* without
+    /// having to opt-in to the dependencies required to emit ANSI formatting.
+    /// This way, code which constructs a formatter that should never emit
+    /// ANSI escape codes can ensure that they are not used, regardless of
+    /// whether or not other crates in the dependency graph enable the "ansi"
+    /// feature flag.
     pub fn with_ansi(self, ansi: bool) -> Self {
         #[cfg(not(feature = "ansi"))]
         if ansi {
             const ERROR: &str =
-                "tracing-subscriber: enabled ANSI terminal colors without the `ansi` crate feature";
+                "tracing-subscriber: the `ansi` crate feature is required to enable ANSI terminal colors";
             #[cfg(debug_assertions)]
             panic!("{}", ERROR);
             #[cfg(not(debug_assertions))]

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -275,9 +275,17 @@ impl<C, N, E, W> Subscriber<C, N, E, W> {
     }
 
     /// Enable ANSI terminal colors for formatted output.
-    #[cfg(feature = "ansi")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
     pub fn with_ansi(self, ansi: bool) -> Self {
+        #[cfg(not(feature = "ansi"))]
+        if ansi {
+            const ERROR: &str =
+                "tracing-subscriber: enabled ANSI terminal colors without the `ansi` crate feature";
+            #[cfg(debug_assertions)]
+            panic!("{}", ERROR);
+            #[cfg(not(debug_assertions))]
+            eprintln!("{}", ERROR);
+        }
+
         Subscriber {
             is_ansi: ansi,
             ..self

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -610,7 +610,21 @@ where
         }
     }
 
-    /// Enable ANSI terminal colors for formatted output.
+    /// Sets whether or not the formatter emits ANSI terminal escape codes
+    /// for colors and other text formatting.
+    ///
+    /// Enabling ANSI escapes (calling `with_ansi(true)`) requires the "ansi"
+    /// crate feature flag. Calling `with_ansi(true)` without the "ansi"
+    /// feature flag enabled will panic if debug assertions are enabled, or
+    /// print a warning otherwise.
+    ///
+    /// This method itself is still available without the feature flag. This
+    /// is to allow ANSI escape codes to be explicitly *disabled* without
+    /// having to opt-in to the dependencies required to emit ANSI formatting.
+    /// This way, code which constructs a formatter that should never emit
+    /// ANSI escape codes can ensure that they are not used, regardless of
+    /// whether or not other crates in the dependency graph enable the "ansi"
+    /// feature flag.
     pub fn with_ansi(self, ansi: bool) -> CollectorBuilder<N, format::Format<L, T>, F, W> {
         CollectorBuilder {
             inner: self.inner.with_ansi(ansi),

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -611,8 +611,6 @@ where
     }
 
     /// Enable ANSI terminal colors for formatted output.
-    #[cfg(feature = "ansi")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
     pub fn with_ansi(self, ansi: bool) -> CollectorBuilder<N, format::Format<L, T>, F, W> {
         CollectorBuilder {
             inner: self.inner.with_ansi(ansi),


### PR DESCRIPTION
## Motivation

Currently it is not possible to disable ANSI in `fmt::Subscriber` without enabling the `ansi` crate feature. This makes it difficult for users to implement interoperable settings that are controllable with crate features without having to pull in the dependencies `ansi` does.

I hit this while writing an application with multiple logging options set during compile-time and I wanted to cut down on dependencies if possible.

## Solution

This adds a simple `fmt::Subscriber::disable_ansi()` that is available even without the `ansi` crate feature.
