### PR TITLE
Make tracing crates consistent about depending on tracing-core without default features

### DIFF
--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -42,7 +42,7 @@ mio = "0.6.23"
 [dev-dependencies]
 futures = "0.3.21"
 tokio-test = "0.4.2"
-tracing-core = { path = "../tracing-core", version = "0.2" }
+tracing-core = { path = "../tracing-core", version = "0.2", default-features = false }
 tracing-mock = { path = "../tracing-mock" }
 tracing-test = { path = "../tracing-test" }
 

--- a/tracing-journald/Cargo.toml
+++ b/tracing-journald/Cargo.toml
@@ -17,11 +17,10 @@ rust-version = "1.63.0"
 
 [dependencies]
 libc = "0.2.126"
-tracing-core = { path = "../tracing-core", version = "0.2" }
+tracing-core = { path = "../tracing-core", version = "0.2", default-features = false }
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry"] }
 
 [dev-dependencies]
 serde_json = "1.0.82"
 serde = { version = "1.0.139", features = ["derive"] }
 tracing = { path = "../tracing", version = "0.2" }
-

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -23,7 +23,7 @@ std = ["log/std"]
 log-tracer = []
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.2"}
+tracing-core = { path = "../tracing-core", version = "0.2", default-features = false }
 log = "0.4.17"
 once_cell = "1.13.0"
 env_logger = { version = "0.8.4", optional = true }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation
Both tracing and tracing-subscriber depend on tracing-core with default-features = false. However, tracing-subscriber also depends on tracing-log (optionally, by but enabled by default), which depends on tracing-core **with** default features. So, building a crate (or workspace) that contains tracing-subscriber, without additional tuning, will build tracing-core **with** default features, even though both tracing-core and tracing-subscriber say they depend on tracing-core without default features.

One subtlety is that in a workspace, if a package is selected (-p/--package) that only depends on tracing-core, they will be built without tracing-core's default features. Consequently, cargo sees a different feature set, and considers it a different "kind" of build, which may be unexpected; e.g. the mangled symbol names will have a different [hash suffix (as per the current, "legacy" mangling scheme)](https://rust-lang.github.io/rfcs/2603-rust-symbol-name-mangling-v0.html#requirements-for-a-symbol-mangling-scheme).

More concretely, one can observe that after building the whole workspace, building the specific package (that only depends on tracing core) isn't a "no-op", since it has a different feature set. Arguably, such a build is unnecessary.

For me, the different feature set and subsequent hashes caused problems when generating and inspecting LLVM IR for a specific crate in a package; of course, I expect the number of other users who have been impacted by the above described edge case minimal.

Also, I'm not 100% sure, but this may create problems for users who transitively depended on tracing-core with default features, without explicitly stating it, since now tracing-core will be included without default features.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Set `default-features = false` for tracing-core dependency in tracing-log, tracing-journald, and tracing-futures.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
