### PR TITLE
feat: extra fields

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -36,6 +36,7 @@ valuable = ["tracing-core/valuable", "valuable_crate", "valuable-serde", "tracin
 # Enables support for local time when using the `time` crate timestamp
 # formatters.
 local-time = ["time/local-offset"]
+extra-fields = []
 
 [dependencies]
 tracing-core = { path = "../tracing-core", version = "0.1.30", default-features = false }

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -311,10 +311,10 @@ impl<S, N, E, W> Layer<S, N, E, W> {
     /// By default, `fmt::Layer` will write any `FormatEvent`-internal errors to
     /// the writer. These errors are unlikely and will only occur if there is a
     /// bug in the `FormatEvent` implementation or its dependencies.
-    /// 
+    ///
     /// If writing to the writer fails, the error message is printed to stderr
     /// as a fallback.
-    /// 
+    ///
     /// [`FormatEvent`]: crate::fmt::FormatEvent
     pub fn log_internal_errors(self, log_internal_errors: bool) -> Self {
         Self {
@@ -620,6 +620,15 @@ impl<S, T, W> Layer<S, format::JsonFields, format::Format<format::Json, T>, W> {
         Layer {
             fmt_event: self.fmt_event.with_span_list(display_span_list),
             fmt_fields: format::JsonFields::new(),
+            ..self
+        }
+    }
+
+    /// Set the function to make extra fields.
+    #[cfg(feature = "extra-fields")]
+    pub fn with_extra_fields(self, make_extra_fields: Box<dyn format::MakeExtraFields>) -> Self {
+        Layer {
+            fmt_event: self.fmt_event.with_make_extra_fields(make_extra_fields),
             ..self
         }
     }
@@ -1288,8 +1297,17 @@ mod test {
         let actual = sanitize_timings(make_writer.get_string());
 
         // Only assert the start because the line number and callsite may change.
-        let expected = concat!("Unable to format the following event. Name: event ", file!(), ":");
-        assert!(actual.as_str().starts_with(expected), "\nactual = {}\nshould start with expected = {}\n", actual, expected);
+        let expected = concat!(
+            "Unable to format the following event. Name: event ",
+            file!(),
+            ":"
+        );
+        assert!(
+            actual.as_str().starts_with(expected),
+            "\nactual = {}\nshould start with expected = {}\n",
+            actual,
+            expected
+        );
     }
 
     #[test]

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -321,6 +321,13 @@ where
                     .serialize_entry("threadId", &format!("{:?}", std::thread::current().id()))?;
             }
 
+            #[cfg(feature = "extra-fields")]
+            if let Some((make_extra_fields, current_span)) = self.make_extra_fields.as_ref().zip(current_span) {
+                for (k, v) in make_extra_fields(current_span.extensions()) {
+                    serializer.serialize_entry(&k, &v)?;
+                }
+            }
+
             serializer.end()
         };
 

--- a/tracing-subscriber/src/fmt/time/mod.rs
+++ b/tracing-subscriber/src/fmt/time/mod.rs
@@ -52,7 +52,7 @@ pub trait FormatTime {
 /// # }
 /// ```
 pub fn time() -> SystemTime {
-    SystemTime::default()
+    SystemTime
 }
 
 /// Returns a new `Uptime` timestamp provider.


### PR DESCRIPTION
Ref #1531.

Currently the trace ID, added to Format, is only serialized for Json.