### PR TITLE
Remove once_cell as a dependency

### DIFF
--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -29,13 +29,12 @@ rust-version = "1.63.0"
 [features]
 default = ["std"]
 alloc = []
-std = ["once_cell", "alloc"]
+std = ["alloc"]
 
 [badges]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-once_cell = { version = "1.13.0", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -167,7 +167,6 @@ pub use self::inner::{rebuild_interest_cache, register};
 #[cfg(feature = "std")]
 mod inner {
     use super::*;
-    use once_cell::sync::Lazy;
     use std::sync::RwLock;
     use std::vec::Vec;
 
@@ -178,10 +177,10 @@ mod inner {
         dispatchers: RwLock<Dispatchers>,
     }
 
-    static REGISTRY: Lazy<Registry> = Lazy::new(|| Registry {
+    static REGISTRY: Registry = Registry {
         callsites: LinkedList::new(),
         dispatchers: RwLock::new(Vec::new()),
-    });
+    };
 
     /// Clear and reregister interest on every [`Callsite`]
     ///

--- a/tracing-flame/Cargo.toml
+++ b/tracing-flame/Cargo.toml
@@ -19,7 +19,7 @@ categories = [
     "asynchronous",
 ]
 keywords = ["tracing", "subscriber", "flamegraph", "profiling"]
-rust-version = "1.63.0"
+rust-version = "1.70.0"
 
 [features]
 default = ["smallvec"]
@@ -28,7 +28,6 @@ smallvec = ["tracing-subscriber/smallvec"]
 [dependencies]
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry", "fmt"] }
 tracing = { path = "../tracing", version = "0.2", default-features = false, features = ["std"] }
-once_cell = "1.13.0"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/tracing-flame/src/lib.rs
+++ b/tracing-flame/src/lib.rs
@@ -10,7 +10,7 @@
 //! issues bottlenecks in an application. For more details, see Brendan Gregg's [post]
 //! on flamegraphs.
 //!
-//! *Compiler support: [requires `rustc` 1.63+][msrv]*
+//! *Compiler support: [requires `rustc` 1.70+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
 //! [post]: http://www.brendangregg.com/flamegraphs.html
@@ -95,7 +95,7 @@
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported
-//! version is 1.63. The current Tracing version is not guaranteed to build on
+//! version is 1.70. The current Tracing version is not guaranteed to build on
 //! Rust versions earlier than the minimum supported version.
 //!
 //! Tracing follows the same compiler support policies as the rest of the Tokio
@@ -136,7 +136,6 @@
 
 use error::Error;
 use error::Kind;
-use once_cell::sync::Lazy;
 use std::cell::Cell;
 use std::fmt;
 use std::fmt::Write as _;
@@ -147,6 +146,7 @@ use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use tracing::span;
 use tracing::Collect;
@@ -157,10 +157,10 @@ use tracing_subscriber::Subscribe;
 
 mod error;
 
-static START: Lazy<Instant> = Lazy::new(Instant::now);
+static START: OnceLock<Instant> = OnceLock::new();
 
 thread_local! {
-    static LAST_EVENT: Cell<Instant> = Cell::new(*START);
+    static LAST_EVENT: Cell<Instant> = Cell::new(*START.get_or_init(Instant::now));
 
     static THREAD_NAME: String = {
         let thread = std::thread::current();
@@ -264,7 +264,7 @@ where
     pub fn new(writer: W) -> Self {
         // Initialize the start used by all threads when initializing the
         // LAST_EVENT when constructing the subscriber
-        let _unused = *START;
+        let _unused = START.get_or_init(Instant::now);
         Self {
             out: Arc::new(Mutex::new(writer)),
             config: Default::default(),

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -15,7 +15,7 @@ categories = [
 keywords = ["logging", "tracing", "log"]
 license = "MIT"
 readme = "README.md"
-rust-version = "1.63.0"
+rust-version = "1.70.0"
 
 [features]
 default = ["log-tracer", "std"]
@@ -25,7 +25,6 @@ log-tracer = []
 [dependencies]
 tracing-core = { path = "../tracing-core", version = "0.2"}
 log = "0.4.17"
-once_cell = "1.13.0"
 env_logger = { version = "0.8.4", optional = true }
 
 [dev-dependencies]

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -20,14 +20,14 @@ categories = [
     "asynchronous",
 ]
 keywords = ["logging", "tracing", "metrics", "subscriber"]
-rust-version = "1.63.0"
+rust-version = "1.70.0"
 
 [features]
 
 default = ["smallvec", "fmt", "ansi", "tracing-log", "std"]
 alloc = ["tracing-core/alloc"]
 std = ["alloc", "tracing-core/std"]
-env-filter = ["matchers", "regex", "once_cell", "tracing", "std", "thread_local"]
+env-filter = ["matchers", "regex", "tracing", "std", "thread_local"]
 fmt = ["registry", "std"]
 ansi = ["fmt", "nu-ansi-term"]
 registry = ["sharded-slab", "thread_local", "std"]
@@ -45,7 +45,6 @@ tracing = { optional = true, path = "../tracing", version = "0.2", default-featu
 matchers = { optional = true, version = "0.1.0" }
 regex = { optional = true, version = "1.6.0", default-features = false, features = ["std", "unicode-case", "unicode-perl"] }
 smallvec = { optional = true, version = "1.9.0" }
-once_cell = { optional = true, version = "1.13.0" }
 
 # fmt
 tracing-log = { path = "../tracing-log", version = "0.2", optional = true, default-features = false, features = ["log-tracer", "std"] }

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -10,7 +10,7 @@
 //! `tracing-subscriber` is intended for use by both `Collector` authors and
 //! application authors using `tracing` to instrument their applications.
 //!
-//! *Compiler support: [requires `rustc` 1.63+][msrv]*
+//! *Compiler support: [requires `rustc` 1.70+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
 //!
@@ -106,7 +106,7 @@
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported
-//! version is 1.63. The current Tracing version is not guaranteed to build on
+//! version is 1.70. The current Tracing version is not guaranteed to build on
 //! Rust versions earlier than the minimum supported version.
 //!
 //! Tracing follows the same compiler support policies as the rest of the Tokio


### PR DESCRIPTION
## Motivation
Decrease the number of dependencies to improve compilation times.

## Solution
Replace existing uses of `once_cell::sync::Lazy` with `std::sync::OnceLock`, or use const initialization where possible. This bumps the MSRV for a few crates to 1.70, but should keep the baseline MSRV at 1.63.