### PR TITLE
chore: Prepare tracing-log 0.1.4

### DIFF
--- a/tracing-log/CHANGELOG.md
+++ b/tracing-log/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Changes
 
-- Deprecated `env_logger` in favor of `tracing_subscriber::fmt::Subscriber` ([#2752])
+- Deprecated `env_logger` feature in favor of `tracing_subscriber::fmt::Subscriber` ([#2752])
 
 #[2752]: https://github.com/tokio-rs/tracing/pull/2752
 

--- a/tracing-log/CHANGELOG.md
+++ b/tracing-log/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.4 (October 23rd, 2023)
+
+### Changes
+
+- Deprecated `env_logger` in favor of `tracing_subscriber::fmt::Subscriber` ([#2752])
+
+#[2752]: https://github.com/tokio-rs/tracing/pull/2752
+
 # 0.1.3 (April 21st, 2022)
 
 ### Added

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"


### PR DESCRIPTION
Bit overdue, but here's the prepared changes for tracing-log 0.1.4.