### PR TITLE
chore: prepare tracing-subscriber 0.3.18 release

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 This release of `tracing-subscriber` adds support for the [`NO_COLOR`] environment
 variable (an informal standard to disable emitting ANSI color escape codes) in
-`fmt::Layer` and reintroduces support for the [`chrono`] crate.
+`fmt::Layer`, reintroduces support for the [`chrono`] crate, and increases the
+minimum supported Rust version (MSRV) to Rust 1.63.0.
 
 It also introduces several minor API improvements.
 
@@ -17,6 +18,7 @@ It also introduces several minor API improvements.
 ### Changed
 
 - **log**: bump version of `tracing-log` to 0.2 ([#2772])
+- Increased minimum supported Rust version (MSRV) to 1.63.0+.
 
 [`chrono`]: https://github.com/chronotope/chrono
 [`NO_COLOR`]: https://no-color.org/

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -8,7 +8,8 @@ It also introduces several minor API improvements.
 ### Added
 
 - **chrono**: Add `chrono` implementations of `FormatTime` ([#2690])
-- **subscriber**: support `NO_COLOR` in `fmt::Layer` ([#2647])
+- **subscriber**: Add support for the `NO_COLOR` environment 
+   variable in `fmt::Layer` ([#2647])
 
 ### Changed
 

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.3.18 (November 6, 2023)
+# 0.3.18 (November 13, 2023)
 
 This release of `tracing-subscriber` adds support for the [`NO_COLOR`] environment
 variable (an informal standard to disable emitting ANSI color escape codes) in

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,29 @@
+# 0.3.18 (November 6, 2023)
+
+This release of `tracing-subscriber` adds support for `NO_COLOR` in
+`fmt::Layer` and reintroduces support for the `chrono` crate.
+It also introduces several minor API improvements.
+
+
+### Added
+
+- **chrono**: Add `chrono` implementations of `FormatTime` ([#2690])
+- **subscriber**: support `NO_COLOR` in `fmt::Layer` ([#2647])
+
+### Changed
+
+- **fmt**: make `format::Writer::new()` public ([#2680])
+- **subscriber**: bump version of `tracing-log` to 0.2 ([#2772])
+- **filter**: Implement `layer::Filter` for `Option<Filter>` ([#2407])
+
+[#2690]: https://github.com/tokio-rs/tracing/pull/2690
+[#2647]: https://github.com/tokio-rs/tracing/pull/2647
+[#2680]: https://github.com/tokio-rs/tracing/pull/2680
+[#2407]: https://github.com/tokio-rs/tracing/pull/2407
+[#2772]: https://github.com/tokio-rs/tracing/pull/2772
+
+Thanks to @shayne-fletcher, @dmlary, @kaifastromai, and @jsgf for contributing!
+
 # 0.3.17 (April 21, 2023)
 
 This release of `tracing-subscriber` fixes a build error when using `env-filter`

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,22 +1,25 @@
 # 0.3.18 (November 6, 2023)
 
-This release of `tracing-subscriber` adds support for `NO_COLOR` in
-`fmt::Layer` and reintroduces support for the `chrono` crate.
-It also introduces several minor API improvements.
+This release of `tracing-subscriber` adds support for the [`NO_COLOR`] environment
+variable (an informal standard to disable emitting ANSI color escape codes) in
+`fmt::Layer` and reintroduces support for the [`chrono`] crate.
 
+It also introduces several minor API improvements.
 
 ### Added
 
-- **chrono**: Add `chrono` implementations of `FormatTime` ([#2690])
-- **subscriber**: Add support for the `NO_COLOR` environment 
-   variable in `fmt::Layer` ([#2647])
+- **chrono**: Add [`chrono`] implementations of `FormatTime` ([#2690])
+- **subscriber**: Add support for the [`NO_COLOR`] environment variable in
+`fmt::Layer` ([#2647])
+- **fmt**: make `format::Writer::new()` public ([#2680])
+- **filter**: Implement `layer::Filter` for `Option<Filter>` ([#2407])
 
 ### Changed
 
-- **fmt**: make `format::Writer::new()` public ([#2680])
 - **log**: bump version of `tracing-log` to 0.2 ([#2772])
-- **filter**: Implement `layer::Filter` for `Option<Filter>` ([#2407])
 
+[`chrono`]: https://github.com/chronotope/chrono
+[`NO_COLOR`]: https://no-color.org/
 [#2690]: https://github.com/tokio-rs/tracing/pull/2690
 [#2647]: https://github.com/tokio-rs/tracing/pull/2647
 [#2680]: https://github.com/tokio-rs/tracing/pull/2680

--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -14,7 +14,7 @@ It also introduces several minor API improvements.
 ### Changed
 
 - **fmt**: make `format::Writer::new()` public ([#2680])
-- **subscriber**: bump version of `tracing-log` to 0.2 ([#2772])
+- **log**: bump version of `tracing-log` to 0.2 ([#2772])
 - **filter**: Implement `layer::Filter` for `Option<Filter>` ([#2407])
 
 [#2690]: https://github.com/tokio-rs/tracing/pull/2690

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",


### PR DESCRIPTION
Bit overdue, but here it is.