### PR TITLE
tracing-subscriber: fix parsing of filters with multiple span fields

### DIFF
--- a/tracing-subscriber/src/filter/env/directive.rs
+++ b/tracing-subscriber/src/filter/env/directive.rs
@@ -192,8 +192,8 @@ impl Directive {
                     .name("fields")
                     .map(|c| {
                         FIELD_FILTER_RE
-                            .find_iter(c.as_str())
-                            .map(|c| field::Match::parse(c.as_str(), regex))
+                            .captures_iter(c.as_str())
+                            .map(|c| field::Match::parse(c.get(1).unwrap().as_str(), regex))
                             .collect::<Result<Vec<_>, _>>()
                     })
                     .unwrap_or_else(|| Ok(Vec::new()));

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -851,7 +851,9 @@ mod tests {
 
     #[test]
     fn callsite_enabled_no_span_directive() {
-        let filter = EnvFilter::new("app=debug").with_collector(NoCollector);
+        let filter = EnvFilter::try_new("app=debug")
+            .unwrap()
+            .with_collector(NoCollector);
         static META: &Metadata<'static> = &Metadata::new(
             "mySpan",
             "app",
@@ -869,7 +871,9 @@ mod tests {
 
     #[test]
     fn callsite_off() {
-        let filter = EnvFilter::new("app=off").with_collector(NoCollector);
+        let filter = EnvFilter::try_new("app=off")
+            .unwrap()
+            .with_collector(NoCollector);
         static META: &Metadata<'static> = &Metadata::new(
             "mySpan",
             "app",
@@ -887,7 +891,9 @@ mod tests {
 
     #[test]
     fn callsite_enabled_includes_span_directive() {
-        let filter = EnvFilter::new("app[mySpan]=debug").with_collector(NoCollector);
+        let filter = EnvFilter::try_new("app[mySpan]=debug")
+            .unwrap()
+            .with_collector(NoCollector);
         static META: &Metadata<'static> = &Metadata::new(
             "mySpan",
             "app",
@@ -905,8 +911,9 @@ mod tests {
 
     #[test]
     fn callsite_enabled_includes_span_directive_field() {
-        let filter =
-            EnvFilter::new("app[mySpan{field=\"value\"}]=debug").with_collector(NoCollector);
+        let filter = EnvFilter::try_new("app[mySpan{field=\"value\"}]=debug")
+            .unwrap()
+            .with_collector(NoCollector);
         static META: &Metadata<'static> = &Metadata::new(
             "mySpan",
             "app",
@@ -924,7 +931,8 @@ mod tests {
 
     #[test]
     fn callsite_enabled_includes_span_directive_multiple_fields() {
-        let filter = EnvFilter::new("app[mySpan{field=\"value\",field2=2}]=debug")
+        let filter = EnvFilter::try_new("app[mySpan{field=\"value\",field2=2}]=debug")
+            .unwrap()
             .with_collector(NoCollector);
         static META: &Metadata<'static> = &Metadata::new(
             "mySpan",

--- a/tracing-subscriber/tests/duplicate_spans.rs
+++ b/tracing-subscriber/tests/duplicate_spans.rs
@@ -5,7 +5,7 @@ use tracing_subscriber::{filter::EnvFilter, fmt::Collector};
 #[test]
 fn duplicate_spans() {
     let collector = Collector::builder()
-        .with_env_filter(EnvFilter::new("[root]=debug"))
+        .with_env_filter(EnvFilter::try_new("[root]=debug").unwrap())
         .finish();
 
     with_default(collector, || {

--- a/tracing-subscriber/tests/env_filter/main.rs
+++ b/tracing-subscriber/tests/env_filter/main.rs
@@ -121,7 +121,7 @@ fn add_directive_enables_event() {
     // this test reproduces tokio-rs/tracing#591
 
     // by default, use info level
-    let mut filter = EnvFilter::new(LevelFilter::INFO.to_string());
+    let mut filter = EnvFilter::try_new(LevelFilter::INFO.to_string()).unwrap();
 
     // overwrite with a more specific directive
     filter = filter.add_directive("hello=trace".parse().expect("directive should parse"));
@@ -192,6 +192,6 @@ fn method_name_resolution() {
     #[allow(unused_imports)]
     use tracing_subscriber::subscribe::{Filter, Subscribe};
 
-    let filter = EnvFilter::new("hello_world=info");
+    let filter = EnvFilter::try_new("hello_world=info").unwrap();
     filter.max_level_hint();
 }

--- a/tracing-subscriber/tests/env_filter/per_subscriber.rs
+++ b/tracing-subscriber/tests/env_filter/per_subscriber.rs
@@ -158,7 +158,7 @@ fn add_directive_enables_event() {
     // this test reproduces tokio-rs/tracing#591
 
     // by default, use info level
-    let mut filter = EnvFilter::new(LevelFilter::INFO.to_string());
+    let mut filter = EnvFilter::try_new(LevelFilter::INFO.to_string()).unwrap();
 
     // overwrite with a more specific directive
     filter = filter.add_directive("hello=trace".parse().expect("directive should parse"));

--- a/tracing-subscriber/tests/utils.rs
+++ b/tracing-subscriber/tests/utils.rs
@@ -34,6 +34,6 @@ fn builders_are_init_ext() {
 fn layered_is_init_ext() {
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::subscriber())
-        .with(tracing_subscriber::EnvFilter::new("foo=info"))
+        .with(tracing_subscriber::EnvFilter::try_new("foo=info").unwrap())
         .set_default();
 }


### PR DESCRIPTION
## Motivation

Closes #2935 
Builds on #2936 

Parsing of filters checking for field values is broken when used with more than one field. There may be multiple directives split by commas (e.g. `lib=warn,bin=info`) but the directives themselves can use commas as separators for span fields (e.g. `[span-name{field1,field2}]`.

Currently, a string containing all directives is first split by commas and then each substring is parsed as its own directive. This does not work when commas are present also because of filters on multiple fields.

## Solution

Make the split aware of `{` and `}` and do not split on commas that are between those two characters. This fix makes the code work as documented and multiple fields can be matched as long as they do not contain `}` in its value (e.g. `[name{json_field="{}"}]`).

Another potential issue is when a user provides a malformed directive such as `[name{]` then all subsequent directives will be considered as part of the malformed directive so they will not be applied.

## Alternatives

Since the feature seems to never have worked, we could also decide to use a different separator for fields, e.g. `;`. Then we could simply have `[span1{field1=0;field2=2}]=info,[span2{field3;field4}]` and the split between directives would not need to be changed. This would require changes to documentation. As `env_logger` does not have any feature like this, having a similar format should not be a concern here.