### PR TITLE
chore: use `dep:valuable` syntax instead of renaming valuable

### DIFF
--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["logging", "tracing", "serialization"]
 rust-version = "1.63.0"
 
 [features]
-valuable = ["valuable_crate", "valuable-serde", "tracing-core/valuable"]
+valuable = ["dep:valuable", "valuable-serde", "tracing-core/valuable"]
 
 [dependencies]
 serde = "1"
@@ -29,7 +29,7 @@ tracing-core = { path = "../tracing-core", version = "0.1.28"}
 serde_json = "1"
 
 [target.'cfg(tracing_unstable)'.dependencies]
-valuable_crate = { package = "valuable", version = "0.1.0", optional = true, default-features = false }
+valuable = { version = "0.1.0", optional = true, default-features = false }
 valuable-serde = { version = "0.1.0", optional = true, default-features = false }
 
 [badges]

--- a/tracing-serde/src/lib.rs
+++ b/tracing-serde/src/lib.rs
@@ -387,11 +387,11 @@ where
 {
     #[cfg(all(tracing_unstable, feature = "valuable"))]
     #[cfg_attr(docsrs, doc(cfg(all(tracing_unstable, feature = "valuable"))))]
-    fn record_value(&mut self, field: &Field, value: valuable_crate::Value<'_>) {
+    fn record_value(&mut self, field: &Field, value: valuable::Value<'_>) {
         if self.state.is_ok() {
             self.state = self
                 .serializer
-                .serialize_entry(field.name(), &valuable_serde::Serializable::new(value));
+                .serialize_entry(field.name(), &valuable::Serializable::new(value));
         }
     }
 
@@ -449,7 +449,7 @@ where
 {
     #[cfg(all(tracing_unstable, feature = "valuable"))]
     #[cfg_attr(docsrs, doc(cfg(all(tracing_unstable, feature = "valuable"))))]
-    fn record_value(&mut self, field: &Field, value: valuable_crate::Value<'_>) {
+    fn record_value(&mut self, field: &Field, value: valuable::Value<'_>) {
         if self.state.is_ok() {
             self.state = self
                 .serializer

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -32,7 +32,7 @@ fmt = ["registry", "std"]
 ansi = ["fmt", "nu-ansi-term"]
 registry = ["sharded-slab", "thread_local", "std"]
 json = ["tracing-serde", "serde", "serde_json"]
-valuable = ["tracing-core/valuable", "valuable_crate", "valuable-serde", "tracing-serde/valuable"]
+valuable = ["tracing-core/valuable", "dep:valuable", "valuable-serde", "tracing-serde/valuable"]
 # Enables support for local time when using the `time` crate timestamp
 # formatters.
 local-time = ["time/local-offset"]
@@ -66,7 +66,7 @@ sharded-slab = { version = "0.1.4", optional = true }
 thread_local = { version = "1.1.4", optional = true }
 
 [target.'cfg(tracing_unstable)'.dependencies]
-valuable_crate = { package = "valuable", version = "0.1.0", optional = true, default-features = false }
+valuable = { version = "0.1.0", optional = true, default-features = false }
 valuable-serde = { version = "0.1.0", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -476,7 +476,7 @@ impl<'a> crate::field::VisitOutput<fmt::Result> for JsonVisitor<'a> {
 
 impl<'a> field::Visit for JsonVisitor<'a> {
     #[cfg(all(tracing_unstable, feature = "valuable"))]
-    fn record_value(&mut self, field: &Field, value: valuable_crate::Value<'_>) {
+    fn record_value(&mut self, field: &Field, value: valuable::Value<'_>) {
         let value = match serde_json::to_value(valuable_serde::Serializable::new(value)) {
             Ok(value) => value,
             Err(_e) => {


### PR DESCRIPTION
This syntax is a bit newer, but falls under tracing's MSRV. It also helps resolve some Buck vendoring nonsense at work.