### PR TITLE
the doc-test for backtrace::SpanTrace::capture uses the attributes feature from tracing

### DIFF
--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -42,6 +42,9 @@ traced-error = []
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry", "fmt"] }
 tracing = { path = "../tracing", version = "0.2", default-features = false, features = ["std"] }
 
+[dev-dependencies]
+tracing = { path = "../tracing", version = "0.2", default-features = false, features = ["attributes"] }
+
 [badges]
 maintenance = { status = "experimental" }
 


### PR DESCRIPTION
Running `cargo test` in tracing-error without this change:

```
---- src/backtrace.rs - backtrace::SpanTrace::capture (line 79) stdout ----
error[E0433]: failed to resolve: could not find `instrument` in `tracing`
  --> src/backtrace.rs:90:12
   |
14 | #[tracing::instrument]
   |            ^^^^^^^^^^ could not find `instrument` in `tracing`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0433`.
Couldn't compile the test.

failures:
    src/backtrace.rs - backtrace::SpanTrace::capture (line 79)

test result: FAILED. 11 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.50s
```

## Motivation

Discovered when packaging the crate for Debian.

## Solution

Pull in the required feature as a dev-dependency.
