### PR TITLE
Use of `?i` requires unicode-case feature in regex crate

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -42,7 +42,7 @@ tracing-core = { path = "../tracing-core", version = "0.2", default-features = f
 # only required by the `env-filter` feature
 tracing = { optional = true, path = "../tracing", version = "0.2", default-features = false }
 matchers = { optional = true, version = "0.1.0" }
-regex = { optional = true, version = "1.6.0", default-features = false, features = ["std"] }
+regex = { optional = true, version = "1.6.0", default-features = false, features = ["std", "unicode-case"] }
 smallvec = { optional = true, version = "1.9.0" }
 once_cell = { optional = true, version = "1.13.0" }
 


### PR DESCRIPTION
Use of tracing-subscriber where the required `regex` feature happens to not be activated will otherwise panic: https://github.com/rune-rs/rune/actions/runs/4764385803/jobs/8468908332

An alternative *might* be to switch to unicode-unaware matching, but I haven't had enough coffee in me today to decide whether that will cause some other issue.

I'm not entirely sure this is enough, but I sure hope so!