### PR TITLE
Remove the matchers crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Created by https://www.gitignore.io/api/rust,macos,visualstudiocode
 
 ### macOS ###
@@ -43,10 +42,9 @@ Cargo.lock
 
 ### VisualStudioCode ###
 .vscode/*
-!.vscode/settings.json
+.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
-
 
 # End of https://www.gitignore.io/api/rust,macos,visualstudiocode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+
 # Created by https://www.gitignore.io/api/rust,macos,visualstudiocode
 
 ### macOS ###
@@ -46,5 +47,6 @@ Cargo.lock
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
 
 # End of https://www.gitignore.io/api/rust,macos,visualstudiocode

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ Cargo.lock
 
 ### VisualStudioCode ###
 .vscode/*
-.vscode/settings.json
+!.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -42,7 +42,7 @@ tracing-core = { path = "../tracing-core", version = "0.2", default-features = f
 
 # only required by the `env-filter` feature
 tracing = { optional = true, path = "../tracing", version = "0.2", default-features = false }
-regex-automata = { optional = true, version = "0.4.6",default-features = false, features = ["syntax", "dfa-build", "dfa-search"] }
+regex-automata = { optional = true, version = "0.4.6", default-features = false, features = ["syntax", "dfa-build", "dfa-search"] }
 regex = { optional = true, version = "1.6.0", default-features = false, features = ["std", "unicode-case", "unicode-perl"] }
 smallvec = { optional = true, version = "1.9.0" }
 once_cell = { optional = true, version = "1.13.0" }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.63.0"
 default = ["smallvec", "fmt", "ansi", "tracing-log", "std"]
 alloc = ["tracing-core/alloc"]
 std = ["alloc", "tracing-core/std"]
-env-filter = ["matchers", "regex", "once_cell", "tracing", "std", "thread_local"]
+env-filter = ["regex-automata", "regex", "once_cell", "tracing", "std", "thread_local"]
 fmt = ["registry", "std"]
 ansi = ["fmt", "nu-ansi-term"]
 registry = ["sharded-slab", "thread_local", "std"]
@@ -42,7 +42,7 @@ tracing-core = { path = "../tracing-core", version = "0.2", default-features = f
 
 # only required by the `env-filter` feature
 tracing = { optional = true, path = "../tracing", version = "0.2", default-features = false }
-matchers = { optional = true, version = "0.1.0" }
+regex-automata = { optional = true, version = "0.4.6",default-features = false, features = ["syntax", "dfa-build", "dfa-search"] }
 regex = { optional = true, version = "1.6.0", default-features = false, features = ["std", "unicode-case", "unicode-perl"] }
 smallvec = { optional = true, version = "1.9.0" }
 once_cell = { optional = true, version = "1.13.0" }

--- a/tracing-subscriber/src/filter/env/field.rs
+++ b/tracing-subscriber/src/filter/env/field.rs
@@ -1,4 +1,3 @@
-use matchers::Pattern;
 use std::{
     cmp::Ordering,
     error::Error,
@@ -10,7 +9,8 @@ use std::{
     },
 };
 
-use super::{FieldMap, LevelFilter};
+use super::{matchers::Pattern, FieldMap, LevelFilter};
+use regex_automata::dfa::dense::BuildError;
 use tracing_core::field::{Field, Visit};
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -234,7 +234,7 @@ impl ValueMatch {
     /// This returns an error if the string didn't contain a valid `bool`,
     /// `u64`, `i64`, or `f64` literal, and couldn't be parsed as a regular
     /// expression.
-    fn parse_regex(s: &str) -> Result<Self, matchers::Error> {
+    fn parse_regex(s: &str) -> Result<Self, BuildError> {
         s.parse::<bool>()
             .map(ValueMatch::Bool)
             .or_else(|_| s.parse::<u64>().map(ValueMatch::U64))
@@ -279,9 +279,9 @@ impl fmt::Display for ValueMatch {
 // === impl MatchPattern ===
 
 impl FromStr for MatchPattern {
-    type Err = matchers::Error;
+    type Err = regex_automata::dfa::dense::BuildError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let matcher = Pattern::new_anchored(s)?;
+        let matcher = Pattern::new(s)?;
         Ok(Self {
             matcher,
             pattern: s.to_owned().into(),

--- a/tracing-subscriber/src/filter/env/field.rs
+++ b/tracing-subscriber/src/filter/env/field.rs
@@ -279,7 +279,7 @@ impl fmt::Display for ValueMatch {
 // === impl MatchPattern ===
 
 impl FromStr for MatchPattern {
-    type Err = regex_automata::dfa::dense::BuildError;
+    type Err = BuildError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let matcher = Pattern::new(s)?;
         Ok(Self {

--- a/tracing-subscriber/src/filter/env/matchers.rs
+++ b/tracing-subscriber/src/filter/env/matchers.rs
@@ -1,0 +1,93 @@
+/// Regex Matchers on characters and byte streams. This code is inspired by the [matchers](https://github.com/hawkw/matchers) crate
+/// The code was stripped down as everything was not needed and uses an updated version of regex-automata. 
+use regex_automata::dfa::dense::{BuildError, DFA};
+use regex_automata::dfa::Automaton;
+use regex_automata::util::primitives::StateID;
+use regex_automata::util::start::Config;
+use regex_automata::Anchored;
+use std::{fmt, fmt::Write};
+
+#[derive(Debug, Clone)]
+pub(crate) struct Pattern<A = DFA<Vec<u32>>> {
+    automaton: A,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Matcher<A = DFA<Vec<u32>>> {
+    automaton: A,
+    state: StateID,
+}
+
+impl Pattern {
+    pub(crate) fn new(pattern: &str) -> Result<Self, BuildError> {
+        let automaton = DFA::new(pattern)?;
+        Ok(Pattern { automaton })
+    }
+}
+
+impl<A: Automaton> Pattern<A> {
+    pub(crate) fn matcher(&self) -> Matcher<&'_ A> {
+        Matcher {
+            automaton: &self.automaton,
+            state: self
+                .automaton
+                .start_state(&Config::new().anchored(Anchored::Yes))
+                .unwrap(),
+        }
+    }
+
+    pub(crate) fn matches(&self, s: &impl AsRef<str>) -> bool {
+        self.matcher().matches(s)
+    }
+
+    pub(crate) fn debug_matches(&self, d: &impl fmt::Debug) -> bool {
+        self.matcher().debug_matches(d)
+    }
+}
+
+// === impl Matcher ===
+
+impl<A> Matcher<A>
+where
+    A: Automaton,
+{
+    #[inline]
+    fn advance(&mut self, input: u8) {
+        self.state = unsafe { self.automaton.next_state_unchecked(self.state, input) };
+    }
+
+    #[inline]
+    pub(crate) fn is_matched(&self) -> bool {
+        let eoi_state = self.automaton.next_eoi_state(self.state);
+        self.automaton.is_match_state(eoi_state)
+    }
+
+    /// Returns `true` if this pattern matches the formatted output of the given
+    /// type implementing `fmt::Debug`.
+    pub(crate) fn matches(mut self, s: &impl AsRef<str>) -> bool {
+        for &byte in s.as_ref().as_bytes() {
+            self.advance(byte);
+            if self.automaton.is_dead_state(self.state) {
+                return false;
+            }
+        }
+        self.is_matched()
+    }
+
+    pub(crate) fn debug_matches(mut self, d: &impl fmt::Debug) -> bool {
+        write!(&mut self, "{:?}", d).expect("matcher write impl should not fail");
+        self.is_matched()
+    }
+}
+
+impl<A: Automaton> fmt::Write for Matcher<A> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for &byte in s.as_bytes() {
+            self.advance(byte);
+            if self.automaton.is_dead_state(self.state) {
+                break;
+            }
+        }
+        Ok(())
+    }
+}

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -8,6 +8,7 @@ pub use self::{builder::Builder, directive::Directive, field::BadName as BadFiel
 mod builder;
 mod directive;
 mod field;
+mod matchers;
 
 use crate::{
     filter::LevelFilter,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation
The matcher's crate has not been updated in 3 years. It is on Regex Automata version "0.1". Due to this I am getting a weird utf-8 error. This part is not a tracing problem. Just an outdated library issue. 



<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
This removes the matchers crate. The code is inspired from matchers crate with updates to Regex Automata 0.4.6. This also strips down the code as we don't need all the features matchers provided. 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
All tests were passed and has zero user facing changes. 

Also this adds .vscode/settings.json to the .gitignore as that file can be developer settings. For instance I needed to enable all features for rust-analyzer. 