### PR TITLE
fix env_logger crate name typo in lib.rs documentation

### DIFF
--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -14,7 +14,7 @@
 //! - [`LogTracer`], a [`log::Log`] implementation that consumes [`log::Record`]s
 //!   and outputs them as [`tracing::Event`].
 //! - An [`env_logger`] module, with helpers for using the [`env_logger` crate]
-//!   with `tracing` (optional, enabled by the `env-logger` feature).
+//!   with `tracing` (optional, enabled by the `env_logger` feature).
 //!
 //! *Compiler support: [requires `rustc` 1.56+][msrv]*
 //!


### PR DESCRIPTION
This fixes a small typo in the crate's module documentation that can mislead a first time user who is looking to use the `env_logger` module in `tracing-log`.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation
A first time user following the [crate.rs documentation ](https://docs.rs/tracing-log/latest/tracing_log/#) will accidentally use `env-logger` as their feature flag, hit a compiler error and spend extra time trying to figure out the correct feature flag name.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Fix the typo by changing `env-logger` to `env_logger`.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
