### PR TITLE
Fix #2585: instrument with "log" feature

### DIFF
--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -340,7 +340,7 @@ fn gen_block<B: ToTokens>(
         // regression in case the level is enabled.
         let __tracing_attr_span;
         let __tracing_attr_guard;
-        if tracing::level_enabled!(#level) {
+        if tracing::level_enabled!(#level) || tracing::if_log_enabled!(#level, {true} else {false}) {
             __tracing_attr_span = #span;
             #follows_from
             __tracing_attr_guard = __tracing_attr_span.enter();


### PR DESCRIPTION
## Motivation

The instrument macro currently doesn't work with the "log" crate feature: #2585

## Solution

Change the generated code to create a span if either `tracing::if_log_enabled!` or `tracing::level_enabled!`. I'm not sure how to add a test for this or if this is the best solution.
