### PR TITLE
Abstract writer creation

### DIFF
--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -37,6 +37,7 @@ criterion = { version = "0.3.6", default-features = false }
 tracing = { path = "../tracing", version = "0.2" }
 time = { version = "0.3.2", default-features = false, features = ["formatting", "parsing"] }
 tempfile = "3.3.0"
+snap = "1.1.1"
 
 [[bench]]
 name = "bench"

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -865,6 +865,7 @@ mod test {
                 prefix.map(ToString::to_string),
                 suffix.map(ToString::to_string),
                 None,
+                std::sync::Arc::new(|id| id),
             )
             .unwrap();
             let path = inner.join_date(&now);
@@ -977,6 +978,7 @@ mod test {
             Some("test_make_writer".to_string()),
             None,
             None,
+            std::sync::Arc::new(|id| id),
         )
         .unwrap();
 
@@ -1059,6 +1061,7 @@ mod test {
             Some("test_max_log_files".to_string()),
             None,
             Some(2),
+            std::sync::Arc::new(|id| id),
         )
         .unwrap();
 

--- a/tracing-appender/src/rolling/builder.rs
+++ b/tracing-appender/src/rolling/builder.rs
@@ -2,7 +2,7 @@ use super::{RollingFileAppender, Rotation};
 use std::{fs::File, io, path::Path, sync::Arc};
 use thiserror::Error;
 
-pub(super) type WriterFn<W> = Arc<dyn Fn(File) -> W>;
+pub(super) type WriterFn<W> = Arc<dyn Fn(File) -> W + Send + Sync>;
 
 /// A [builder] for configuring [`RollingFileAppender`]s.
 ///
@@ -81,7 +81,7 @@ impl<W> Builder<W> {
     ///
     /// # Examples
     /// TODO
-    pub fn writer_builder(self, builder: impl Fn(File) -> W + 'static) -> Self {
+    pub fn writer_builder(self, builder: impl Fn(File) -> W + Send + Sync + 'static) -> Self {
         Self {
             make_writer: Arc::new(builder),
             ..self

--- a/tracing-appender/src/rolling/builder.rs
+++ b/tracing-appender/src/rolling/builder.rs
@@ -72,6 +72,21 @@ impl Builder {
             make_writer: Arc::new(|file| file),
         }
     }
+}
+
+impl<W> Builder<W> {
+    /// Wraps the current file writer with the provided writer
+    ///
+    /// With this approach, compression can be enabled if a compression writer builder is provided.
+    ///
+    /// # Examples
+    /// TODO
+    pub fn writer_builder(self, builder: impl Fn(File) -> W + 'static) -> Self {
+        Self {
+            make_writer: Arc::new(builder),
+            ..self
+        }
+    }
 
     /// Sets the [rotation strategy] for log files.
     ///
@@ -248,7 +263,12 @@ impl Builder {
             ..self
         }
     }
+}
 
+impl<W> Builder<W>
+where
+    for<'a> &'a W: std::io::Write,
+{
     /// Builds a new [`RollingFileAppender`] with the configured parameters,
     /// emitting log files to the provided directory.
     ///
@@ -277,7 +297,7 @@ impl Builder {
     /// # drop(appender);
     /// # }
     /// ```
-    pub fn build(&self, directory: impl AsRef<Path>) -> Result<RollingFileAppender, InitError> {
+    pub fn build(&self, directory: impl AsRef<Path>) -> Result<RollingFileAppender<W>, InitError> {
         RollingFileAppender::from_builder(self, directory)
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

This is second take on #2584 (first one was #2596).

This PR adds the feature of wrapping the default File writer with a user provided one. It is writer agnostic.

This change would allow (as shown in docs) to use `BufWriter` or some compression on top of regular file, which is supper useful if you want to have

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

In contrast to the #2596, PR still uses `RwLock` to store Writer and because of that requires users of library to implement `Write for &UserWriter`.

This PR changes API a bit (adds generics with default values and removes one `const` constructor).

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
