### PR TITLE
subscriber: support browser target by using the `instant` crate

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -32,6 +32,7 @@ fmt = ["registry", "std"]
 ansi = ["fmt", "nu-ansi-term"]
 registry = ["sharded-slab", "thread_local", "std"]
 json = ["tracing-serde", "serde", "serde_json"]
+wasm-bindgen = ["instant"]
 # Enables support for local time when using the `time` crate timestamp
 # formatters.
 local-time = ["time/local-offset"]
@@ -62,6 +63,9 @@ parking_lot = { version = "0.12.1", optional = true }
 # registry
 sharded-slab = { version = "0.1.4", optional = true }
 thread_local = { version = "1.1.4", optional = true }
+
+[target.'cfg(all(target_family = "wasm", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
+instant = { version = "0.1", features = ["wasm-bindgen"], optional = true }
 
 [dev-dependencies]
 tracing = { path = "../tracing", version = "0.2" }

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -1,14 +1,12 @@
 use crate::{
     field::RecordFields,
+    fmt::time::Instant,
     fmt::{format, FormatEvent, FormatFields, MakeWriter, TestWriter},
     registry::{self, LookupSpan, SpanRef},
     subscribe::{self, Context},
 };
 use format::{FmtSpan, TimingDisplay};
-use std::{
-    any::TypeId, cell::RefCell, fmt, io, marker::PhantomData, ops::Deref, ptr::NonNull,
-    time::Instant,
-};
+use std::{any::TypeId, cell::RefCell, fmt, io, marker::PhantomData, ops::Deref, ptr::NonNull};
 use tracing_core::{
     field,
     span::{Attributes, Current, Id, Record},

--- a/tracing-subscriber/src/fmt/time/datetime.rs
+++ b/tracing-subscriber/src/fmt/time/datetime.rs
@@ -193,6 +193,7 @@
 // obstacle to adoption, that text has been removed.
 
 
+use super::system_time;
 use std::fmt;
 
 /// A date/time type which exists primarily to convert `SystemTime` timestamps into an ISO 8601
@@ -243,8 +244,8 @@ impl fmt::Display for DateTime {
     }
 }
 
-impl From<std::time::SystemTime> for DateTime {
-    fn from(timestamp: std::time::SystemTime) -> DateTime {
+impl From<system_time::SystemTime> for DateTime {
+    fn from(timestamp: system_time::SystemTime) -> DateTime {
         let (t, nanos) = match timestamp.duration_since(std::time::UNIX_EPOCH) {
             Ok(duration) => {
                 debug_assert!(duration.as_secs() <= std::i64::MAX as u64);

--- a/tracing-subscriber/src/fmt/time/mod.rs
+++ b/tracing-subscriber/src/fmt/time/mod.rs
@@ -1,7 +1,18 @@
 //! Formatters for event timestamps.
 use crate::fmt::format::Writer;
+#[cfg(all(
+    target_family = "wasm",
+    not(any(target_os = "emscripten", target_os = "wasi")),
+    feature = "wasm-bindgen"
+))]
+pub(crate) use instant::{self as system_time, Instant};
 use std::fmt;
-use std::time::Instant;
+#[cfg(not(all(
+    target_family = "wasm",
+    not(any(target_os = "emscripten", target_os = "wasi")),
+    feature = "wasm-bindgen"
+)))]
+pub(crate) use std::time::{self as system_time, Instant};
 
 mod datetime;
 
@@ -121,7 +132,7 @@ impl FormatTime for SystemTime {
         write!(
             w,
             "{}",
-            datetime::DateTime::from(std::time::SystemTime::now())
+            datetime::DateTime::from(system_time::SystemTime::now())
         )
     }
 }

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -74,6 +74,8 @@
 //!   than `Vec`) as a performance optimization. Enabled by default.
 //! - [`parking_lot`]: Use the `parking_lot` crate's `RwLock` implementation
 //!   rather than the Rust standard library's implementation.
+//! - `wasm-bindgen`: Uses the [`instant`] crate to allow `Uptime` and `SystemTime` to
+//!   be used in browsers.
 //!
 //! ### `no_std` Support
 //!
@@ -129,6 +131,7 @@
 //! [`time` crate]: https://crates.io/crates/time
 //! [`liballoc`]: https://doc.rust-lang.org/alloc/index.html
 //! [`libstd`]: https://doc.rust-lang.org/std/index.html
+//! [`instant`]: https://crates.io/crates/instant
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     html_favicon_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/favicon.ico",


### PR DESCRIPTION
## Motivation

Currently `Uptime` and `SystemTime` panic on browsers, this is because `std::time` is not supported on browsers.

## Solution

This PR uses the `instant` crate to implement replacements that should work seamlessly. This would pull in a lot of dependencies, so it is hidden behind a new crate `wasm-bindgen` feature.

Adding a new crate feature should probably have been discussed before creating this PR, but I was already done with it when I noticed this will pull in a bunch of dependencies.

This would play well with other crates like https://crates.io/crates/tracing-web.