### PR TITLE
Implement `Copy` for `FmtSpan`

### DIFF
--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1485,7 +1485,7 @@ impl<'a, F> fmt::Debug for FieldFnVisitor<'a, F> {
 /// Configures what points in the span lifecycle are logged as events.
 ///
 /// See also [`with_span_events`](super::CollectorBuilder::with_span_events()).
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub struct FmtSpan(u8);
 
 impl FmtSpan {
@@ -1508,7 +1508,7 @@ impl FmtSpan {
 
     /// Check whether or not a certain flag is set for this [`FmtSpan`]
     fn contains(&self, other: FmtSpan) -> bool {
-        self.clone() & other.clone() == other
+        *self & other == other
     }
 }
 
@@ -1558,7 +1558,7 @@ impl Debug for FmtSpan {
             Ok(())
         };
 
-        if FmtSpan::NONE | self.clone() == FmtSpan::NONE {
+        if FmtSpan::NONE | *self == FmtSpan::NONE {
             f.write_str("FmtSpan::NONE")?;
         } else {
             write_flags(FmtSpan::NEW, "FmtSpan::NEW")?;


### PR DESCRIPTION
## Motivation

`FmtSpan` is a `u8`, but I have to `.clone()` it instead of being able to copy its single byte implicitly.

## Solution

Add `#[derive(Copy)]` for `FmtSpan` and remove a few `.clone()` calls.
