### PR TITLE
macros: Fix if_log_enabled condition.

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -3129,7 +3129,7 @@ macro_rules! if_log_enabled {
         $crate::if_log_enabled! { $lvl, $if_log else {} }
     };
     ($lvl:expr, $if_log:block else $else_block:block) => {
-        if $crate::level_to_log!($lvl) <= $crate::log::STATIC_MAX_LEVEL {
+        if $crate::level_to_log!($lvl) > $crate::log::STATIC_MAX_LEVEL {
             if !$crate::dispatch::has_been_set() {
                 $if_log
             } else {
@@ -3152,7 +3152,7 @@ macro_rules! if_log_enabled {
         $crate::if_log_enabled! { $lvl, $if_log else {} }
     };
     ($lvl:expr, $if_log:block else $else_block:block) => {
-        if $crate::level_to_log!($lvl) <= $crate::log::STATIC_MAX_LEVEL {
+        if $crate::level_to_log!($lvl) > $crate::log::STATIC_MAX_LEVEL {
             #[allow(unused_braces)]
             $if_log
         } else {


### PR DESCRIPTION
Prior to this patch the feature 'max_level_info' failed to prevent codegen from the expansion of `debug!` and `trace!` macros. Indeed their logging output was muted as expected, but code was still being generated for them; explaining how this could remain unnoticed.

Furthermore, after this patch without 'max_level_info' featured, the macros expand to approximately half the amount of code than before.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
