### PR TITLE
chore: prepare tracing-log 0.2.0

### DIFF
--- a/tracing-log/CHANGELOG.md
+++ b/tracing-log/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 0.2.0 (October 23rd, 2023)
+
+This release contains a breaking change: the removal of the `env_logger`
+feature. Users who desire a similar experience should instead use
+[`tracing_subscriber::fmt::Subscriber`] or [`tracing_subscriber::fmt::Layer`]
+with the [`Targets`] or [`EnvFilter`] filters.
+
+### Breaking Changes
+
+- Remove `env_logger` feature ([#2771])
+
+[#2771]: https://github.com/tokio-rs/tracing/pull/2771
+[`tracing_subscriber::fmt::Subscriber`]: https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/fmt/struct.Subscriber.html
+[`tracing_subscriber::fmt::Layer`]: https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/fmt/struct.Layer.html
+[`Targets`]: https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/filter/targets/struct.Targets.html
+[`EnvFilter`]: https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/filter/struct.EnvFilter.html
+
 # 0.1.4 (October 23rd, 2023)
 
 ### Changes

--- a/tracing-log/CHANGELOG.md
+++ b/tracing-log/CHANGELOG.md
@@ -4,20 +4,26 @@ This release contains two breaking changes: the removal of the `env_logger`
 and `trace_logger` features. Below are the suggested migration paths:
 
 - `env_logger`: users should use [`tracing_subscriber::fmt::Subscriber`]
-or [`tracing_subscriber::fmt::Layer`] with the [`Targets`] or [`EnvFilter`]
-filters instead.
-- `trace_logger`: users should use the `tracing` crate's "log" feature flag instead.
+  or [`tracing_subscriber::fmt::Layer`] with the [`Targets`] or
+  [`EnvFilter`] filters instead.
+- `trace_logger`: users should use the `tracing` crate's
+  ["log" feature flag][log-feature] instead. 
 
 ### Breaking Changes
 
-- Remove `env_logger` feature ([#2771])
-- Remove `trace_logger` feature ([#2771])
+- Remove deprecated `env_logger` feature. This removes the dependency
+  on the unmaintained `atty` crate, resolving the security advisory
+  [GHSA-g98v-hv3f-hcfr]/[RUSTSEC-2021-0145]. ([#2771])  
+- Remove deprecated `trace_logger` feature. ([#2771])
 
 [#2771]: https://github.com/tokio-rs/tracing/pull/2771
 [`tracing_subscriber::fmt::Subscriber`]: https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/fmt/struct.Subscriber.html
 [`tracing_subscriber::fmt::Layer`]: https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/fmt/struct.Layer.html
 [`Targets`]: https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/filter/targets/struct.Targets.html
 [`EnvFilter`]: https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/filter/struct.EnvFilter.html
+[log-feature]: https://docs.rs/tracing/latest/tracing/#emitting-log-records
+[GHSA-g98v-hv3f-hcfr]: https://github.com/advisories/GHSA-g98v-hv3f-hcfr
+[RUSTSEC-2021-0145]: https://rustsec.org/advisories/RUSTSEC-2021-0145.html
 
 # 0.1.4 (October 23rd, 2023)
 

--- a/tracing-log/CHANGELOG.md
+++ b/tracing-log/CHANGELOG.md
@@ -1,13 +1,17 @@
 # 0.2.0 (October 23rd, 2023)
 
-This release contains a breaking change: the removal of the `env_logger`
-feature. Users who desire a similar experience should instead use
-[`tracing_subscriber::fmt::Subscriber`] or [`tracing_subscriber::fmt::Layer`]
-with the [`Targets`] or [`EnvFilter`] filters.
+This release contains two breaking changes: the removal of the `env_logger`
+and `trace_logger` features. Below are the suggested migration paths:
+
+- `env_logger`: users should use [`tracing_subscriber::fmt::Subscriber`]
+or [`tracing_subscriber::fmt::Layer`] with the [`Targets`] or [`EnvFilter`]
+filters instead.
+- `trace_logger`: users should use the `tracing` crate's "log" feature flag instead.
 
 ### Breaking Changes
 
 - Remove `env_logger` feature ([#2771])
+- Remove `trace_logger` feature ([#2771])
 
 [#2771]: https://github.com/tokio-rs/tracing/pull/2771
 [`tracing_subscriber::fmt::Subscriber`]: https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/fmt/struct.Subscriber.html

--- a/tracing-log/CHANGELOG.md
+++ b/tracing-log/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.2.0 (October 23rd, 2023)
+# 0.2.0 (October 24th, 2023)
 
 This release contains two breaking changes: the removal of the `env_logger`
 and `trace_logger` features. Below are the suggested migration paths:

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-log"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/tracing"

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -48,7 +48,7 @@ smallvec = { optional = true, version = "1.9.0" }
 once_cell = { optional = true, version = "1.13.0" }
 
 # fmt
-tracing-log = { path = "../tracing-log", version = "0.1.3", optional = true, default-features = false, features = ["log-tracer", "std"] }
+tracing-log = { path = "../tracing-log", version = "0.2.0", optional = true, default-features = false, features = ["log-tracer", "std"] }
 nu-ansi-term = { version = "0.46.0", optional = true }
 time = { version = "0.3.2", features = ["formatting"], optional = true }
 
@@ -73,7 +73,7 @@ valuable-serde = { version = "0.1.0", optional = true, default-features = false 
 tracing = { path = "../tracing", version = "0.1.35" }
 tracing-mock = { path = "../tracing-mock", features = ["tracing-subscriber"] }
 log = "0.4.17"
-tracing-log = { path = "../tracing-log", version = "0.1.3" }
+tracing-log = { path = "../tracing-log", version = "0.2.0" }
 criterion = { version = "0.3.6", default-features = false }
 regex = { version = "1", default-features = false, features = ["std"] }
 tracing-futures = { path = "../tracing-futures", version = "0.2.0", default-features = false, features = ["std-future", "std"] }


### PR DESCRIPTION
This branch prepares a release of `tracing-log 0.2.0`. The sole breaking change
is the removal of the `env_logger` feature. Please refer to #2771 and #2750 
for the context behind this decision.

(Note that this branch depends on #2770 and #2771. I will rebase this branch to
catch changes that exist on v0.1.x when those branches land.)