### PR TITLE
Feat: Rolling Appender Custom Rotation

### DIFF
--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -507,9 +507,11 @@ impl Rotation {
             Self(RotationKind::Custom(duration)) => {
                 let date_nanos = date.unix_timestamp_nanos();
                 let duration_nanos = duration.whole_nanoseconds();
+                debug_assert!(duration_nanos > 0);
 
-                // find how many nanoseconds after the next rotation time we are
-                // Use euclidean division to properly handle negative date values
+                // find how many nanoseconds after the next rotation time we are.
+                // Use euclidean division to properly handle negative date values.
+                // This is safe because `Duration` is always positive.
                 let nanos_above = date_nanos.rem_euclid(duration_nanos);
                 let round_nanos = date_nanos - nanos_above;
 

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -461,7 +461,7 @@ impl Rotation {
     pub fn custom(duration: Duration) -> Result<Self, String> {
         if !duration.is_positive() {
             Err("Custom Rotation duration must be positive".to_string())
-        } else if duration > Duration::weeks(52 * 10) {
+        } else if duration > Duration::days(365 * 10) {
             // 10 years... Ridiculous, but we need to cap it somewhere to avoid overflow.
             Err("Custom Rotation duration must be less than 10 years".to_string())
         } else {

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -511,7 +511,6 @@ impl Rotation {
                 // find how many nanoseconds after the next rotation time we are
                 // Use euclidean division to properly handle negative date values
                 let nanos_above = date_nanos.rem_euclid(duration_nanos);
-
                 let round_nanos = date_nanos - nanos_above;
 
                 // `0 <= nanos_above < duration_nanos` (by euclidean division definition)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Currently there are only 4 distinct rotations to choose from for the rolling appender: one minute, one hour, one day, and never. This PR makes it possible to specify custom durations such as 45 minutes, 6 hours, 5 years (???), or however often you desire your logs to be rotated. Closes #778.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I added an additional `Custom` variant to the `RotationKind` enum that stores a `time::Duration`, along with a new `custom` constructor on `Rotation`, which validates the duration length to be positive and less than 10 years. The 10 years is completely arbitrary and is mainly used to avoid potential time overflows with the `OffsetDateTime` in the `next_date` and `round_date` functions. This also means a 1ns duration is allowed. I think in practice this translates to something like 1 log per file, which may be useful somehow, but also feels a bit ridiculous. Would love some feedback on whether more realistic bounds would be better here. 

I made the `date_format` for `Custom` be dynamic to avoid redundant precision. 

The `round_date` implementation is probably the most important here and is equivalent to how the `chrono` crate does its `DurationRound` trait: https://github.com/chronotope/chrono/blob/38b19bbe4e21c402f81edfa2932a43831e679a35/src/round.rs#L214. The main differences are the lack of error handling (since we can't return a `Result` in this context) and using the euclidean remainder operation to handle negative current `DateTimes` (which shouldn't really be possible in the first place in our case) instead of their manual implementation it. Not having the error handling here is fine because all inputs should already be valid: the duration must be positive and the resulting `DateTime` should always be valid. I left comments explaining this.

Still to do: 
- [ ] Update the doc comments
- [ ] Add a `custom` constructor method for `RollingFileAppender`

I held off on the last two things to make sure my implementation here is sufficient enough. If it looks okay, I'll be happy to finish that off!