### PR TITLE
subscriber: prepare to release v0.3.17

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -16,7 +16,7 @@ improvements.
 - **filter**: Add `fmt::Display` impl for `filter::Targets` ([#2343])
 - **fmt**: Made `with_ansi(false)` no longer require the "ansi" feature, so that
   ANSI formatting escapes can be disabled without requiring ANSI-specific
-  dependencies ([#2535])
+  dependencies ([#2532])
 
 ### Changed
 
@@ -32,7 +32,7 @@ Thanks to @keepsimple1, @andrewhalle, @LeoniePhiline, @LukeMathWalker,
 [#2368]: https://github.com/tokio-rs/tracing/pull/2368
 [#2548]: https://github.com/tokio-rs/tracing/pull/2548
 [#2343]: https://github.com/tokio-rs/tracing/pull/2343
-[#2535]: https://github.com/tokio-rs/tracing/pull/2535
+[#2532]: https://github.com/tokio-rs/tracing/pull/2532
 [#2409]: https://github.com/tokio-rs/tracing/pull/2409
 
 # 0.3.16 (October 6, 2022)

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,40 @@
+# 0.3.17 (April 21, 2023)
+
+This release of `tracing-subscriber` fixes a build error when using `env-filter`
+with recent versions of the `regex` crate. It also introduces several minor API
+improvements.
+
+### Fixed
+
+- **env-filter**: Add "unicode-case" and "unicode-perl" to the `regex`
+  dependency, fixing a build error with recent versions of `regex` ([#2566])
+- A number of minor documentation typos and other fixes ([#2384], [#2378],
+  [#2368], [#2548])
+
+### Added
+
+- **filter**: Add `fmt::Display` impl for `filter::Targets` ([#2343])
+- **fmt**: Made `with_ansi(false)` no longer require the "ansi" feature, so that
+  ANSI formatting escapes can be disabled without requiring ANSI-specific
+  dependencies ([#2535])
+
+### Changed
+
+- **fmt**: Dim targets in the `Compact` formatter, matching the default
+  formatter ([#2409])
+
+Thanks to @keepsimple1, @andrewhalle, @LeoniePhiline, @LukeMathWalker,
+@howardjohn, @daxpedda, and @dbidwell94 for contributing to this release!
+
+[#2566]: https://github.com/tokio-rs/tracing/pull/2566
+[#2384]: https://github.com/tokio-rs/tracing/pull/2384
+[#2378]: https://github.com/tokio-rs/tracing/pull/2378
+[#2368]: https://github.com/tokio-rs/tracing/pull/2368
+[#2548]: https://github.com/tokio-rs/tracing/pull/2548
+[#2343]: https://github.com/tokio-rs/tracing/pull/2343
+[#2535]: https://github.com/tokio-rs/tracing/pull/2535
+[#2409]: https://github.com/tokio-rs/tracing/pull/2409
+
 # 0.3.16 (October 6, 2022)
 
 This release of `tracing-subscriber` fixes a regression introduced in

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",


### PR DESCRIPTION
# 0.3.17 (April 21, 2023)

This release of `tracing-subscriber` fixes a build error when using `env-filter` with recent versions of the `regex` crate. It also introduces several minor API improvements.

### Fixed

- **env-filter**: Add "unicode-case" and "unicode-perl" to the `regex` dependency, fixing a build error with recent versions of `regex` (#2566)
- A number of minor documentation typos and other fixes (#2384, #2378, #2368, #2548)

### Added

- **filter**: Add `fmt::Display` impl for `filter::Targets` (#2343)
- **fmt**: Made `with_ansi(false)` no longer require the "ansi" feature, so that ANSI formatting escapes can be disabled without requiring ANSI-specific dependencies (#2532)

### Changed

- **fmt**: Dim targets in the `Compact` formatter, matching the default formatter (#2409)

Thanks to @keepsimple1, @andrewhalle, @LeoniePhiline, @LukeMathWalker, @howardjohn, @daxpedda, and @dbidwell94 for contributing to this release!