### PR TITLE
journald: Map "info" level to journald "info" priority

### DIFF
--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -66,8 +66,8 @@ mod socket;
 ///
 /// - `ERROR` => Error (3)
 /// - `WARN` => Warning (4)
-/// - `INFO` => Notice (5)
-/// - `DEBUG` => Informational (6)
+/// - `INFO` => Informational (6)
+/// - `DEBUG` => Debug (7)
 /// - `TRACE` => Debug (7)
 ///
 /// The standard journald `CODE_LINE` and `CODE_FILE` fields are automatically emitted. A `TARGET`
@@ -346,9 +346,8 @@ fn put_priority(buf: &mut Vec<u8>, meta: &Metadata) {
         match *meta.level() {
             Level::ERROR => b"3",
             Level::WARN => b"4",
-            Level::INFO => b"5",
-            Level::DEBUG => b"6",
-            Level::TRACE => b"7",
+            Level::INFO => b"6",
+            Level::DEBUG | Level::TRACE => b"7",
         },
     );
 }

--- a/tracing-journald/tests/journal.rs
+++ b/tracing-journald/tests/journal.rs
@@ -163,7 +163,7 @@ fn simple_message() {
 
         let message = retry_read_one_line_from_journal("simple_message");
         assert_eq!(message["MESSAGE"], "Hello World");
-        assert_eq!(message["PRIORITY"], "5");
+        assert_eq!(message["PRIORITY"], "6");
     });
 }
 
@@ -199,7 +199,7 @@ fn internal_null_byte() {
 
         let message = retry_read_one_line_from_journal("internal_null_byte");
         assert_eq!(message["MESSAGE"], b"An internal\x00byte"[..]);
-        assert_eq!(message["PRIORITY"], "6");
+        assert_eq!(message["PRIORITY"], "7");
     });
 }
 
@@ -214,7 +214,7 @@ fn large_message() {
             message["MESSAGE"],
             format!("Message: {}", large_string).as_str()
         );
-        assert_eq!(message["PRIORITY"], "6");
+        assert_eq!(message["PRIORITY"], "7");
     });
 }
 
@@ -229,7 +229,7 @@ fn simple_metadata() {
 
         let message = retry_read_one_line_from_journal("simple_metadata");
         assert_eq!(message["MESSAGE"], "Hello World");
-        assert_eq!(message["PRIORITY"], "5");
+        assert_eq!(message["PRIORITY"], "6");
         assert_eq!(message["TARGET"], "journal");
         assert_eq!(message["SYSLOG_IDENTIFIER"], "test_ident");
         assert!(message["CODE_FILE"].as_text().is_some());
@@ -247,7 +247,7 @@ fn span_metadata() {
 
         let message = retry_read_one_line_from_journal("span_metadata");
         assert_eq!(message["MESSAGE"], "Hello World");
-        assert_eq!(message["PRIORITY"], "5");
+        assert_eq!(message["PRIORITY"], "6");
         assert_eq!(message["TARGET"], "journal");
 
         assert_eq!(message["SPAN_FIELD1"].as_text(), Some("foo1"));
@@ -273,7 +273,7 @@ fn multiple_spans_metadata() {
 
         let message = retry_read_one_line_from_journal("multiple_spans_metadata");
         assert_eq!(message["MESSAGE"], "Hello World");
-        assert_eq!(message["PRIORITY"], "5");
+        assert_eq!(message["PRIORITY"], "6");
         assert_eq!(message["TARGET"], "journal");
 
         assert_eq!(message["SPAN_FIELD1"], vec!["foo1", "foo2"]);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

In the current implementation, "info" level is mapped to Journald "notice" priority. This mapping is not reasonable, because, according to https://en.wikipedia.org/wiki/Syslog#Severity_level:

> notice: Conditions that are not error conditions, but that may require special handling

and in reality, `journactl` displays "notice" message as bold text, in constrast to normal style of "info".
So this PR is to remap "info" tracing level to Journald "info" priority.

## Solution

Remap:

`info` => `info`
`debug` | `tracing` => `debug`.
