### PR TITLE
subscriber: update time crate to 0.3.18

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -49,7 +49,7 @@ once_cell = { optional = true, version = "1.13.0" }
 # fmt
 tracing-log = { path = "../tracing-log", version = "0.2", optional = true, default-features = false, features = ["log-tracer", "std"] }
 nu-ansi-term = { version = "0.46.0", optional = true }
-time = { version = "0.3.2", features = ["formatting"], optional = true }
+time = { version = "0.3.18", features = ["formatting"], optional = true }
 
 # only required by the json feature
 serde_json = { version = "1.0.82", optional = true }
@@ -73,7 +73,7 @@ regex = { version = "1.6.0", default-features = false, features = ["std"] }
 tracing-futures = { path = "../tracing-futures", version = "0.3", default-features = false, features = ["std-future", "std"] }
 tokio = { version = "1.20.0", features = ["rt", "macros"] }
 # Enable the `time` crate's `macros` feature, for examples.
-time = { version = "0.3.2", features = ["formatting", "macros"] }
+time = { version = "0.3.18", features = ["formatting", "macros"] }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/tracing-subscriber/src/fmt/time/time_crate.rs
+++ b/tracing-subscriber/src/fmt/time/time_crate.rs
@@ -6,17 +6,6 @@ use time::{format_description::well_known, formatting::Formattable, OffsetDateTi
 ///
 /// To format the current [UTC time] instead, use the [`UtcTime`] type.
 ///
-/// <div class="example-wrap" style="display:inline-block">
-/// <pre class="compile_fail" style="white-space:normal;font:inherit;">
-///     <strong>Warning</strong>: The <a href = "https://docs.rs/time/0.3/time/"><code>time</code>
-///     crate</a> must be compiled with <code>--cfg unsound_local_offset</code> in order to use
-///     local timestamps. When this cfg is not enabled, local timestamps cannot be recorded, and
-///     events will be logged without timestamps.
-///
-///    See the <a href="https://docs.rs/time/0.3.4/time/#feature-flags"><code>time</code>
-///    documentation</a> for more details.
-/// </pre></div>
-///
 /// [local time]: https://docs.rs/time/0.3/time/struct.OffsetDateTime.html#method.now_local
 /// [UTC time]: https://docs.rs/time/0.3/time/struct.OffsetDateTime.html#method.now_utc
 /// [formatter]: https://docs.rs/time/0.3/time/formatting/trait.Formattable.html
@@ -75,19 +64,6 @@ impl<F: Formattable> LocalTime<F> {
     /// Returns a formatter that formats the current [local time] using the
     /// [`time` crate] with the provided provided format. The format may be any
     /// type that implements the [`Formattable`] trait.
-    ///
-    ///
-    /// <div class="example-wrap" style="display:inline-block">
-    /// <pre class="compile_fail" style="white-space:normal;font:inherit;">
-    ///     <strong>Warning</strong>: The <a href = "https://docs.rs/time/0.3/time/">
-    ///     <code>time</code> crate</a> must be compiled with <code>--cfg
-    ///     unsound_local_offset</code> in order to use local timestamps. When this
-    ///     cfg is not enabled, local timestamps cannot be recorded, and
-    ///     events will be logged without timestamps.
-    ///
-    ///    See the <a href="https://docs.rs/time/0.3.4/time/#feature-flags">
-    ///    <code>time</code> documentation</a> for more details.
-    /// </pre></div>
     ///
     /// Typically, the format will be a format description string, or one of the
     /// `time` crate's [well-known formats].


### PR DESCRIPTION
## Motivation

As I asked earlier in [discussions](https://github.com/tokio-rs/tracing/discussions/2545), I'm trying to use `LocalTime` in `tracing-subscriber::fmt`, i.e. something like this: 
```
tracing_subscriber::fmt()
        .with_timer(tracing_subscriber::fmt::time::LocalTime::rfc_3339())
```

However, with the `time` crate 0.3.2, I need to build with `--cfg unsound_local_offset`, which is not desirable. In fact, `time` crate has removed this requirement since v0.3.18. Hence I propose to update `time` crate version in this branch.

## Solution

Update `time` crate to version `0.3.18`. I tried locally to use `LocalTime` after updating, there is no problem without `--cfg unsound_local_offset`.

