### PR TITLE
tracing: make it possible to use remote IDs as parent span ID

### DIFF
--- a/tracing-attributes/tests/parents.rs
+++ b/tracing-attributes/tests/parents.rs
@@ -1,4 +1,4 @@
-use tracing::{collect::with_default, Id, Level};
+use tracing::{collect::with_default, Level, ParentId};
 use tracing_attributes::instrument;
 use tracing_mock::*;
 
@@ -8,7 +8,7 @@ fn with_default_parent() {}
 #[instrument(parent = parent_span, skip(parent_span))]
 fn with_explicit_parent<P>(parent_span: P)
 where
-    P: Into<Option<Id>>,
+    P: Into<ParentId>,
 {
 }
 

--- a/tracing-core/src/event.rs
+++ b/tracing-core/src/event.rs
@@ -1,6 +1,6 @@
 //! Events represent single points in time during the execution of a program.
 use crate::parent::Parent;
-use crate::span::Id;
+use crate::span::ParentId;
 use crate::{field, Metadata};
 
 /// `Event`s represent single points in time where something occurred during the
@@ -51,13 +51,13 @@ impl<'a> Event<'a> {
     /// provided metadata and set of values.
     #[inline]
     pub fn new_child_of(
-        parent: impl Into<Option<Id>>,
+        parent: impl Into<ParentId>,
         metadata: &'static Metadata<'static>,
         fields: &'a field::ValueSet<'a>,
     ) -> Self {
         let parent = match parent.into() {
-            Some(p) => Parent::Explicit(p),
-            None => Parent::Root,
+            ParentId::None => Parent::Root,
+            parent => Parent::Explicit(parent),
         };
         Event {
             fields,
@@ -69,7 +69,7 @@ impl<'a> Event<'a> {
     /// Constructs a new `Event` with the specified metadata and set of values,
     /// and observes it with the current collector and an explicit parent.
     pub fn child_of(
-        parent: impl Into<Option<Id>>,
+        parent: impl Into<ParentId>,
         metadata: &'static Metadata<'static>,
         fields: &'a field::ValueSet<'_>,
     ) {
@@ -119,10 +119,10 @@ impl<'a> Event<'a> {
     ///
     /// Otherwise (if the new event is a root or is a child of the current span),
     /// returns `None`.
-    pub fn parent(&self) -> Option<&Id> {
+    pub fn parent(&self) -> &ParentId {
         match self.parent {
-            Parent::Explicit(ref p) => Some(p),
-            _ => None,
+            Parent::Explicit(ref p) => p,
+            _ => &ParentId::None,
         }
     }
 }

--- a/tracing-core/src/parent.rs
+++ b/tracing-core/src/parent.rs
@@ -1,4 +1,4 @@
-use crate::span::Id;
+use crate::span::ParentId;
 
 #[derive(Debug)]
 pub(crate) enum Parent {
@@ -7,5 +7,5 @@ pub(crate) enum Parent {
     /// The new span will be rooted in the current span.
     Current,
     /// The new span has an explicitly-specified parent.
-    Explicit(Id),
+    Explicit(ParentId),
 }

--- a/tracing-mock/src/event.rs
+++ b/tracing-mock/src/event.rs
@@ -581,7 +581,7 @@ impl ExpectedEvent {
             let actual_parent = get_parent_name();
             expected_parent.check_parent_name(
                 actual_parent.as_deref(),
-                event.parent().cloned(),
+                event.parent().local().cloned(),
                 event.metadata().name(),
                 collector_name,
             )

--- a/tracing-mock/src/span.rs
+++ b/tracing-mock/src/span.rs
@@ -715,7 +715,7 @@ impl NewSpan {
             let actual_parent = get_parent_name();
             expected_parent.check_parent_name(
                 actual_parent.as_deref(),
-                span.parent().cloned(),
+                span.parent().local().cloned(),
                 format_args!("span `{}`", name),
                 collector_name,
             )

--- a/tracing-mock/src/subscriber.rs
+++ b/tracing-mock/src/subscriber.rs
@@ -939,6 +939,7 @@ where
             if let Expect::NewSpan(mut expected) = expected.pop_front().unwrap() {
                 let get_parent_name = || {
                     span.parent()
+                        .local()
                         .and_then(|id| cx.span(id))
                         .or_else(|| cx.lookup_current())
                         .map(|span| span.name().to_string())

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -237,6 +237,7 @@ where
             {
                 event
                     .parent()
+                    .local()
                     .and_then(|id| ctx.span(id))
                     .or_else(|| ctx.lookup_current())
             } else {

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -284,6 +284,7 @@ where
         let bold = writer.bold();
         let span = event
             .parent()
+            .local()
             .and_then(|id| ctx.span(id))
             .or_else(|| ctx.lookup_current());
 

--- a/tracing-subscriber/src/registry/extensions.rs
+++ b/tracing-subscriber/src/registry/extensions.rs
@@ -112,8 +112,8 @@ impl<'a> ExtensionsMut<'a> {
 
 /// A type map of span extensions.
 ///
-/// [ExtensionsInner] is used by [Data] to store and
-/// span-specific data. A given [Subscriber] can read and write
+/// [ExtensionsInner] is used by [Data](crate::registry::Data) to store and
+/// span-specific data. A given [Subscribe](crate::Subscribe) can read and write
 /// data that it is interested in recording and emitting.
 #[derive(Default)]
 pub(crate) struct ExtensionsInner {

--- a/tracing-subscriber/src/subscribe/context.rs
+++ b/tracing-subscriber/src/subscribe/context.rs
@@ -110,7 +110,7 @@ where
     }
 
     /// Returns a [`SpanRef`] for the parent span of the given [`Event`], if
-    /// it has a parent.
+    /// it has a local parent.
     ///
     /// If the event has an explicitly overridden parent, this method returns
     /// a reference to that span. If the event's parent is the current span,
@@ -176,7 +176,7 @@ where
             self.lookup_current()
         } else {
             // TODO(eliza): this should handle parent IDs
-            event.parent().and_then(|id| self.span(id))
+            event.parent().local().and_then(|id| self.span(id))
         }
     }
 

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -969,7 +969,7 @@ pub use self::instrument::Instrument;
 pub use self::{collect::Collect, dispatch::Dispatch, event::Event, field::Value};
 
 #[doc(hidden)]
-pub use self::span::Id;
+pub use self::span::{Id, ParentId};
 
 #[doc(hidden)]
 pub use tracing_core::{


### PR DESCRIPTION
## Motivation

Currrently, only locally tracked spans can be used as a parent span. However, in distributed systems, the parent is actually often a span originating in another service and this relationship is desirable to be tracked.

For example, a server handling a request may have received a header specifying an ID of a remote span of the client making this call and some information from this should be saved and be available for subscribers to use.

The main example of this would be OpenTelemetry, which propagates globally unique trace and span IDs by which different spans from different systems are grouped into a single trace.

Currently, `tracing-opentelemetry` exposes a method that allows a span to to add the information about the remote parent after the span is already created. This is suboptimal because the span may be entered before this information is provided and it can be even changed later on. It would be instead better to force the user to provide the information during span creation time and not afterwards.

## Solution

Parent ID was tracked as `Option<span::Id>` which was changed to a custom enum with three variants, one equivalent to the former `Option::None` for root spans, one equivalent to `Option::Some(id)` for locally tracked spans which can be looked up in the same `Collect` that tracks the child span (if it implements `LookupSpan`) and a new variant for remote spans.

This variant wraps a trait object that can be then downcasted by `Subscribe` implementations. This is because `tracing` should not force users to use any representation for their remote spans.

One possibly major change this creates is that `Span::child_of` now takes an argument of `T: Into<ParentId>`, where it used to take `T: Into<Option<Id>>`. All implementations that were provided before were added, but this may break some users which may have implemented `Into<Option<Id>>` for their own types.

## TODO

These things should be done before merging but can wait until I get a greenlight on the current implementation.

`no_std` support -- Since the remote ID variant uses `Box`, this only works with `alloc`. I will add conditional compilation as needed.
tests -- all current tests work but of course they don't test for remote contexts at all.
docs -- new public API is documented but I will have to look through all current documentation for mentions of `Option<Id>` and possibly add some explanation in the root of the crate and other places.