### PR TITLE
tracing: add record! macro

### DIFF
--- a/examples/examples/record.rs
+++ b/examples/examples/record.rs
@@ -1,0 +1,29 @@
+//! An example of using the [`record`][crate::record] macro to add a field to a span.
+#![deny(rust_2018_idioms)]
+#![allow(clippy::try_err)]
+
+use rand::{seq::SliceRandom, thread_rng};
+use tracing::{instrument, record};
+
+fn main() {
+    tracing_subscriber::fmt()
+        // enable everything
+        .with_max_level(tracing::Level::TRACE)
+        // sets this to be the default, global collector for this application.
+        .init();
+
+    do_something();
+}
+
+#[instrument(fields(important_number = tracing::field::Empty))]
+fn do_something() {
+    let important_number = get_important_number();
+    record!("important_number", %important_number);
+
+    tracing::info!("log entry with important number");
+}
+
+fn get_important_number() -> u8 {
+    let numbers = [42, 13];
+    *numbers.choose(&mut thread_rng()).unwrap()
+}

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -3160,3 +3160,19 @@ macro_rules! if_log_enabled {
         }
     };
 }
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! record {
+    ($field:expr, %$value:expr) => {
+        $crate::record!($field, ::tracing::field::display(&$value))
+    };
+    ($field:expr, ?$value:expr) => {
+        $crate::record!($field, ::tracing::field::debug(&$value))
+    };
+    ($field:expr, $value:expr) => {{
+        #[allow(unused)]
+        use ::tracing::field::{debug, display};
+        ::tracing::Span::current().record($field, $value);
+    }};
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->
Add a macro that provides a more consise way of recording a new value for a field.

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
The ability to record updated values for a span is very useful. However, it can be a bit verbose, and for what I assume is the most common scenario, adding fields to the current span, the update can quickly capture four lines in an already-busy function.

Here's an example from a code base I'm contributing to, with some names changed, using a helper function to format a `time::Instant` value inside of a `tracing::Span::record` call:

```rust
impl RetroEncabulator for AcmeEncabulator {
    #[tracing::instrument(fields(request.start = tracing::field::Empty, request.deadline = tracing::field::Empty))]
    async fn prevent_sidefumbling(&self, foo: Bar, baz: Qux) {
        /* omitted for brevity */

        tracing::Span::current().record(
            "request.start",
            tracing::field::display(display_instant(start)),
        );
        tracing::Span::current().record(
            "request.deadline",
            tracing::field::display(display_instant(deadline)),
        );

        /* ... etc */
    }
}
```

## Solution

My proposal is to add a way to record a field on the current span. This PR has one such implementation, which, using the code sample above, gives:

```rust
impl RetroEncabulator for AcmeEncabulator {
    #[tracing::instrument(fields(request.start = tracing::field::Empty, request.deadline = tracing::field::Empty))]
    async fn prevent_sidefumbling(&self, foo: Bar, baz: Qux) {
        /* omitted for brevity */

        tracing::record!("request.start", %display_instant(start));
        tracing::record!("request.deadline", %display_instant(deadline));

        /* ... etc */
    }
}
```

I'm open to other suggestions, of course, and if the maintainers agree that this is something that should be solved in the `tracing` package, I need some help figuring out where such an implementation belongs. This example implementation "feels" right as `tracing::field::record!`, but I've yet to fully understand how macro exports work.