### PR TITLE
Allow complete reloading of a filtered layer

### DIFF
--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -161,8 +161,8 @@ pub struct Registration<T = &'static dyn Callsite> {
     next: AtomicPtr<Registration<T>>,
 }
 
-pub(crate) use self::inner::register_dispatch;
 pub use self::inner::{rebuild_interest_cache, register};
+pub(crate) use self::inner::{register_dispatch, REGISTRY};
 
 #[cfg(feature = "std")]
 mod inner {
@@ -173,12 +173,12 @@ mod inner {
 
     type Dispatchers = Vec<dispatch::Registrar>;
 
-    struct Registry {
+    pub(crate) struct Registry {
         callsites: Callsites,
-        dispatchers: RwLock<Dispatchers>,
+        pub(crate) dispatchers: RwLock<Dispatchers>,
     }
 
-    static REGISTRY: Lazy<Registry> = Lazy::new(|| Registry {
+    pub(crate) static REGISTRY: Lazy<Registry> = Lazy::new(|| Registry {
         callsites: LinkedList::new(),
         dispatchers: RwLock::new(Vec::new()),
     });

--- a/tracing-core/src/collect.rs
+++ b/tracing-core/src/collect.rs
@@ -457,6 +457,11 @@ pub trait Collect: 'static {
     /// [`Current::none`]: super::span::Current::none
     fn current_span(&self) -> span::Current;
 
+    /// Rebuild filter cache for all spans
+    fn rebuild_span_filter_cache(&self, dispatch: &Dispatch) {
+        let _ = dispatch;
+    }
+
     // === Downcasting methods ================================================
 
     /// If `self` is the same type as the provided `TypeId`, returns an untyped
@@ -769,6 +774,11 @@ where
     fn current_span(&self) -> span::Current {
         self.as_ref().current_span()
     }
+
+    #[inline]
+    fn rebuild_span_filter_cache(&self, dispatch: &Dispatch) {
+        self.as_ref().rebuild_span_filter_cache(dispatch)
+    }
 }
 
 #[cfg(feature = "alloc")]
@@ -847,5 +857,10 @@ where
 
     fn current_span(&self) -> span::Current {
         self.as_ref().current_span()
+    }
+
+    #[inline]
+    fn rebuild_span_filter_cache(&self, dispatch: &Dispatch) {
+        self.as_ref().rebuild_span_filter_cache(dispatch)
     }
 }

--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -1,6 +1,7 @@
 //! Spans represent periods of time in the execution of a program.
 use core::num::NonZeroU64;
 
+use crate::callsite::REGISTRY;
 use crate::field::FieldSet;
 use crate::parent::Parent;
 use crate::{field, Metadata};
@@ -54,6 +55,15 @@ enum CurrentInner {
     },
     None,
     Unknown,
+}
+
+/// Rebuild filter cache for all spans stored in the dispatchers.
+pub fn rebuild_filter_cache() {
+    for registrar in &*REGISTRY.dispatchers.read().unwrap() {
+        if let Some(dispatch) = registrar.upgrade() {
+            dispatch.collector().rebuild_span_filter_cache(&dispatch);
+        }
+    }
 }
 
 // ===== impl Span =====

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -192,7 +192,7 @@
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [`fmt::format`]: mod@crate::fmt::format
 use std::{any::TypeId, error::Error, io, ptr::NonNull};
-use tracing_core::{collect::Interest, span, Event, Metadata};
+use tracing_core::{collect::Interest, span, Dispatch, Event, Metadata};
 
 mod fmt_subscriber;
 #[cfg_attr(docsrs, doc(cfg(all(feature = "fmt", feature = "std"))))]
@@ -433,6 +433,11 @@ where
     #[inline]
     fn max_level_hint(&self) -> Option<tracing_core::LevelFilter> {
         self.inner.max_level_hint()
+    }
+
+    #[inline]
+    fn rebuild_span_filter_cache(&self, dispatch: &Dispatch) {
+        self.inner.rebuild_span_filter_cache(dispatch)
     }
 
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -150,7 +150,7 @@ pub trait LookupSpan<'a> {
     /// [check]: SpanData::is_enabled_for
     #[cfg(feature = "registry")]
     #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
-    fn register_filter(&mut self) -> FilterId {
+    fn register_filter(&self) -> FilterId {
         panic!(
             "{} does not currently support filters",
             std::any::type_name::<Self>()
@@ -288,6 +288,11 @@ feature! {
                 },
             )
         }
+
+        #[cfg(feature = "registry")]
+        fn register_filter(&self) -> FilterId {
+            self.as_ref().register_filter()
+        }
     }
 
     impl<'a, S> LookupSpan<'a> for Box<S>
@@ -317,6 +322,11 @@ feature! {
                     filter,
                 },
             )
+        }
+
+        #[cfg(feature = "registry")]
+        fn register_filter(&self) -> FilterId {
+            self.as_ref().register_filter()
         }
     }
 

