### PR TITLE
Fix incorrectly updated incorrect docs for `tracing_core::LevelFilter`

### DIFF
--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -223,10 +223,9 @@ pub struct Level(LevelInner);
 
 /// A filter comparable to a verbosity [`Level`].
 ///
-/// If a [`Level`] is considered less than a `LevelFilter`, it should be
-/// considered enabled; if greater than or equal to the `LevelFilter`,
-/// that level is disabled. See [`LevelFilter::current`] for more
-/// details.
+/// If a [`Level`] is considered less than or equal to a `LevelFilter`, it
+/// should be considered enabled; if greater than the `LevelFilter`, that level
+/// is disabled. See [`LevelFilter::current`] for more details.
 ///
 /// Note that this is essentially identical to the `Level` type, but with the
 /// addition of an [`OFF`] level that completely disables all trace


### PR DESCRIPTION
These docs were updated (in response to #1669), but the "or equal to" phrase should have been moved to the other case.

Fixes: #1993

## Motivation

When these docs were updated in response to #1669, they were updated incompletely (a level that is equal to a filter is _enabled_, not _disabled_) and therefore remained incorrect.

## Solution

The docs were updated, moving the "or equal to" phrase to the other case.