### PR TITLE
tracing_subscriber: add additional fields for printing to json fmt subscriber

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,8 @@ This directory contains a collection of examples that demonstrate the use of the
     both the terminal and the system journal.
   + `toggle-subscribers` : Demonstrates how subscribers can be wrapped with an `Option` allowing
     them to be dynamically toggled.
+  + `fmt-additional-fields`: Demonstrates how to create a subscriber that enriches
+    the `fmt` collector with additional information.
 - **tracing-futures**:
   + `spawny-thing`: Demonstrates the use of the `#[instrument]` attribute macro
     asynchronous functions.

--- a/examples/examples/fmt-additional-fields.rs
+++ b/examples/examples/fmt-additional-fields.rs
@@ -1,0 +1,73 @@
+#![deny(rust_2018_idioms)]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tracing::{span, Collect};
+use tracing_subscriber::{
+    fmt::format::AdditionalFmtSpanFields,
+    registry::LookupSpan,
+    subscribe::{CollectExt, Context},
+    util::SubscriberInitExt,
+    Subscribe,
+};
+#[path = "fmt/yak_shave.rs"]
+mod yak_shave;
+
+struct CountingSubscribe(AtomicUsize);
+
+impl<C: Collect + for<'lookup> LookupSpan<'lookup>> Subscribe<C> for CountingSubscribe {
+    fn on_new_span(&self, _attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, C>) {
+        // Find the span.
+        let span = ctx
+            .span(id)
+            .expect("The span should exist in the registry.");
+
+        // Get its extensions.
+        let mut extensions = span.extensions_mut();
+
+        // Find the additional fields in the extensions or create new ones. It's
+        // important to always look for a previous value as another layer may
+        // have already added some fields.
+        let mut additional_fields = extensions
+            .remove::<AdditionalFmtSpanFields>()
+            .unwrap_or_default();
+
+        // Add something to the fields.
+        let ordinal = self.0.fetch_add(1, Ordering::Relaxed);
+        additional_fields.insert("ordinal".to_owned(), ordinal.to_string());
+
+        // And don't forget to then put the additional fields into the extensions!
+        extensions.insert(additional_fields);
+    }
+}
+
+fn main() {
+    tracing_subscriber::fmt()
+        // Use json output...
+        .json()
+        // Enable additional span fields.
+        .with_additional_span_fields(true)
+        // Disable things not needed for the example to make the output more readable.
+        .with_span_list(false)
+        .without_time()
+        .with_target(false)
+        // Enable all levels.
+        .with_max_level(tracing::Level::TRACE)
+        // Create the collector...
+        .finish()
+        // and add our enriching subscriber as another layer.
+        // Try removing this and see what changes in the output!
+        .with(CountingSubscribe(AtomicUsize::new(0)))
+        // Set this to be the default, global collector for this application.
+        .init();
+
+    let number_of_yaks = 3;
+    // this creates a new event, outside of any spans.
+    tracing::info!(number_of_yaks, "preparing to shave yaks");
+
+    let number_shaved = yak_shave::shave_all(number_of_yaks);
+    tracing::info!(
+        all_yaks_shaved = number_shaved == number_of_yaks,
+        "yak shaving completed."
+    );
+}

--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -638,6 +638,24 @@ impl<C, T, W> Subscriber<C, format::JsonFields, format::Format<format::Json, T>,
             ..self
         }
     }
+
+    /// Sets whether or not the JSON subscriber being built will include
+    /// additional span fields dynamically added by
+    /// [`Subscribe`](crate::Subscribe) implementations in formatted events.
+    ///
+    /// See [`format::Json`] for details.
+    pub fn with_additional_span_fields(
+        self,
+        display_additional_span_fields: bool,
+    ) -> Subscriber<C, format::JsonFields, format::Format<format::Json, T>, W> {
+        Subscriber {
+            fmt_event: self
+                .fmt_event
+                .with_additional_span_fields(display_additional_span_fields),
+            fmt_fields: format::JsonFields::new(),
+            ..self
+        }
+    }
 }
 
 impl<C, N, E, W> Subscriber<C, N, E, W> {

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -815,6 +815,23 @@ impl<T, F, W> CollectorBuilder<format::JsonFields, format::Format<format::Json, 
             inner: self.inner.with_span_list(display_span_list),
         }
     }
