### PR TITLE
use fully qualified names in macros for items exported from std prelude

### DIFF
--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -318,40 +318,40 @@ macro_rules! impl_values {
 
 macro_rules! ty_to_nonzero {
     (u8) => {
-        NonZeroU8
+        ::core::num::NonZeroU8
     };
     (u16) => {
-        NonZeroU16
+        ::core::num::NonZeroU16
     };
     (u32) => {
-        NonZeroU32
+        ::core::num::NonZeroU32
     };
     (u64) => {
-        NonZeroU64
+        ::core::num::NonZeroU64
     };
     (u128) => {
-        NonZeroU128
+        ::core::num::NonZeroU128
     };
     (usize) => {
-        NonZeroUsize
+        ::core::num::NonZeroUsize
     };
     (i8) => {
-        NonZeroI8
+        ::core::num::NonZeroI8
     };
     (i16) => {
-        NonZeroI16
+        ::core::num::NonZeroI16
     };
     (i32) => {
-        NonZeroI32
+        ::core::num::NonZeroI32
     };
     (i64) => {
-        NonZeroI64
+        ::core::num::NonZeroI64
     };
     (i128) => {
-        NonZeroI128
+        ::core::num::NonZeroI128
     };
     (isize) => {
-        NonZeroIsize
+        ::core::num::NonZeroIsize
     };
 }
 
@@ -950,7 +950,7 @@ macro_rules! impl_valid_len {
     ( $( $len:tt ),+ ) => {
         $(
             impl<'a> private::ValidLen<'a> for
-                [(&'a Field, Option<&'a (dyn Value + 'a)>); $len] {}
+                [(&'a Field, ::core::option::Option<&'a (dyn Value + 'a)>); $len] {}
         )+
     }
 }

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -318,40 +318,40 @@ macro_rules! impl_values {
 
 macro_rules! ty_to_nonzero {
     (u8) => {
-        ::core::num::NonZeroU8
+        NonZeroU8
     };
     (u16) => {
-        ::core::num::NonZeroU16
+        NonZeroU16
     };
     (u32) => {
-        ::core::num::NonZeroU32
+        NonZeroU32
     };
     (u64) => {
-        ::core::num::NonZeroU64
+        NonZeroU64
     };
     (u128) => {
-        ::core::num::NonZeroU128
+        NonZeroU128
     };
     (usize) => {
-        ::core::num::NonZeroUsize
+        NonZeroUsize
     };
     (i8) => {
-        ::core::num::NonZeroI8
+        NonZeroI8
     };
     (i16) => {
-        ::core::num::NonZeroI16
+        NonZeroI16
     };
     (i32) => {
-        ::core::num::NonZeroI32
+        NonZeroI32
     };
     (i64) => {
-        ::core::num::NonZeroI64
+        NonZeroI64
     };
     (i128) => {
-        ::core::num::NonZeroI128
+        NonZeroI128
     };
     (isize) => {
-        ::core::num::NonZeroIsize
+        NonZeroIsize
     };
 }
 

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -263,9 +263,9 @@ macro_rules! metadata {
             $name,
             $target,
             $level,
-            Some(file!()),
-            Some(line!()),
-            Some(module_path!()),
+            ::core::option::Option::Some(file!()),
+            ::core::option::Option::Some(line!()),
+            ::core::option::Option::Some(module_path!()),
             $crate::field::FieldSet::new($fields, $crate::identify_callsite!($callsite)),
             $kind,
         )

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -280,9 +280,9 @@ macro_rules! log_cs {
             "log event",
             "log",
             $level,
-            None,
-            None,
-            None,
+            ::core::option::Option::None,
+            ::core::option::Option::None,
+            ::core::option::Option::None,
             field::FieldSet::new(FIELD_NAMES, identify_callsite!(&$cs)),
             Kind::EVENT,
         );

--- a/tracing-subscriber/src/filter/subscriber_filters/mod.rs
+++ b/tracing-subscriber/src/filter/subscriber_filters/mod.rs
@@ -475,7 +475,7 @@ macro_rules! filter_impl_body {
         }
 
         #[inline]
-        fn max_level_hint(&self) -> ::core::option::Option<LevelFilter> {
+        fn max_level_hint(&self) -> Option<LevelFilter> {
             self.deref().max_level_hint()
         }
     };

--- a/tracing-subscriber/src/filter/subscriber_filters/mod.rs
+++ b/tracing-subscriber/src/filter/subscriber_filters/mod.rs
@@ -475,7 +475,7 @@ macro_rules! filter_impl_body {
         }
 
         #[inline]
-        fn max_level_hint(&self) -> Option<LevelFilter> {
+        fn max_level_hint(&self) -> ::core::option::Option<LevelFilter> {
             self.deref().max_level_hint()
         }
     };

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -778,7 +778,7 @@ macro_rules! with_event_from_span {
         #[allow(unused)]
         let mut iter = fs.iter();
         let v = [$(
-            (&iter.next().unwrap(), Some(&$value as &dyn field::Value)),
+            (&iter.next().unwrap(), ::core::option::Option::Some(&$value as &dyn field::Value)),
         )*];
         let vs = fs.value_set(&v);
         let $event = Event::new_child_of($id, meta, &vs);

--- a/tracing-subscriber/src/macros.rs
+++ b/tracing-subscriber/src/macros.rs
@@ -4,7 +4,7 @@ macro_rules! try_lock {
         try_lock!($lock, else return)
     };
     ($lock:expr, else $els:expr) => {
-        if let Ok(l) = $lock {
+        if let ::core::result::Result::Ok(l) = $lock {
             l
         } else if std::thread::panicking() {
             $els

--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -1723,13 +1723,13 @@ macro_rules! subscriber_impl_body {
         }
 
         #[inline]
-        fn max_level_hint(&self) -> Option<LevelFilter> {
+        fn max_level_hint(&self) -> ::core::option::Option<LevelFilter> {
             self.deref().max_level_hint()
         }
 
         #[doc(hidden)]
         #[inline]
-        unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
+        unsafe fn downcast_raw(&self, id: TypeId) -> ::core::option::Option<NonNull<()>> {
             self.deref().downcast_raw(id)
         }
     };

--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -1723,7 +1723,7 @@ macro_rules! subscriber_impl_body {
         }
 
         #[inline]
-        fn max_level_hint(&self) -> ::core::option::Option<LevelFilter> {
+        fn max_level_hint(&self) -> Option<LevelFilter> {
             self.deref().max_level_hint()
         }
 

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -2196,79 +2196,79 @@ macro_rules! valueset {
     // };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&debug(&$val) as &dyn Value)) },
+            @ { $($out),*, (&$next, ::core::option::Option::Some(&debug(&$val) as &dyn Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&display(&$val) as &dyn Value)) },
+            @ { $($out),*, (&$next, ::core::option::Option::Some(&display(&$val) as &dyn Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = $val:expr, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&$val as &dyn Value)) },
+            @ { $($out),*, (&$next, ::core::option::Option::Some(&$val as &dyn Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&$($k).+ as &dyn Value)) },
+            @ { $($out),*, (&$next, ::core::option::Option::Some(&$($k).+ as &dyn Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, ?$($k:ident).+, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&debug(&$($k).+) as &dyn Value)) },
+            @ { $($out),*, (&$next, ::core::option::Option::Some(&debug(&$($k).+) as &dyn Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, %$($k:ident).+, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&display(&$($k).+) as &dyn Value)) },
+            @ { $($out),*, (&$next, ::core::option::Option::Some(&display(&$($k).+) as &dyn Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = ?$val:expr) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&debug(&$val) as &dyn Value)) },
+            @ { $($out),*, (&$next, ::core::option::Option::Some(&debug(&$val) as &dyn Value)) },
             $next,
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = %$val:expr) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&display(&$val) as &dyn Value)) },
+            @ { $($out),*, (&$next, ::core::option::Option::Some(&display(&$val) as &dyn Value)) },
             $next,
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+ = $val:expr) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&$val as &dyn Value)) },
+            @ { $($out),*, (&$next, ::core::option::Option::Some(&$val as &dyn Value)) },
             $next,
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $($k:ident).+) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&$($k).+ as &dyn Value)) },
+            @ { $($out),*, (&$next, ::core::option::Option::Some(&$($k).+ as &dyn Value)) },
             $next,
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, ?$($k:ident).+) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&debug(&$($k).+) as &dyn Value)) },
+            @ { $($out),*, (&$next, ::core::option::Option::Some(&debug(&$($k).+) as &dyn Value)) },
             $next,
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, %$($k:ident).+) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&display(&$($k).+) as &dyn Value)) },
+            @ { $($out),*, (&$next, ::core::option::Option::Some(&display(&$($k).+) as &dyn Value)) },
             $next,
         )
     };
