### PR TITLE
tracing: allow `&[u8]` to be recorded as event/span field

### DIFF
--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -224,6 +224,11 @@ pub trait Visit {
         self.record_debug(field, &value)
     }
 
+    /// Visit a byte slice.
+    fn record_byte_slice(&mut self, field: &Field, value: &[u8]) {
+        self.record_debug(field, &value)
+    }
+
     /// Records a type implementing `Error`.
     ///
     /// <div class="example-wrap" style="display:inline-block">
@@ -440,6 +445,14 @@ impl crate::sealed::Sealed for str {}
 impl Value for str {
     fn record(&self, key: &Field, visitor: &mut dyn Visit) {
         visitor.record_str(key, self)
+    }
+}
+
+impl crate::sealed::Sealed for [u8] {}
+
+impl Value for [u8] {
+    fn record(&self, key: &Field, visitor: &mut dyn Visit) {
+        visitor.record_byte_slice(key, self)
     }
 }
 

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -225,8 +225,8 @@ pub trait Visit {
     }
 
     /// Visit a byte slice.
-    fn record_byte_slice(&mut self, field: &Field, value: &[u8]) {
-        self.record_debug(field, &value)
+    fn record_bytes(&mut self, field: &Field, value: &[u8]) {
+        self.record_debug(field, &HexBytes(value))
     }
 
     /// Records a type implementing `Error`.
@@ -286,6 +286,18 @@ where
     T: fmt::Debug,
 {
     DebugValue(t)
+}
+
+struct HexBytes<'a>(&'a [u8]);
+
+impl<'a> fmt::Debug for HexBytes<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.0 {
+            f.write_fmt(format_args!("{byte:02x}"))?;
+        }
+
+        Ok(())
+    }
 }
 
 // ===== impl Visit =====
@@ -452,7 +464,7 @@ impl crate::sealed::Sealed for [u8] {}
 
 impl Value for [u8] {
     fn record(&self, key: &Field, visitor: &mut dyn Visit) {
-        visitor.record_byte_slice(key, self)
+        visitor.record_bytes(key, self)
     }
 }
 
@@ -1143,5 +1155,24 @@ mod test {
             write!(&mut result, "{:?}", value).unwrap();
         });
         assert_eq!(result, format!("{}", err));
+    }
+
+    #[test]
+    fn record_bytes() {
+        let fields = TEST_META_1.fields();
+        let first = &b"abc"[..];
+        let second: &[u8] = &[192, 255, 238];
+        let values = &[
+            (&fields.field("foo").unwrap(), Some(&first as &dyn Value)),
+            (&fields.field("bar").unwrap(), Some(&" " as &dyn Value)),
+            (&fields.field("baz").unwrap(), Some(&second as &dyn Value)),
+        ];
+        let valueset = fields.value_set(values);
+        let mut result = String::new();
+        valueset.record(&mut |_: &Field, value: &dyn fmt::Debug| {
+            use core::fmt::Write;
+            write!(&mut result, "{:?}", value).unwrap();
+        });
+        assert_eq!(result, format!("{}", r#"616263" "c0ffee"#));
     }
 }

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -38,7 +38,7 @@
 use crate::callsite;
 use core::{
     borrow::Borrow,
-    fmt,
+    fmt::{self, Write},
     hash::{Hash, Hasher},
     num,
     ops::Range,
@@ -292,11 +292,19 @@ struct HexBytes<'a>(&'a [u8]);
 
 impl<'a> fmt::Debug for HexBytes<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for byte in self.0 {
+        f.write_char('[')?;
+
+        let mut bytes = self.0.iter();
+
+        if let Some(byte) = bytes.next() {
             f.write_fmt(format_args!("{byte:02x}"))?;
         }
 
-        Ok(())
+        for byte in bytes {
+            f.write_fmt(format_args!(" {byte:02x}"))?;
+        }
+
+        f.write_char(']')
     }
 }
 
@@ -1173,6 +1181,6 @@ mod test {
             use core::fmt::Write;
             write!(&mut result, "{:?}", value).unwrap();
         });
