### PR TITLE
tracing-journald: remove unnecessary `mut`

### DIFF
--- a/tracing-journald/src/socket.rs
+++ b/tracing-journald/src/socket.rs
@@ -68,7 +68,7 @@ pub fn send_one_fd_to<P: AsRef<Path>>(socket: &UnixDatagram, fd: RawFd, path: P)
     msg.msg_control = unsafe { cmsg_buffer.buffer.as_mut_ptr() as _ };
     msg.msg_controllen = unsafe { CMSG_SPACE(size_of::<RawFd>() as _) as _ };
 
-    let mut cmsg: &mut cmsghdr =
+    let cmsg: &mut cmsghdr =
         unsafe { CMSG_FIRSTHDR(&msg).as_mut() }.expect("Control message buffer exhausted");
 
     cmsg.cmsg_level = SOL_SOCKET;

--- a/tracing-subscriber/src/fmt/time/mod.rs
+++ b/tracing-subscriber/src/fmt/time/mod.rs
@@ -48,7 +48,7 @@ pub trait FormatTime {
 /// # }
 /// ```
 pub fn time() -> SystemTime {
-    SystemTime::default()
+    SystemTime
 }
 
 /// Returns a new `Uptime` timestamp provider.


### PR DESCRIPTION
This lint is blocking landing https://github.com/tokio-rs/tracing/pull/2407, so I'd like get rid of that blocker.

(cc: @jsgf)