### PR TITLE
Opt in to traced fields (redone based on 2023 branch)

### DIFF
--- a/tracing-attributes/tests/destructuring.rs
+++ b/tracing-attributes/tests/destructuring.rs
@@ -4,7 +4,7 @@ use tracing_mock::*;
 
 #[test]
 fn destructure_tuples() {
-    #[instrument]
+    #[instrument(fields(?arg1, ?arg2))]
     fn my_fn((arg1, arg2): (usize, usize)) {}
 
     let span = expect::span().named("my_fn");
@@ -33,7 +33,7 @@ fn destructure_tuples() {
 
 #[test]
 fn destructure_nested_tuples() {
-    #[instrument]
+    #[instrument(fields(?arg1, ?arg2, ?arg3, ?arg4))]
     fn my_fn(((arg1, arg2), (arg3, arg4)): ((usize, usize), (usize, usize))) {}
 
     let span = expect::span().named("my_fn");
@@ -64,15 +64,18 @@ fn destructure_nested_tuples() {
 
 #[test]
 fn destructure_refs() {
-    #[instrument]
+    #[instrument(fields(?arg1))]
     fn my_fn(&arg1: &usize) {}
 
     let span = expect::span().named("my_fn");
 
     let (collector, handle) = collector::mock()
         .new_span(
-            span.clone()
-                .with_field(expect::field("arg1").with_value(&1usize).only()),
+            span.clone().with_field(
+                expect::field("arg1")
+                    .with_value(&tracing::field::debug(1usize))
+                    .only(),
+            ),
         )
         .enter(span.clone())
         .exit(span.clone())
@@ -91,7 +94,7 @@ fn destructure_refs() {
 fn destructure_tuple_structs() {
     struct Foo(usize, usize);
 
-    #[instrument]
+    #[instrument(fields(?arg1, ?arg2))]
     fn my_fn(Foo(arg1, arg2): Foo) {}
 
     let span = expect::span().named("my_fn");
@@ -100,8 +103,8 @@ fn destructure_tuple_structs() {
         .new_span(
             span.clone().with_field(
                 expect::field("arg1")
-                    .with_value(&format_args!("1"))
-                    .and(expect::field("arg2").with_value(&format_args!("2")))
+                    .with_value(&tracing::field::debug(1))
+                    .and(expect::field("arg2").with_value(&tracing::field::debug(2)))
                     .only(),
             ),
         )
@@ -125,7 +128,7 @@ fn destructure_structs() {
         baz: usize,
     }
 
-    #[instrument]
+    #[instrument(fields(?arg1, ?arg2))]
     fn my_fn(
         Foo {
             bar: arg1,
@@ -141,8 +144,8 @@ fn destructure_structs() {
         .new_span(
             span.clone().with_field(
                 expect::field("arg1")
-                    .with_value(&format_args!("1"))
-                    .and(expect::field("arg2").with_value(&format_args!("2")))
+                    .with_value(&tracing::field::debug(1))
+                    .and(expect::field("arg2").with_value(&tracing::field::debug(2)))
                     .only(),
             ),
         )
@@ -169,7 +172,7 @@ fn destructure_everything() {
     struct Bar((usize, usize));
     struct NoDebug;
 
-    #[instrument]
+    #[instrument(fields(?arg1, ?arg2, ?arg3, ?arg4))]
     fn my_fn(
         &Foo {
             bar: Bar((arg1, arg2)),
@@ -186,10 +189,10 @@ fn destructure_everything() {
         .new_span(
             span.clone().with_field(
                 expect::field("arg1")
-                    .with_value(&format_args!("1"))
-                    .and(expect::field("arg2").with_value(&format_args!("2")))
-                    .and(expect::field("arg3").with_value(&format_args!("3")))
-                    .and(expect::field("arg4").with_value(&format_args!("4")))
+                    .with_value(&tracing::field::debug(1))
+                    .and(expect::field("arg2").with_value(&tracing::field::debug(2)))
+                    .and(expect::field("arg3").with_value(&tracing::field::debug(3)))
+                    .and(expect::field("arg4").with_value(&tracing::field::debug(4)))
                     .only(),
             ),
         )

--- a/tracing-attributes/tests/err.rs
+++ b/tracing-attributes/tests/err.rs
@@ -149,7 +149,7 @@ fn test_mut_async() {
 fn impl_trait_return_type() {
     // Reproduces https://github.com/tokio-rs/tracing/issues/1227
 
-    #[instrument(err)]
+    #[instrument(err, fields(?x))]
     fn returns_impl_trait(x: usize) -> Result<impl Iterator<Item = usize>, String> {
         Ok(0..x)
     }
@@ -158,8 +158,11 @@ fn impl_trait_return_type() {
 
     let (collector, handle) = collector::mock()
         .new_span(
-            span.clone()
-                .with_field(expect::field("x").with_value(&10usize).only()),
+            span.clone().with_field(
+                expect::field("x")
+                    .with_value(&tracing::field::debug(10usize))
+                    .only(),
+            ),
         )
         .enter(span.clone())
         .exit(span.clone())

--- a/tracing-attributes/tests/fields.rs
+++ b/tracing-attributes/tests/fields.rs
@@ -5,16 +5,16 @@ use tracing_mock::{collector, expect, span::NewSpan};
 #[instrument(fields(foo = "bar", dsa = true, num = 1))]
 fn fn_no_param() {}
 
-#[instrument(fields(foo = "bar"))]
+#[instrument(fields(?param, foo = "bar"))]
 fn fn_param(param: u32) {}
 
 #[instrument(fields(foo = "bar", empty))]
 fn fn_empty_field() {}
 
-#[instrument(fields(len = s.len()))]
+#[instrument(fields(?s, len = s.len()))]
 fn fn_expr_field(s: &str) {}
 
-#[instrument(fields(s.len = s.len(), s.is_empty = s.is_empty()))]
+#[instrument(fields(?s, s.len = s.len(), s.is_empty = s.is_empty()))]
 fn fn_two_expr_fields(s: &str) {
     let _ = s;
 }
@@ -40,7 +40,7 @@ struct HasField {
 }
 
 impl HasField {
-    #[instrument(fields(my_field = self.my_field), skip(self))]
+    #[instrument(fields(my_field = self.my_field))]
     fn self_expr_field(&self) {}
 }
 
@@ -62,7 +62,7 @@ fn fields() {
 fn expr_field() {
     let span = expect::span().with_field(
         expect::field("s")
-            .with_value(&"hello world")
+            .with_value(&tracing::field::debug("hello world"))
             .and(expect::field("len").with_value(&"hello world".len()))
             .only(),
     );
@@ -75,7 +75,7 @@ fn expr_field() {
 fn two_expr_fields() {
     let span = expect::span().with_field(
         expect::field("s")
-            .with_value(&"hello world")
+            .with_value(&tracing::field::debug("hello world"))
             .and(expect::field("s.len").with_value(&"hello world".len()))
             .and(expect::field("s.is_empty").with_value(&false))
             .only(),
@@ -122,7 +122,7 @@ fn parameters_with_fields() {
     let span = expect::span().with_field(
         expect::field("foo")
             .with_value(&"bar")
-            .and(expect::field("param").with_value(&1u32))
+            .and(expect::field("param").with_value(&tracing::field::debug(1u32)))
             .only(),
     );
     run_test(span, || {

--- a/tracing-attributes/tests/follows_from.rs
+++ b/tracing-attributes/tests/follows_from.rs
@@ -2,10 +2,10 @@ use tracing::{collect::with_default, Id, Level, Span};
 use tracing_attributes::instrument;
 use tracing_mock::*;
 
-#[instrument(follows_from = causes, skip(causes))]
+#[instrument(follows_from = causes)]
 fn with_follows_from_sync(causes: impl IntoIterator<Item = impl Into<Option<Id>>>) {}
 
-#[instrument(follows_from = causes, skip(causes))]
+#[instrument(follows_from = causes)]
 async fn with_follows_from_async(causes: impl IntoIterator<Item = impl Into<Option<Id>>>) {}
 
 #[instrument(follows_from = [&Span::current()])]

--- a/tracing-attributes/tests/parents.rs
+++ b/tracing-attributes/tests/parents.rs
@@ -5,7 +5,7 @@ use tracing_mock::*;
 #[instrument]
 fn with_default_parent() {}
 
-#[instrument(parent = parent_span, skip(parent_span))]
+#[instrument(parent = parent_span)]
 fn with_explicit_parent<P>(parent_span: P)
 where
     P: Into<Option<Id>>,

--- a/tracing-mock/README.md
+++ b/tracing-mock/README.md
@@ -104,7 +104,7 @@ Below is a slightly more complex example. `tracing-mock` asserts that, in order:
 use tracing::collect::with_default;
 use tracing_mock::{collector, expect, field};
 
-#[tracing::instrument]
+#[tracing::instrument(fields(%number_of_yaks))]
 fn yak_shaving(number_of_yaks: u32) {
     tracing::info!(number_of_yaks, "preparing to shave yaks");
 
@@ -121,7 +121,7 @@ let span = expect::span().named("yak_shaving");
 let (collector, handle) = collector::mock()
     .new_span(
         span.clone()
-            .with_field(expect::field("number_of_yaks").with_value(&yak_count).only()),
+            .with_field(expect::field("number_of_yaks").with_value(&tracing::field::debug(yak_count)).only()),
     )
     .enter(span.clone())
     .event(

--- a/tracing-mock/src/span.rs
+++ b/tracing-mock/src/span.rs
@@ -105,6 +105,13 @@ impl ExpectedSpan {
             ..Default::default()
         }
     }
+
+    pub fn with_no_fields(self) -> NewSpan {
+        NewSpan {
+            span: self,
+            ..Default::default()
+        }
+    }
 }
 
 impl fmt::Debug for ExpectedSpan {


### PR DESCRIPTION
* Remove skip arg from instrument macro
* Fields need to be added explicitly instead

Of course, due credit to LukeMathWalker's original work back in 2021: https://github.com/tokio-rs/tracing/pull/1306

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

Closes https://github.com/tokio-rs/tracing/issues/651

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

* Remove existing skip logic, converting the annotation from opt-out to opt-in;
* Adapt existing tests to the new behavior

Note: Existing deprecation warning covers use of skip - but a special-cased message for skip mentioning the switch form opt-out to opt-in would be excellent!

Still got the surprising behavior mentioned in https://github.com/tokio-rs/tracing/pull/1306
I'd vote for making the switch as part of a breaking change.

My git/rebasing skills are such that starting again with the original PR as a guide seemed easier than merging over 2 years worth of changes 😄 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