-        assert_eq!(result, format!("{}", r#"616263" "c0ffee"#));
+        assert_eq!(result, format!("{}", r#"[61 62 63]" "[c0 ff ee]"#));
     }
 }

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -488,11 +488,6 @@ impl<'a> field::Visit for JsonVisitor<'a> {
             .insert(field.name(), serde_json::Value::from(value));
     }
 
-    fn record_byte_slice(&mut self, field: &Field, value: &[u8]) {
-        self.values
-            .insert(field.name(), serde_json::Value::from(value));
-    }
-
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
         match field.name() {
             // Skip fields that are actually log metadata that have already been handled
@@ -533,7 +528,7 @@ mod test {
     #[test]
     fn json() {
         let expected =
-        "{\"timestamp\":\"fake time\",\"level\":\"INFO\",\"span\":{\"answer\":42,\"name\":\"json_span\",\"number\":3,\"slice\":[97,98,99]},\"spans\":[{\"answer\":42,\"name\":\"json_span\",\"number\":3,\"slice\":[97,98,99]}],\"target\":\"tracing_subscriber::fmt::format::json::test\",\"fields\":{\"message\":\"some json test\"}}\n";
+        "{\"timestamp\":\"fake time\",\"level\":\"INFO\",\"span\":{\"answer\":42,\"name\":\"json_span\",\"number\":3,\"slice\":\"616263\"},\"spans\":[{\"answer\":42,\"name\":\"json_span\",\"number\":3,\"slice\":\"616263\"}],\"target\":\"tracing_subscriber::fmt::format::json::test\",\"fields\":{\"message\":\"some json test\"}}\n";
         let collector = collector()
             .flatten_event(false)
             .with_current_span(true)

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -488,6 +488,11 @@ impl<'a> field::Visit for JsonVisitor<'a> {
             .insert(field.name(), serde_json::Value::from(value));
     }
 
+    fn record_bytes(&mut self, field: &Field, value: &[u8]) {
+        self.values
+            .insert(field.name(), serde_json::Value::from(value));
+    }
+
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
         match field.name() {
             // Skip fields that are actually log metadata that have already been handled
@@ -528,13 +533,19 @@ mod test {
     #[test]
     fn json() {
         let expected =
-        "{\"timestamp\":\"fake time\",\"level\":\"INFO\",\"span\":{\"answer\":42,\"name\":\"json_span\",\"number\":3,\"slice\":\"616263\"},\"spans\":[{\"answer\":42,\"name\":\"json_span\",\"number\":3,\"slice\":\"616263\"}],\"target\":\"tracing_subscriber::fmt::format::json::test\",\"fields\":{\"message\":\"some json test\"}}\n";
+        "{\"timestamp\":\"fake time\",\"level\":\"INFO\",\"span\":{\"answer\":42,\"name\":\"json_span\",\"number\":3,\"slice\":[97,98,99]},\"spans\":[{\"answer\":42,\"name\":\"json_span\",\"number\":3,\"slice\":[97,98,99]}],\"target\":\"tracing_subscriber::fmt::format::json::test\",\"fields\":{\"message\":\"some json test\"}}\n";
         let collector = collector()
             .flatten_event(false)
             .with_current_span(true)
             .with_span_list(true);
         test_json(expected, collector, || {
-            let span = tracing::span!(tracing::Level::INFO, "json_span", answer = 42, number = 3, slice = &b"abc"[..]);
+            let span = tracing::span!(
+                tracing::Level::INFO,
+                "json_span",
+                answer = 42,
+                number = 3,
+                slice = &b"abc"[..]
+            );
             let _guard = span.enter();
             tracing::info!("some json test");
         });

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -488,6 +488,11 @@ impl<'a> field::Visit for JsonVisitor<'a> {
             .insert(field.name(), serde_json::Value::from(value));
     }
 
+    fn record_byte_slice(&mut self, field: &Field, value: &[u8]) {
+        self.values
+            .insert(field.name(), serde_json::Value::from(value));
+    }
+
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
         match field.name() {
             // Skip fields that are actually log metadata that have already been handled
@@ -528,13 +533,13 @@ mod test {
     #[test]
     fn json() {
         let expected =
-        "{\"timestamp\":\"fake time\",\"level\":\"INFO\",\"span\":{\"answer\":42,\"name\":\"json_span\",\"number\":3},\"spans\":[{\"answer\":42,\"name\":\"json_span\",\"number\":3}],\"target\":\"tracing_subscriber::fmt::format::json::test\",\"fields\":{\"message\":\"some json test\"}}\n";
+        "{\"timestamp\":\"fake time\",\"level\":\"INFO\",\"span\":{\"answer\":42,\"name\":\"json_span\",\"number\":3,\"slice\":[97,98,99]},\"spans\":[{\"answer\":42,\"name\":\"json_span\",\"number\":3,\"slice\":[97,98,99]}],\"target\":\"tracing_subscriber::fmt::format::json::test\",\"fields\":{\"message\":\"some json test\"}}\n";
         let collector = collector()
             .flatten_event(false)
             .with_current_span(true)
             .with_span_list(true);
         test_json(expected, collector, || {
-            let span = tracing::span!(tracing::Level::INFO, "json_span", answer = 42, number = 3);
+            let span = tracing::span!(tracing::Level::INFO, "json_span", answer = 42, number = 3, slice = &b"abc"[..]);
             let _guard = span.enter();
             tracing::info!("some json test");
         });

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -426,17 +426,6 @@ impl<'a> PrettyVisitor<'a> {
 }
 
 impl<'a> field::Visit for PrettyVisitor<'a> {
-    fn record_byte_slice(&mut self, field: &Field, value: &[u8]) {
-        let hex =
-            value
-                .iter()
-                .fold(String::with_capacity(value.len() * 2), |mut acc, byte| {
-                    acc.push_str(&format!("{byte:02x}"));
-                    acc
-                });
-        self.record_debug(field, &format_args!("{}", hex));
-    }
-
     fn record_str(&mut self, field: &Field, value: &str) {
         if self.result.is_err() {
             return;

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -426,6 +426,17 @@ impl<'a> PrettyVisitor<'a> {
 }
 
 impl<'a> field::Visit for PrettyVisitor<'a> {
+    fn record_byte_slice(&mut self, field: &Field, value: &[u8]) {
+        let hex =
+            value
+                .iter()
+                .fold(String::with_capacity(value.len() * 2), |mut acc, byte| {
+                    acc.push_str(&format!("{byte:02x}"));
+                    acc
+                });
+        self.record_debug(field, &format_args!("{}", hex));
+    }
+
     fn record_str(&mut self, field: &Field, value: &str) {
         if self.result.is_err() {
             return;


### PR DESCRIPTION
## Motivation

Users may want to pass data to `Subscribe`s which is not valid UTF-8. Currently, it would have to be encoded into `&str` to be passed as a field value.

## Solution

This branch adds a `record_byte_slice` method to `Visit`. It has an implementation falling back to `record_debug` so it is not be a breaking change.

`JsonVisitor` got an overridden implementation as it should not use `Debug` output and encode it as a string, but rather store the bytes as an array.

`PrettyVisitor` go an overridden implementation to make the output more pretty.