### PR TITLE
Exit spans the same way we enter them

### DIFF
--- a/tracing-subscriber/src/subscribe/layered.rs
+++ b/tracing-subscriber/src/subscribe/layered.rs
@@ -160,8 +160,8 @@ where
     }
 
     fn exit(&self, span: &span::Id) {
-        self.inner.exit(span);
         self.subscriber.on_exit(span, self.ctx());
+        self.inner.exit(span);
     }
 
     fn clone_span(&self, old: &span::Id) -> span::Id {


### PR DESCRIPTION
We call `inner.enter` before we call `layer.on_enter`, so it feels wrong to then call `inner.exit` before we call `layer.on_exit`. Either the inner's view of the span wraps the outer's view of the span, or the other way around.

## Motivation

The current behavior feels wrong. I haven't actually run into anything breaking because of this, but while reading through it code having the same ordering in enter and exit (as opposed to inverted ordering on exit) just seemed odd.