### PR TITLE
appender: add filter to limit and rotate log files by size

### DIFF
--- a/tracing-appender/src/rolling/builder.rs
+++ b/tracing-appender/src/rolling/builder.rs
@@ -11,6 +11,7 @@ pub struct Builder {
     pub(super) prefix: Option<String>,
     pub(super) suffix: Option<String>,
     pub(super) max_files: Option<usize>,
+    pub(super) max_size_bytes: Option<usize>,
 }
 
 /// Errors returned by [`Builder::build`].
@@ -42,11 +43,13 @@ impl Builder {
     /// | [`filename_prefix`] | `""` | By default, log file names will not have a prefix. |
     /// | [`filename_suffix`] | `""` | By default, log file names will not have a suffix. |
     /// | [`max_log_files`] | `None` | By default, there is no limit for maximum log file count. |
+    /// | [`max_log_size_bytes`] | `None` | By default, there is no limit for maximum file size. |
     ///
     /// [`rotation`]: Self::rotation
     /// [`filename_prefix`]: Self::filename_prefix
     /// [`filename_suffix`]: Self::filename_suffix
     /// [`max_log_files`]: Self::max_log_files
+    /// [`max_log_size_bytes`]: Self::max_log_size_bytes
     #[must_use]
     pub const fn new() -> Self {
         Self {
@@ -54,6 +57,7 @@ impl Builder {
             prefix: None,
             suffix: None,
             max_files: None,
+            max_size_bytes: None,
         }
     }
 
@@ -230,6 +234,39 @@ impl Builder {
         Self {
             max_files: Some(n),
             ..self
+        }
+    }
+
+    /// Limits the size of log files.
+    ///
+    /// When a log file reaches the specified size, it will be rotated
+    /// and a new log file will be created.
+    /// If no value is supplied or the value is 0, the `RollingAppender` will
+    /// not limit the size of log files.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tracing_appender::rolling::RollingFileAppender;
+    ///
+    /// # fn docs() {
+    /// let appender = RollingFileAppender::builder()
+    ///     .max_log_size_bytes(10 * 1024 * 1024) // rotate the log file when it reaches 10 MiB
+    ///     // ...
+    ///     .build("/var/log")
+    ///     .expect("failed to initialize rolling file appender");
+    /// # drop(appender)
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn max_log_size_bytes(self, bytes: usize) -> Self {
+        if bytes > 0 {
+            Self {
+                max_size_bytes: Some(bytes),
+                ..self
+            }
+        } else {
+            self
         }
     }
 


### PR DESCRIPTION
## Motivation

The `RollingFileAppender` currently allows you to rotate the log files by time and limit the number of previous files kept on disk. In some environments where the disk capacity is limited, we also need to control and limit the size of the logs.

So far, two PR's have been submitted to add this feature: https://github.com/tokio-rs/tracing/pull/2904 and https://github.com/tokio-rs/tracing/pull/2497. Both try to add a new `Rotation` variant, forcing the user to choose between rotating by time or size, which can limit the UX depending on the needs of the user.

What I'd like ideally is to rotate logs on a frequency basis, but also limit the max size of a log file. The main goal though can be achieved with any of the 3 open PR's, which is having the ability to determine the max size of the logs of an application to get a better estimate of the host machine's disk requirements.

Closes https://github.com/tokio-rs/tracing/issues/1940
Closes https://github.com/tokio-rs/tracing/issues/858

## Solution

This PR adds a new filter to limit the size of the logs files, which can be used together with the frequency rotation filter. The first condition to be met will decide how the file is rotated.