### PR TITLE
Zipping

### DIFF
--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -25,6 +25,7 @@ crossbeam-channel = "0.5.5"
 time = { version = "0.3.2", default-features = false, features = ["formatting", "parsing"] }
 parking_lot = { optional = true, version = "0.12.1" }
 thiserror = "1.0.31"
+zip = "0.6"
 
 [dependencies.tracing-subscriber]
 path = "../tracing-subscriber"

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -25,7 +25,7 @@ crossbeam-channel = "0.5.5"
 time = { version = "0.3.2", default-features = false, features = ["formatting", "parsing"] }
 parking_lot = { optional = true, version = "0.12.1" }
 thiserror = "1.0.31"
-zip = "0.6"
+zip = { version = "0.6", optional = true }
 
 [dependencies.tracing-subscriber]
 path = "../tracing-subscriber"
@@ -38,6 +38,10 @@ criterion = { version = "0.3.6", default_features = false }
 tracing = { path = "../tracing", version = "0.2" }
 time = { version = "0.3.2", default-features = false, features = ["formatting", "parsing"] }
 tempfile = "3.3.0"
+
+[features]
+default = []
+zipping = ["zip"]
 
 [[bench]]
 name = "bench"

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -25,7 +25,7 @@ crossbeam-channel = "0.5.5"
 time = { version = "0.3.2", default-features = false, features = ["formatting", "parsing"] }
 parking_lot = { optional = true, version = "0.12.1" }
 thiserror = "1.0.31"
-zip = { version = "0.6", optional = true }
+lz4 = { version = "1.24", optional = true}
 
 [dependencies.tracing-subscriber]
 path = "../tracing-subscriber"
@@ -41,7 +41,7 @@ tempfile = "3.3.0"
 
 [features]
 default = []
-zipping = ["zip"]
+zipping = ["lz4"]
 
 [[bench]]
 name = "bench"

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -30,11 +30,14 @@ use crate::sync::{RwLock, RwLockReadGuard};
 use std::{
     fmt::{self, Debug},
     fs::{self, File, OpenOptions},
-    io::{self, Read, Write},
+    io::{self, Write},
     path::{Path, PathBuf},
     sync::atomic::{AtomicUsize, Ordering},
 };
 use time::{format_description, Date, Duration, OffsetDateTime, Time};
+
+#[cfg(feature = "zipping")]
+use io::Read;
 #[cfg(feature = "zipping")]
 use zip::{write::FileOptions, CompressionMethod, ZipWriter};
 

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -35,6 +35,7 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 use time::{format_description, Date, Duration, OffsetDateTime, Time};
+#[cfg(feature = "zipping")]
 use zip::{write::FileOptions, CompressionMethod, ZipWriter};
 
 mod builder;
@@ -675,6 +676,7 @@ impl Inner {
     }
 
     // This function is called after each refresh (rotating to a new file). Thus, it only zips the latest log file