@@ -2276,47 +2276,47 @@ macro_rules! valueset {
     // Handle literal names
     (@ { $(,)* $($out:expr),* }, $next:expr, $k:literal = ?$val:expr, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&debug(&$val) as &dyn Value)) },
+            @ { $($out),*, (&$next, ::core::option::Option::Some(&debug(&$val) as &dyn Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $k:literal = %$val:expr, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&display(&$val) as &dyn Value)) },
+            @ { $($out),*, (&$next, ::core::option::Option::Some(&display(&$val) as &dyn Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $k:literal = $val:expr, $($rest:tt)*) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&$val as &dyn Value)) },
+            @ { $($out),*, (&$next, ::core::option::Option::Some(&$val as &dyn Value)) },
             $next,
             $($rest)*
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $k:literal = ?$val:expr) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&debug(&$val) as &dyn Value)) },
+            @ { $($out),*, (&$next, ::core::option::Option::Some(&debug(&$val) as &dyn Value)) },
             $next,
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $k:literal = %$val:expr) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&display(&$val) as &dyn Value)) },
+            @ { $($out),*, (&$next, ::core::option::Option::Some(&display(&$val) as &dyn Value)) },
             $next,
         )
     };
     (@ { $(,)* $($out:expr),* }, $next:expr, $k:literal = $val:expr) => {
         $crate::valueset!(
-            @ { $($out),*, (&$next, Some(&$val as &dyn Value)) },
+            @ { $($out),*, (&$next, ::core::option::Option::Some(&$val as &dyn Value)) },
             $next,
         )
     };
 
     // Remainder is unparsable, but exists --- must be format args!
     (@ { $(,)* $($out:expr),* }, $next:expr, $($rest:tt)+) => {
-        $crate::valueset!(@ { (&$next, Some(&format_args!($($rest)+) as &dyn Value)), $($out),* }, $next, )
+        $crate::valueset!(@ { (&$next, ::core::option::Option::Some(&format_args!($($rest)+) as &dyn Value)), $($out),* }, $next, )
     };
 
     // === entry ===
