### PR TITLE
appender: Add fallback to file creation date

### DIFF
--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -687,9 +687,12 @@ impl Inner {
                         datetime = datetime.strip_suffix('.')?;
                     }
 
-                    Some(PrimitiveDateTime::parse(datetime, &self.date_format)
-                        .ok()?
-                        .assume_utc().into())
+                    Some(
+                        PrimitiveDateTime::parse(datetime, &self.date_format)
+                            .ok()?
+                            .assume_utc()
+                            .into(),
+                    )
                 })?;
                 Some((entry, created))
             })


### PR DESCRIPTION
When using the linux-musl target for rust, the file creation time cannot be retrieved, as the current version does not support it yet ( This will be fixed with [^0]). In the meantime, we parse the datetime from the filename and use that as a fallback.

Fixes: #2999

[^0]: https://github.com/rust-lang/rust/pull/125692
