### PR TITLE
attributes: bump minimum version of proc-macro2 to 1.0.60

### DIFF
--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -34,7 +34,7 @@ rust-version = "1.56.0"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.40"
+proc-macro2 = "1.0.60"
 syn = { version = "2.0", default-features = false, features = ["full", "parsing", "printing", "visit-mut", "clone-impls", "extra-traits", "proc-macro"] }
 quote = "1.0.20"
 


### PR DESCRIPTION
As part of landing #2728, I noticed that the `-Zminimal-versions` check fails due to proc-macro2 1.0.40 referencing a since-removed, nightly-only (`proc_macro_span_shrink`) feature. Since this change doesn't change the MSRV of `proc-macro2` (or `tracing`, for that matter), this feels like a safe change to make.