### PR TITLE
chore: prepare tracing 0.1.39

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -2,22 +2,22 @@
 
 ### Added
 
-- Allow constant field names in macros [#2617]
-- Allow setting event names in macros [#2699]
-- Allow `ValueSet`s of any length [#2508]
+- Allow constant field names in macros ([#2617])
+- Allow setting event names in macros ([#2699])
+- Allow `ValueSet`s of any length ([#2508])
 
 ### Fixed
 
-- Use fully qualified names in macros for items exported from std prelude [#2621]
+- Use fully qualified names in macros for items exported from std prelude ([#2621])
 
 ### Documented
 
-- Add `axum-insights` to relevant crates. [#2713]
-- Fix link to RAI pattern crate documentation [#2612]
-- Fix docs typos and warnings [#2581]
-- Add `clippy-tracing` to related crates [#2628]
-- Add `tracing-cloudwatch` to related crates [#2667]
-- Fix deadlink to `tracing-etw` repo [#2602]
+- Add `axum-insights` to relevant crates. ([#2713])
+- Fix link to RAI pattern crate documentation ([#2612])
+- Fix docs typos and warnings ([#2581])
+- Add `clippy-tracing` to related crates ([#2628])
+- Add `tracing-cloudwatch` to related crates ([#2667]) 
+- Fix deadlink to `tracing-etw` repo ([#2602])
 
 [#2617]: https://github.com/tokio-rs/tracing/pull/2617
 [#2699]: https://github.com/tokio-rs/tracing/pull/2699

--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,34 @@
+# 0.1.39 (October 12, 2023)
+
+### Added
+
+- Allow constant field names in macros [#2617]
+- Allow setting event names in macros [#2699]
+- Allow `ValueSet`s of any length [#2508]
+
+### Fixed
+
+- Use fully qualified names in macros for items exported from std prelude [#2621]
+
+### Documented
+
+- Add `axum-insights` to relevant crates. [#2713]
+- Fix link to RAI pattern crate documentation [#2612]
+- Fix docs typos and warnings [#2581]
+- Add `clippy-tracing` to related crates [#2628]
+- Add `tracing-cloudwatch` to related crates [#2667]
+- Fix deadlink to `tracing-etw` repo [#2602]
+
+[#2617]: https://github.com/tokio-rs/tracing/pull/2617
+[#2699]: https://github.com/tokio-rs/tracing/pull/2699
+[#2508]: https://github.com/tokio-rs/tracing/pull/2508
+[#2621]: https://github.com/tokio-rs/tracing/pull/2621
+[#2713]: https://github.com/tokio-rs/tracing/pull/2713
+[#2581]: https://github.com/tokio-rs/tracing/pull/2581
+[#2628]: https://github.com/tokio-rs/tracing/pull/2628
+[#2667]: https://github.com/tokio-rs/tracing/pull/2667
+[#2602]: https://github.com/tokio-rs/tracing/pull/2602
+
 # 0.1.38 (April 25th, 2023)
 
 This `tracing` release changes the `Drop` implementation for `Instrumented`

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.38"
+version = "0.1.39"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
Cherry-picked out of https://github.com/tokio-rs/tracing/pull/2749.