### PR TITLE
chore: fix clippy lints

### DIFF
--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -33,7 +33,7 @@ default-features = false
 features = ["fmt", "std"]
 
 [dev-dependencies]
-criterion = { version = "0.3.6", default_features = false }
+criterion = { version = "0.3.6", default-features = false }
 tracing = { path = "../tracing", version = "0.2" }
 time = { version = "0.3.2", default-features = false, features = ["formatting", "parsing"] }
 tempfile = "3.3.0"

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -713,9 +713,9 @@ impl FieldSet {
     /// Returns the [`Field`] named `name`, or `None` if no such field exists.
     ///
     /// [`Field`]: super::Field
-    pub fn field<Q: ?Sized>(&self, name: &Q) -> Option<Field>
+    pub fn field<Q>(&self, name: &Q) -> Option<Field>
     where
-        Q: Borrow<str>,
+        Q: Borrow<str> + ?Sized,
     {
         let name = &name.borrow();
         self.names.iter().position(|f| f == name).map(|i| Field {

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -70,7 +70,7 @@ tracing = { path = "../tracing", version = "0.2" }
 tracing-mock = { path = "../tracing-mock", features = ["tracing-subscriber"] }
 log = "0.4.17"
 tracing-log = { path = "../tracing-log", version = "0.2" }
-criterion = { version = "0.3.6", default_features = false }
+criterion = { version = "0.3.6", default-features = false }
 regex = { version = "1.6.0", default-features = false, features = ["std"] }
 tracing-futures = { path = "../tracing-futures", version = "0.3", default-features = false, features = ["std-future", "std"] }
 tokio = { version = "1.20.0", features = ["rt", "macros"] }

--- a/tracing-subscriber/src/filter/env/field.rs
+++ b/tracing-subscriber/src/filter/env/field.rs
@@ -267,7 +267,7 @@ impl fmt::Display for ValueMatch {
         match self {
             ValueMatch::Bool(ref inner) => fmt::Display::fmt(inner, f),
             ValueMatch::F64(ref inner) => fmt::Display::fmt(inner, f),
-            ValueMatch::NaN => fmt::Display::fmt(&std::f64::NAN, f),
+            ValueMatch::NaN => fmt::Display::fmt(&f64::NAN, f),
             ValueMatch::I64(ref inner) => fmt::Display::fmt(inner, f),
             ValueMatch::U64(ref inner) => fmt::Display::fmt(inner, f),
             ValueMatch::Debug(ref inner) => fmt::Display::fmt(inner, f),
@@ -507,7 +507,7 @@ impl<'a> Visit for MatchVisitor<'a> {
                 matched.store(true, Release);
             }
             Some((ValueMatch::F64(ref e), ref matched))
-                if (value - *e).abs() < std::f64::EPSILON =>
+                if (value - *e).abs() < f64::EPSILON =>
             {
                 matched.store(true, Release);
             }

--- a/tracing-subscriber/src/fmt/time/datetime.rs
+++ b/tracing-subscriber/src/fmt/time/datetime.rs
@@ -247,12 +247,12 @@ impl From<std::time::SystemTime> for DateTime {
     fn from(timestamp: std::time::SystemTime) -> DateTime {
         let (t, nanos) = match timestamp.duration_since(std::time::UNIX_EPOCH) {
             Ok(duration) => {
-                debug_assert!(duration.as_secs() <= std::i64::MAX as u64);
+                debug_assert!(duration.as_secs() <= i64::MAX as u64);
                 (duration.as_secs() as i64, duration.subsec_nanos())
             }
             Err(error) => {
                 let duration = error.duration();
-                debug_assert!(duration.as_secs() <= std::i64::MAX as u64);
+                debug_assert!(duration.as_secs() <= i64::MAX as u64);
                 let (secs, nanos) = (duration.as_secs() as i64, duration.subsec_nanos());
                 if nanos == 0 {
                     (-secs, 0)
@@ -332,7 +332,6 @@ impl From<std::time::SystemTime> for DateTime {
 
 #[cfg(test)]
 mod tests {
-    use std::i32;
     use std::time::{Duration, UNIX_EPOCH};
 
     use super::*;
@@ -382,8 +381,8 @@ mod tests {
             1,
         );
 
-        case("2038-01-19T03:14:07.000000Z", std::i32::MAX as i64, 0);
-        case("2038-01-19T03:14:08.000000Z", std::i32::MAX as i64 + 1, 0);
+        case("2038-01-19T03:14:07.000000Z", i32::MAX as i64, 0);
+        case("2038-01-19T03:14:08.000000Z", i32::MAX as i64 + 1, 0);
         case("1901-12-13T20:45:52.000000Z", i32::MIN as i64, 0);
         case("1901-12-13T20:45:51.000000Z", i32::MIN as i64 - 1, 0);
 
@@ -392,8 +391,8 @@ mod tests {
         // high date value tests to panic
         #[cfg(not(target_os = "windows"))]
         {
-            case("+292277026596-12-04T15:30:07.000000Z", std::i64::MAX, 0);
-            case("+292277026596-12-04T15:30:06.000000Z", std::i64::MAX - 1, 0);
+            case("+292277026596-12-04T15:30:07.000000Z", i64::MAX, 0);
+            case("+292277026596-12-04T15:30:06.000000Z", i64::MAX - 1, 0);
             case("-292277022657-01-27T08:29:53.000000Z", i64::MIN + 1, 0);
         }
 

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -210,7 +210,11 @@ feature! {
     #![all(feature = "registry", feature = "std")]
     pub use registry::Registry;
 
+    /// Creates a default [`Registry`], a [`Collect`](tracing_core::Collect)
+    /// implementation which tracks per-span data and exposes it to
+    /// [`Subscribe`]s.
     ///
+    /// For more information see [`Registry`].
     pub fn registry() -> Registry {
         Registry::default()
     }

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -541,10 +541,6 @@ mod tests {
         Collect,
     };
 
-    #[derive(Debug)]
-    struct DoesNothing;
-    impl<C: Collect> Subscribe<C> for DoesNothing {}
-
     struct AssertionSubscriber;
     impl<C> Subscribe<C> for AssertionSubscriber
     where

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -348,7 +348,7 @@ impl Collect for Registry {
 
         let refs = span.ref_count.fetch_sub(1, Ordering::Release);
         if !std::thread::panicking() {
-            assert!(refs < std::usize::MAX, "reference count overflow!");
+            assert!(refs < usize::MAX, "reference count overflow!");
         }
         if refs > 1 {
             return false;

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -37,8 +37,8 @@ tracing-attributes = { path = "../tracing-attributes", version = "0.2", optional
 pin-project-lite = "0.2.9"
 
 [dev-dependencies]
-criterion = { version = "0.3.6", default_features = false }
-futures = { version = "0.3.21", default_features = false }
+criterion = { version = "0.3.6", default-features = false }
+futures = { version = "0.3.21", default-features = false }
 log = "0.4.17"
 tracing-mock = { path = "../tracing-mock" }
 

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -1105,9 +1105,9 @@ impl Span {
 
     /// Returns a [`Field`](super::field::Field) for the field with the
     /// given `name`, if one exists,
-    pub fn field<Q: ?Sized>(&self, field: &Q) -> Option<field::Field>
+    pub fn field<Q>(&self, field: &Q) -> Option<field::Field>
     where
-        Q: field::AsField,
+        Q: field::AsField + ?Sized,
     {
         self.metadata().and_then(|meta| field.as_field(meta))
     }
@@ -1115,9 +1115,9 @@ impl Span {
     /// Returns true if this `Span` has a field for the given
     /// [`Field`](super::field::Field) or field name.
     #[inline]
-    pub fn has_field<Q: ?Sized>(&self, field: &Q) -> bool
+    pub fn has_field<Q>(&self, field: &Q) -> bool
     where
-        Q: field::AsField,
+        Q: field::AsField + ?Sized,
     {
         self.field(field).is_some()
     }
@@ -1193,9 +1193,9 @@ impl Span {
     ///
     /// [`field::Empty`]: super::field::Empty
     /// [`Metadata`]: super::Metadata
-    pub fn record<Q: ?Sized, V>(&self, field: &Q, value: V) -> &Self
+    pub fn record<Q, V>(&self, field: &Q, value: V) -> &Self
     where
-        Q: field::AsField,
+        Q: field::AsField + ?Sized,
         V: field::Value,
     {
         if let Some(meta) = self.meta {
@@ -1594,9 +1594,11 @@ unsafe impl Sync for PhantomNotSend {}
 mod test {
     use super::*;
 
+    #[allow(dead_code)]
     trait AssertSend: Send {}
     impl AssertSend for Span {}
 
+    #[allow(dead_code)]
     trait AssertSync: Sync {}
     impl AssertSync for Span {}
     impl AssertSync for Entered<'_> {}


### PR DESCRIPTION
## Motivation

New lints were added to 1.78 which breaks CI.

## Solution

New lints are fixed. I also fixed lints present in the beta channel for 1.79.