### PR TITLE
appender: adding utc timezone offsets support settings for tracing_ap…

### DIFF
--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -34,7 +34,7 @@ use std::{
     path::{Path, PathBuf},
     sync::atomic::{AtomicUsize, Ordering},
 };
-use time::{format_description, Date, Duration, OffsetDateTime, Time};
+use time::{format_description, Date, Duration, OffsetDateTime, Time, UtcOffset};
 
 mod builder;
 pub use builder::{Builder, InitError};
@@ -105,6 +105,7 @@ struct Inner {
     log_filename_prefix: Option<String>,
     log_filename_suffix: Option<String>,
     date_format: Vec<format_description::FormatItem<'static>>,
+    offset: UtcOffset,
     rotation: Rotation,
     next_date: AtomicUsize,
     max_files: Option<usize>,
@@ -174,6 +175,7 @@ impl RollingFileAppender {
     ///     .rotation(Rotation::HOURLY) // rotate log files once every hour
     ///     .filename_prefix("myapp") // log file names will be prefixed with `myapp.`
     ///     .filename_suffix("log") // log file names will be suffixed with `.log`
+    ///     .time_zone(8) // log time will be in UTC+8
     ///     .build("/var/log") // try to build an appender that stores log files in `/var/log`
     ///     .expect("initializing rolling file appender failed");
     /// # drop(file_appender);
@@ -190,11 +192,17 @@ impl RollingFileAppender {
             ref prefix,
             ref suffix,
             ref max_files,
+            ref time_zone
         } = builder;
         let directory = directory.as_ref().to_path_buf();
-        let now = OffsetDateTime::now_utc();
+        let offset = UtcOffset::from_hms(time_zone.unwrap_or(0)%24, 0, 0).unwrap();
+
+        #[cfg(test)]
+        let now = move ||OffsetDateTime::now_utc()
+            .to_offset(offset);
         let (state, writer) = Inner::new(
-            now,
+            OffsetDateTime::now_utc().to_offset(offset),
+            offset,
             rotation.clone(),
             directory,
             prefix.clone(),
@@ -205,18 +213,20 @@ impl RollingFileAppender {
             state,
             writer,
             #[cfg(test)]
-            now: Box::new(OffsetDateTime::now_utc),
+            now: Box::new(now),
         })
     }
 
     #[inline]
     fn now(&self) -> OffsetDateTime {
+    
         #[cfg(test)]
         return (self.now)();
 
         #[cfg(not(test))]
-        OffsetDateTime::now_utc()
+        OffsetDateTime::now_utc().to_offset(self.state.offset)
     }
+    
 }
 
 impl io::Write for RollingFileAppender {
@@ -520,6 +530,7 @@ impl io::Write for RollingWriter<'_> {
 impl Inner {
     fn new(
         now: OffsetDateTime,
+        offset: UtcOffset,
         rotation: Rotation,
         directory: impl AsRef<Path>,
         log_filename_prefix: Option<String>,
@@ -535,6 +546,7 @@ impl Inner {
             log_filename_prefix,
             log_filename_suffix,
             date_format,
+            offset,
             next_date: AtomicUsize::new(
                 next_date
                     .map(|date| date.unix_timestamp() as usize)
@@ -706,6 +718,8 @@ fn create_writer(directory: &Path, filename: &str) -> Result<File, InitError> {
 
 #[cfg(test)]
 mod test {
+    use time::macros::offset;
+
     use super::*;
     use std::fs;
     use std::io::Write;
@@ -824,6 +838,7 @@ mod test {
                     }| {
             let (inner, _) = Inner::new(
                 now,
+                offset!(+00:00:00),
                 rotation.clone(),
                 directory.path(),
                 prefix.map(ToString::to_string),
@@ -936,6 +951,7 @@ mod test {
         let directory = tempfile::tempdir().expect("failed to create tempdir");
         let (state, writer) = Inner::new(
             now,
+            offset!(+00:00:00),
             Rotation::HOURLY,
             directory.path(),
             Some("test_make_writer".to_string()),
@@ -1018,6 +1034,7 @@ mod test {
         let directory = tempfile::tempdir().expect("failed to create tempdir");
         let (state, writer) = Inner::new(
             now,
+            offset!(+00:00:00),
             Rotation::HOURLY,
             directory.path(),
             Some("test_max_log_files".to_string()),

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -192,14 +192,13 @@ impl RollingFileAppender {
             ref prefix,
             ref suffix,
             ref max_files,
-            ref time_zone
+            ref time_zone,
         } = builder;
         let directory = directory.as_ref().to_path_buf();
-        let offset = UtcOffset::from_hms(time_zone.unwrap_or(0)%24, 0, 0).unwrap();
+        let offset = UtcOffset::from_hms(time_zone.unwrap_or(0) % 24, 0, 0).unwrap();
 
         #[cfg(test)]
-        let now = move ||OffsetDateTime::now_utc()
-            .to_offset(offset);
+        let now = move || OffsetDateTime::now_utc().to_offset(offset);
         let (state, writer) = Inner::new(
             OffsetDateTime::now_utc().to_offset(offset),
             offset,
@@ -219,14 +218,12 @@ impl RollingFileAppender {
 
     #[inline]
     fn now(&self) -> OffsetDateTime {
-    
         #[cfg(test)]
         return (self.now)();
 
         #[cfg(not(test))]
         OffsetDateTime::now_utc().to_offset(self.state.offset)
     }
-    
 }
 
 impl io::Write for RollingFileAppender {
@@ -718,7 +715,6 @@ fn create_writer(directory: &Path, filename: &str) -> Result<File, InitError> {
 
 #[cfg(test)]
 mod test {
-    use time::macros::offset;
 
     use super::*;
     use std::fs;
@@ -838,7 +834,7 @@ mod test {
                     }| {
             let (inner, _) = Inner::new(
                 now,
-                offset!(+00:00:00),
+                UtcOffset::from_hms(0, 0,0).unwrap(),
                 rotation.clone(),
                 directory.path(),
                 prefix.map(ToString::to_string),
@@ -951,7 +947,7 @@ mod test {
         let directory = tempfile::tempdir().expect("failed to create tempdir");
         let (state, writer) = Inner::new(
             now,
-            offset!(+00:00:00),
+            UtcOffset::from_hms(0, 0,0).unwrap(),
             Rotation::HOURLY,
             directory.path(),
             Some("test_make_writer".to_string()),
@@ -1034,7 +1030,7 @@ mod test {
         let directory = tempfile::tempdir().expect("failed to create tempdir");
         let (state, writer) = Inner::new(
             now,
-            offset!(+00:00:00),
+            UtcOffset::from_hms(0, 0,0).unwrap(),
             Rotation::HOURLY,
             directory.path(),
             Some("test_max_log_files".to_string()),

--- a/tracing-appender/src/rolling/builder.rs
+++ b/tracing-appender/src/rolling/builder.rs
@@ -11,6 +11,7 @@ pub struct Builder {
     pub(super) prefix: Option<String>,
     pub(super) suffix: Option<String>,
     pub(super) max_files: Option<usize>,
+    pub(super) time_zone: Option<i8>
 }
 
 /// Errors returned by [`Builder::build`].
@@ -42,11 +43,13 @@ impl Builder {
     /// | [`filename_prefix`] | `""` | By default, log file names will not have a prefix. |
     /// | [`filename_suffix`] | `""` | By default, log file names will not have a suffix. |
     /// | [`max_log_files`] | `None` | By default, there is no limit for maximum log file count. |
+    /// | [time_zone] | `0` | By default, the time zone is 0 from UTC. |
     ///
     /// [`rotation`]: Self::rotation
     /// [`filename_prefix`]: Self::filename_prefix
     /// [`filename_suffix`]: Self::filename_suffix
     /// [`max_log_files`]: Self::max_log_files
+    /// [`time_zone`]: i8
     #[must_use]
     pub const fn new() -> Self {
         Self {
@@ -54,6 +57,7 @@ impl Builder {
             prefix: None,
             suffix: None,
             max_files: None,
+            time_zone: None
         }
     }
 
@@ -229,6 +233,30 @@ impl Builder {
     pub fn max_log_files(self, n: usize) -> Self {
         Self {
             max_files: Some(n),
+            ..self
+        }
+    }
+
+    /// Sets the timezone of output logs
+    /// etc: 8 for UTC+8, -3 for UTC-3. If the number is set larger than 24 or lesser than -24,
+    /// if will count as 24's remainder, ex: +30 => +6
+    /// # Examples
+    ///
+    /// ```
+    /// use tracing_appender::rolling::RollingFileAppender;
+    ///
+    /// # fn docs() {
+    /// let appender = RollingFileAppender::builder()
+    ///     .time_zone(-3) // the time of logs will now be in UTC-3
+    ///     //..
+    ///     .build("/var/log")
+    ///     .expect("failed to initialize rolling file appender");
+    /// # drop(appender)
+    /// # }
+    /// ```
+    pub fn time_zone(self, tz: i8) -> Self{
+        Self{
+            time_zone: Some(tz),
             ..self
         }
     }

--- a/tracing-appender/src/rolling/builder.rs
+++ b/tracing-appender/src/rolling/builder.rs
@@ -11,7 +11,7 @@ pub struct Builder {
     pub(super) prefix: Option<String>,
     pub(super) suffix: Option<String>,
     pub(super) max_files: Option<usize>,
-    pub(super) time_zone: Option<i8>
+    pub(super) time_zone: Option<i8>,
 }
 
 /// Errors returned by [`Builder::build`].
@@ -57,7 +57,7 @@ impl Builder {
             prefix: None,
             suffix: None,
             max_files: None,
-            time_zone: None
+            time_zone: None,
         }
     }
 
@@ -254,8 +254,8 @@ impl Builder {
     /// # drop(appender)
     /// # }
     /// ```
-    pub fn time_zone(self, tz: i8) -> Self{
-        Self{
+    pub fn time_zone(self, tz: i8) -> Self {
+        Self {
             time_zone: Some(tz),
             ..self
         }

--- a/tracing-appender/src/rolling/builder.rs
+++ b/tracing-appender/src/rolling/builder.rs
@@ -43,7 +43,7 @@ impl Builder {
     /// | [`filename_prefix`] | `""` | By default, log file names will not have a prefix. |
     /// | [`filename_suffix`] | `""` | By default, log file names will not have a suffix. |
     /// | [`max_log_files`] | `None` | By default, there is no limit for maximum log file count. |
-    /// | [time_zone] | `0` | By default, the time zone is 0 from UTC. |
+    /// | [`time_zone`] | `0` | By default, the time zone is 0 from UTC. |
     ///
     /// [`rotation`]: Self::rotation
     /// [`filename_prefix`]: Self::filename_prefix


### PR DESCRIPTION
…pender::rolling::RollingFileAppender

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation
With the timezone matching the users zone, it makes them easier for users to figure out when the log was appended.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
This commit enables users to set their desired timezone for their appender , and does not expose a specific time library api, instead uses numbers.
- the timezone data is stored in rolling::Inner, and is read when rolling::RollingFileAppender::now() is called.
- Added fn time_zone(tz: i8) for rolling::Builder
- Exposes i8 instead of UTCOffset which does not force users to use a certain library
- Made it compatible with tests( the box function now in RollingFileAppender uses timezones when built by the Builder) 

Refs: #2691  #1645
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
