### PR TITLE
feat: otel feature, writing the OTel trace ID

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -36,6 +36,7 @@ valuable = ["tracing-core/valuable", "valuable_crate", "valuable-serde", "tracin
 # Enables support for local time when using the `time` crate timestamp
 # formatters.
 local-time = ["time/local-offset"]
+otel = ["opentelemetry"]
 
 [dependencies]
 tracing-core = { path = "../tracing-core", version = "0.1.30", default-features = false }
@@ -63,6 +64,9 @@ parking_lot = { version = "0.12.1", optional = true }
 # registry
 sharded-slab = { version = "0.1.4", optional = true }
 thread_local = { version = "1.1.4", optional = true }
+
+# otel
+opentelemetry = { version = "0.19", optional = true, default-features = false }
 
 [target.'cfg(tracing_unstable)'.dependencies]
 valuable_crate = { package = "valuable", version = "0.1.0", optional = true, default-features = false }

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -311,10 +311,10 @@ impl<S, N, E, W> Layer<S, N, E, W> {
     /// By default, `fmt::Layer` will write any `FormatEvent`-internal errors to
     /// the writer. These errors are unlikely and will only occur if there is a
     /// bug in the `FormatEvent` implementation or its dependencies.
-    /// 
+    ///
     /// If writing to the writer fails, the error message is printed to stderr
     /// as a fallback.
-    /// 
+    ///
     /// [`FormatEvent`]: crate::fmt::FormatEvent
     pub fn log_internal_errors(self, log_internal_errors: bool) -> Self {
         Self {
@@ -623,6 +623,16 @@ impl<S, T, W> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
             ..self
         }
     }
+
+    /// Set the function to optionally make an OTel `TraceId`.
+    #[cfg(feature = "otel")]
+    pub fn with_make_trace_id(self, make_trace_id: Box<dyn format::MakeTraceId>) -> Self {
+        Layer {
+            fmt_event: self.fmt_event.with_make_trace_id(make_trace_id),
+            ..self
+        }
+    }
+
 }
 
 impl<S, N, E, W> Layer<S, N, E, W> {

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -321,6 +321,13 @@ where
                     .serialize_entry("threadId", &format!("{:?}", std::thread::current().id()))?;
             }
 
+            #[cfg(feature = "otel")]
+            if let Some((make_trace_id, current_span)) = self.make_trace_id.as_ref().zip(current_span) {
+                if let Some(trace_id) = make_trace_id(current_span.extensions()) {
+                    serializer.serialize_entry("trace_id", &trace_id.to_string())?;
+                }
+            }
+
             serializer.end()
         };
 


### PR DESCRIPTION
Ref #1531. Based upon branch `v0.1.x`.

Currently the trace ID, added to `Format`, is only serialized for `Json`.