+    #[cfg(feature = "zipping")]
     fn zip_log(&self) -> io::Result<()> {
         // Read the log directory to find the log files
         let mut files = self
@@ -725,6 +727,8 @@ impl Inner {
             self.prune_old_logs(max_files);
         }
 
+        // don't know how long this might take, should we start this in a thread?
+        #[cfg(feature = "zipping")]
         if self.zipping {
             if let Err(err) = self.zip_log() {
                 eprintln!("Couldn't successfully zip the latest log file: {}", err);
@@ -1201,6 +1205,7 @@ mod test {
     }
 }
 
+#[cfg(feature = "zipping")]
 #[test]
 fn test_zipping() {
     use std::sync::{Arc, Mutex};
@@ -1303,6 +1308,7 @@ fn test_zipping() {
     assert!(!found_original, "Expected the first log file to be removed");
 }
 
+#[cfg(feature = "zipping")]
 #[test]
 fn test_integration_prune_and_zip() {
     use std::sync::{Arc, Mutex};

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -705,6 +705,8 @@ impl Inner {
 
         let output_filename = format!("{}.zip", input_filename);
 
+        let output_file_path = input_file_path.with_file_name(output_filename);
+
         // Create a new ZIP archive and write the input file's content to it
         let output_file = File::create(&output_file_path)?;
         let mut zip_writer = ZipWriter::new(output_file);

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -180,7 +180,7 @@ impl RollingFileAppender {
     ///     .rotation(Rotation::HOURLY) // rotate log files once every hour
     ///     .filename_prefix("myapp") // log file names will be prefixed with `myapp.`
     ///     .filename_suffix("log") // log file names will be suffixed with `.log`
-    ///     .max_files(5) // keep maximum 5 log files at a time
+    ///     .max_log_files(5) // keep maximum 5 log files at a time
     ///     .zipping(true) // zip the finalized log files
     ///     .build("/var/log") // try to build an appender that stores log files in `/var/log`
     ///     .expect("initializing rolling file appender failed");

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -696,8 +696,14 @@ impl Inner {
         let mut input_file = File::open(&input_file_path)?;
         input_file.read_to_end(&mut file_contents)?;
 
-        // Replace the file extension with .zip
-        let output_file_path = input_file_path.with_extension("zip");
+        // Add `.zip` extension to the filename
+        let input_filename = input_file_path
+            .file_name()
+            .expect("Filename should be present")
+            .to_str()
+            .expect("Filename should be valid UTF-8");
+
+        let output_filename = format!("{}.zip", input_filename);
 
         // Create a new ZIP archive and write the input file's content to it
         let output_file = File::create(&output_file_path)?;

--- a/tracing-appender/src/rolling/builder.rs
+++ b/tracing-appender/src/rolling/builder.rs
@@ -11,6 +11,7 @@ pub struct Builder {
     pub(super) prefix: Option<String>,
     pub(super) suffix: Option<String>,
     pub(super) max_files: Option<usize>,
+    pub(super) zipping: bool,
 }
 
 /// Errors returned by [`Builder::build`].
@@ -54,6 +55,7 @@ impl Builder {
             prefix: None,
             suffix: None,
             max_files: None,
+            zipping: false,
         }
     }
 
@@ -229,6 +231,49 @@ impl Builder {
     pub fn max_log_files(self, n: usize) -> Self {
         Self {
             max_files: Some(n),
+            ..self
+        }
+    }
+
+    /// zips the finalized log files. Zipped logs are not excluded from the rotation!
+    ///
+    /// When a new log file is created, if there are `n` or more
+    /// existing log files in the directory, the oldest will be deleted.
+    /// If no value is supplied, the `RollingAppender` will not remove any files.
+    ///
+    /// Files are considered candidates for zipping based on the following
+    /// criteria:
+    ///
+    /// * The file must not be a directory or symbolic link.
+    /// * If the appender is configured with a [`filename_prefix`], the file
+    ///   name must start with that prefix.
+    /// * If the appender is configured with a [`filename_suffix`], the file
+    ///   name must end with that suffix.
+    /// * If the appender has neither a filename prefix nor a suffix, then the
+    ///   file name must parse as a valid date based on the appender's date
+    ///   format.
+    ///
+    /// [`filename_prefix`]: Self::filename_prefix
+    /// [`filename_suffix`]: Self::filename_suffix
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tracing_appender::rolling::RollingFileAppender;
+    ///
+    /// # fn docs() {
+    /// let appender = RollingFileAppender::builder()
+    ///     .zipping(true) // enable zipping
+    ///     // ...
+    ///     .build("/var/log")
+    ///     .expect("failed to initialize rolling file appender");
+    /// # drop(appender)
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn zipping(self, flag: bool) -> Self {
+        Self {
+            zipping: flag,
             ..self
         }
     }


### PR DESCRIPTION
## Motivation

Logs can be quite big. For some applications, it might make sense to `zip` the logs after they are finalized to minimize the space occupied by the logs. 
In this PR, I'm suggesting a new feature, called `zipping`, which zips the finalized logs.

## Solution

In each `refresh_writer` call (which rotates into a new file), the code zips the most recent finalized log file (based on the creation date). 
The code should be pretty straight forward to read.


Caveat: I'm not sure for a big log file, if this zipping will create issues since it's blocking. I've also added a note in the codebase as a comment. Maybe spawning this process in a thread might make more sense.

I've also created an issue: https://github.com/tokio-rs/tracing/issues/2584
