### PR TITLE
docs: Remove misleading comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ use tracing::info;
 use tracing_subscriber;
 
 fn main() {
-    // install global collector configured based on RUST_LOG env var.
     tracing_subscriber::fmt::init();
 
     let number_of_yaks = 3;
@@ -398,7 +397,7 @@ are not maintained by the `tokio` project. These include:
 - [`tracing-elastic-apm`] provides a layer for reporting traces to [Elastic APM].
 - [`tracing-etw`] provides a layer for emitting Windows [ETW] events.
 - [`sentry-tracing`] provides a layer for reporting events and traces to [Sentry].
-- [`tracing-forest`] provides a subscriber that preserves contextual coherence by 
+- [`tracing-forest`] provides a subscriber that preserves contextual coherence by
   grouping together logs from the same spans during writing.
 - [`tracing-loki`] provides a layer for shipping logs to [Grafana Loki].
 - [`tracing-logfmt`] provides a layer that formats events and spans into the logfmt format.


### PR DESCRIPTION
This comment describes a behavior that's not true. Unless you configure
an `EnvFilter`, the global collector will not respect `RUST_LOG`.

I've opted to remove the comment since the surrounding context is only
the minimal intro of the crate, instead of adding more information that
requires more context right at the introduction of the crate.

Closes #2993
