### PR TITLE
fix: align `EnvFilter::try_new` with its documentation

### DIFF
--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -354,8 +354,10 @@ impl EnvFilter {
     /// ```
     ///
     /// [`ERROR`]: tracing::Level::ERROR
-    pub fn try_new<S: AsRef<str>>(dirs: S) -> Result<Self, directive::ParseError> {
-        Self::builder().parse(dirs)
+    pub fn try_new<S: AsRef<str>>(directives: S) -> Result<Self, directive::ParseError> {
+        Self::builder()
+            .with_default_directive(LevelFilter::ERROR.into())
+            .parse(directives)
     }
 
     /// Returns a new `EnvFilter` from the value of the `RUST_LOG` environment


### PR DESCRIPTION
`EnvFilter::try_new` documentation is clearly missleading. However, the documentation is aligned with `EnvFilter::new` behavior (and documentation). So I assume the fix must be to align `EnvFilter::try_new` code with its documentation, and not the opposite. I also renamed the parameter to align it with `EnvFilter::new`.