### PR TITLE
subscriber: unify interface of `enabled` functions

### DIFF
--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -472,7 +472,7 @@ impl EnvFilter {
     /// This is equivalent to calling the [`Subscribe::enabled`] or
     /// [`Filter::enabled`] methods on `EnvFilter`'s implementations of those
     /// traits, but it does not require the trait to be in scope.
-    pub fn enabled<C>(&self, metadata: &Metadata<'_>, _: Context<'_, C>) -> bool {
+    pub fn enabled<C>(&self, metadata: &Metadata<'_>, _: &Context<'_, C>) -> bool {
         let level = metadata.level();
 
         // is it possible for a dynamic filter directive to enable this event?
@@ -648,7 +648,7 @@ impl<C: Collect> Subscribe<C> for EnvFilter {
     }
 
     #[inline]
-    fn enabled(&self, metadata: &Metadata<'_>, ctx: Context<'_, C>) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>, ctx: &Context<'_, C>) -> bool {
         self.enabled(metadata, ctx)
     }
 
@@ -685,7 +685,7 @@ feature! {
     impl<C> Filter<C> for EnvFilter {
         #[inline]
         fn enabled(&self, meta: &Metadata<'_>, ctx: &Context<'_, C>) -> bool {
-            self.enabled(meta, ctx.clone())
+            self.enabled(meta, ctx)
         }
 
         #[inline]

--- a/tracing-subscriber/src/filter/filter_fn.rs
+++ b/tracing-subscriber/src/filter/filter_fn.rs
@@ -326,7 +326,7 @@ where
     F: Fn(&Metadata<'_>) -> bool + 'static,
     C: Collect,
 {
-    fn enabled(&self, metadata: &Metadata<'_>, _: Context<'_, C>) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>, _: &Context<'_, C>) -> bool {
         self.is_enabled(metadata)
     }
 
@@ -646,7 +646,7 @@ where
     R: Fn(&'static Metadata<'static>) -> Interest + 'static,
     C: Collect,
 {
-    fn enabled(&self, metadata: &Metadata<'_>, cx: Context<'_, C>) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>, cx: &Context<'_, C>) -> bool {
         self.is_enabled(metadata, &cx)
     }
 

--- a/tracing-subscriber/src/filter/level.rs
+++ b/tracing-subscriber/src/filter/level.rs
@@ -17,7 +17,7 @@ impl<C: Collect> crate::Subscribe<C> for LevelFilter {
         }
     }
 
-    fn enabled(&self, metadata: &Metadata<'_>, _: crate::subscribe::Context<'_, C>) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>, _: &crate::subscribe::Context<'_, C>) -> bool {
         self >= metadata.level()
     }
 

--- a/tracing-subscriber/src/filter/subscriber_filters/mod.rs
+++ b/tracing-subscriber/src/filter/subscriber_filters/mod.rs
@@ -744,15 +744,15 @@ where
         Interest::always()
     }
 
-    fn enabled(&self, metadata: &Metadata<'_>, cx: Context<'_, C>) -> bool {
-        let cx = cx.with_filter(self.id());
+    fn enabled(&self, metadata: &Metadata<'_>, cx: &Context<'_, C>) -> bool {
+        let cx = cx.clone().with_filter(self.id());
         let enabled = self.filter.enabled(metadata, &cx);
         FILTERING.with(|filtering| filtering.set(self.id(), enabled));
 
         if enabled {
             // If the filter enabled this metadata, ask the wrapped subscriber if
             // _it_ wants it --- it might have a global filter.
-            self.subscriber.enabled(metadata, cx)
+            self.subscriber.enabled(metadata, &cx)
         } else {
             // Otherwise, return `true`. The _per-subscriber_ filter disabled this
             // metadata, but returning `false` in `Subscribe::enabled` will

--- a/tracing-subscriber/src/filter/targets.rs
+++ b/tracing-subscriber/src/filter/targets.rs
@@ -440,7 +440,7 @@ impl<C> subscribe::Subscribe<C> for Targets
 where
     C: Collect,
 {
-    fn enabled(&self, metadata: &Metadata<'_>, _: subscribe::Context<'_, C>) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>, _: &subscribe::Context<'_, C>) -> bool {
         self.0.enabled(metadata)
     }
 

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -82,7 +82,7 @@ where
     }
 
     #[inline]
-    fn enabled(&self, metadata: &Metadata<'_>, ctx: subscribe::Context<'_, C>) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>, ctx: &subscribe::Context<'_, C>) -> bool {
         try_lock!(self.inner.read(), else return false).enabled(metadata, ctx)
     }
 

--- a/tracing-subscriber/src/subscribe/layered.rs
+++ b/tracing-subscriber/src/subscribe/layered.rs
@@ -99,7 +99,7 @@ where
     }
 
     fn enabled(&self, metadata: &Metadata<'_>) -> bool {
-        if self.subscriber.enabled(metadata, self.ctx()) {
+        if self.subscriber.enabled(metadata, &self.ctx()) {
             // if the outer subscriber enables the callsite metadata, ask the collector.
             self.inner.enabled(metadata)
         } else {
@@ -261,8 +261,8 @@ where
         })
     }
 
-    fn enabled(&self, metadata: &Metadata<'_>, ctx: Context<'_, C>) -> bool {
-        if self.subscriber.enabled(metadata, ctx.clone()) {
+    fn enabled(&self, metadata: &Metadata<'_>, ctx: &Context<'_, C>) -> bool {
+        if self.subscriber.enabled(metadata, ctx) {
             // if the outer subscriber enables the callsite metadata, ask the inner subscriber.
             self.inner.enabled(metadata, ctx)
         } else {

--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -825,7 +825,7 @@ where
     /// [`self.enabled`]: Subscribe::enabled()
     /// [the trait-level documentation]: #filtering-with-subscribers
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
-        if self.enabled(metadata, Context::none()) {
+        if self.enabled(metadata, &Context::none()) {
             Interest::always()
         } else {
             Interest::never()
@@ -860,7 +860,7 @@ where
     ///
     /// [`Interest`]: tracing_core::Interest
     /// [the trait-level documentation]: #filtering-with-subscribers
-    fn enabled(&self, metadata: &Metadata<'_>, ctx: Context<'_, C>) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>, ctx: &Context<'_, C>) -> bool {
         let _ = (metadata, ctx);
         true
     }
@@ -1583,7 +1583,7 @@ where
     }
 
     #[inline]
-    fn enabled(&self, metadata: &Metadata<'_>, ctx: Context<'_, C>) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>, ctx: &Context<'_, C>) -> bool {
         match self {
             Some(ref inner) => inner.enabled(metadata, ctx),
             None => true,
@@ -1695,7 +1695,7 @@ macro_rules! subscriber_impl_body {
         }
 
         #[inline]
-        fn enabled(&self, metadata: &Metadata<'_>, ctx: Context<'_, C>) -> bool {
+        fn enabled(&self, metadata: &Metadata<'_>, ctx: &Context<'_, C>) -> bool {
             self.deref().enabled(metadata, ctx)
         }
 
@@ -1803,8 +1803,8 @@ feature! {
             interest
         }
 
-        fn enabled(&self, metadata: &Metadata<'_>, ctx: Context<'_, C>) -> bool {
-            self.iter().all(|s| s.enabled(metadata, ctx.clone()))
+        fn enabled(&self, metadata: &Metadata<'_>, ctx: &Context<'_, C>) -> bool {
+            self.iter().all(|s| s.enabled(metadata, ctx))
         }
 
         fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, C>) {

--- a/tracing-subscriber/tests/event_enabling.rs
+++ b/tracing-subscriber/tests/event_enabling.rs
@@ -15,7 +15,7 @@ impl<C> Subscribe<C> for TrackingLayer
 where
     C: Collect + Send + Sync + 'static,
 {
-    fn enabled(&self, _metadata: &Metadata<'_>, _ctx: Context<'_, C>) -> bool {
+    fn enabled(&self, _metadata: &Metadata<'_>, _ctx: &Context<'_, C>) -> bool {
         self.enabled
     }
 

--- a/tracing-subscriber/tests/option.rs
+++ b/tracing-subscriber/tests/option.rs
@@ -10,7 +10,7 @@ impl<C: Collect> tracing_subscriber::Subscribe<C> for BasicLayer {
         Interest::sometimes()
     }
 
-    fn enabled(&self, _m: &Metadata<'_>, _: subscribe::Context<'_, C>) -> bool {
+    fn enabled(&self, _m: &Metadata<'_>, _: &subscribe::Context<'_, C>) -> bool {
         true
     }
 

--- a/tracing-subscriber/tests/reload.rs
+++ b/tracing-subscriber/tests/reload.rs
@@ -42,7 +42,7 @@ impl<S: Collect> tracing_subscriber::Subscribe<S> for NopSubscriber {
         Interest::sometimes()
     }
 
-    fn enabled(&self, _m: &Metadata<'_>, _: subscribe::Context<'_, S>) -> bool {
+    fn enabled(&self, _m: &Metadata<'_>, _: &subscribe::Context<'_, S>) -> bool {
         true
     }
 }
@@ -63,7 +63,7 @@ fn reload_handle() {
             Interest::sometimes()
         }
 
-        fn enabled(&self, m: &Metadata<'_>, _: subscribe::Context<'_, S>) -> bool {
+        fn enabled(&self, m: &Metadata<'_>, _: &subscribe::Context<'_, S>) -> bool {
             println!("ENABLED: {:?}", m);
             match self {
                 Filter::One => FILTER1_CALLS.fetch_add(1, Ordering::SeqCst),


### PR DESCRIPTION
across all implementations in traits (for `Filter` and `Context`) and associated functions for structs.

The API from the `Filter` trait takes a `&Context`, while individual implementations previously took `Context` by value. This was likely an oversight because a) the `Context` argument is ignored in a few places and not used at all and b) `Context` is `Clone` so can be turned into a value from a reference when required.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

I noticed this inconsistency while trying to implement a complex filter with `DynFilterFn`. The `DynFilterFn::new` function passes a `&Context` to the closure, which conforms to the API defined in the `Filter` trait. Part of my filter is an `EnvFilter`, which has an associated function `enabled` defined on the struct (i.e. next to the `Filter` impl). Quoting from the docs:

> Returns true if this EnvFilter would enable the provided metadata in the current context.
>
> This is equivalent to calling the [Layer::enabled](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/trait.Layer.html#method.enabled) or [Filter::enabled](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/trait.Filter.html#tymethod.enabled) methods on EnvFilter’s implementations of those traits, but it does not require the trait to be in scope.

Since the `Context` argument is taken by value in some implementations but by reference in others, this is not true. So I decided to make a proposal to change this. Since it is part of the public API, I'm afraid it will break existing code that has already arranged with this.


## Solution

Changes all `enabled` functions in the codebase to take their `Context` argument by reference.

Here's a quick regex to check if all have been caught (although it's not multiline):

```bash
rg -e "fn enabled\(.*Context"
```