### PR TITLE
tracing-core: Do not add `valuable/std` feature as dependency unless …

### DIFF
--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 rust-version = "1.63.0"
 
 [features]
-default = ["std", "valuable/std"]
+default = ["std", "valuable?/std"]
 std = ["once_cell"]
 
 [badges]


### PR DESCRIPTION
## Motivation

`tracing-core` adds a dependency on `valuable` anytime the `std` (or `default`) feature is enabled even when `valuable` is not meant to be used. This was pointed out by [this comment](https://github.com/tokio-rs/tracing/pull/1608#discussion_r1626673415).

## Solution

Only add the feature dependency when something enables `valuable`.

This does not apply to `master` as `valuable` support there is always on.