### PR TITLE
tracing-subscriber: bump nu-ansi-term to v0.50.0

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -49,7 +49,7 @@ once_cell = { optional = true, version = "1.13.0" }
 
 # fmt
 tracing-log = { path = "../tracing-log", version = "0.2", optional = true, default-features = false, features = ["log-tracer", "std"] }
-nu-ansi-term = { version = "0.46.0", optional = true }
+nu-ansi-term = { version = "0.50.0", optional = true }
 time = { version = "0.3.2", features = ["formatting"], optional = true }
 
 # only required by the json feature


### PR DESCRIPTION
## Motivation

Dependency was outdated and depended on obsolete dependencies, as can be seen in https://crates.io/crates/nu-ansi-term/0.46.0/dependencies

## Solution

Update it and solve the problem https://crates.io/crates/nu-ansi-term/0.50.0/dependencies