### PR TITLE
subscriber: don't gate `with_ansi()` on the "ansi" feature

### DIFF
--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -627,8 +627,6 @@ where
     /// ANSI escape codes can ensure that they are not used, regardless of
     /// whether or not other crates in the dependency graph enable the "ansi"
     /// feature flag.
-    #[cfg(feature = "ansi")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
     pub fn with_ansi(self, ansi: bool) -> SubscriberBuilder<N, format::Format<L, T>, F, W> {
         SubscriberBuilder {
             inner: self.inner.with_ansi(ansi),


### PR DESCRIPTION
The commit 1cb523b87d3d removed this cfg gate on master. However, when the change was backported in 049ad730c1ba the docs were updated but the `cfg` change was omitted. Some more detail and links are in issue #2996.

This made the docs misleading, since they say "This method itself is still available without the feature flag."

Fixes #2996.