### PR TITLE
stabilize `valuable` in 0.1.x

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,11 +12,11 @@ default = []
 
 # tracing crates
 tracing = { path = "../tracing", version = "0.1.35" }
-tracing-core = { path = "../tracing-core", version = "0.1.28" }
+tracing-core = { path = "../tracing-core", version = "0.1.28", features = ["valuable"] }
 tracing-error = { path = "../tracing-error" }
 tracing-flame = { path = "../tracing-flame" }
 tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.3.0", features = ["json", "env-filter"] }
+tracing-subscriber = { path = "../tracing-subscriber", version = "0.3.0", features = ["json", "env-filter", "valuable"] }
 tracing-futures = { version = "0.2.1", path = "../tracing-futures", features = ["futures-01"] }
 tracing-attributes = { path = "../tracing-attributes", version = "0.1.22" }
 tracing-serde = { path = "../tracing-serde" }
@@ -52,7 +52,3 @@ thiserror = "1.0.31"
 
 # valuable examples 
 valuable = { version = "0.1.0", features = ["derive"] }
-
-[target.'cfg(tracing_unstable)'.dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.28", features = ["valuable"]}
-tracing-subscriber = { path = "../tracing-subscriber", version = "0.3.0", features = ["json", "env-filter", "valuable"]}

--- a/examples/examples/valuable.rs
+++ b/examples/examples/valuable.rs
@@ -6,12 +6,11 @@
 //! visitors to extract individual fields or elements of structs, maps, arrays, and other
 //! nested structures.
 //!
-//! `tracing`'s support for `valuable` is currently feature flagged. Additionally, `valuable`
-//! support is considered an *unstable feature*: in order to use `valuable` with `tracing`,
-//! the project must be built with `RUSTFLAGS="--cfg tracing_unstable`.
+//! `tracing`'s support for `valuable` is currently feature flagged.
 //!
-//! Therefore, when `valuable` support is not enabled, this example falls back to using
-//! `fmt::Debug` to record fields that implement `valuable::Valuable`.
+//! Therefore, when `valuable` support is not enabled also in the subscriber,
+//! its implementation falls back to using `fmt::Debug` to record fields that
+//! implement `valuable::Valuable`.
 use tracing::{info, info_span};
 use valuable::Valuable;
 
@@ -44,14 +43,8 @@ fn main() {
         },
     };
 
-    // If the `valuable` feature is enabled, record `user` using its'
-    // `valuable::Valuable` implementation:
-    #[cfg(tracing_unstable)]
+    // Record `user` using its `valuable::Valuable` implementation:
     let span = info_span!("Processing", user = user.as_value());
-
-    // Otherwise, record `user` using its `fmt::Debug` implementation:
-    #[cfg(not(tracing_unstable))]
-    let span = info_span!("Processing", user = ?user);
 
     let _handle = span.enter();
     info!("Nothing to do");