+
+    /// Sets whether or not the JSON subscriber being built will include
+    /// additional span fields dynamically added by
+    /// [`Subscribe`](crate::Subscribe) implementations in formatted events.
+    ///
+    /// See [`format::Json`] for details.
+    pub fn with_additional_span_fields(
+        self,
+        display_additional_span_fields: bool,
+    ) -> CollectorBuilder<format::JsonFields, format::Format<format::Json, T>, F, W> {
+        CollectorBuilder {
+            filter: self.filter,
+            inner: self
+                .inner
+                .with_additional_span_fields(display_additional_span_fields),
+        }
+    }
 }
 
 impl<N, E, F, W> CollectorBuilder<N, E, reload::Subscriber<F>, W>

--- a/tracing-subscriber/tests/json_additional_fields.rs
+++ b/tracing-subscriber/tests/json_additional_fields.rs
@@ -1,0 +1,82 @@
+#![cfg(all(feature = "fmt", feature = "json"))]
+//! This test is mostly the same as one in
+//! `tracing_subscriber::fmt::format::json`, but having an integration test also
+//! checks that all the necessary APIs are accessible from outside the crate.
+use std::{
+    io,
+    sync::{Arc, Mutex},
+};
+
+use tracing::{collect::with_default, span, Collect};
+use tracing_subscriber::{
+    fmt::{format::AdditionalFmtSpanFields, CollectorBuilder},
+    registry::LookupSpan,
+    subscribe::{self, CollectExt},
+    Subscribe,
+};
+
+#[derive(Clone)]
+struct MockWriter(Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for MockWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.lock().unwrap().flush()
+    }
+}
+
+struct InjectingSubscriber;
+impl<C: Collect + for<'lookup> LookupSpan<'lookup>> Subscribe<C> for InjectingSubscriber {
+    fn on_new_span(
+        &self,
+        _attrs: &span::Attributes<'_>,
+        id: &span::Id,
+        ctx: subscribe::Context<'_, C>,
+    ) {
+        let mut additional = AdditionalFmtSpanFields::default();
+        additional.insert("additional".to_owned(), "value".to_owned());
+        let span_ref = ctx.span(id).unwrap();
+        let mut extensions = span_ref.extensions_mut();
+        extensions.insert(additional);
+    }
+}
+
+#[test]
+fn json_additional_fields() {
+    let expected =
+    "{\"level\":\"INFO\",\"span\":{\"answer\":42,\"name\":\"json_span\",\"number\":3,\"additional\":\"value\"},\"spans\":[{\"answer\":42,\"name\":\"json_span\",\"number\":3,\"additional\":\"value\"}],\"fields\":{\"message\":\"some json test\"}}\n";
+    let writer = MockWriter(Arc::new(Mutex::new(Vec::new())));
+    let make_writer = {
+        let writer = writer.clone();
+        move || writer.clone()
+    };
+
+    let collector = CollectorBuilder::default()
+        .json()
+        .without_time()
+        .flatten_event(false)
+        .with_target(false)
+        .with_current_span(true)
+        .with_span_list(true)
+        .with_additional_span_fields(true)
+        .with_writer(make_writer.clone())
+        .finish()
+        .with(InjectingSubscriber);
+
+    with_default(collector, || {
+        let span = tracing::span!(tracing::Level::INFO, "json_span", answer = 42, number = 3);
+        let _guard = span.enter();
+        tracing::info!("some json test");
+    });
+
+    let buf = writer.0.lock().unwrap();
+    let actual = std::str::from_utf8(&buf[..]).unwrap();
+    assert_eq!(
+        serde_json::from_str::<std::collections::HashMap<&str, serde_json::Value>>(expected)
+            .unwrap(),
+        serde_json::from_str(actual).unwrap()
+    );
+}


### PR DESCRIPTION
## Motivation

Closes #1531

There are scenarios where one wants to add some information to logs emitted by `FmtSubscriber`, for example adding OpenTelemetry trace ID and span ID.


## Solution

This adds an extension which all other subscribers can fill with any fields and then the formatting subscriber can emit these fields alongside the normal ones. 

The extension currently wraps a `HashMap<String, String>`, but it could also feasibly be something like `HashMap<String, Box<dyn Value>>` but the flexibility of having other types than string permissible here ~didn't seem to offset the additional allocations for this~ `String` also needs an allocation. Otherwise we could use `HashMap<String, serde_json::Value>` if this would be considered to be json-specific but I don't think we should go that way now.

Currently, only the `Json` formatter prints these fields as other ones do not print span attributes at all.