### PR TITLE
attributes: extract match scrutinee

### DIFF
--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -277,7 +277,8 @@ fn gen_block<B: ToTokens>(
         let mk_fut = match (err_event, ret_event) {
             (Some(err_event), Some(ret_event)) => quote_spanned!(block.span()=>
                 async move {
-                    match async move #block.await {
+                    let __match_scrutinee = async move #block.await;
+                    match  __match_scrutinee {
                         #[allow(clippy::unit_arg)]
                         Ok(x) => {
                             #ret_event;


### PR DESCRIPTION
On clippy version 1.76.0 this gives a warning, extracting the scrutinee to a variable fixes this.

Fixes: #2876
