### PR TITLE
Add `EnvFilter::from_directives`

### DIFF
--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -302,6 +302,56 @@ impl EnvFilter {
             .from_env_lossy()
     }
 
+    /// Returns a new `EnvFilter` from the given directives.
+    ///
+    /// If the directives are empty, no default directive is added.
+    ///
+    /// To set additional configuration options prior to creating the filter, use
+    /// the [`Builder`] type instead.
+    ///
+    /// This function is roughly equivalent to the following:
+    ///
+    /// ```rust
+    /// use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+    ///
+    /// # fn docs() -> EnvFilter {
+    /// # let dirs = [
+    ///    # "myapp=debug".parse().expect("hard-coded default directive should be valid"),
+    ///    # LevelFilter::INFO.into(),
+    /// # ];
+    /// let mut filter = EnvFilter::default();
+    /// for dir in dirs {
+    ///     filter = filter.add_directive(dir);
+    /// }
+    /// # assert_eq!(filter.to_string(), "myapp=debug,info");
+    /// filter
+    /// # }
+    /// ```
+    ///
+    /// # Examples
+    ///
+    /// [`Directive`]s can be parsed independently and used to create a new `EnvFilter`:
+    ///
+    /// ```rust
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+    ///
+    /// let dirs = [
+    ///     LevelFilter::INFO.into(),
+    ///     "myapp=debug"
+    ///         .parse()
+    ///         .expect("hard-coded default directive should be valid"),
+    /// ];
+    ///
+    /// let filter = EnvFilter::from_directives(dirs);
+    ///
+    /// assert_eq!(filter.to_string(), "myapp=debug,info");
+    /// # Ok(()) }
+    /// ```
+    pub fn from_directives(dirs: impl IntoIterator<Item = Directive>) -> Self {
+        Self::builder().from_directives(dirs)
+    }
+
     /// Returns a new `EnvFilter` from the directives in the given string,
     /// ignoring any that are invalid.
     ///


### PR DESCRIPTION
## Motivation

I was using an `EnvFilter` within a `tracing_subscriber::reload` layer, to be able to change the filter at runtime via a config file.
Here, I let the deserialization take care of validating the correctness of the configured filter directives.
However, there wasn't a straightforward way to construct the `EnvFilter` via already parsed directives.

## Solution

There is a private `from_directives` method on the `Builder`, which was already considered by @hawkw to be made public.
Instead, I opted to creating  a new, similar method directly on the `EnvFilter`.
This should be easier to discover and more convenient than having to call `EnvFilter::builder().from_directives()`.
Though, we could consider making both variants public.

This is my first contribution to tokio, so let me know if something is missing from the PR!