### PR TITLE
Fix unknown_lints in generated code

### DIFF
--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -65,8 +65,8 @@ pub(crate) fn gen_function<'a, B: ToTokens + 'a>(
     // exactly that way for it to do its magic.
     let fake_return_edge = quote_spanned! {return_span=>
         #[allow(
-            unreachable_code, clippy::diverging_sub_expression, clippy::let_unit_value,
-            clippy::unreachable, clippy::let_with_type_underscore
+            unknown_lints, unreachable_code, clippy::diverging_sub_expression,
+            clippy::let_unit_value, clippy::unreachable, clippy::let_with_type_underscore
         )]
         if false {
             let __tracing_attr_fake_return: #return_type =


### PR DESCRIPTION

## Motivation

#2609 added an allow to generated code to allow a lint that was added in Clippy 1.70.0. This was released with a patch bump so anyone who uses an older version and latest tracing gets a compilation warning about an unkonwn lint.

## Solution

Allowing unkonwn lints should fix this now and prevent similar issues in the future. If the lints are unknown it will most likely be because the lints are introduced only in newer compiler. There is just a higher risk that a future contributor tries to add another allow and if they make a typo, the issue will not be caught.