### PR TITLE
fix: make `reload::Subscriber` compatible with per-subscriber filters

### DIFF
--- a/tracing-subscriber/src/filter/subscriber_filters/mod.rs
+++ b/tracing-subscriber/src/filter/subscriber_filters/mod.rs
@@ -1272,6 +1272,13 @@ impl FilterState {
 #[derive(Clone, Copy)]
 #[repr(transparent)]
 struct MagicPsfDowncastMarker(FilterId);
+
+static MAGIC_MARKER: MagicPsfDowncastMarker = MagicPsfDowncastMarker(FilterId::disabled());
+
+pub(crate) fn static_psf_downcast_marker() -> NonNull<()> {
+    NonNull::from(&MAGIC_MARKER).cast()
+}
+
 impl fmt::Debug for MagicPsfDowncastMarker {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Just pretend that `MagicPsfDowncastMarker` doesn't exist for

--- a/tracing-subscriber/tests/reload_filter.rs
+++ b/tracing-subscriber/tests/reload_filter.rs
@@ -1,0 +1,32 @@
+use tracing::{collect::with_default, Level};
+use tracing_mock::{expect, subscriber};
+use tracing_subscriber::{filter, reload, Subscribe};
+
+#[test]
+fn reload_filter() {
+    let filter = filter::LevelFilter::INFO;
+    let (mock_subscriber, mock_handle) = subscriber::mock()
+        .event(expect::event().at_level(Level::INFO).named("before 1"))
+        .event(expect::event().at_level(Level::WARN).named("before 2"))
+        .event(expect::event().at_level(Level::WARN).named("after 2"))
+        .only()
+        .run_with_handle();
+
+    let filtered_subscriber = mock_subscriber.with_filter(filter);
+    let (reload_layer, reload_handle) = reload::Subscriber::new(filtered_subscriber);
+    let collector = reload_layer.with_collector(tracing_subscriber::registry());
+
+    with_default(collector, || {
+        tracing::info!(name: "before 1", "");
+        tracing::warn!(name: "before 2", "");
+        reload_handle
+            .modify(|layer| {
+                *layer.filter_mut() = filter::LevelFilter::WARN;
+            })
+            .unwrap();
+        tracing::info!(name: "after 1", "");
+        tracing::warn!(name: "after 2", "");
+    });
+
+    mock_handle.assert_finished();
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

If the `reload::Subscriber` was used with a filtered `Subscribe`, the filters panicked with `debug_assertions` because nothing cleared interests of the filters. This is because `on_subscribe` was not called and so the `Registry` didn't know there were filters involved.

See the new test for an example of what currently panics on `master`.

`downcast_raw` also did not special-case the magic filter marker so even if the inner subscriber was filtered, other layers could never find out.

## Solution

I've added an implementation for `on_subscribe` in `reload::Subscriber` so that filters are properly registered within the `Registry`.

I've also added an unsafe implementation to downcasting to special-case the magic marker. I've tried to make sure for this to be completely safe even if the caller decides to dereference the returned pointer. This implementation is needed so that `Layered` and others can tell whether the `reload::Subscriber` uses psf or not.