### PR TITLE
chore: remove non-existing features from comments

### DIFF
--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -24,16 +24,6 @@
 //! This crate provides a number of feature flags that enable compatibility
 //! features with other crates in the asynchronous ecosystem:
 //!
-//! - `tokio`: Enables compatibility with the `tokio` crate, including
-//!    [`Instrument`] and [`WithCollector`] implementations for
-//!    `tokio::executor::Executor`, `tokio::runtime::Runtime`, and
-//!    `tokio::runtime::current_thread`. Enabled by default.
-//! - `tokio-executor`: Enables compatibility with the `tokio-executor`
-//!    crate, including [`Instrument`] and [`WithCollector`]
-//!    implementations for types implementing `tokio_executor::Executor`.
-//!    This is intended primarily for use in crates which depend on
-//!    `tokio-executor` rather than `tokio`; in general the `tokio` feature
-//!    should be used instead.
 //! - `std-future`: Enables compatibility with `std::future::Future`.
 //! - `futures-01`: Enables compatibility with version 0.1.x of the [`futures`]
 //!   crate.
@@ -50,7 +40,7 @@
 //!   tracing-futures = { version = "0.2.3", default-features = false }
 //!   ```
 //!
-//! The `tokio`, `std-future` and `std` features are enabled by default.
+//! The `std-future` and `std` features are enabled by default.
 //!
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [span]: mod@tracing::span


### PR DESCRIPTION
It seems currently `tokio` and `tokio-executor` features don't exist any more for `tracing-futures`.