### PR TITLE
journald: fix clippy `unwrap_or_default` warning

### DIFF
--- a/tracing-attributes/tests/async_fn.rs
+++ b/tracing-attributes/tests/async_fn.rs
@@ -17,7 +17,6 @@ async fn test_async_fn(polls: usize) -> Result<(), ()> {
 #[allow(dead_code)] // this is just here to test whether it compiles.
 #[instrument]
 async fn test_ret_impl_trait(n: i32) -> Result<impl Iterator<Item = i32>, ()> {
-    let n = n;
     Ok((0..10).filter(move |x| *x < n))
 }
 

--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -109,7 +109,7 @@ impl Subscriber {
                     .and_then(|p| p.file_name())
                     .map(|n| n.to_string_lossy().into_owned())
                     // If we fail to get the name of the current executable fall back to an empty string.
-                    .unwrap_or_else(String::new),
+                    .unwrap_or_default(),
                 additional_fields: Vec::new(),
             };
             // Check that we can talk to journald, by sending empty payload which journald discards.


### PR DESCRIPTION
The latest Clippy emits warnings for uses of `unwrap_or_else` with
functions that return a type's `Default::default` value, such as
`.unwrap_or_else(String::new)`. Clippy would prefer us to use
`unwrap_or_default` instead, which does the same thing.

This commit fixes the lint. Personally, I don't really care about this,
but it makes the warning go away...