### PR TITLE
Feat: rolling by local time

### DIFF
--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -219,10 +219,11 @@ impl RollingFileAppender {
         return (self.now)();
 
         #[cfg(not(test))]
-        dbg!(local_datetime(OffsetDateTime::now_utc(), self.state.offset))
+        local_datetime(OffsetDateTime::now_utc(), self.state.offset)
     }
 }
 
+// This turns a UTC time to a local time.
 fn local_datetime(dt: OffsetDateTime, tz: UtcOffset) -> OffsetDateTime {
     let secs = tz.whole_seconds();
     let secs_abs = secs.abs() as u64;

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -226,7 +226,7 @@ impl RollingFileAppender {
 // This turns a UTC time to a local time.
 fn local_datetime(dt: OffsetDateTime, tz: UtcOffset) -> OffsetDateTime {
     let secs = tz.whole_seconds();
-    let secs_abs = secs.abs() as u64;
+    let secs_abs = secs.unsigned_abs().into();
     let local = if secs.is_negative() {
         dt - StdDuration::from_secs(secs_abs)
     } else {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

* `rolling::daily` appends the date by UTC time, this PR supports rolling by local time
* some tests in `rolling::test` mod look verbose, so before adding my test, two helper function is created

ref: https://github.com/tokio-rs/tracing/issues/1645 (issue) | https://github.com/tokio-rs/tracing/pull/2697 (didn't realize a PR comes before mine)

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This PR doesn't change `rolling::daily`, instead it adds a new method `offset` to `rolling::Builder` to set the timezone, ands replace the clock `OffsetDateTime::now_utc()` in `Inner.now` and `RollingFileAppender::now` by `local_datetime(OffsetDateTime::now_utc(), offset)`.