### PR TITLE
Adds a check in `tracing_appender` 

### DIFF
--- a/tracing-appender/src/rolling/builder.rs
+++ b/tracing-appender/src/rolling/builder.rs
@@ -208,6 +208,8 @@ impl Builder {
     /// Files matching these criteria may be deleted if the maximum number of
     /// log files in the directory has been reached.
     ///
+    /// Panics if and only if `n` is 0.
+    ///
     /// [`filename_prefix`]: Self::filename_prefix
     /// [`filename_suffix`]: Self::filename_suffix
     ///
@@ -227,6 +229,9 @@ impl Builder {
     /// ```
     #[must_use]
     pub fn max_log_files(self, n: usize) -> Self {
+        if n == 0 {
+            panic!("Must keep at least one log file.");
+        }
         Self {
             max_files: Some(n),
             ..self
@@ -269,5 +274,17 @@ impl Builder {
 impl Default for Builder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Builder;
+
+    /// Test that [`Builder::max_log_files`] panics if `n` is 0.
+    #[test]
+    #[should_panic(expected = "Must keep at least one log file.")]
+    fn test_zero_max_log_files() {
+        let _ = Builder::new().max_log_files(0);
     }
 }


### PR DESCRIPTION
PR #2323 added a feature that allows the creation of a [`RollingFileAppender`](https://docs.rs/tracing-appender/latest/tracing_appender/rolling/struct.RollingFileAppender.html#) that keeps only the `n` most recent log files on each rotation.

I find this feature to be very useful and have been using it in my code every since `tracing_appender` 0.2.3 came out. I opened this PR with the intention of introducing a couple of minor improvements on top of the changes brought by PR #2323.

## Motivation
The current version of the code leaves open the possibility for `n` to be 0, a value that makes no sense and that causes a crash in `prune_old_logs` at [line 626 of `src/rolling.rs`](https://github.com/tokio-rs/tracing/blob/c6bedbe2725830c1e78cbcdb9168de69c98e42fc/tracing-appender/src/rolling.rs#L626C73-L626C73), when an attempt at computing `max_files - 1` is made. It seems to me that this is not a major pitfall for the user, as it is easy to avoid passing 0 to [`Builder::max_log_files`](https://github.com/tokio-rs/tracing/blob/c6bedbe2725830c1e78cbcdb9168de69c98e42fc/tracing-appender/src/rolling/builder.rs#L229), but I believe that the code should still perform some basic check.

Moreover, when I first read the [documentation for this method](https://docs.rs/tracing-appender/latest/tracing_appender/rolling/struct.Builder.html#method.max_log_files) I was confused by the fact that `n` was modelled with an `usize` and that no mention of the special value of 0 was made. In particular, I did not understand if 0 was just a forbidden value, a special value with an ad-hoc meaning, or if I was misinterpreting the meaning of `n` altogether.

## Solution
This PR adds checks for the positiveness of `n` in the public-facing parts of the API, i.e. in `Builder::max_log_files`. This method panics if the check fails, thus anticipating the error that would occur during rotation at the source of the error, making the error easier to debug.

It also adds a line in the documentation that makes it clear that 0 is a forbidden value.

## Future Improvements
Making `n` a `NonZeroUsize` instead of an `usize` would make its semantics clearer and reduce the likelihood of an error, both for the users and in the internal parts of the code. It would, however, constitute a breaking change, so it could be reserved e.g. for v0.3 of `tracing_appender`. If you are favourable to this change, I could work on it and open a PR to have it fixed.