### PR TITLE
Fix Vec implementation of tracing_subscriber::layer::Layer

### DIFF
--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -1802,11 +1802,17 @@ feature! {
         }
 
         fn enabled(&self, metadata: &Metadata<'_>, ctx: Context<'_, S>) -> bool {
-            self.iter().all(|l| l.enabled(metadata, ctx.clone()))
+            // We can't use `any()` here because we *must* iterate over
+            // all the subscribers, rather than short-circuiting, in case any of
+            // them are using per-layer filtering.
+            self.iter().fold(false, |enabled, l| enabled | l.enabled(metadata, ctx.clone()))
         }
 
         fn event_enabled(&self, event: &Event<'_>, ctx: Context<'_, S>) -> bool {
-            self.iter().all(|l| l.event_enabled(event, ctx.clone()))
+            // We can't use `any()` here because we *must* iterate over
+            // all the subscribers, rather than short-circuiting, in case any of
+            // them are using per-layer filtering.
+            self.iter().fold(false, |event_enabled, l| event_enabled | l.event_enabled(event, ctx.clone()))
         }
 
         fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {

--- a/tracing-subscriber/tests/layer_filters/vec.rs
+++ b/tracing-subscriber/tests/layer_filters/vec.rs
@@ -77,6 +77,62 @@ fn with_filters_boxed() {
 }
 
 #[test]
+fn check_enabled() {
+    let (debug_layer, debug_handle) = layer::named("debug")
+        .enabled(false)
+        .only()
+        .run_with_handle();
+    let debug_layer = debug_layer.with_filter(LevelFilter::DEBUG);
+
+    let (info_layer, info_handle) = layer::named("info")
+        .event(expect::event().at_level(Level::INFO))
+        .only()
+        .run_with_handle();
+    let info_layer = info_layer.with_filter(LevelFilter::INFO);
+
+    let (error_layer, error_handle) = layer::named("error").only().run_with_handle();
+    let error_layer = error_layer.with_filter(LevelFilter::ERROR);
+
+    let _subscriber = tracing_subscriber::registry()
+        .with(vec![debug_layer, info_layer, error_layer])
+        .set_default();
+
+    tracing::info!("hello info");
+
+    debug_handle.assert_finished();
+    info_handle.assert_finished();
+    error_handle.assert_finished();
+}
+
+#[test]
+fn check_event_enabled() {
+    let (debug_layer, debug_handle) = layer::named("debug")
+        .event_enabled(false)
+        .only()
+        .run_with_handle();
+    let debug_layer = debug_layer.with_filter(LevelFilter::DEBUG);
+
+    let (info_layer, info_handle) = layer::named("info")
+        .event(expect::event().at_level(Level::INFO))
+        .only()
+        .run_with_handle();
+    let info_layer = info_layer.with_filter(LevelFilter::INFO);
+
+    let (error_layer, error_handle) = layer::named("error").only().run_with_handle();
+    let error_layer = error_layer.with_filter(LevelFilter::ERROR);
+
+    let _subscriber = tracing_subscriber::registry()
+        .with(vec![debug_layer, info_layer, error_layer])
+        .set_default();
+
+    tracing::info!("hello info");
+
+    debug_handle.assert_finished();
+    info_handle.assert_finished();
+    error_handle.assert_finished();
+}
+
+#[test]
 fn mixed_max_level_hint() {
     let unfiltered = layer::named("unfiltered").run().boxed();
     let info = layer::named("info")


### PR DESCRIPTION
## Motivation

The `Layer` implementation for a `Vec` was introduced in https://github.com/tokio-rs/tracing/pull/2027, and a bug in the `Layer::enabled()` trait method was introduced in https://github.com/tokio-rs/tracing/pull/2027/commits/28e55d217ef9de1d04f302e84a1a32040091fb15, then was further transformed in https://github.com/tokio-rs/tracing/pull/2027/commits/012da661a61325dbf1a4eba0f9ad9649d2b1a477.

## Solution

This PR fixes the [`Layer::enabled()`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/trait.Layer.html#method.enabled) and [`Layer::event_enabled()`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/trait.Layer.html#method.event_enabled) methods by using `fold` and inverting the incorrect condition.