### PR TITLE
Allow `ValueSet`s to be constructed with slices in addition to arrays

### DIFF
--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -1081,6 +1081,7 @@ mod private {
     pub trait ValidLen<'a>: Borrow<[(&'a Field, Option<&'a (dyn Value + 'a)>)]> {}
 
     impl<'a, const N: usize> ValidLen<'a> for [(&'a Field, Option<&'a (dyn Value + 'a)>); N] {}
+    impl<'a> ValidLen<'a> for &[(&'a Field, Option<&'a (dyn Value + 'a)>)] {}
 }
 
 #[cfg(test)]

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -1081,7 +1081,7 @@ mod private {
     pub trait ValidLen<'a>: Borrow<[(&'a Field, Option<&'a (dyn Value + 'a)>)]> {}
 
     impl<'a, const N: usize> ValidLen<'a> for [(&'a Field, Option<&'a (dyn Value + 'a)>); N] {}
-    impl<'a> ValidLen<'a> for &[(&'a Field, Option<&'a (dyn Value + 'a)>)] {}
+    impl<'a> ValidLen<'a> for &'a [(&'a Field, Option<&'a (dyn Value + 'a)>)] {}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Motivation

I'm working on an implementation of `Subscriber` that needs to be able to store (in a form as close as possible to the original) the inputs to its methods, and reconstruct them later to be passed to another `Subscriber`. For the most part, this works really well, but the biggest sticking point by far came from trying to reconstruct a `ValueSet` from a stored list of `(Field, Value)` pairs.

The core of the problem is the `ValidLen` trait and its usage by `FieldSet::value_set()`. In order to call that function, you have to be able to provide a statically-sized array, because that's the only type that implements `ValidLen`.

While, in theory, constructing an array for my use case should be _just about_ possible (although the tricks necessary to do so likely involve a macro and the reimposition of an arbitrary length limit), lifetime issues (that appear to result from a call to `<[_; N]>::try_from()`) make it impossible. I'm going to construct a minimal example of this and investigate further at some point, but in the meantime:

## Solution

Since #2508 removed the limitation on array length here, there doesn't seem to be a drawback to simply adding an implementation of `ValidLen` for slices. They already meet the `Borrow` supertrait requirement, so no additional machinery is needed.

This makes this API trivially easy to call for my use case, and I can't think of any associated drawbacks.