--- a/tracing-subscriber/src/subscribe/layered.rs
+++ b/tracing-subscriber/src/subscribe/layered.rs
@@ -206,6 +206,11 @@ where
         self.inner.current_span()
     }
 
+    #[inline]
+    fn rebuild_span_filter_cache(&self, dispatch: &Dispatch) {
+        self.inner.rebuild_span_filter_cache(dispatch)
+    }
+
     #[doc(hidden)]
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<NonNull<()>> {
         // Unlike the implementation of `Subscribe` for `Layered`, we don't have to
@@ -250,7 +255,7 @@ where
         self.inner.on_register_dispatch(collector);
     }
 
-    fn on_subscribe(&mut self, collect: &mut C) {
+    fn on_subscribe(&mut self, collect: &C) {
         self.subscriber.on_subscribe(collect);
         self.inner.on_subscribe(collect);
     }
@@ -395,7 +400,7 @@ where
     }
 
     #[cfg(all(feature = "registry", feature = "std"))]
-    fn register_filter(&mut self) -> FilterId {
+    fn register_filter(&self) -> FilterId {
         self.inner.register_filter()
     }
 }
@@ -416,7 +421,9 @@ where
 {
     pub(super) fn new(subscriber: A, inner: B, inner_has_subscriber_filter: bool) -> Self {
         #[cfg(all(feature = "registry", feature = "std"))]
-        let inner_is_registry = TypeId::of::<C>() == TypeId::of::<crate::registry::Registry>();
+        let inner_is_registry = TypeId::of::<C>() == TypeId::of::<crate::registry::Registry>()
+            || TypeId::of::<C>() == TypeId::of::<std::sync::Arc<crate::registry::Registry>>();
+
         #[cfg(not(all(feature = "registry", feature = "std")))]
         let inner_is_registry = false;
 

--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -769,7 +769,7 @@ where
     /// [per-subscribe filtering]: #per-subscriber-filtering
     /// [`FilterId`]: crate::filter::FilterId
     /// [collector]: tracing_core::Collect
-    fn on_subscribe(&mut self, collector: &mut C) {
+    fn on_subscribe(&mut self, collector: &C) {
         let _ = collector;
     }
 
@@ -1070,12 +1070,12 @@ where
     ///```
     ///
     /// [`Collect`]: tracing_core::Collect
-    fn with_collector(mut self, mut inner: C) -> Layered<Self, C>
+    fn with_collector(mut self, inner: C) -> Layered<Self, C>
     where
         Self: Sized,
     {
         let inner_has_subscriber_filter = filter::collector_has_psf(&inner);
-        self.on_subscribe(&mut inner);
+        self.on_subscribe(&inner);
         Layered::new(self, inner, inner_has_subscriber_filter)
     }
 
@@ -1544,7 +1544,7 @@ where
         }
     }
 
-    fn on_subscribe(&mut self, collector: &mut C) {
+    fn on_subscribe(&mut self, collector: &C) {
         if let Some(ref mut subscriber) = self {
             subscriber.on_subscribe(collector)
         }
@@ -1663,7 +1663,7 @@ macro_rules! subscriber_impl_body {
         }
 
         #[inline]
-        fn on_subscribe(&mut self, collect: &mut C) {
+        fn on_subscribe(&mut self, collect: &C) {
             self.deref_mut().on_subscribe(collect);
         }
 
@@ -1765,7 +1765,7 @@ feature! {
             }
         }
 
-        fn on_subscribe(&mut self, collector: &mut C) {
+        fn on_subscribe(&mut self, collector: &C) {
             for s in self {
                 s.on_subscribe(collector);
             }

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -300,7 +300,7 @@
 //! [`follows_from`]: Span::follows_from()
 //! [guard]: Entered
 //! [parent]: #span-relationships
-pub use tracing_core::span::{Attributes, Id, Record};
+pub use tracing_core::span::{rebuild_filter_cache, Attributes, Id, Record};
 
 use crate::{
     dispatch::{self, Dispatch},


### PR DESCRIPTION
## Motivation

This PR makes the breaking changes needed to allow reloading filtered layers dynamically after initialization, so that creating and registering new filters is possible.

## Solution

This solves #1629 by implementing #2101, and adds a new method to the `Collect` trait, `rebuild_span_filter_cache()`, which is used by the `Registry` to recompute the `FilterMap` associated to the existing spans, taking the new filters into account.

A successful usage example using a custom reloading layer can be found in a separate repository: https://github.com/stormshield-kg/tracing-reload-example.
 