### PR TITLE
attributes: prepare to release v0.1.26

### DIFF
--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.1.26 (June 21th, 2023)
+
+This release of `tracing-attributes` fixes warnings due to `allow` attributes in
+generated code that allow lints which may not exist on earlier versions of rustc.
+
+### Fixed
+
+- Allow `unknown_lints` in macro-generated code ([#2626])
+
+Thanks to @mladedav for contributing to this release!
+
 # 0.1.25 (June 19th, 2023)
 
 This release of `tracing-attributes` fixes the Clippy lint

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-attributes"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.25"
+version = "0.1.26"
 authors = [
     "Tokio Contributors <team@tokio.rs>",
     "Eliza Weisman <eliza@buoyant.io>",

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -18,7 +18,7 @@ Macro attributes for application-level tracing.
 [crates-badge]: https://img.shields.io/crates/v/tracing-attributes.svg
 [crates-url]: https://crates.io/crates/tracing-attributes
 [docs-badge]: https://docs.rs/tracing-attributes/badge.svg
-[docs-url]: https://docs.rs/tracing-attributes/0.1.25
+[docs-url]: https://docs.rs/tracing-attributes/0.1.26
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_attributes
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -47,7 +47,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing-attributes = "0.1.25"
+tracing-attributes = "0.1.26"
 ```
 
 


### PR DESCRIPTION
# 0.1.26 (June 21th, 2023)

This release of `tracing-attributes` fixes warnings due to `allow` attributes in generated code that allow lints which may not exist on earlier versions of rustc.

### Fixed

- Allow `unknown_lints` in macro-generated code ([#2626])

Thanks to @mladedav for contributing to this release!