### PR TITLE
subcriber: update docs for EnvFilter Builder

### DIFF
--- a/tracing-subscriber/src/filter/env/builder.rs
+++ b/tracing-subscriber/src/filter/env/builder.rs
@@ -170,15 +170,15 @@ impl Builder {
         self.parse_lossy(var)
     }
 
-    /// Returns a new [`EnvFilter`] from the directives in the in the configured
-    /// environment variable, or an error if the environment variable is not set
-    /// or contains invalid directives.
+    /// Returns a new [`EnvFilter`] from the directives in the configured
+    /// environment variable. If the environment variable is unset no directive is added.
+    /// An error is returned if the environment contains invalid directives.
     pub fn from_env(&self) -> Result<EnvFilter, FromEnvError> {
         let var = env::var(self.env_var_name()).unwrap_or_default();
         self.parse(var).map_err(Into::into)
     }
 
-    /// Returns a new [`EnvFilter`] from the directives in the in the configured
+    /// Returns a new [`EnvFilter`] from the directives in the configured
     /// environment variable, or an error if the environment variable is not set
     /// or contains invalid directives.
     pub fn try_from_env(&self) -> Result<EnvFilter, FromEnvError> {

--- a/tracing-subscriber/src/filter/env/builder.rs
+++ b/tracing-subscriber/src/filter/env/builder.rs
@@ -171,7 +171,7 @@ impl Builder {
     }
 
     /// Returns a new [`EnvFilter`] from the directives in the configured
-    /// environment variable. If the environment variable is unset no directive is added.
+    /// environment variable. If the environment variable is unset, no directive is added.
     /// An error is returned if the environment contains invalid directives.
     pub fn from_env(&self) -> Result<EnvFilter, FromEnvError> {
         let var = env::var(self.env_var_name()).unwrap_or_default();

--- a/tracing-subscriber/src/filter/env/builder.rs
+++ b/tracing-subscriber/src/filter/env/builder.rs
@@ -172,6 +172,7 @@ impl Builder {
 
     /// Returns a new [`EnvFilter`] from the directives in the configured
     /// environment variable. If the environment variable is unset, no directive is added.
+    ///
     /// An error is returned if the environment contains invalid directives.
     pub fn from_env(&self) -> Result<EnvFilter, FromEnvError> {
         let var = env::var(self.env_var_name()).unwrap_or_default();


### PR DESCRIPTION
The from_env and try_from_env method on the builder had the same documentation. This change updates their docs to correctly describe their difference in behavior.


## Motivation

Make the docs more clear, so that users need not look at the source to understand the difference between these two functions.

## Solution

Updated the docs