### PR TITLE
docs: enable and clean up ignored doc tests

### DIFF
--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -279,9 +279,10 @@ pub trait Subscriber: 'static {
     /// but values for them won't be recorded at this time.
     ///
     /// ```rust,ignore
-    /// use tracing::{field::Empty, span};
+    /// # // This is ignored because we cannot depend on `tracing::span`
+    /// use tracing::{field::Empty, info_span};
     ///
-    /// let mut span = span!("my_span", foo = 3, bar = Empty, baz = Empty);
+    /// let mut span = info_span!("my_span", foo = 3, bar = Empty, baz = Empty);
     ///
     /// // `Subscriber::record` will be called with a `Record`
     /// // containing "bar = false"

--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -279,9 +279,9 @@ pub trait Subscriber: 'static {
     /// but values for them won't be recorded at this time.
     ///
     /// ```rust,ignore
-    /// # use tracing::span;
+    /// use tracing::{field::Empty, span};
     ///
-    /// let mut span = span!("my_span", foo = 3, bar, baz);
+    /// let mut span = span!("my_span", foo = 3, bar = Empty, baz = Empty);
     ///
     /// // `Subscriber::record` will be called with a `Record`
     /// // containing "bar = false"

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -134,8 +134,7 @@ pub trait Instrument: Sized {
     ///
     /// Instrumenting a future:
     ///
-    // TODO: ignored until async-await is stable...
-    /// ```rust,ignore
+    /// ```rust
     /// use tracing_futures::Instrument;
     ///
     /// # async fn doc() {
@@ -170,8 +169,7 @@ pub trait Instrument: Sized {
     ///
     /// # Examples
     ///
-    // TODO: ignored until async-await is stable...
-    /// ```rust,ignore
+    /// ```rust
     /// use tracing_futures::Instrument;
     ///
     /// # async fn doc() {
@@ -184,7 +182,8 @@ pub trait Instrument: Sized {
     ///     tracing::debug!("this event will occur inside `my_span`");
     ///     // ...
     /// };
-    /// tokio::spawn(future.in_current_span());
+    ///
+    /// future.in_current_span().await;
     /// # }
     /// ```
     ///

--- a/tracing-subscriber/src/filter/layer_filters/combinator.rs
+++ b/tracing-subscriber/src/filter/layer_filters/combinator.rs
@@ -66,6 +66,7 @@ where
     /// above a certain level:
     ///
     /// ```ignore
+    /// # // Ignored because this uses a private API
     /// use tracing_subscriber::{
     ///     filter::{filter_fn, LevelFilter, combinator::And},
     ///     prelude::*,
@@ -216,6 +217,7 @@ where
     /// and events with a particular target:
     ///
     /// ```ignore
+    /// # // Ignored because this uses a private API
     /// use tracing_subscriber::{
     ///     filter::{filter_fn, LevelFilter, combinator::Or},
     ///     prelude::*,
@@ -255,6 +257,7 @@ where
     /// conjunction with the [`And`] combinator:
     ///
     /// ```ignore
+    /// # // Ignored because this uses a private API
     /// use tracing_subscriber::{
     ///     filter::{filter_fn, LevelFilter, combinator},
     ///     prelude::*,

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -133,9 +133,12 @@
 //! variables, you can use the [`EnvFilter`] as follows:
 //!
 //! ```rust
+//! # #[cfg(feature = "env-filter")]
+//! # {
 //! use tracing_subscriber::EnvFilter;
 //!
 //! let filter = EnvFilter::from_default_env();
+//! # }
 //! ```
 //!
 //! As mentioned above, the [`EnvFilter`] allows `Span`s and `Event`s to
@@ -166,6 +169,8 @@
 //! Composing an [`EnvFilter`] `Layer` and a [format `Layer`][super::fmt::Layer]:
 //!
 //! ```rust
+//! # #[cfg(feature = "env-filter")]
+//! # {
 //! use tracing_subscriber::{fmt, EnvFilter};
 //! use tracing_subscriber::prelude::*;
 //!
@@ -179,6 +184,7 @@
 //!     .with(filter_layer)
 //!     .with(fmt_layer)
 //!     .init();
+//! # }
 //! ```
 //!
 //! [`EnvFilter`]: super::filter::EnvFilter
@@ -1231,10 +1237,13 @@ pub fn try_init() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 /// If the `env-filter` feature is enabled, this is shorthand for
 ///
 /// ```rust
+/// # #[cfg(feature = "env-filter")]
+/// # {
 /// # use tracing_subscriber::EnvFilter;
 /// tracing_subscriber::fmt()
 ///     .with_env_filter(EnvFilter::from_default_env())
 ///     .init();
+/// # }
 /// ```
 ///
 /// # Panics

--- a/tracing-subscriber/src/fmt/time/time_crate.rs
+++ b/tracing-subscriber/src/fmt/time/time_crate.rs
@@ -336,7 +336,10 @@ impl OffsetTime<well_known::Rfc3339> {
     /// ```
     /// use tracing_subscriber::fmt::time::OffsetTime;
     ///
+    /// # /*
     /// #[tokio::main]
+    /// # */
+    /// # #[tokio::main(flavor = "current_thread")]
     /// async fn run() {
     ///     tracing::info!("runtime initialized");
     ///

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -155,9 +155,9 @@
 //! fields using `fmt::Debug`.
 //!
 //! For example:
-//! ```ignore
-//! # // this doctest is ignored because we don't have a way to say
-//! # // that it should only be run with cfg(feature = "attributes")
+//! ```
+//! # #[cfg(feature = "attributes")]
+//! # {
 //! use tracing::{Level, event, instrument};
 //!
 //! #[instrument]
@@ -168,6 +168,7 @@
 //!     // ...
 //! }
 //! # fn main() {}
+//! # }
 //! ```
 //!
 //! For functions which don't have built-in tracing support and can't have

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -481,7 +481,7 @@
 //!
 //! Let's consider the `log` crate's yak-shaving example:
 //!
-//! ```rust,ignore
+//! ```rust
 //! use std::{error::Error, io};
 //! use tracing::{debug, error, info, span, warn, Level};
 //!

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -662,7 +662,7 @@ impl Span {
     ///   the future yields.
     ///
     ///   `Instrument` can be used with an async block inside an async function:
-    ///   ```ignore
+    ///   ```rust
     ///   # use tracing::info_span;
     ///   use tracing::Instrument;
     ///
@@ -686,7 +686,7 @@ impl Span {
     ///
     ///   It can also be used to instrument calls to async functions at the
     ///   callsite:
-    ///   ```ignore
+    ///   ```rust
     ///   # use tracing::debug_span;
     ///   use tracing::Instrument;
     ///
@@ -703,7 +703,7 @@ impl Span {
     /// * The [`#[instrument]` attribute macro][attr] can automatically generate
     ///   correct code when used on an async function:
     ///
-    ///   ```ignore
+    ///   ```rust
     ///   # async fn some_other_async_function() {}
     ///   #[tracing::instrument(level = "info")]
     ///   async fn my_async_function() {


### PR DESCRIPTION

## Motivation

Some tests were ignored with a TODO to enable them.

The doc-test for `Subscriber::record` provides misleading code that does not compile.

## Solution

I enabled the tests that can be enabled.

I fixed the usage of omitted fields in `Subscriber::record` docs, but since the example uses a macro from `tracing`, it cannot be enabled.
