### PR TITLE
chore: suppress clippy lint

### DIFF
--- a/examples/examples/sloggish/sloggish_collector.rs
+++ b/examples/examples/sloggish/sloggish_collector.rs
@@ -230,6 +230,7 @@ impl Collect for SloggishCollector {
             self.print_indent(&mut stderr, indent).unwrap();
             stack.push(span_id.clone());
             if let Some(data) = data {
+                #[allow(clippy::map_identity)] // TODO remove in Rust 1.77
                 self.print_kvs(&mut stderr, data.kvs.iter().map(|(k, v)| (k, v)), "")
                     .unwrap();
             }


### PR DESCRIPTION
@taiki-e Sorry, I can't reopen https://github.com/tokio-rs/tracing/pull/2842 cuz I pushed first.

Anyway, turns out this seems to only be a bug on 1.75. I couldn't repro because I'm on nightly, so we can just suppress it for now.