--- a/examples/examples/valuable_instrument.rs
+++ b/examples/examples/valuable_instrument.rs
@@ -1,4 +1,3 @@
-#[cfg(tracing_unstable)]
 mod app {
     use std::collections::HashMap;
     use tracing::field::valuable;
@@ -38,8 +37,5 @@ fn main() {
         .with_max_level(tracing::Level::TRACE)
         .init();
 
-    #[cfg(tracing_unstable)]
     app::run();
-    #[cfg(not(tracing_unstable))]
-    println!("Nothing to do, this example needs --cfg=tracing_unstable to run");
 }

--- a/examples/examples/valuable_json.rs
+++ b/examples/examples/valuable_json.rs
@@ -5,14 +5,6 @@
 //! `valuable` provides a lightweight but flexible way to record structured data, allowing
 //! visitors to extract individual fields or elements of structs, maps, arrays, and other
 //! nested structures.
-//!
-//! `tracing`'s support for `valuable` is currently feature flagged. Additionally, `valuable`
-//! support is considered an *unstable feature*: in order to use `valuable` with `tracing`,
-//! the project must be built with `RUSTFLAGS="--cfg tracing_unstable`.
-//!
-//! Therefore, when `valuable` support is not enabled, this example falls back to using
-//! `fmt::Debug` to record fields that implement `valuable::Valuable`.
-#[cfg(tracing_unstable)]
 use tracing::field::valuable;
 use valuable::Valuable;
 
@@ -50,14 +42,7 @@ fn main() {
     // implementation:
     tracing::info!(valuable = false, user = ?user);
 
-    // If the `valuable` feature is enabled, record `user` using its'
+    // If the `valuable` feature is enabled, record `user` using its
     // `valuable::Valuable` implementation:
-    #[cfg(tracing_unstable)]
     tracing::info!(valuable = true, user = valuable(&user));
-
-    #[cfg(not(tracing_unstable))]
-    tracing::warn!(
-        "note: this example was run without `valuable` support enabled!\n\
-        rerun with `RUSTFLAGS=\"--cfg tracing_unstable\" to enable `valuable`",
-    );
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,10 +10,8 @@
     -D warnings \
     --force-warn rustdoc::redundant-explicit-links \
     --force-warn renamed-and-removed-lints \
-    --cfg docsrs \
-    --cfg tracing_unstable
+    --cfg docsrs
     """
-  RUSTFLAGS="--cfg tracing_unstable"
 
 [[redirects]]
   from = "/"

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -35,14 +35,8 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 once_cell = { version = "1.13.0", optional = true }
-
-[target.'cfg(tracing_unstable)'.dependencies]
 valuable = { version = "0.1.0", optional = true, default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true
-# enable unstable features in the documentation
-rustdoc-args = ["--cfg", "docsrs", "--cfg", "tracing_unstable"]
-# it's necessary to _also_ pass `--cfg tracing_unstable` to rustc, or else
-# dependencies will not be enabled, and the docs build will fail.
-rustc-args = ["--cfg", "tracing_unstable"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -45,12 +45,6 @@
 //! If the [`Subscriber`] also supports the `valuable` crate, it can
 //! then visit those types fields as structured values using `valuable`.
 //!
-//! <pre class="ignore" style="white-space:normal;font:inherit;">
-//!     <strong>Note</strong>: <code>valuable</code> support is an
-//!     <a href = "../index.html#unstable-features">unstable feature</a>. See
-//!     the documentation on unstable features for details on how to enable it.
-//! </pre>
-//!
 //! For example:
 //! ```ignore
 //! // Derive `Valuable` for our types:
@@ -267,8 +261,8 @@ pub trait Visit {
     /// Visits an arbitrary type implementing the [`valuable`] crate's `Valuable` trait.
     ///
     /// [`valuable`]: https://docs.rs/valuable
-    #[cfg(all(tracing_unstable, feature = "valuable"))]
-    #[cfg_attr(docsrs, doc(cfg(all(tracing_unstable, feature = "valuable"))))]
+    #[cfg(feature = "valuable")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "valuable")))]
     fn record_value(&mut self, field: &Field, value: valuable::Value<'_>) {
         self.record_debug(field, &value)
     }
@@ -371,8 +365,8 @@ where
 /// can be recorded using its `Valuable` implementation.
 ///
 /// [`Valuable`]: https://docs.rs/valuable/latest/valuable/trait.Valuable.html
-#[cfg(all(tracing_unstable, feature = "valuable"))]
-#[cfg_attr(docsrs, doc(cfg(all(tracing_unstable, feature = "valuable"))))]
+#[cfg(feature = "valuable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "valuable")))]
 pub fn valuable<T>(t: &T) -> valuable::Value<'_>
 where
     T: valuable::Valuable,
@@ -716,22 +710,22 @@ impl<T: fmt::Debug> fmt::Debug for DebugValue<T> {
 
 // ===== impl ValuableValue =====
 
-#[cfg(all(tracing_unstable, feature = "valuable"))]
+#[cfg(feature = "valuable")]
 impl crate::sealed::Sealed for valuable::Value<'_> {}
 
-#[cfg(all(tracing_unstable, feature = "valuable"))]
-#[cfg_attr(docsrs, doc(cfg(all(tracing_unstable, feature = "valuable"))))]
+#[cfg(feature = "valuable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "valuable")))]
 impl Value for valuable::Value<'_> {
     fn record(&self, key: &Field, visitor: &mut dyn Visit) {
         visitor.record_value(key, *self)
     }
 }
 
-#[cfg(all(tracing_unstable, feature = "valuable"))]
+#[cfg(feature = "valuable")]
 impl crate::sealed::Sealed for &'_ dyn valuable::Valuable {}
 
-#[cfg(all(tracing_unstable, feature = "valuable"))]
-#[cfg_attr(docsrs, doc(cfg(all(tracing_unstable, feature = "valuable"))))]
+#[cfg(feature = "valuable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "valuable")))]
 impl Value for &'_ dyn valuable::Valuable {
     fn record(&self, key: &Field, visitor: &mut dyn Visit) {
         visitor.record_value(key, self.as_value())

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -58,37 +58,6 @@
 //!
 //!   **Note**:`tracing-core`'s `no_std` support requires `liballoc`.
 //!
-//! ### Unstable Features
-//!
-//! These feature flags enable **unstable** features. The public API may break in 0.1.x
-//! releases. To enable these features, the `--cfg tracing_unstable` must be passed to
-//! `rustc` when compiling.
-//!
-//! The following unstable feature flags are currently available:
-//!
-//! * `valuable`: Enables support for recording [field values] using the
-//!   [`valuable`] crate.
-//!
-//! #### Enabling Unstable Features
-//!
-//! The easiest way to set the `tracing_unstable` cfg is to use the `RUSTFLAGS`
-//! env variable when running `cargo` commands:
-//!
-//! ```shell
-//! RUSTFLAGS="--cfg tracing_unstable" cargo build
-//! ```
-//! Alternatively, the following can be added to the `.cargo/config` file in a
-//! project to automatically enable the cfg flag for that project:
-//!
-//! ```toml
-//! [build]
-//! rustflags = ["--cfg", "tracing_unstable"]
-//! ```
-//!
-//! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
-//! [field values]: crate::field
-//! [`valuable`]: https://crates.io/crates/valuable
-//!
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported

--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -19,18 +19,17 @@ keywords = ["logging", "tracing", "serialization"]
 rust-version = "1.63.0"
 
 [features]
-valuable = ["valuable_crate", "valuable-serde", "tracing-core/valuable"]
+valuable = ["dep:valuable", "valuable-serde", "tracing-core/valuable"]
 
 [dependencies]
 serde = "1"
 tracing-core = { path = "../tracing-core", version = "0.1.28"}
+valuable = { version = "0.1.0", optional = true, default-features = false }
+valuable-serde = { version = "0.1.0", optional = true, default-features = false }
+
 
 [dev-dependencies]
 serde_json = "1"
-
-[target.'cfg(tracing_unstable)'.dependencies]
-valuable_crate = { package = "valuable", version = "0.1.0", optional = true, default-features = false }
-valuable-serde = { version = "0.1.0", optional = true, default-features = false }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/tracing-serde/src/lib.rs
+++ b/tracing-serde/src/lib.rs
@@ -109,36 +109,6 @@
 //! subscriber (`JsonSubscriber` in the above example) to record serialized
 //! trace data.
 //!
-//! ### Unstable Features
-//!
-//! These feature flags enable **unstable** features. The public API may break in 0.1.x
-//! releases. To enable these features, the `--cfg tracing_unstable` must be passed to
-//! `rustc` when compiling.
-//!
-//! The following unstable feature flags are currently available:
-//!
-//! * `valuable`: Enables [`Visit::record_value`] implementations, for
-//!   serializing values recorded using the [`valuable`] crate.
-//!
-//! #### Enabling Unstable Features
-//!
-//! The easiest way to set the `tracing_unstable` cfg is to use the `RUSTFLAGS`
-//! env variable when running `cargo` commands:
-//!
-//! ```shell
-//! RUSTFLAGS="--cfg tracing_unstable" cargo build
-//! ```
-//! Alternatively, the following can be added to the `.cargo/config` file in a
-//! project to automatically enable the cfg flag for that project:
-//!
-//! ```toml
-//! [build]
-//! rustflags = ["--cfg", "tracing_unstable"]
-//! ```
-//!
-//! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
-//! [`valuable`]: https://crates.io/crates/valuable
-//!
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported
@@ -386,9 +356,9 @@ impl<S> Visit for SerdeMapVisitor<S>
 where
     S: SerializeMap,
 {
-    #[cfg(all(tracing_unstable, feature = "valuable"))]
-    #[cfg_attr(docsrs, doc(cfg(all(tracing_unstable, feature = "valuable"))))]
-    fn record_value(&mut self, field: &Field, value: valuable_crate::Value<'_>) {
+    #[cfg(feature = "valuable")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "valuable")))]
+    fn record_value(&mut self, field: &Field, value: valuable::Value<'_>) {
         if self.state.is_ok() {
             self.state = self
                 .serializer
@@ -448,9 +418,9 @@ impl<S> Visit for SerdeStructVisitor<S>
 where
     S: SerializeStruct,
 {
-    #[cfg(all(tracing_unstable, feature = "valuable"))]
-    #[cfg_attr(docsrs, doc(cfg(all(tracing_unstable, feature = "valuable"))))]
-    fn record_value(&mut self, field: &Field, value: valuable_crate::Value<'_>) {
+    #[cfg(feature = "valuable")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "valuable")))]
+    fn record_value(&mut self, field: &Field, value: valuable::Value<'_>) {
         if self.state.is_ok() {
             self.state = self
                 .serializer

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -32,7 +32,7 @@ fmt = ["registry", "std"]
 ansi = ["fmt", "nu-ansi-term"]
 registry = ["sharded-slab", "thread_local", "std"]
 json = ["tracing-serde", "serde", "serde_json"]
-valuable = ["tracing-core/valuable", "valuable_crate", "valuable-serde", "tracing-serde/valuable"]
+valuable = ["tracing-core/valuable", "dep:valuable", "valuable-serde", "tracing-serde/valuable"]
 # Enables support for local time when using the `time` crate timestamp
 # formatters.
 local-time = ["time/local-offset"]
@@ -65,8 +65,8 @@ chrono = { version = "0.4.26", default-features = false, features = ["clock", "s
 sharded-slab = { version = "0.1.4", optional = true }
 thread_local = { version = "1.1.4", optional = true }
 
-[target.'cfg(tracing_unstable)'.dependencies]
-valuable_crate = { package = "valuable", version = "0.1.0", optional = true, default-features = false }
+# valuable support
+valuable = { version = "0.1.0", optional = true, default-features = false }
 valuable-serde = { version = "0.1.0", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -71,20 +71,15 @@ use tracing_log::NormalizeEvent;
 ///
 /// # Valuable Support
 ///
-/// Experimental support is available for using the [`valuable`] crate to record
-/// user-defined values as structured JSON. When the ["valuable" unstable
-/// feature][unstable] is enabled, types implementing [`valuable::Valuable`] will
-/// be recorded as structured JSON, rather than
-/// using their [`std::fmt::Debug`] implementations.
-///
-/// **Note**: This is an experimental feature. [Unstable features][unstable]
-/// must be enabled in order to use `valuable` support.
+/// Support is available for using the [`valuable`] crate to record user-defined
+/// values as structured JSON. When the "valuable" feature is enabled, types
+/// implementing [`valuable::Valuable`] will be recorded as structured JSON,
+/// rather than using their [`std::fmt::Debug`] implementations.
 ///
 /// [`Json::flatten_event`]: Json::flatten_event()
 /// [`Json::with_current_span`]: Json::with_current_span()
 /// [`Json::with_span_list`]: Json::with_span_list()
 /// [`valuable`]: https://crates.io/crates/valuable
-/// [unstable]: crate#unstable-features
 /// [`valuable::Valuable`]: https://docs.rs/valuable/latest/valuable/trait.Valuable.html
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Json {
@@ -475,8 +470,8 @@ impl<'a> crate::field::VisitOutput<fmt::Result> for JsonVisitor<'a> {
 }
 
 impl<'a> field::Visit for JsonVisitor<'a> {
-    #[cfg(all(tracing_unstable, feature = "valuable"))]
-    fn record_value(&mut self, field: &Field, value: valuable_crate::Value<'_>) {
+    #[cfg(feature = "valuable")]
+    fn record_value(&mut self, field: &Field, value: valuable::Value<'_>) {
         let value = match serde_json::to_value(valuable_serde::Serializable::new(value)) {
             Ok(value) => value,
             Err(_e) => {

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -104,37 +104,6 @@
 //! tracing-subscriber = { version = "0.3", default-features = false, features = ["alloc"] }
 //! ```
 //!
-//! ### Unstable Features
-//!
-//! These feature flags enable **unstable** features. The public API may break in 0.1.x
-//! releases. To enable these features, the `--cfg tracing_unstable` must be passed to
-//! `rustc` when compiling.
-//!
-//! The following unstable feature flags are currently available:
-//!
-//! * `valuable`: Enables support for serializing values recorded using the
-//!   [`valuable`] crate as structured JSON in the [`format::Json`] formatter.
-//!
-//! #### Enabling Unstable Features
-//!
-//! The easiest way to set the `tracing_unstable` cfg is to use the `RUSTFLAGS`
-//! env variable when running `cargo` commands:
-//!
-//! ```shell
-//! RUSTFLAGS="--cfg tracing_unstable" cargo build
-//! ```
-//! Alternatively, the following can be added to the `.cargo/config` file in a
-//! project to automatically enable the cfg flag for that project:
-//!
-//! ```toml
-//! [build]
-//! rustflags = ["--cfg", "tracing_unstable"]
-//! ```
-//!
-//! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
-//! [`valuable`]: https://crates.io/crates/valuable
-//! [`format::Json`]: crate::fmt::format::Json
-//!
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -108,8 +108,4 @@ maintenance = { status = "actively-developed" }
 
 [package.metadata.docs.rs]
 all-features = true
-# enable unstable features in the documentation
-rustdoc-args = ["--cfg", "docsrs", "--cfg", "tracing_unstable"]
-# it's necessary to _also_ pass `--cfg tracing_unstable` to rustc, or else
-# dependencies will not be enabled, and the docs build will fail.
-rustc-args = ["--cfg", "tracing_unstable"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/tracing/src/field.rs
+++ b/tracing/src/field.rs
@@ -38,18 +38,13 @@
 //! user-defined `struct` and `enum` types without having to format them as
 //! unstructured text.
 //!
-//! To address `Value`'s limitations, `tracing` offers experimental support for
-//! the [`valuable`] crate, which provides object-safe inspection of structured
+//! To address `Value`'s limitations, `tracing` offers support for the
+//! [`valuable`] crate, which provides object-safe inspection of structured
 //! values. User-defined types can implement the [`valuable::Valuable`] trait,
 //! and be recorded as a `tracing` field by calling their [`as_value`] method.
-//! If the [`Subscriber`] also supports the `valuable` crate, it can
-//! then visit those types fields as structured values using `valuable`.
-//!
-//! <pre class="ignore" style="white-space:normal;font:inherit;">
-//!     <strong>Note</strong>: <code>valuable</code> support is an
-//!     <a href = "../index.html#unstable-features">unstable feature</a>. See
-//!     the documentation on unstable features for details on how to enable it.
-//! </pre>
+//! If the [`Subscriber`] also supports the `valuable` crate, it can then visit
+//! those types fields as structured values using `valuable`. Otherwise, it will
+//! fall back to using the type's [`fmt::Debug`] implementation.
 //!
 //! For example:
 //! ```ignore

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -837,37 +837,6 @@
 //!     requires <code>liballoc</code>.
 //! </pre>
 //!
-//! ### Unstable Features
-//!
-//! These feature flags enable **unstable** features. The public API may break in 0.1.x
-//! releases. To enable these features, the `--cfg tracing_unstable` must be passed to
-//! `rustc` when compiling.
-//!
-//! The following unstable feature flags are currently available:
-//!
-//! * `valuable`: Enables support for recording [field values] using the
-//!   [`valuable`] crate.
-//!
-//! #### Enabling Unstable Features
-//!
-//! The easiest way to set the `tracing_unstable` cfg is to use the `RUSTFLAGS`
-//! env variable when running `cargo` commands:
-//!
-//! ```shell
-//! RUSTFLAGS="--cfg tracing_unstable" cargo build
-//! ```
-//! Alternatively, the following can be added to the `.cargo/config` file in a
-//! project to automatically enable the cfg flag for that project:
-//!
-//! ```toml
-//! [build]
-//! rustflags = ["--cfg", "tracing_unstable"]
-//! ```
-//!
-//! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
-//! [field values]: crate::field
-//! [`valuable`]: https://crates.io/crates/valuable
-//!
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported


### PR DESCRIPTION
## Motivation

`valuable` support has had unstable support for two years now with no major issues. The crate has close to 30 million downloads on crates.io and all its dependants with more than 3 million downloads are `tracing` in this repository so it is safe to say that some people have used it.

There seem to be [no blockers](https://github.com/tokio-rs/tracing/discussions/1906#discussioncomment-9241897) so I think that this could be stabilized and given to anyone who has not opted-in into the unstable features.

## Solution

The unstable feature checks were removed as well as its mentions. Cargo feature is still present.

## Potential Issues

- Turning the feature on only for `tracing` but not for `tracing-subscriber`. There seem to have been instances ([here](https://github.com/tokio-rs/tracing/issues/1570#issuecomment-1095230523) and [here](https://github.com/tokio-rs/tracing/issues/1570#issuecomment-1507862521)) where people did this and then were surprised by the (json) subscriber using `fmt::Debug` instead of a specialized implementation.
  This can be solved by removing the cargo feature completely without providing an option to opt-out of `valuable` usage.