@@ -2327,7 +2327,7 @@ macro_rules! valueset {
             let mut iter = $fields.iter();
             $fields.value_set($crate::valueset!(
                 @ { },
-                iter.next().expect("FieldSet corrupted (this is a bug)"),
+                ::core::iter::Iterator::next(&mut iter).expect("FieldSet corrupted (this is a bug)"),
                 $($kvs)+
             ))
         }

--- a/tracing/tests/macros.rs
+++ b/tracing/tests/macros.rs
@@ -1,4 +1,8 @@
 #![deny(warnings)]
+// We call all macros in this module with `no_implicit_prelude` to ensure they do not depend on the standard prelude.
+#![no_implicit_prelude]
+extern crate tracing;
+
 use tracing::{
     callsite, debug, debug_span, enabled, error, error_span, event, event_enabled, info, info_span,
     span, span_enabled, trace, trace_span, warn, warn_span, Level,
@@ -111,80 +115,80 @@ fn error_span() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn span_root() {
-    span!(target: "foo_events", parent: None, Level::TRACE, "foo", bar.baz = 2, quux = 3);
-    span!(target: "foo_events", parent: None, Level::TRACE, "foo", bar.baz = 2, quux = 3);
-    span!(target: "foo_events", parent: None, Level::TRACE, "foo", bar.baz = 2, quux = 4,);
-    span!(target: "foo_events", parent: None, Level::TRACE, "foo");
-    span!(target: "foo_events", parent: None, Level::TRACE, "bar",);
-    span!(parent: None, Level::DEBUG, "foo", bar.baz = 2, quux = 3);
-    span!(parent: None, Level::DEBUG, "foo", bar.baz = 2, quux = 4,);
-    span!(parent: None, Level::DEBUG, "foo");
-    span!(parent: None, Level::DEBUG, "bar",);
+    span!(target: "foo_events", parent: ::core::option::Option::None, Level::TRACE, "foo", bar.baz = 2, quux = 3);
+    span!(target: "foo_events", parent: ::core::option::Option::None, Level::TRACE, "foo", bar.baz = 2, quux = 3);
+    span!(target: "foo_events", parent: ::core::option::Option::None, Level::TRACE, "foo", bar.baz = 2, quux = 4,);
+    span!(target: "foo_events", parent: ::core::option::Option::None, Level::TRACE, "foo");
+    span!(target: "foo_events", parent: ::core::option::Option::None, Level::TRACE, "bar",);
+    span!(parent: ::core::option::Option::None, Level::DEBUG, "foo", bar.baz = 2, quux = 3);
+    span!(parent: ::core::option::Option::None, Level::DEBUG, "foo", bar.baz = 2, quux = 4,);
+    span!(parent: ::core::option::Option::None, Level::DEBUG, "foo");
+    span!(parent: ::core::option::Option::None, Level::DEBUG, "bar",);
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn trace_span_root() {
-    trace_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 3);
-    trace_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 4,);
-    trace_span!(target: "foo_events", parent: None, "foo");
-    trace_span!(target: "foo_events", parent: None, "bar",);
-    trace_span!(parent: None, "foo", bar.baz = 2, quux = 3);
-    trace_span!(parent: None, "foo", bar.baz = 2, quux = 4,);
-    trace_span!(parent: None, "foo");
-    trace_span!(parent: None, "bar",);
+    trace_span!(target: "foo_events", parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 3);
+    trace_span!(target: "foo_events", parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 4,);
+    trace_span!(target: "foo_events", parent: ::core::option::Option::None, "foo");
+    trace_span!(target: "foo_events", parent: ::core::option::Option::None, "bar",);
+    trace_span!(parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 3);
+    trace_span!(parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 4,);
+    trace_span!(parent: ::core::option::Option::None, "foo");
+    trace_span!(parent: ::core::option::Option::None, "bar",);
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn debug_span_root() {
-    debug_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 3);
-    debug_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 4,);
-    debug_span!(target: "foo_events", parent: None, "foo");
-    debug_span!(target: "foo_events", parent: None, "bar",);
-    debug_span!(parent: None, "foo", bar.baz = 2, quux = 3);
-    debug_span!(parent: None, "foo", bar.baz = 2, quux = 4,);
-    debug_span!(parent: None, "foo");
-    debug_span!(parent: None, "bar",);
+    debug_span!(target: "foo_events", parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 3);
+    debug_span!(target: "foo_events", parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 4,);
+    debug_span!(target: "foo_events", parent: ::core::option::Option::None, "foo");
+    debug_span!(target: "foo_events", parent: ::core::option::Option::None, "bar",);
+    debug_span!(parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 3);
+    debug_span!(parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 4,);
+    debug_span!(parent: ::core::option::Option::None, "foo");
+    debug_span!(parent: ::core::option::Option::None, "bar",);
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn info_span_root() {
-    info_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 3);
-    info_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 4,);
-    info_span!(target: "foo_events", parent: None, "foo");
-    info_span!(target: "foo_events", parent: None, "bar",);
-    info_span!(parent: None, "foo", bar.baz = 2, quux = 3);
-    info_span!(parent: None, "foo", bar.baz = 2, quux = 4,);
-    info_span!(parent: None, "foo");
-    info_span!(parent: None, "bar",);
+    info_span!(target: "foo_events", parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 3);
+    info_span!(target: "foo_events", parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 4,);
+    info_span!(target: "foo_events", parent: ::core::option::Option::None, "foo");
+    info_span!(target: "foo_events", parent: ::core::option::Option::None, "bar",);
+    info_span!(parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 3);
+    info_span!(parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 4,);
+    info_span!(parent: ::core::option::Option::None, "foo");
+    info_span!(parent: ::core::option::Option::None, "bar",);
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn warn_span_root() {
-    warn_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 3);
-    warn_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 4,);
-    warn_span!(target: "foo_events", parent: None, "foo");
-    warn_span!(target: "foo_events", parent: None, "bar",);
-    warn_span!(parent: None, "foo", bar.baz = 2, quux = 3);
-    warn_span!(parent: None, "foo", bar.baz = 2, quux = 4,);
-    warn_span!(parent: None, "foo");
-    warn_span!(parent: None, "bar",);
+    warn_span!(target: "foo_events", parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 3);
+    warn_span!(target: "foo_events", parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 4,);
+    warn_span!(target: "foo_events", parent: ::core::option::Option::None, "foo");
+    warn_span!(target: "foo_events", parent: ::core::option::Option::None, "bar",);
+    warn_span!(parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 3);
+    warn_span!(parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 4,);
+    warn_span!(parent: ::core::option::Option::None, "foo");
+    warn_span!(parent: ::core::option::Option::None, "bar",);
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn error_span_root() {
-    error_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 3);
-    error_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 4,);
-    error_span!(target: "foo_events", parent: None, "foo");
-    error_span!(target: "foo_events", parent: None, "bar",);
-    error_span!(parent: None, "foo", bar.baz = 2, quux = 3);
-    error_span!(parent: None, "foo", bar.baz = 2, quux = 4,);
-    error_span!(parent: None, "foo");
-    error_span!(parent: None, "bar",);
+    error_span!(target: "foo_events", parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 3);
+    error_span!(target: "foo_events", parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 4,);
+    error_span!(target: "foo_events", parent: ::core::option::Option::None, "foo");
+    error_span!(target: "foo_events", parent: ::core::option::Option::None, "bar",);
+    error_span!(parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 3);
+    error_span!(parent: ::core::option::Option::None, "foo", bar.baz = 2, quux = 4,);
+    error_span!(parent: ::core::option::Option::None, "foo");
+    error_span!(parent: ::core::option::Option::None, "bar",);
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -605,144 +609,144 @@ fn error() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn event_root() {
-    event!(parent: None, Level::DEBUG, foo = ?3, bar.baz = %2, quux = false);
+    event!(parent: ::core::option::Option::None, Level::DEBUG, foo = ?3, bar.baz = %2, quux = false);
     event!(
-        parent: None,
+        parent: ::core::option::Option::None,
         Level::DEBUG,
         foo = 3,
         bar.baz = 2,
         quux = false
     );
-    event!(parent: None, Level::DEBUG, foo = 3, bar.baz = 3,);
-    event!(parent: None, Level::DEBUG, "foo");
-    event!(parent: None, Level::DEBUG, "foo: {}", 3);
-    event!(parent: None, Level::DEBUG, { foo = 3, bar.baz = 80 }, "quux");
-    event!(parent: None, Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
-    event!(parent: None, Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    event!(parent: None, Level::DEBUG, { foo = ?2, bar.baz = %78 }, "quux");
-    event!(target: "foo_events", parent: None, Level::DEBUG, foo = 3, bar.baz = 2, quux = false);
-    event!(target: "foo_events", parent: None, Level::DEBUG, foo = 3, bar.baz = 3,);
-    event!(target: "foo_events", parent: None, Level::DEBUG, "foo");
-    event!(target: "foo_events", parent: None, Level::DEBUG, "foo: {}", 3);
-    event!(target: "foo_events", parent: None, Level::DEBUG, { foo = 3, bar.baz = 80 }, "quux");
-    event!(target: "foo_events", parent: None, Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
-    event!(target: "foo_events", parent: None, Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    event!(target: "foo_events", parent: None, Level::DEBUG, { foo = 2, bar.baz = 78, }, "quux");
+    event!(parent: ::core::option::Option::None, Level::DEBUG, foo = 3, bar.baz = 3,);
+    event!(parent: ::core::option::Option::None, Level::DEBUG, "foo");
+    event!(parent: ::core::option::Option::None, Level::DEBUG, "foo: {}", 3);
+    event!(parent: ::core::option::Option::None, Level::DEBUG, { foo = 3, bar.baz = 80 }, "quux");
+    event!(parent: ::core::option::Option::None, Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    event!(parent: ::core::option::Option::None, Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    event!(parent: ::core::option::Option::None, Level::DEBUG, { foo = ?2, bar.baz = %78 }, "quux");
+    event!(target: "foo_events", parent: ::core::option::Option::None, Level::DEBUG, foo = 3, bar.baz = 2, quux = false);
+    event!(target: "foo_events", parent: ::core::option::Option::None, Level::DEBUG, foo = 3, bar.baz = 3,);
+    event!(target: "foo_events", parent: ::core::option::Option::None, Level::DEBUG, "foo");
+    event!(target: "foo_events", parent: ::core::option::Option::None, Level::DEBUG, "foo: {}", 3);
+    event!(target: "foo_events", parent: ::core::option::Option::None, Level::DEBUG, { foo = 3, bar.baz = 80 }, "quux");
+    event!(target: "foo_events", parent: ::core::option::Option::None, Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    event!(target: "foo_events", parent: ::core::option::Option::None, Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    event!(target: "foo_events", parent: ::core::option::Option::None, Level::DEBUG, { foo = 2, bar.baz = 78, }, "quux");
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn trace_root() {
-    trace!(parent: None, foo = ?3, bar.baz = %2, quux = false);
-    trace!(parent: None, foo = 3, bar.baz = 2, quux = false);
-    trace!(parent: None, foo = 3, bar.baz = 3,);
-    trace!(parent: None, "foo");
-    trace!(parent: None, "foo: {}", 3);
-    trace!(parent: None, { foo = 3, bar.baz = 80 }, "quux");
-    trace!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
-    trace!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    trace!(parent: None, { foo = 2, bar.baz = 78 }, "quux");
-    trace!(parent: None, { foo = ?2, bar.baz = %78 }, "quux");
-    trace!(target: "foo_events", parent: None, foo = 3, bar.baz = 2, quux = false);
-    trace!(target: "foo_events", parent: None, foo = 3, bar.baz = 3,);
-    trace!(target: "foo_events", parent: None, "foo");
-    trace!(target: "foo_events", parent: None, "foo: {}", 3);
-    trace!(target: "foo_events", parent: None, { foo = 3, bar.baz = 80 }, "quux");
-    trace!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
-    trace!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    trace!(target: "foo_events", parent: None, { foo = 2, bar.baz = 78, }, "quux");
+    trace!(parent: ::core::option::Option::None, foo = ?3, bar.baz = %2, quux = false);
+    trace!(parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
+    trace!(parent: ::core::option::Option::None, foo = 3, bar.baz = 3,);
+    trace!(parent: ::core::option::Option::None, "foo");
+    trace!(parent: ::core::option::Option::None, "foo: {}", 3);
+    trace!(parent: ::core::option::Option::None, { foo = 3, bar.baz = 80 }, "quux");
+    trace!(parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    trace!(parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    trace!(parent: ::core::option::Option::None, { foo = 2, bar.baz = 78 }, "quux");
+    trace!(parent: ::core::option::Option::None, { foo = ?2, bar.baz = %78 }, "quux");
+    trace!(target: "foo_events", parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
+    trace!(target: "foo_events", parent: ::core::option::Option::None, foo = 3, bar.baz = 3,);
+    trace!(target: "foo_events", parent: ::core::option::Option::None, "foo");
+    trace!(target: "foo_events", parent: ::core::option::Option::None, "foo: {}", 3);
+    trace!(target: "foo_events", parent: ::core::option::Option::None, { foo = 3, bar.baz = 80 }, "quux");
+    trace!(target: "foo_events", parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    trace!(target: "foo_events", parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    trace!(target: "foo_events", parent: ::core::option::Option::None, { foo = 2, bar.baz = 78, }, "quux");
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn debug_root() {
-    debug!(parent: None, foo = ?3, bar.baz = %2, quux = false);
-    debug!(parent: None, foo = 3, bar.baz = 2, quux = false);
-    debug!(parent: None, foo = 3, bar.baz = 3,);
-    debug!(parent: None, "foo");
-    debug!(parent: None, "foo: {}", 3);
-    debug!(parent: None, { foo = 3, bar.baz = 80 }, "quux");
-    debug!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
-    debug!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    debug!(parent: None, { foo = 2, bar.baz = 78 }, "quux");
-    debug!(parent: None, { foo = ?2, bar.baz = %78 }, "quux");
-    debug!(target: "foo_events", parent: None, foo = 3, bar.baz = 2, quux = false);
-    debug!(target: "foo_events", parent: None, foo = 3, bar.baz = 3,);
-    debug!(target: "foo_events", parent: None, "foo");
-    debug!(target: "foo_events", parent: None, "foo: {}", 3);
-    debug!(target: "foo_events", parent: None, { foo = 3, bar.baz = 80 }, "quux");
-    debug!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
-    debug!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    debug!(target: "foo_events", parent: None, { foo = 2, bar.baz = 78, }, "quux");
+    debug!(parent: ::core::option::Option::None, foo = ?3, bar.baz = %2, quux = false);
+    debug!(parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
+    debug!(parent: ::core::option::Option::None, foo = 3, bar.baz = 3,);
+    debug!(parent: ::core::option::Option::None, "foo");
+    debug!(parent: ::core::option::Option::None, "foo: {}", 3);
+    debug!(parent: ::core::option::Option::None, { foo = 3, bar.baz = 80 }, "quux");
+    debug!(parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    debug!(parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    debug!(parent: ::core::option::Option::None, { foo = 2, bar.baz = 78 }, "quux");
+    debug!(parent: ::core::option::Option::None, { foo = ?2, bar.baz = %78 }, "quux");
+    debug!(target: "foo_events", parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
+    debug!(target: "foo_events", parent: ::core::option::Option::None, foo = 3, bar.baz = 3,);
+    debug!(target: "foo_events", parent: ::core::option::Option::None, "foo");
+    debug!(target: "foo_events", parent: ::core::option::Option::None, "foo: {}", 3);
+    debug!(target: "foo_events", parent: ::core::option::Option::None, { foo = 3, bar.baz = 80 }, "quux");
+    debug!(target: "foo_events", parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    debug!(target: "foo_events", parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    debug!(target: "foo_events", parent: ::core::option::Option::None, { foo = 2, bar.baz = 78, }, "quux");
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn info_root() {
-    info!(parent: None, foo = ?3, bar.baz = %2, quux = false);
-    info!(parent: None, foo = 3, bar.baz = 2, quux = false);
-    info!(parent: None, foo = 3, bar.baz = 3,);
-    info!(parent: None, "foo");
-    info!(parent: None, "foo: {}", 3);
-    info!(parent: None, { foo = 3, bar.baz = 80 }, "quux");
-    info!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
-    info!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    info!(parent: None, { foo = 2, bar.baz = 78 }, "quux");
-    info!(parent: None, { foo = ?2, bar.baz = %78 }, "quux");
-    info!(target: "foo_events", parent: None, foo = 3, bar.baz = 2, quux = false);
-    info!(target: "foo_events", parent: None, foo = 3, bar.baz = 3,);
-    info!(target: "foo_events", parent: None, "foo");
-    info!(target: "foo_events", parent: None, "foo: {}", 3);
-    info!(target: "foo_events", parent: None, { foo = 3, bar.baz = 80 }, "quux");
-    info!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
-    info!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    info!(target: "foo_events", parent: None, { foo = 2, bar.baz = 78, }, "quux");
+    info!(parent: ::core::option::Option::None, foo = ?3, bar.baz = %2, quux = false);
+    info!(parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
+    info!(parent: ::core::option::Option::None, foo = 3, bar.baz = 3,);
+    info!(parent: ::core::option::Option::None, "foo");
+    info!(parent: ::core::option::Option::None, "foo: {}", 3);
+    info!(parent: ::core::option::Option::None, { foo = 3, bar.baz = 80 }, "quux");
+    info!(parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    info!(parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    info!(parent: ::core::option::Option::None, { foo = 2, bar.baz = 78 }, "quux");
+    info!(parent: ::core::option::Option::None, { foo = ?2, bar.baz = %78 }, "quux");
+    info!(target: "foo_events", parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
+    info!(target: "foo_events", parent: ::core::option::Option::None, foo = 3, bar.baz = 3,);
+    info!(target: "foo_events", parent: ::core::option::Option::None, "foo");
+    info!(target: "foo_events", parent: ::core::option::Option::None, "foo: {}", 3);
+    info!(target: "foo_events", parent: ::core::option::Option::None, { foo = 3, bar.baz = 80 }, "quux");
+    info!(target: "foo_events", parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    info!(target: "foo_events", parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    info!(target: "foo_events", parent: ::core::option::Option::None, { foo = 2, bar.baz = 78, }, "quux");
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn warn_root() {
-    warn!(parent: None, foo = ?3, bar.baz = %2, quux = false);
-    warn!(parent: None, foo = 3, bar.baz = 2, quux = false);
-    warn!(parent: None, foo = 3, bar.baz = 3,);
-    warn!(parent: None, "foo");
-    warn!(parent: None, "foo: {}", 3);
-    warn!(parent: None, { foo = 3, bar.baz = 80 }, "quux");
-    warn!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
-    warn!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    warn!(parent: None, { foo = 2, bar.baz = 78 }, "quux");
-    warn!(parent: None, { foo = ?2, bar.baz = %78 }, "quux");
-    warn!(target: "foo_events", parent: None, foo = 3, bar.baz = 2, quux = false);
-    warn!(target: "foo_events", parent: None, foo = 3, bar.baz = 3,);
-    warn!(target: "foo_events", parent: None, "foo");
-    warn!(target: "foo_events", parent: None, "foo: {}", 3);
-    warn!(target: "foo_events", parent: None, { foo = 3, bar.baz = 80 }, "quux");
-    warn!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
-    warn!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    warn!(target: "foo_events", parent: None, { foo = 2, bar.baz = 78, }, "quux");
+    warn!(parent: ::core::option::Option::None, foo = ?3, bar.baz = %2, quux = false);
+    warn!(parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
+    warn!(parent: ::core::option::Option::None, foo = 3, bar.baz = 3,);
+    warn!(parent: ::core::option::Option::None, "foo");
+    warn!(parent: ::core::option::Option::None, "foo: {}", 3);
+    warn!(parent: ::core::option::Option::None, { foo = 3, bar.baz = 80 }, "quux");
+    warn!(parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    warn!(parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    warn!(parent: ::core::option::Option::None, { foo = 2, bar.baz = 78 }, "quux");
+    warn!(parent: ::core::option::Option::None, { foo = ?2, bar.baz = %78 }, "quux");
+    warn!(target: "foo_events", parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
+    warn!(target: "foo_events", parent: ::core::option::Option::None, foo = 3, bar.baz = 3,);
+    warn!(target: "foo_events", parent: ::core::option::Option::None, "foo");
+    warn!(target: "foo_events", parent: ::core::option::Option::None, "foo: {}", 3);
+    warn!(target: "foo_events", parent: ::core::option::Option::None, { foo = 3, bar.baz = 80 }, "quux");
+    warn!(target: "foo_events", parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    warn!(target: "foo_events", parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    warn!(target: "foo_events", parent: ::core::option::Option::None, { foo = 2, bar.baz = 78, }, "quux");
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
 fn error_root() {
-    error!(parent: None, foo = ?3, bar.baz = %2, quux = false);
-    error!(parent: None, foo = 3, bar.baz = 2, quux = false);
-    error!(parent: None, foo = 3, bar.baz = 3,);
-    error!(parent: None, "foo");
-    error!(parent: None, "foo: {}", 3);
-    error!(parent: None, { foo = 3, bar.baz = 80 }, "quux");
-    error!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
-    error!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    error!(parent: None, { foo = 2, bar.baz = 78 }, "quux");
-    error!(parent: None, { foo = ?2, bar.baz = %78 }, "quux");
-    error!(target: "foo_events", parent: None, foo = 3, bar.baz = 2, quux = false);
-    error!(target: "foo_events", parent: None, foo = 3, bar.baz = 3,);
-    error!(target: "foo_events", parent: None, "foo");
-    error!(target: "foo_events", parent: None, "foo: {}", 3);
-    error!(target: "foo_events", parent: None, { foo = 3, bar.baz = 80 }, "quux");
-    error!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
-    error!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    error!(target: "foo_events", parent: None, { foo = 2, bar.baz = 78, }, "quux");
+    error!(parent: ::core::option::Option::None, foo = ?3, bar.baz = %2, quux = false);
+    error!(parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
+    error!(parent: ::core::option::Option::None, foo = 3, bar.baz = 3,);
+    error!(parent: ::core::option::Option::None, "foo");
+    error!(parent: ::core::option::Option::None, "foo: {}", 3);
+    error!(parent: ::core::option::Option::None, { foo = 3, bar.baz = 80 }, "quux");
+    error!(parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    error!(parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    error!(parent: ::core::option::Option::None, { foo = 2, bar.baz = 78 }, "quux");
+    error!(parent: ::core::option::Option::None, { foo = ?2, bar.baz = %78 }, "quux");
+    error!(target: "foo_events", parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
+    error!(target: "foo_events", parent: ::core::option::Option::None, foo = 3, bar.baz = 3,);
+    error!(target: "foo_events", parent: ::core::option::Option::None, "foo");
+    error!(target: "foo_events", parent: ::core::option::Option::None, "foo: {}", 3);
+    error!(target: "foo_events", parent: ::core::option::Option::None, { foo = 3, bar.baz = 80 }, "quux");
+    error!(target: "foo_events", parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    error!(target: "foo_events", parent: ::core::option::Option::None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    error!(target: "foo_events", parent: ::core::option::Option::None, { foo = 2, bar.baz = 78, }, "quux");
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -913,7 +917,7 @@ fn field_shorthand_only() {
 #[test]
 fn borrow_val_events() {
     // Reproduces https://github.com/tokio-rs/tracing/issues/954
-    let mut foo = (String::new(), String::new());
+    let mut foo = (::std::string::String::new(), ::std::string::String::new());
     let zero = &mut foo.0;
     trace!(one = ?foo.1);
     debug!(one = ?foo.1);
@@ -927,7 +931,7 @@ fn borrow_val_events() {
 #[test]
 fn borrow_val_spans() {
     // Reproduces https://github.com/tokio-rs/tracing/issues/954
-    let mut foo = (String::new(), String::new());
+    let mut foo = (::std::string::String::new(), ::std::string::String::new());
     let zero = &mut foo.0;
     let _span = trace_span!("span", one = ?foo.1);
     let _span = debug_span!("span", one = ?foo.1);


### PR DESCRIPTION
## Motivation

Currently, in many places, macros do not use fully qualified names for items exported from the prelude. This means that naming collisions (`struct Some`) or the removal of the std library prelude will cause compilation errors.

## Solution

- Identify and use fully qualified names in macros were we previously assumed the Rust std prelude. We use `::core` rather than `::std`.
- Add [`no_implicit_prelude`](https://doc.rust-lang.org/reference/names/preludes.html#the-no_implicit_prelude-attribute) to `tracing/tests/macros.rs`. I'm unsure if this is giving us good coverage - can we improve on this approach? I'm not confident I've caught everything.