### PR TITLE
examples(all-levels.rs): update documentation

### DIFF
--- a/examples/examples/all-levels.rs
+++ b/examples/examples/all-levels.rs
@@ -8,7 +8,7 @@ pub fn event() {
 
 fn main() {
     tracing_subscriber::fmt()
-        // all spans/events with a level higher than TRACE (e.g, info, warn, etc.)
+        // all spans/events with a level lower than TRACE (e.g, info, warn, etc.)
         // will be written to stdout.
         .with_max_level(Level::TRACE)
         // sets this to be the default, global collector for this application.


### PR DESCRIPTION
`Trace` is the most verbose logging level. Writing `info, warn, etc.` logs to stdout, needs them to be a lower level of logging verbosity than trace.

## Motivation

correct documentation

~~## Solution~~, no code change
