### PR TITLE
parse only comma-less field part as field

### DIFF
--- a/tracing-subscriber/src/filter/env/directive.rs
+++ b/tracing-subscriber/src/filter/env/directive.rs
@@ -192,8 +192,8 @@ impl Directive {
                     .name("fields")
                     .map(|c| {
                         FIELD_FILTER_RE
-                            .find_iter(c.as_str())
-                            .map(|c| field::Match::parse(c.as_str(), regex))
+                            .captures_iter(c.as_str())
+                            .map(|c| field::Match::parse(c.get(1).unwrap().as_str(), regex))
                             .collect::<Result<Vec<_>, _>>()
                     })
                     .unwrap_or_else(|| Ok(Vec::new()));

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -924,7 +924,7 @@ mod tests {
 
     #[test]
     fn callsite_enabled_includes_span_directive_multiple_fields() {
-        let filter = EnvFilter::new("app[mySpan{field=\"value\",field2=2}]=debug")
+        let filter = EnvFilter::try_new("app[mySpan{field=\"value\",field2=2}]=debug").unwrap()
             .with_collector(NoCollector);
         static META: &Metadata<'static> = &Metadata::new(
             "mySpan",
@@ -939,6 +939,20 @@ mod tests {
 
         let interest = filter.register_callsite(META);
         assert!(interest.is_never());
+        
+        static META2: &Metadata<'static> = &Metadata::new(
+            "mySpan",
+            "app",
+            Level::TRACE,
+            None,
+            None,
+            None,
+            FieldSet::new(&["field", "field2"], identify_callsite!(&Cs)),
+            Kind::SPAN,
+        );
+
+        let interest = filter.register_callsite(META);
+        assert!(interest.is_always());
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

Multiple field parsing is broken: even if proper string is passed to the parser, commas are parsed as part of the field
This partially fixes #2935
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Pass only 1st capture group to the field parser, instead of the whole string

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
