### PR TITLE
docs: attributes: fix small backporting error

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -96,10 +96,10 @@ mod expand;
 /// By default, all arguments to the function are included as fields on the
 /// span. Arguments that are `tracing` [primitive types] implementing the
 /// [`Value` trait] will be recorded as fields of that type. Types which do
-/// not implement `Value` will be recorded using [`std::fmt::Debug`].
+/// not implement `Value` will be recorded using [`fmt::Debug`].
 ///
 /// [primitive types]: https://docs.rs/tracing/latest/tracing/field/trait.Value.html#foreign-impls
-/// [`Value` trait]: https://docs.rs/tracing/latest/tracing/field/trait.Value.html.
+/// [`Value` trait]: https://docs.rs/tracing/latest/tracing/field/trait.Value.html
 ///
 /// # Overriding Span Attributes
 ///


### PR DESCRIPTION
There was an error when backporting #1378 (here: #1418) and a trailing dot (.) was forgotten (which was breaking the link). Fixed also the link to `std::fmt::Debug`.
