### PR TITLE
Document that `OffsetTime::local_rfc_3339()` requires the `local-time` feature

### DIFF
--- a/tracing-subscriber/src/fmt/time/time_crate.rs
+++ b/tracing-subscriber/src/fmt/time/time_crate.rs
@@ -312,6 +312,7 @@ where
 
 // === impl OffsetTime ===
 
+#[cfg_attr(docsrs, doc(cfg(feature = "local-time")))]
 #[cfg(feature = "local-time")]
 impl OffsetTime<well_known::Rfc3339> {
     /// Returns a formatter that formats the current time using the [local time offset] in the [RFC


### PR DESCRIPTION
I was trying to use this method in my own code, but clippy kept saying it didn't exist despite me enabling the "time" feature, and felt like I was having a stroke until I checked the source and saw that this particular method also needs "local-time".