### PR TITLE
Allow empty value match for fields

### DIFF
--- a/tracing-subscriber/src/filter/env/directive.rs
+++ b/tracing-subscriber/src/filter/env/directive.rs
@@ -152,7 +152,7 @@ impl Directive {
                     # field name
                     [[:word:]][[[:word:]]\.]*
                     # value part (optional)
-                    (?:=[^,]+)?
+                    (?:=[^,]*)?
                 )
                 # trailing comma or EOS
                 (?:,\s?|$)
@@ -863,5 +863,19 @@ mod test {
 
         let dirs = parse_directives(format!("target[{}]=info", invalid_span_name));
         assert_eq!(dirs.len(), 0, "\nparsed: {:#?}", dirs);
+    }
+
+    #[test]
+    fn should_parse_field_match_with_empty_value() {
+        let directive = "a[b{field=}]";
+        let expected_match = field::Match {
+            name: "field".to_string(),
+            value: Some(field::ValueMatch::Pat(Box::new("".parse().unwrap()))),
+        };
+
+        let mut dir = Directive::parse(&directive, true).unwrap();
+        let field_match = dir.fields.pop().unwrap();
+
+        assert_eq!(field_match, expected_match, "got {:?}", field_match);
     }
 }


### PR DESCRIPTION
## Motivation

In the current version of `EnvFilter`, the directive `[span{field=}]` does not work as expected.

The directive `[span{field}]` filter for all spans `span` that have a field `field` while the directive `[{field=a}]` filters for all spans `span` where the field `field` has the value `a`. In contrast, the directive `[span{field=}]` filters only for spans `span`. IMHO this is unexpected behavior. 

## Solution

Digging into the code for parsing `Directive`s the regex for field matches didn't consider the `field=` case. This PR changes the regex so that `field=` is interpreted as a match on an empty string.

With regex enabled this means that now `field=` behaves like `field`.

## Alternative solution

Instead of accepting the `field=` directive, it could trigger an error instead invalidating the whole directive.
