### PR TITLE
Owo color

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -39,7 +39,7 @@ bytes = "1.2.0"
 argh = "0.1.8"
 
 # sloggish example
-nu-ansi-term = "0.46.0"
+owo-colors = "4.0"
 humantime = "2.1.0"
 log = "0.4.17"
 

--- a/examples/examples/sloggish/sloggish_collector.rs
+++ b/examples/examples/sloggish/sloggish_collector.rs
@@ -1,4 +1,4 @@
-use nu_ansi_term::{Color, Style};
+use owo_colors::OwoColorize;
 use tracing::{
     field::{Field, Visit},
     Collect, Id, Level, Metadata,
@@ -79,13 +79,12 @@ struct ColorLevel<'a>(&'a Level);
 impl<'a> fmt::Display for ColorLevel<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self.0 {
-            Level::TRACE => Color::Purple.paint("TRACE"),
-            Level::DEBUG => Color::Blue.paint("DEBUG"),
-            Level::INFO => Color::Green.paint("INFO "),
-            Level::WARN => Color::Yellow.paint("WARN "),
-            Level::ERROR => Color::Red.paint("ERROR"),
+            Level::TRACE => "TRACE".purple().fmt(f),
+            Level::DEBUG => "DEBUG".blue().fmt(f),
+            Level::INFO => "INFO".green().fmt(f),
+            Level::WARN => "WARN".yellow().fmt(f),
+            Level::ERROR => "ERROR".red().fmt(f),
         }
-        .fmt(f)
     }
 }
 
@@ -117,21 +116,9 @@ impl<'a> Visit for Event<'a> {
         .unwrap();
         let name = field.name();
         if name == "message" {
-            write!(
-                &mut self.stderr,
-                "{}",
-                // Have to alloc here due to `nu_ansi_term`'s API...
-                Style::new().bold().paint(format!("{:?}", value))
-            )
-            .unwrap();
+            write!(&mut self.stderr, "{:?}", value.bold()).unwrap();
         } else {
-            write!(
-                &mut self.stderr,
-                "{}: {:?}",
-                Style::new().bold().paint(name),
-                value
-            )
-            .unwrap();
+            write!(&mut self.stderr, "{}: {:?}", name.bold(), value).unwrap();
         }
         self.comma = true;
     }
