### PR TITLE
docs: use the latest version in usage instruction

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -116,7 +116,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tracing = "0.1"
+//! tracing = "0.2"
 //! ```
 //!
 //! ## Recording Spans and Events


### PR DESCRIPTION
## Motivation

We should always use `0.2` in the document.

## Solution

Just updated it:(