### PR TITLE
Fix doc link to RAI pattern crate documentation

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -192,7 +192,7 @@
 //!
 //! You can find more examples showing how to use this crate [here][examples].
 //!
-//! [RAII]: https://github.com/rust-unofficial/patterns/blob/master/patterns/behavioural/RAII.md
+//! [RAII]: https://github.com/rust-unofficial/patterns/blob/main/src/patterns/behavioural/RAII.md
 //! [examples]: https://github.com/tokio-rs/tracing/tree/master/examples
 //!
 //! ### Events


### PR DESCRIPTION


## Motivation

While reading tracing docs on https://docs.rs/tracing/latest/tracing/index.html# I found a dead link which should have lead to RAII pattern documentation. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

I'm submitting a code change to update the reference foremented document to refer to correct location for the RAII pattern.
