### PR TITLE
subscriber: skip padding when skipping `log.*` fields in `DefaultVisitor`

### DIFF
--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1239,34 +1239,34 @@ impl<'a> field::Visit for DefaultVisitor<'a> {
             return;
         }
 
-        self.result = match field.name() {
-            "message" => {
-                self.maybe_pad();
-                write!(self.writer, "{:?}", value)
-            }
-            // Skip fields that are actually log metadata that have already been handled
-            #[cfg(feature = "tracing-log")]
-            name if name.starts_with("log.") => Ok(()),
-            name if name.starts_with("r#") => {
-                self.maybe_pad();
-                write!(
-                    self.writer,
-                    "{}{}{:?}",
-                    self.writer.italic().paint(&name[2..]),
-                    self.writer.dimmed().paint("="),
-                    value
-                )
-            }
-            name => {
-                self.maybe_pad();
-                write!(
-                    self.writer,
-                    "{}{}{:?}",
-                    self.writer.italic().paint(name),
-                    self.writer.dimmed().paint("="),
-                    value
-                )
-            }
+        let name = field.name();
+
+        // Skip fields that are actually log metadata that have already been handled
+        #[cfg(feature = "tracing-log")]
+        if name.starts_with("log.") {
+            debug_assert_eq!(self.result, Ok(())); // no need to update self.result
+            return;
+        }
+
+        // emit separating spaces if needed
+        self.maybe_pad();
+
+        self.result = match name {
+            "message" => write!(self.writer, "{:?}", value),
+            name if name.starts_with("r#") => write!(
+                self.writer,
+                "{}{}{:?}",
+                self.writer.italic().paint(&name[2..]),
+                self.writer.dimmed().paint("="),
+                value
+            ),
+            name => write!(
+                self.writer,
+                "{}{}{:?}",
+                self.writer.italic().paint(name),
+                self.writer.dimmed().paint("="),
+                value
+            ),
         };
     }
 }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1239,26 +1239,34 @@ impl<'a> field::Visit for DefaultVisitor<'a> {
             return;
         }
 
-        self.maybe_pad();
         self.result = match field.name() {
-            "message" => write!(self.writer, "{:?}", value),
+            "message" => {
+                self.maybe_pad();
+                write!(self.writer, "{:?}", value)
+            }
             // Skip fields that are actually log metadata that have already been handled
             #[cfg(feature = "tracing-log")]
             name if name.starts_with("log.") => Ok(()),
-            name if name.starts_with("r#") => write!(
-                self.writer,
-                "{}{}{:?}",
-                self.writer.italic().paint(&name[2..]),
-                self.writer.dimmed().paint("="),
-                value
-            ),
-            name => write!(
-                self.writer,
-                "{}{}{:?}",
-                self.writer.italic().paint(name),
-                self.writer.dimmed().paint("="),
-                value
-            ),
+            name if name.starts_with("r#") => {
+                self.maybe_pad();
+                write!(
+                    self.writer,
+                    "{}{}{:?}",
+                    self.writer.italic().paint(&name[2..]),
+                    self.writer.dimmed().paint("="),
+                    value
+                )
+            }
+            name => {
+                self.maybe_pad();
+                write!(
+                    self.writer,
+                    "{}{}{:?}",
+                    self.writer.italic().paint(name),
+                    self.writer.dimmed().paint("="),
+                    value
+                )
+            }
         };
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

Closes #2979. 

The current behaviour of `DefaultVisitor` is that it will write padding even if it is going to skip writing a value, which results in extraneous padding being added when values are skipped by the `tracing-log` integration.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

With this change, `DefaultVisitor` will only insert padding if it is actually going to write a value.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
