### PR TITLE
updated UI tests using TRYBUILD=overwrite with the latest stable vers…

### DIFF
--- a/tracing-attributes/tests/ui/async_instrument.stderr
+++ b/tracing-attributes/tests/ui/async_instrument.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
 10 |     ""
    |     ^^- help: try using a conversion method: `.to_string()`
    |     |
-   |     expected struct `String`, found `&str`
+   |     expected `String`, found `&str`
    |
 note: return type inferred to be `String` here
   --> tests/ui/async_instrument.rs:9:31
@@ -47,7 +47,7 @@ error[E0308]: mismatched types
   --> tests/ui/async_instrument.rs:23:5
    |
 23 |     ""
-   |     ^^ expected struct `Wrapper`, found `&str`
+   |     ^^ expected `Wrapper<_>`, found `&str`
    |
    = note: expected struct `Wrapper<_>`
            found reference `&'static str`
@@ -79,7 +79,7 @@ error[E0308]: mismatched types
 36 |         return "";
    |                ^^- help: try using a conversion method: `.to_string()`
    |                |
-   |                expected struct `String`, found `&str`
+   |                expected `String`, found `&str`
    |
 note: return type inferred to be `String` here
   --> tests/ui/async_instrument.rs:34:28


### PR DESCRIPTION
updated UI tests using TRYBUILD=overwrite with the latest stable version of Rust

## Motivation

UI tests are failing on the latest stable version of Rust

## Solution

Run `TRYBUILD=overwrite cargo test` to update the effected files.
