### PR TITLE
attributes: force instrumented function to be `FnOnce`

### DIFF
--- a/tracing-attributes/tests/async_fn.rs
+++ b/tracing-attributes/tests/async_fn.rs
@@ -83,6 +83,34 @@ fn repro_1831_2() -> impl Future<Output = Result<(), Infallible>> {
     async { Ok(()) }
 }
 
+// This checks that a Fn or FnMut can be instrumented
+#[allow(dead_code)] // this is just here to test whether it compiles.
+#[tracing::instrument(ret(Debug))]
+fn repro_2857(x: &mut ()) -> &mut () {
+    x
+}
+
+// This checks that a Fn or FnMut can be instrumented
+#[allow(dead_code)] // this is just here to test whether it compiles.
+#[tracing::instrument(ret(Debug))]
+async fn repro_2857_2(x: &mut ()) -> &mut () {
+    x
+}
+
+// This checks that a Fn or FnMut can be instrumented
+#[allow(dead_code)] // this is just here to test whether it compiles.
+#[tracing::instrument(err(Debug))]
+fn repro_2857_3(x: &()) -> Result<(), &()> {
+    Ok(())
+}
+
+// This checks that a Fn or FnMut can be instrumented
+#[allow(dead_code)] // this is just here to test whether it compiles.
+#[tracing::instrument(err(Debug))]
+async fn repro_2857_4(x: &()) -> Result<(), &()> {
+    Ok(())
+}
+
 #[test]
 fn async_fn_only_enters_for_polls() {
     let (subscriber, handle) = subscriber::mock()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

Closes #2857 


## Motivation

Functions which are `Fn` or `FnMut` fail to compile when they are instrumented with `#[instrument(ret)]`

## Solution

I've added a non-copy zst (`[&mut (), 0]`) to the generated code that is moved inside the function so that it is forced to be no more than `FnOnce`.
