### PR TITLE
log: deprecate `env_logger` in favor of `tracing_subscriber::fmt::Subscriber`

### DIFF
--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -164,6 +164,10 @@ pub use self::trace_logger::TraceLogger;
 
 #[cfg(feature = "env_logger")]
 #[cfg_attr(docsrs, doc(cfg(feature = "env_logger")))]
+#[deprecated(
+    since = "0.1.4",
+    note = "use `tracing-subscriber`'s `fmt::Subscriber` instead"
+)]
 pub mod env_logger;
 
 pub use log;


### PR DESCRIPTION
Continuation of the plan outlined in #2750.

(Note that this is intentionally _not_ targeting the `master` branch, as we'll just remove `env_logger` feature there.)