### PR TITLE
chore: fix `wasm_bindgen_test` macros

### DIFF
--- a/tracing/tests/macros.rs
+++ b/tracing/tests/macros.rs
@@ -2,6 +2,8 @@
 // We call all macros in this module with `no_implicit_prelude` to ensure they do not depend on the standard prelude.
 #![no_implicit_prelude]
 extern crate tracing;
+#[cfg(target_arch = "wasm32")]
+extern crate wasm_bindgen_test;
 
 use tracing::{
     callsite, debug, debug_span, enabled, error, error_span, event, event_enabled, info, info_span,

--- a/tracing/tests/macros.rs
+++ b/tracing/tests/macros.rs
@@ -5,6 +5,10 @@ extern crate tracing;
 #[cfg(target_arch = "wasm32")]
 extern crate wasm_bindgen_test;
 
+// TODO: remove this once https://github.com/tokio-rs/tracing/pull/2675#issuecomment-1667628907 is resolved
+#[cfg(target_arch = "wasm32")]
+use ::core::option::Option::None;
+
 use tracing::{
     callsite, debug, debug_span, enabled, error, error_span, event, event_enabled, info, info_span,
     span, span_enabled, trace, trace_span, warn, warn_span, Level,


### PR DESCRIPTION
## Motivation

Tests involving `wasm_bindgen_test` currently fail:

https://github.com/tokio-rs/tracing/actions/runs/5756318807/job/15605512576

## Solution

- [x] Use `extern crate wasm_bindgen_test` to side step `no_implicit_prelude`.
- [x] https://github.com/rustwasm/wasm-bindgen/pull/3549
- [ ] Consume the release `wasm_bindgen_test` containing said change.
