### PR TITLE
log: revert #2740

### DIFF
--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -26,7 +26,7 @@ log-tracer = []
 tracing-core = { path = "../tracing-core", version = "0.2"}
 log = "0.4.17"
 once_cell = "1.13.0"
-env_logger = { version = "0.10", optional = true }
+env_logger = { version = "0.8.4", optional = true }
 
 [dev-dependencies]
 tracing = { path = "../tracing", version = "0.2"}


### PR DESCRIPTION
Due to minimum version selection issues, a desire to remove the `env_logger` feature wholesale, and to keep the number of breaking changes to a minimum, I'm reverting #2740 in favor of marking the `tracing-log/env_logger` feature as deprecated and releasing `tracing-log` 0.2.0 _without_ `env_logger`.