### PR TITLE
CI: fix clippy warnings for v0.1.x

### DIFF
--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -133,7 +133,6 @@
     rust_2018_idioms,
     unreachable_pub,
     bad_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,

--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -134,7 +134,7 @@ fn gen_block<B: ToTokens>(
             .into_iter()
             .flat_map(|param| match param {
                 FnArg::Typed(PatType { pat, ty, .. }) => {
-                    param_names(*pat, RecordType::parse_from_ty(&*ty))
+                    param_names(*pat, RecordType::parse_from_ty(&ty))
                 }
                 FnArg::Receiver(_) => Box::new(iter::once((
                     Ident::new("self", param.span()),

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -64,7 +64,6 @@
     rust_2018_idioms,
     unreachable_pub,
     bad_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,

--- a/tracing-attributes/tests/ui/async_instrument.stderr
+++ b/tracing-attributes/tests/ui/async_instrument.stderr
@@ -93,6 +93,6 @@ error[E0308]: mismatched types
 42 |   async fn extra_semicolon() -> i32 {
    |  ___________________________________^
 43 | |     1;
-   | |      - help: remove this semicolon
+   | |      - help: remove this semicolon to return this value
 44 | | }
    | |_^ expected `i32`, found `()`

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -368,7 +368,7 @@ where
     CURRENT_STATE
         .try_with(|state| {
             if let Some(entered) = state.enter() {
-                return f(&*entered.current());
+                return f(&entered.current());
             }
 
             f(&Dispatch::none())
@@ -390,7 +390,7 @@ pub fn get_current<T>(f: impl FnOnce(&Dispatch) -> T) -> Option<T> {
     CURRENT_STATE
         .try_with(|state| {
             let entered = state.enter()?;
-            Some(f(&*entered.current()))
+            Some(f(&entered.current()))
         })
         .ok()?
 }

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -129,7 +129,6 @@
     rust_2018_idioms,
     unreachable_pub,
     bad_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -190,7 +190,6 @@
     rust_2018_idioms,
     unreachable_pub,
     bad_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,

--- a/tracing-flame/src/lib.rs
+++ b/tracing-flame/src/lib.rs
@@ -117,7 +117,6 @@
     rust_2018_idioms,
     unreachable_pub,
     bad_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -81,7 +81,6 @@
     rust_2018_idioms,
     unreachable_pub,
     bad_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -112,7 +112,6 @@
     rust_2018_idioms,
     unreachable_pub,
     bad_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,

--- a/tracing-serde/src/lib.rs
+++ b/tracing-serde/src/lib.rs
@@ -168,7 +168,6 @@
     rust_2018_idioms,
     unreachable_pub,
     bad_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,

--- a/tracing-subscriber/src/filter/targets.rs
+++ b/tracing-subscriber/src/filter/targets.rs
@@ -324,7 +324,7 @@ impl Targets {
     /// assert_eq!(filter.default_level(), Some(LevelFilter::OFF));
     /// ```
     pub fn default_level(&self) -> Option<LevelFilter> {
-        self.0.directives().into_iter().find_map(|d| {
+        self.0.directives().find_map(|d| {
             if d.target.is_none() {
                 Some(d.level)
             } else {

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -180,7 +180,6 @@
     rust_2018_idioms,
     unreachable_pub,
     bad_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -422,7 +422,7 @@ impl<'a> SpanData<'a> for Data<'a> {
     }
 
     fn metadata(&self) -> &'static Metadata<'static> {
-        (*self).inner.metadata
+        self.inner.metadata
     }
 
     fn parent(&self) -> Option<&Id> {

--- a/tracing-tower/src/lib.rs
+++ b/tracing-tower/src/lib.rs
@@ -9,7 +9,6 @@
     rust_2018_idioms,
     unreachable_pub,
     bad_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -911,7 +911,6 @@
     rust_2018_idioms,
     unreachable_pub,
     bad_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,


### PR DESCRIPTION
## Motivation

Clippy check fails in recent CI runs in v0.1.x branch PRs, for example this run: https://github.com/tokio-rs/tracing/actions/runs/4641107803/jobs/8215263838 .

Relevant error logs:
```
error: lint `const_err` has been removed: converted into hard error, see issue #71800 <https://github.com/rust-lang/rust/issues/71800> for more information
   --> tracing-core/src/lib.rs:132:5
    |
132 |     const_err,
    |     ^^^^^^^^^
    |
    = note: `-D renamed-and-removed-lints` implied by `-D warnings`


error: deref which would be done by auto-deref
   --> tracing-core/src/dispatcher.rs:371:26
    |
371 |                 return f(&*entered.current());
    |                          ^^^^^^^^^^^^^^^^^^^ help: try this: `&entered.current()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref
    = note: `-D clippy::explicit-auto-deref` implied by `-D warnings`


error: deref which would be done by auto-deref
   --> tracing-core/src/dispatcher.rs:393:20
    |
393 |             Some(f(&*entered.current()))
    |                    ^^^^^^^^^^^^^^^^^^^ help: try this: `&entered.current()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref
```

## Solution

Fix the warnings based on the suggestions for Clippy.