### PR TITLE
Generate less dead code for async block return type hint

### DIFF
--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -66,11 +66,11 @@ pub(crate) fn gen_function<'a, B: ToTokens + 'a>(
     let fake_return_edge = quote_spanned! {return_span=>
         #[allow(
             unknown_lints, unreachable_code, clippy::diverging_sub_expression,
-            clippy::let_unit_value, clippy::unreachable, clippy::let_with_type_underscore
+            clippy::let_unit_value, clippy::unreachable, clippy::let_with_type_underscore,
+            clippy::empty_loop
         )]
         if false {
-            let __tracing_attr_fake_return: #return_type =
-                unreachable!("this is just for type inference, and is unreachable code");
+            let __tracing_attr_fake_return: #return_type = loop {};
             return __tracing_attr_fake_return;
         }
     };


### PR DESCRIPTION
## Motivation

`#[tracing::instrument]` uses `unreachable!()` macro which needlessly expands to panicking and formatting code. It only needs any `!` type.

## Solution

`loop {}` works just as well for a `!` type, and it crates less work for the compiler. The code is truly unreachable, so the message would never be useful. Rust used to be concerned about semantics of empty loops in LLVM, but this [has been solved](https://reviews.llvm.org/D85393).