### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+Tracing is part of the Tokio project and uses the same security policy as [Tokio][tokio-security].
+
+## Report a security issue
+
+The process for reporting an issue is the same as for [Tokio][tokio-security]. This includes private reporting via security@tokio.rs.
+
+[tokio-security]: https://github.com/tokio-rs/tokio/security/policy


### PR DESCRIPTION
We should make it explicit that tracing uses the security policy of Tokio.