### PR TITLE
docs: document `registry` feature requirement for `fmt` feature

### DIFF
--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -54,7 +54,7 @@
 //!   similar to the [`env_logger` crate]. **Requires "std"**.
 //! - `fmt`: Enables the [`fmt`] module, which provides a subscriber
 //!   implementation for printing formatted representations of trace events.
-//!   Enabled by default. **Requires "std"**.
+//!   Enabled by default. **Requires "registry" and "std"**.
 //! - `ansi`: Enables `fmt` support for ANSI terminal colors. Enabled by
 //!   default.
 //! - `registry`: enables the [`registry`] module. Enabled by default.


### PR DESCRIPTION
## Motivation

This was inconsistent with other features, which mention their requirements, and a reader might assume they don't need to inspect the feature flags page or manifest.

## Solution

Document the requirement.