@@ -162,16 +149,10 @@ impl SloggishCollector {
     {
         let mut kvs = kvs.into_iter();
         if let Some((k, v)) = kvs.next() {
-            write!(
-                writer,
-                "{}{}: {}",
-                leading,
-                Style::new().bold().paint(k.as_ref()),
-                v
-            )?;
+            write!(writer, "{}{}: {}", leading, k.as_ref().bold(), v)?;
         }
         for (k, v) in kvs {
-            write!(writer, ", {}: {}", Style::new().bold().paint(k.as_ref()), v)?;
+            write!(writer, ", {}: {}", k.as_ref().bold(), v)?;
         }
         Ok(())
     }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -29,7 +29,7 @@ alloc = ["tracing-core/alloc"]
 std = ["alloc", "tracing-core/std"]
 env-filter = ["matchers", "regex", "once_cell", "tracing", "std", "thread_local"]
 fmt = ["registry", "std"]
-ansi = ["fmt", "nu-ansi-term"]
+ansi = ["fmt", "owo-colors"]
 registry = ["sharded-slab", "thread_local", "std"]
 json = ["tracing-serde", "serde", "serde_json"]
 
@@ -49,7 +49,7 @@ once_cell = { optional = true, version = "1.13.0" }
 
 # fmt
 tracing-log = { path = "../tracing-log", version = "0.2", optional = true, default-features = false, features = ["log-tracer", "std"] }
-nu-ansi-term = { version = "0.46.0", optional = true }
+owo-colors = { version = "4.0", optional = true }
 time = { version = "0.3.2", features = ["formatting"], optional = true }
 
 # only required by the json feature

--- a/tracing-subscriber/src/filter/env/builder.rs
+++ b/tracing-subscriber/src/filter/env/builder.rs
@@ -210,45 +210,39 @@ impl Builder {
         }
 
         if !disabled.is_empty() {
-            #[cfg(feature = "nu_ansi_term")]
-            use nu_ansi_term::{Color, Style};
+            #[cfg(feature = "ansi")]
+            use owo_colors::{OwoColorize, XtermColors};
             // NOTE: We can't use a configured `MakeWriter` because the EnvFilter
             // has no knowledge of any underlying subscriber or collector, which
             // may or may not use a `MakeWriter`.
             let warn = |msg: &str| {
-                #[cfg(not(feature = "nu_ansi_term"))]
+                #[cfg(not(feature = "ansi"))]
                 let msg = format!("warning: {}", msg);
-                #[cfg(feature = "nu_ansi_term")]
-                let msg = {
-                    let bold = Style::new().bold();
-                    let mut warning = Color::Yellow.paint("warning");
-                    warning.style_ref_mut().is_bold = true;
-                    format!("{}{} {}", warning, ":".style(bold), msg.style(bold))
-                };
+                #[cfg(feature = "ansi")]
+                let msg = { format!("{}{} {}", "warning".yellow().bold(), ":".bold(), msg.bold()) };
                 eprintln!("{}", msg);
             };
             let ctx_prefixed = |prefix: &str, msg: &str| {
-                #[cfg(not(feature = "nu_ansi_term"))]
+                #[cfg(not(feature = "ansi"))]
                 let msg = format!("{} {}", prefix, msg);
-                #[cfg(feature = "nu_ansi_term")]
+                #[cfg(feature = "ansi")]
                 let msg = {
-                    let mut equal = Color::Fixed(21).paint("="); // dark blue
-                    equal.style_ref_mut().is_bold = true;
-                    format!(" {} {} {}", equal, Style::new().bold().paint(prefix), msg)
+                    format!(
+                        " {} {} {}",
+                        "=".color(XtermColors::Blue).bold(),
+                        prefix.bold(),
+                        msg
+                    )
                 };
                 eprintln!("{}", msg);
             };
             let ctx_help = |msg| ctx_prefixed("help:", msg);
             let ctx_note = |msg| ctx_prefixed("note:", msg);
             let ctx = |msg: &str| {
-                #[cfg(not(feature = "nu_ansi_term"))]
+                #[cfg(not(feature = "ansi"))]
                 let msg = format!("note: {}", msg);
-                #[cfg(feature = "nu_ansi_term")]
-                let msg = {
-                    let mut pipe = Color::Fixed(21).paint("|");
-                    pipe.style_ref_mut().is_bold = true;
-                    format!(" {} {}", pipe, msg)
-                };
+                #[cfg(feature = "ansi")]
+                let msg = { format!(" {} {}", "|".color(XtermColors::Blue).bold(), msg) };
                 eprintln!("{}", msg);
             };
             warn("some trace filter directives would enable traces that are disabled statically");

--- a/tracing-subscriber/src/filter/env/builder.rs
+++ b/tracing-subscriber/src/filter/env/builder.rs
@@ -223,7 +223,7 @@ impl Builder {
                     let bold = Style::new().bold();
                     let mut warning = Color::Yellow.paint("warning");
                     warning.style_ref_mut().is_bold = true;
-                    format!("{}{} {}", warning, bold.paint(":"), bold.paint(msg))
+                    format!("{}{} {}", warning, ":".style(bold), msg.style(bold))
                 };
                 eprintln!("{}", msg);
             };

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1732,7 +1732,7 @@ pub(super) mod test {
     #[cfg(feature = "ansi")]
     #[test]
     fn with_ansi_true() {
-        let expected = "\u{1b}[2mfake time\u{1b}[0m \u{1b}[32m INFO\u{1b}[0m \u{1b}[2mtracing_subscriber::fmt::format::test\u{1b}[0m\u{1b}[2m:\u{1b}[0m hello\n";
+        let expected = "\u{1b}[2mfake time\u{1b}[0m \u{1b}[32m INFO\u{1b}[39m \u{1b}[2mtracing_subscriber::fmt::format::test\u{1b}[0m\u{1b}[2m:\u{1b}[0m hello\n";
         assert_info_hello_ansi(true, expected);
     }
 

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -233,7 +233,11 @@ where
         v.finish()?;
         writer.write_char('\n')?;
 
-        let dimmed = writer.dimmed_style();
+        let dimmed_italic = if writer.has_ansi_escapes() {
+            Style::new().dimmed().italic()
+        } else {
+            Style::new()
+        };
         let thread = self.display_thread_name || self.display_thread_id;
 
         if let (Some(file), true, true) = (
@@ -241,7 +245,7 @@ where
             self.format.display_location,
             self.display_filename,
         ) {
-            write!(writer, "    {} {}", dimmed.paint("at"), file,)?;
+            write!(writer, "    {} {}", dimmed_italic.paint("at"), file,)?;
 
             if let Some(line) = line_number {
                 write!(writer, ":{}", line)?;
@@ -252,7 +256,7 @@ where
         };
 
         if thread {
-            write!(writer, "{} ", dimmed.paint("on"))?;
+            write!(writer, "{} ", dimmed_italic.paint("on"))?;
             let thread = std::thread::current();
             if self.display_thread_name {
                 if let Some(name) = thread.name() {
@@ -282,7 +286,7 @@ where
                 write!(
                     writer,
                     "    {} {}::{}",
-                    dimmed.paint("in"),
+                    dimmed_italic.paint("in"),
                     meta.target(),
                     bold.paint(meta.name()),
                 )?;
@@ -290,7 +294,7 @@ where
                 write!(
                     writer,
                     "    {} {}",
-                    dimmed.paint("in"),
+                    dimmed_italic.paint("in"),
                     bold.paint(meta.name()),
                 )?;
             }
@@ -300,7 +304,7 @@ where
                 .get::<FormattedFields<N>>()
                 .expect("Unable to find FormattedFields in extensions; this is a bug");
             if !fields.is_empty() {
-                write!(writer, " {} {}", dimmed.paint("with"), fields)?;
+                write!(writer, " {} {}", dimmed_italic.paint("with"), fields)?;
             }
             writer.write_char('\n')?;
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation
Fix #2759 

## Solution
Replaced nu-ansi-term with owo-colors. 

I then ran all the unit tests `cargo test`, and tested the `cargo run --example sloggish` and `cargo run --example fmt-pretty` examples. I did my best to verify that the output hasn't changed.

## Questions

During development, rust-analyzer always shows me bogus error messages and I'm not entirely sure what I'm doing wrong. I frequently ended up having to work with `cargo check` and a bit of guesswork.
![image](https://github.com/tokio-rs/tracing/assets/10220080/60b98508-86bf-446e-8bf2-d95a7b4de446)

### Old fmt-pretty output

![image](https://github.com/tokio-rs/tracing/assets/10220080/3f476102-7116-4087-adad-33c2b542f499)

### New, visually unchanged fmt-pretty output

![image](https://github.com/tokio-rs/tracing/assets/10220080/a8c9eea3-240c-484f-b95e-ea5aac748592)
