### PR TITLE
Skip recording `Span` fields when not requested

### DIFF
--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -399,7 +399,7 @@ pub struct Full;
 /// intended for use in development.
 #[derive(Debug, Clone)]
 pub struct Format<F = Full, T = SystemTime> {
-    format: F,
+    pub(crate) format: F,
     pub(crate) timer: T,
     pub(crate) ansi: Option<bool>,
     pub(crate) display_timestamp: bool,
@@ -2114,6 +2114,47 @@ pub(super) mod test {
             );
 
             assert_info_hello_ignore_numeric(subscriber, make_writer, &expected)
+        }
+    }
+
+    mod json {
+        use core::cell::Cell;
+
+        use super::*;
+
+        struct CountDebugCalls(Cell<usize>);
+
+        impl fmt::Debug for CountDebugCalls {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                let value = self.0.get() + 1;
+                self.0.set(value);
+                write!(f, "CountDebugCalls({value})")
+            }
+        }
+
+        #[test]
+        fn does_not_record_span_fields() {
+            let make_writer = MockMakeWriter::default();
+            let subscriber = crate::fmt::Subscriber::builder()
+                .json()
+                .with_current_span(false)
+                .with_span_list(false)
+                .with_writer(make_writer.clone())
+                .with_timer(MockTime);
+            let _default = set_default(&subscriber.into());
+
+            let count_debug_calls = CountDebugCalls(Cell::default());
+
+            let span = tracing::info_span!("a span", fields = ?count_debug_calls);
+            let _guard = span.enter();
+            tracing::info!("an event");
+
+            let result = make_writer.get_string();
+            assert_eq!(
+                result.trim(),
+                r#"{"timestamp":"fake time","level":"INFO","fields":{"message":"an event"},"target":"tracing_subscriber::fmt::format::test::json"}"#
+            );
+            assert_eq!(count_debug_calls.0.get(), 0);
         }
     }
 


### PR DESCRIPTION
In particular for the `Json` formatter, one can disable output of spans, in which case it is not necessary to record all of the span fields, as that is potentially expensive.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Creating `Span`s is a lot more frequent than capturing `Event`s (in particular with `#[instrument]`).
In some profiling I have done, it shows that the overhead of `tracing` is quite high, in particular recording of all the `Span` fields.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

There is already a mechanism to disable *outputting* all the spans of `Event`s, at least for the `Json` formatter. However that was still recording all the fields, even though they are never being used. This will now skip that.