### PR TITLE
chore: fix clippy lints

### DIFF
--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -24,7 +24,7 @@
 //!  - Using a [`RollingFileAppender`] to perform writes to a log file. This will block on writes.
 //!  - Using *any* type implementing [`std::io::Write`][write] in a non-blocking fashion.
 //!  - Using a combination of [`NonBlocking`] and [`RollingFileAppender`] to allow writes to a log file
-//! without blocking.
+//!    without blocking.
 //!
 //! ## File Appender
 //!

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -10,11 +10,11 @@
 //! The following helpers are available for creating a rolling file appender.
 //!
 //! - [`Rotation::minutely()`][minutely]: A new log file in the format of `some_directory/log_file_name_prefix.yyyy-MM-dd-HH-mm`
-//! will be created minutely (once per minute)
+//!   will be created minutely (once per minute)
 //! - [`Rotation::hourly()`][hourly]: A new log file in the format of `some_directory/log_file_name_prefix.yyyy-MM-dd-HH`
-//! will be created hourly
+//!   will be created hourly
 //! - [`Rotation::daily()`][daily]: A new log file in the format of `some_directory/log_file_name_prefix.yyyy-MM-dd`
-//! will be created daily
+//!   will be created daily
 //! - [`Rotation::never()`][never()]: This will result in log file located at `some_directory/log_file_name`
 //!
 //!

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -26,10 +26,10 @@
 //!
 //! - `traced-error` - Enables the [`TracedError`] type and related Traits
 //!     - [`InstrumentResult`] and [`InstrumentError`] extension traits, which
-//!     provide an [`in_current_span()`] method for bundling errors with a
-//!     [`SpanTrace`].
+//!       provide an [`in_current_span()`] method for bundling errors with a
+//!       [`SpanTrace`].
 //!     - [`ExtractSpanTrace`] extension trait, for extracting `SpanTrace`s from
-//!     behind `dyn Error` trait objects.
+//!       behind `dyn Error` trait objects.
 //!
 //! ## Usage
 //!

--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -573,6 +573,7 @@
 //!    the [`INFO`] [level] and above.
 //! - A third subscriber, `subscriber_c`, which should receive spans and events at
 //!    the [`DEBUG`] [level] as well.
+//!
 //! The subscribers and filters would be composed thusly:
 //!
 //! ```

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -1115,15 +1115,15 @@ macro_rules! span_enabled {
 /// in false positives or false negatives include:
 ///
 /// - If a collector is using a filter which may enable a span or event based
-/// on field names, but `enabled!` is invoked without listing field names,
-/// `enabled!` may return a false negative if a specific field name would
-/// cause the collector to enable something that would otherwise be disabled.
+///   on field names, but `enabled!` is invoked without listing field names,
+///   `enabled!` may return a false negative if a specific field name would
+///   cause the collector to enable something that would otherwise be disabled.
 /// - If a collector is using a filter which enables or disables specific events by
-/// file path and line number,  a particular event may be enabled/disabled
-/// even if an `enabled!` invocation with the same level, target, and fields
-/// indicated otherwise.
+///   file path and line number,  a particular event may be enabled/disabled
+///   even if an `enabled!` invocation with the same level, target, and fields
+///   indicated otherwise.
 /// - The collector can choose to enable _only_ spans or _only_ events, which `enabled`
-/// will not reflect.
+///   will not reflect.
 ///
 /// `enabled!()` requires a [level](crate::Level) argument, an optional `target:`
 /// argument, and an optional set of field names. If the fields are not provided,


### PR DESCRIPTION
1.80 had a bunch of indentation-related Clippy lints; fixing them.