### PR TITLE
fix: prefix macro calls with ::core to avoid clashing with local macros

### DIFF
--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -264,9 +264,9 @@ macro_rules! metadata {
             $name,
             $target,
             $level,
-            ::core::option::Option::Some(file!()),
-            ::core::option::Option::Some(line!()),
-            ::core::option::Option::Some(module_path!()),
+            ::core::option::Option::Some(::core::file!()),
+            ::core::option::Option::Some(::core::line!()),
+            ::core::option::Option::Some(::core::module_path!()),
             $crate::field::FieldSet::new($fields, $crate::identify_callsite!($callsite)),
             $kind,
         )

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -165,6 +165,14 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+#[doc(hidden)]
+pub mod __macro_support {
+    // Re-export the `core` functions that are used in macros. This allows
+    // a crate to be named `core` and avoid name clashes.
+    // See here: https://github.com/tokio-rs/tracing/issues/2761
+    pub use core::{file, line, module_path, option::Option};
+}
+
 /// Statically constructs an [`Identifier`] for the provided [`Callsite`].
 ///
 /// This may be used in contexts, such as static initializers, where the
@@ -264,9 +272,9 @@ macro_rules! metadata {
             $name,
             $target,
             $level,
-            ::core::option::Option::Some(::core::file!()),
-            ::core::option::Option::Some(::core::line!()),
-            ::core::option::Option::Some(::core::module_path!()),
+            $crate::__macro_support::Option::Some($crate::__macro_support::file!()),
+            $crate::__macro_support::Option::Some($crate::__macro_support::line!()),
+            $crate::__macro_support::Option::Some($crate::__macro_support::module_path!()),
             $crate::field::FieldSet::new($fields, $crate::identify_callsite!($callsite)),
             $kind,
         )

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1005,7 +1005,7 @@ pub mod __macro_support {
     // Re-export the `core` functions that are used in macros. This allows
     // a crate to be named `core` and avoid name clashes.
     // See here: https://github.com/tokio-rs/tracing/issues/2761
-    pub use core::{concat, format_args, iter::Iterator, option::Option};
+    pub use core::{concat, file, format_args, iter::Iterator, line, option::Option};
 
     /// Callsite implementation used by macro-generated code.
     ///

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -693,11 +693,11 @@ macro_rules! event {
     (target: $target:expr, parent: $parent:expr, $lvl:expr, { $($fields:tt)* } )=> ({
         use $crate::__macro_support::Callsite as _;
         static __CALLSITE: $crate::__macro_support::MacroCallsite = $crate::callsite2! {
-            name: concat!(
+            name: ::core::concat!(
                 "event ",
-                file!(),
+                ::core::file!(),
                 ":",
-                line!()
+                ::core::line!()
             ),
             kind: $crate::metadata::Kind::EVENT,
             target: $target,
@@ -854,11 +854,11 @@ macro_rules! event {
     (target: $target:expr, $lvl:expr, { $($fields:tt)* } )=> ({
         use $crate::__macro_support::Callsite as _;
         static __CALLSITE: $crate::__macro_support::MacroCallsite = $crate::callsite2! {
-            name: concat!(
+            name: ::core::concat!(
                 "event ",
-                file!(),
+                ::core::file!(),
                 ":",
-                line!()
+                ::core::line!()
             ),
             kind: $crate::metadata::Kind::EVENT,
             target: $target,
@@ -1184,11 +1184,11 @@ macro_rules! enabled {
         if $crate::level_enabled!($lvl) {
             use $crate::__macro_support::Callsite as _;
             static __CALLSITE: $crate::__macro_support::MacroCallsite = $crate::callsite2! {
-                name: concat!(
+                name: ::core::concat!(
                     "enabled ",
-                    file!(),
+                    ::core::file!(),
                     ":",
-                    line!()
+                    ::core::line!()
                 ),
                 kind: $kind.hint(),
                 target: $target,

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -693,11 +693,11 @@ macro_rules! event {
     (target: $target:expr, parent: $parent:expr, $lvl:expr, { $($fields:tt)* } )=> ({
         use $crate::__macro_support::Callsite as _;
         static __CALLSITE: $crate::__macro_support::MacroCallsite = $crate::callsite2! {
-            name: ::core::concat!(
+            name: $crate::__macro_support::concat!(
                 "event ",
-                ::core::file!(),
+                $crate::__macro_support::file!(),
                 ":",
-                ::core::line!()
+                $crate::__macro_support::line!()
             ),
             kind: $crate::metadata::Kind::EVENT,
             target: $target,
@@ -854,11 +854,11 @@ macro_rules! event {
     (target: $target:expr, $lvl:expr, { $($fields:tt)* } )=> ({
         use $crate::__macro_support::Callsite as _;
         static __CALLSITE: $crate::__macro_support::MacroCallsite = $crate::callsite2! {
-            name: ::core::concat!(
+            name: $crate::__macro_support::concat!(
                 "event ",
-                ::core::file!(),
+                $crate::__macro_support::file!(),
                 ":",
-                ::core::line!()
+                $crate::__macro_support::line!()
             ),
             kind: $crate::metadata::Kind::EVENT,
             target: $target,
@@ -1184,11 +1184,11 @@ macro_rules! enabled {
         if $crate::level_enabled!($lvl) {
             use $crate::__macro_support::Callsite as _;
             static __CALLSITE: $crate::__macro_support::MacroCallsite = $crate::callsite2! {
-                name: ::core::concat!(
+                name: $crate::__macro_support::concat!(
                     "enabled ",
-                    ::core::file!(),
+                    $crate::__macro_support::file!(),
                     ":",
-                    ::core::line!()
+                    $crate::__macro_support::line!()
                 ),
                 kind: $kind.hint(),
                 target: $target,


### PR DESCRIPTION
## Motivation

This commit fixes a bug where a macro call to macros defined in the
standard lib from the `tracing` and `tracing-core` crates could be
resolved to a local macro with the same name, causing a compilation
error. 

## Solution

This commit prefixes these calls with `::core::` to ensure that
they are resolved to the standard library macros.

Fixes: <https://github.com/tokio-rs/tracing/issues/3023>

While this fixes the specific issue at hand, there's likely many macro calls that are impacted by this problem - specifically every call to module_path (there are many). I haven't updated all of those places as I was unsure if that was a good idea as there's about 220 calls of that macro. I also haven't checked for other macros that would also be problematic.