### PR TITLE
tracing, tracing-futures: instrument futures with Spans in Drop

### DIFF
--- a/tracing-attributes/tests/async_fn.rs
+++ b/tracing-attributes/tests/async_fn.rs
@@ -83,14 +83,17 @@ fn repro_1831_2() -> impl Future<Output = Result<(), Infallible>> {
 
 #[test]
 fn async_fn_only_enters_for_polls() {
+    let span = expect::span().named("test_async_fn");
     let (collector, handle) = collector::mock()
-        .new_span(expect::span().named("test_async_fn"))
-        .enter(expect::span().named("test_async_fn"))
+        .new_span(span.clone())
+        .enter(span.clone())
         .event(expect::event().with_fields(expect::field("awaiting").with_value(&true)))
-        .exit(expect::span().named("test_async_fn"))
-        .enter(expect::span().named("test_async_fn"))
-        .exit(expect::span().named("test_async_fn"))
-        .drop_span(expect::span().named("test_async_fn"))
+        .exit(span.clone())
+        .enter(span.clone())
+        .exit(span.clone())
+        .enter(span.clone())
+        .exit(span.clone())
+        .drop_span(span)
         .only()
         .run_with_handle();
     with_default(collector, || {
@@ -120,7 +123,11 @@ fn async_fn_nested() {
         .enter(span2.clone())
         .event(expect::event().with_fields(expect::field("nested").with_value(&true)))
         .exit(span2.clone())
+        .enter(span2.clone())
+        .exit(span2.clone())
         .drop_span(span2)
+        .exit(span.clone())
+        .enter(span.clone())
         .exit(span.clone())
         .drop_span(span)
         .only()
@@ -199,12 +206,18 @@ fn async_fn_with_async_trait() {
         .enter(span3.clone())
         .event(expect::event().with_fields(expect::field("val").with_value(&2u64)))
         .exit(span3.clone())
+        .enter(span3.clone())
+        .exit(span3.clone())
         .drop_span(span3)
         .new_span(span2.clone().with_field(expect::field("self")))
         .enter(span2.clone())
         .event(expect::event().with_fields(expect::field("val").with_value(&5u64)))
         .exit(span2.clone())
+        .enter(span2.clone())
+        .exit(span2.clone())
         .drop_span(span2)
+        .exit(span.clone())
+        .enter(span.clone())
         .exit(span.clone())
         .drop_span(span)
         .only()
@@ -254,6 +267,8 @@ fn async_fn_with_async_trait_and_fields_expressions() {
                     .and(expect::field("val2").with_value(&42u64)),
             ),
         )
+        .enter(span.clone())
+        .exit(span.clone())
         .enter(span.clone())
         .exit(span.clone())
         .drop_span(span)
@@ -331,7 +346,11 @@ fn async_fn_with_async_trait_and_fields_expressions_with_generic_parameter() {
                 .with_field(expect::field("Self").with_value(&std::any::type_name::<TestImpl>())),
         )
         .enter(span4.clone())
+        .exit(span4.clone())
+        .enter(span4.clone())
         .exit(span4)
+        .exit(span2.clone())
+        .enter(span2.clone())
         .exit(span2.clone())
         .drop_span(span2)
         .new_span(
@@ -339,6 +358,8 @@ fn async_fn_with_async_trait_and_fields_expressions_with_generic_parameter() {
                 .clone()
                 .with_field(expect::field("Self").with_value(&std::any::type_name::<TestImpl>())),
         )
+        .enter(span3.clone())
+        .exit(span3.clone())
         .enter(span3.clone())
         .exit(span3.clone())
         .drop_span(span3)
@@ -382,6 +403,8 @@ fn out_of_scope_fields() {
         .new_span(span.clone())
         .enter(span.clone())
         .exit(span.clone())
+        .enter(span.clone())
+        .exit(span.clone())
         .drop_span(span)
         .only()
         .run_with_handle();
@@ -417,6 +440,8 @@ fn manual_impl_future() {
         .enter(span.clone())
         .event(poll_event())
         .exit(span.clone())
+        .enter(span.clone())
+        .exit(span.clone())
         .drop_span(span)
         .only()
         .run_with_handle();
@@ -447,6 +472,8 @@ fn manual_box_pin() {
         .new_span(span.clone())
         .enter(span.clone())
         .event(poll_event())
+        .exit(span.clone())
+        .enter(span.clone())
         .exit(span.clone())
         .drop_span(span)
         .only()

--- a/tracing-attributes/tests/err.rs
+++ b/tracing-attributes/tests/err.rs
@@ -78,6 +78,8 @@ fn test_async() {
         .enter(span.clone())
         .event(expect::event().at_level(Level::ERROR))
         .exit(span.clone())
+        .enter(span.clone())
+        .exit(span.clone())
         .drop_span(span)
         .only()
         .run_with_handle();
@@ -131,6 +133,8 @@ fn test_mut_async() {
         .exit(span.clone())
         .enter(span.clone())
         .event(expect::event().at_level(Level::ERROR))
+        .exit(span.clone())
+        .enter(span.clone())
         .exit(span.clone())
         .drop_span(span)
         .only()

--- a/tracing-attributes/tests/follows_from.rs
+++ b/tracing-attributes/tests/follows_from.rs
@@ -58,7 +58,10 @@ fn follows_from_async_test() {
         .follows_from(consequence.clone(), cause_b)
         .follows_from(consequence.clone(), cause_c)
         .enter(consequence.clone())
-        .exit(consequence)
+        .exit(consequence.clone())
+        .enter(consequence.clone())
+        .exit(consequence.clone())
+        .drop_span(consequence)
         .only()
         .run_with_handle();
 

--- a/tracing-attributes/tests/ret.rs
+++ b/tracing-attributes/tests/ret.rs
@@ -138,6 +138,8 @@ fn test_async() {
                 .at_level(Level::INFO),
         )
         .exit(span.clone())
+        .enter(span.clone())
+        .exit(span.clone())
         .drop_span(span)
         .only()
         .run_with_handle();

--- a/tracing-futures/src/executor/futures_03.rs
+++ b/tracing-futures/src/executor/futures_03.rs
@@ -15,7 +15,10 @@ where
     /// tasks.
     fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
         let future = future.instrument(self.span.clone());
-        self.inner.spawn_obj(FutureObj::new(Box::new(future)))
+        self.inner
+            .as_ref()
+            .unwrap()
+            .spawn_obj(FutureObj::new(Box::new(future)))
     }
 
     /// Determines whether the executor is able to spawn new tasks.
@@ -26,7 +29,7 @@ where
     /// not guaranteed, to yield an error.
     #[inline]
     fn status(&self) -> Result<(), SpawnError> {
-        self.inner.status()
+        self.inner.as_ref().unwrap().status()
     }
 }
 
@@ -74,6 +77,8 @@ where
     fn spawn_local_obj(&self, future: LocalFutureObj<'static, ()>) -> Result<(), SpawnError> {
         let future = future.instrument(self.span.clone());
         self.inner
+            .as_ref()
+            .unwrap()
             .spawn_local_obj(LocalFutureObj::new(Box::new(future)))
     }
 
@@ -85,7 +90,7 @@ where
     /// not guaranteed, to yield an error.
     #[inline]
     fn status_local(&self) -> Result<(), SpawnError> {
-        self.inner.status_local()
+        self.inner.as_ref().unwrap().status_local()
     }
 }
 

--- a/tracing-futures/tests/std_future.rs
+++ b/tracing-futures/tests/std_future.rs
@@ -4,12 +4,15 @@ use tracing_mock::*;
 
 #[test]
 fn enter_exit_is_reasonable() {
+    let span = expect::span().named("foo");
     let (collector, handle) = collector::mock()
-        .enter(expect::span().named("foo"))
-        .exit(expect::span().named("foo"))
-        .enter(expect::span().named("foo"))
-        .exit(expect::span().named("foo"))
-        .drop_span(expect::span().named("foo"))
+        .enter(span.clone())
+        .exit(span.clone())
+        .enter(span.clone())
+        .exit(span.clone())
+        .enter(span.clone())
+        .exit(span.clone())
+        .drop_span(span)
         .only()
         .run_with_handle();
     with_default(collector, || {
@@ -21,12 +24,15 @@ fn enter_exit_is_reasonable() {
 
 #[test]
 fn error_ends_span() {
+    let span = expect::span().named("foo");
     let (collector, handle) = collector::mock()
-        .enter(expect::span().named("foo"))
-        .exit(expect::span().named("foo"))
-        .enter(expect::span().named("foo"))
-        .exit(expect::span().named("foo"))
-        .drop_span(expect::span().named("foo"))
+        .enter(span.clone())
+        .exit(span.clone())
+        .enter(span.clone())
+        .exit(span.clone())
+        .enter(span.clone())
+        .exit(span.clone())
+        .drop_span(span)
         .only()
         .run_with_handle();
     with_default(collector, || {


### PR DESCRIPTION
Resolves #2541 

## Motivation

See https://github.com/tokio-rs/tracing/issues/2541

## Solution

Wrap `Instrumented::inner` (both in `tracing` and `tracing-futures`) into `Option`. `Pin::set` it to `None` in the `PinnedDrop` `impl` to drop the future in the context of a `Span` that we enter in the said impl.

This implementation uses `Option::unwrap_unchecked` in places where we need to extract `inner` future, as the only time we set it to `None` is in `Drop`, or in a method which takes `Instrumented` by value, guaranteeing that there is no case for UB.

Alternative was to use `ManuallyDrop`, but I don't think we can `Future::poll` `Pin<&mut ManuallyDrop<T>>` easily?
