### PR TITLE
GlobalDefaultReservation to enable late setup of the global dispatch

### DIFF
--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -426,7 +426,7 @@ fn finalize_reservation(dispatcher: Dispatch) -> Result<(), SetGlobalDefaultErro
 /// Creates a global default reservation, see [`GlobalDefaultReservation`].
 /// Useful if setting up the default dispatch requires work that may cause threads to interact
 /// with [`get_default`], since doing so before setting up the global dispatcher will
-/// cause that thread to permanently get [`NONE`] as their dispatcher.
+/// cause that thread to permanently get [`Dispatch::none()`] as their dispatcher.
 pub fn reserve_global_default() -> Result<GlobalDefaultReservation, SetGlobalDefaultError> {
     if GLOBAL_INIT
         .compare_exchange(UNINITIALIZED, RESERVED, Ordering::SeqCst, Ordering::SeqCst)


### PR DESCRIPTION
## Motivation
Fixes https://github.com/tokio-rs/tracing/issues/2587

## Solution

A lot of the context is in the issue, this creates a global_default guard which will prevent threads from setting its local dispatch to the none-dispatcher permanently in cases where the global default isn't found.

In the case of an application that doesn't set up a subscriber, it will immediately hit the `UNINITIALIZED` path of `get_global_if_not_reserved()` and set the thread local to the none-dispatcher immediately. 
In cases where the user has reserved a global default it will defer the setting of its thread local state and temporarily use the `NONE`-dispatcher. Other than that it works as expected and the only downside should be code-bloat.

I would have added more tests but messing with the global static makes that pretty difficult.

E: 
This is an okayish solution but it runs into a bit of an issue depending on the state of the application when the global subscriber picks up. 

Another interesting solution I tried out was to just make a buffering subscriber, that's kind of a mess in itself but imagine a temporary store that's guarded the same way as this fix, but it just saves events and then replays them once the real subscriber connects. That would likely come with its own set of challenges though, since then you really have to take care to not mess up spans that may be entered but not exited when the swap is made.