### PR TITLE
Fix deadlock with `tracing-error` + `fmt::Subscriber`

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -848,20 +848,21 @@ where
 
     fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, C>) {
         let span = ctx.span(id).expect("Span not found, this is a bug");
-        let mut extensions = span.extensions_mut();
-        if let Some(fields) = extensions.get_mut::<FormattedFields<N>>() {
-            let _ = self.fmt_fields.add_fields(fields, values);
-            return;
-        }
 
-        let mut fields = FormattedFields::<N>::new(String::new());
+        let mut new_fields = FormattedFields::<N>::new(String::new());
         if self
             .fmt_fields
-            .format_fields(fields.as_writer().with_ansi(self.is_ansi), values)
+            .format_fields(new_fields.as_writer().with_ansi(self.is_ansi), values)
             .is_ok()
         {
-            fields.was_ansi = self.is_ansi;
-            extensions.insert(fields);
+            new_fields.was_ansi = self.is_ansi;
+        }
+
+        let mut extensions = span.extensions_mut();
+        if let Some(fields) = extensions.get_mut::<FormattedFields<N>>() {
+            let _ = self.fmt_fields.merge_fields(fields, new_fields);
+        } else {
+            extensions.insert(new_fields);
         }
     }
 

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -250,6 +250,34 @@ pub trait FormatFields<'writer> {
         }
         self.format_fields(current.as_writer(), fields)
     }
+
+    /// Merge fields of two [`FormatFields`] instances to add additinal fields
+    /// on an existing spans.
+    ///
+    /// By default, if both the provided formatted fields' sets are non-empty,
+    /// this appends a space to the current set of fields and then the other
+    /// field's contents.  If exactly one of them is non-empty, it is set as the
+    /// current set.
+    ///
+    /// If different behavior is required, the default implementation of this
+    /// method can be overridden.
+    fn merge_fields(
+        &self,
+        current: &'writer mut FormattedFields<Self>,
+        other: FormattedFields<Self>,
+    ) -> fmt::Result {
+        if !current.fields.is_empty() {
+            if !other.fields.is_empty() {
+                current.fields.reserve(other.fields.len() + 1);
+                current.fields.push(' ');
+                current.fields.push_str(&other.fields);
+            }
+        } else {
+            current.fields = other.fields;
+        }
+
+        fmt::Result::Ok(())
+    }
 }
 
 /// Returns the default configuration for an [event formatter].

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -340,6 +340,24 @@ impl<'writer> FormatFields<'writer> for Pretty {
         fields.record(&mut v);
         v.finish()
     }
+
+    fn merge_fields(
+            &self,
+            current: &'writer mut FormattedFields<Self>,
+            other: FormattedFields<Self>,
+        ) -> fmt::Result {
+        match (current.is_empty(), other.is_empty()) {
+            (_, true) => {}
+            (true, false) => { current.fields = other.fields; }
+            (false, false) => {
+                current.fields.reserve(other.fields.len() + 2);
+                current.fields.push_str(", ");
+                current.fields.push_str(&other.fields);
+            }
+        }
+
+        Ok(())
+    }
 }
 
 // === impl PrettyFields ===


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

#1565 

## Solution

I've added a method to the `FormatFields` implementation with a provided default implementation based on what was already in the `add_fields` method. This is potentially a breaking change in a subtle manner as anyone who has manually implemented the `add_fields` method will most likely also want to implement this.

When fields should be printed, they are first printed to a new instance and then they are merged with the original.