### PR TITLE
chore: bump env-logger version

### DIFF
--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -26,7 +26,7 @@ log-tracer = []
 tracing-core = { path = "../tracing-core", version = "0.2"}
 log = "0.4.17"
 once_cell = "1.13.0"
-env_logger = { version = "0.8.4", optional = true }
+env_logger = { version = "0.10.0", optional = true }
 
 [dev-dependencies]
 tracing = { path = "../tracing", version = "0.2"}


### PR DESCRIPTION
## Motivation

Bump env_logger to 0.10.0 to patch cve

```
Fetching advisory database from `[https://github.com/RustSec/advisory-db.git`](https://github.com/RustSec/advisory-db.git%60)
      Loaded 553 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (428 crate dependencies)
Crate:     atty
Version:   0.2.14
Warning:   unsound
Title:     Potential unaligned read
Date:      2021-0[7](https://github.com/ScuffleTV/scuffle/actions/runs/5458287853/jobs/9933216685#step:7:8)-04
ID:        RUSTSEC-2021-0145
URL:       https://rustsec.org/advisories/RUSTSEC-2021-0145
Dependency tree:
atty 0.2.14
└── env_logger 0.[8](https://github.com/ScuffleTV/scuffle/actions/runs/5458287853/jobs/9933216685#step:7:9).4
    └── tracing-log 0.2.0
```
