### PR TITLE
subscriber: strip quotes of EnvFilter field values

### DIFF
--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -4,7 +4,11 @@
 // these are publicly re-exported, but the compiler doesn't realize
 // that for some reason.
 #[allow(unreachable_pub)]
-pub use self::{builder::Builder, directive::Directive, field::BadName as BadFieldName};
+pub use self::{
+    builder::Builder,
+    directive::Directive,
+    field::{BadName as BadFieldName, BadValueQuotation as BadFieldValueQuotation},
+};
 mod builder;
 mod directive;
 mod field;


### PR DESCRIPTION
## Motivation

The documentation states that `[span_b{name=\"bob\"}]` should match spans where the value of `name` is `bob` but it does match spans where the value of `name` is `"bob"`.

Additionally there is no good way to match strings which happen to be true, false or a number. `[{value="true"}]` matches the rust string `r#""true""#` and `[{value=true}]` only matches a bool value true but not a string `true`.

## Solution

- for values wrapped into `"` quotes we stip them when parsing `ValueMatach` / `MatchDebug`
- if encountering unbalanced outer quotes (e.g. `"bob`, `bob"` or `"` we treat it as a syntax error)
- the behavior of quotes inside of a value (e.g. `bo"b`) is not changed (i.e. `bo"b` matches `bo"b`)

Partially Fixes: #1181
Fixes: #2809

## Stability Considerations

- some malformed/ambiguous directives did pass parsing, it might make sense to change the behavior for unbalanced outer quotes (`"bob`, `bob"`) to not create an error but parse include the `"` in the regex like previously

- if anyone did accidentally log a string as debug (e.g. `foo = %"my string"`) then the previous filter happened to work, and this happening isn't even that unlikely (due to `instrument`) . At the same time not stripping the quotes is a huge problem for anything of which the debug/display output is `true`/`false` or a number 
   - in context of this maybe it makes sense to provide an alternative `Directive` parsing algorithm and some form to opt into it. We could start by defining a grammar for the syntax. Avoiding ambiguity and allowing escaping of various characters (e.g. `,[{}]`) on the level of the  directive string representation. Which would  fix multiple issues caused from the current formats ambiguities.
       - this could be a feature flag, as this aspect tends to be handled by the final upstream crate and not libraries
       - this could be available through methods like  `EnvFilter::builder2()` and similar 
   -  or deprecating the `EnvFilter` after providing a alternative more robust implementation  could also work (e.g. a `FilterDirectives` given that the `EnvFilter` is IMHO by now more focused on flexible filter directives then on).
   - EDIT: or provide an interface to programmatically build `Directives` in which case external crates can provide their own parsing solutions (or e.g. from config deserialization) without having to re-implement the  filter application logic. I really like this idea. Through that would make the `EnvFilter` have even less to do with the env. 


