### PR TITLE
Fixes flaky test

### DIFF
--- a/tracing-subscriber/tests/reload.rs
+++ b/tracing-subscriber/tests/reload.rs
@@ -47,7 +47,15 @@ impl<S: Collect> tracing_subscriber::Subscribe<S> for NopSubscriber {
     }
 }
 
+/// Running these two tests in parallel will cause flaky failures, since they are both modifying the MAX_LEVEL value.
+/// "cargo test -- --test-threads=1 fixes it, but it runs all tests in serial.
+/// The only way to run tests in serial in a single file is this way.
 #[test]
+fn run_all_reload_test() {
+    reload_handle();
+    reload_filter();
+}
+
 fn reload_handle() {
     static FILTER1_CALLS: AtomicUsize = AtomicUsize::new(0);
     static FILTER2_CALLS: AtomicUsize = AtomicUsize::new(0);
@@ -104,7 +112,6 @@ fn reload_handle() {
     })
 }
 
-#[test]
 fn reload_filter() {
     static FILTER1_CALLS: AtomicUsize = AtomicUsize::new(0);
     static FILTER2_CALLS: AtomicUsize = AtomicUsize::new(0);


### PR DESCRIPTION
fixes https://github.com/tokio-rs/tracing/actions/runs/6785393202/job/18443641813

cargo test runs tests in the same file in parallel by default, causing race condition,
this can be proven by running 
`cargo test --test reload -- --test-threads=1` => successes 
`cargo test --test reload -- --test-threads=2` => flaky
multiple times 

This fix runs only the two tests in serial.
We could seperate the tests in different files, but they share the same testing dependencies, so I left them in the same file.


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->
