### PR TITLE
macros: Allow field path segments to be keywords

### DIFF
--- a/tracing-attributes/tests/fields.rs
+++ b/tracing-attributes/tests/fields.rs
@@ -34,6 +34,9 @@ fn fn_string(s: String) {
     let _ = s;
 }
 
+#[instrument(fields(keywords.impl.type.fn = _arg), skip(_arg))]
+fn fn_keyword_ident_in_field(_arg: &str) {}
+
 #[derive(Debug)]
 struct HasField {
     my_field: &'static str,
@@ -144,6 +147,16 @@ fn string_field() {
     run_test(span, || {
         fn_string(String::from("hello world"));
     });
+}
+
+#[test]
+fn keyword_ident_in_field_name() {
+    let span = expect::span().with_fields(
+        expect::field("keywords.impl.type.fn")
+            .with_value(&"test")
+            .only(),
+    );
+    run_test(span, || fn_keyword_ident_in_field("test"));
 }
 
 fn run_test<F: FnOnce() -> T, T>(span: NewSpan, fun: F) {

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -3069,8 +3069,8 @@ macro_rules! level_to_log {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __tracing_stringify {
-    ($s:expr) => {
-        stringify!($s)
+    ($($t:tt)*) => {
+        stringify!($($t)*)
     };
 }
 

--- a/tracing/tests/event.rs
+++ b/tracing/tests/event.rs
@@ -497,3 +497,15 @@ fn constant_field_name() {
 
     handle.assert_finished();
 }
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn keyword_ident_in_field_name() {
+    let (collector, handle) = collector::mock()
+        .event(expect::event().with_fields(expect::field("crate").with_value(&"tracing")))
+        .only()
+        .run_with_handle();
+
+    with_default(collector, || error!(crate = "tracing", "message"));
+    handle.assert_finished();
+}

--- a/tracing/tests/span.rs
+++ b/tracing/tests/span.rs
@@ -7,6 +7,7 @@ use std::thread;
 
 use tracing::{
     collect::with_default,
+    error_span,
     field::{debug, display},
     Level, Span,
 };
@@ -864,5 +865,22 @@ fn constant_field_name() {
         );
     });
 
+    handle.assert_finished();
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn keyword_ident_in_field_name_span_macro() {
+    #[derive(Debug)]
+    struct Foo;
+
+    let (collector, handle) = collector::mock()
+        .new_span(expect::span().with_fields(expect::field("self").with_value(&debug(Foo)).only()))
+        .only()
+        .run_with_handle();
+
+    with_default(collector, || {
+        error_span!("span", self = ?Foo);
+    });
     handle.assert_finished();
 }


### PR DESCRIPTION
## Motivation

Currently, a keyword like `type` fails compilation as (a path segment of) a field name, for no clear reason. Trying to use `r#type` instead leads to the `r#` being part of the field name, which is unhelpful¹. 

## Solution

Don't require the field path to match a `macro_rules!` `expr`, use repeated `tt` instead. I can't tell why this was ever required: The internal stringify macro was introduced in https://github.com/tokio-rs/tracing/commit/55091c92edb537bfc126e32f1f24acd614ad9fe0#diff-315c02cd05738da173861537577d159833f70f79cfda8cd7cf1a0d7a28ace31b with an `expr` matcher without any explanation, and no tests are failing from making it match upstream's `stringify!` input format.

Special thanks to whoever implemented the unstable `macro-backtrace` feature in rustc, otherwise this would have been nigh impossible to track down!

¹ this can likely be fixed too by some sort of "unraw" macro that turns `r#foo` into `foo`, but that's a separate change not made in this PR