### PR TITLE
flame: fix folded formatting

### DIFF
--- a/tracing-flame/src/lib.rs
+++ b/tracing-flame/src/lib.rs
@@ -233,7 +233,7 @@ impl Default for Config {
             empty_samples: true,
             threads_collapsed: false,
             module_path: true,
-            file_and_line: true,
+            file_and_line: false,
         }
     }
 }
@@ -404,7 +404,7 @@ where
 
         if let Some(second) = first.parent() {
             for parent in second.scope().from_root() {
-                stack += "; ";
+                stack += ";";
                 write(&mut stack, parent, &self.config)
                     .expect("expected: write to String never fails");
             }
@@ -446,7 +446,7 @@ where
         }
 
         for parent in first.scope().from_root() {
-            stack += "; ";
+            stack += ";";
             expect!(
                 write(&mut stack, parent, &self.config),
                 "expected: write to String never fails"


### PR DESCRIPTION
## Motivation

The `.folded` format expects a `;`-separated list of the stack function, optionally followed up by a sample count.

The implementation before this commit added a blank space after each `;` which made parsers, such as `inferno-flamegraph` mis-interpret the data.

Furthermore, normally one wouldn't expect the filename and line-number in such stack trace.

## Solution

Remove white-space between `;` for the generated file and remove filename and line-number by default.
