### PR TITLE
Improve error message for `json()` formatting

### DIFF
--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -186,7 +186,12 @@ where
             // If we *aren't* in debug mode, it's probably best not
             // crash the program, but let's at least make sure it's clear
             // that the fields are not supposed to be missing.
-            Err(e) => serializer.serialize_entry("field_error", &format!("{}", e))?,
+            Err(e) => serializer.serialize_entry(
+                "field_error",
+                &format!("span '{}' dropped malformed fields: {}",
+                self.0.metadata().name(),
+                e
+            ))?,
         };
         serializer.serialize_entry("name", self.0.metadata().name())?;
         serializer.end()


### PR DESCRIPTION
When a malformed field isn't valid and debug_assertions are active, the span name and the malformed data are included in the error message. When !debug_assertions, only an error message is shown without noting which span introduced the bad field. I understand why including the bad data in its entirety would be undesirable, but just the span name seems nice to have.

## Motivation

When a malformed field isn't valid and debug_assertions are active, the span name and the malformed data are included in the error message. When !debug_assertions, only an error message is shown without noting which span introduced the bad field. I understand why including the bad data in its entirety would be undesirable, but just the span name seems nice to have.

Current error message example:
```json
  {
    "field_error": "EOF while parsing a value at line 1 column 0",
    "name": "AsyncRequireAuthorizationLayer"
  },
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
This change introduces the name of the span into the `field_error` message. 