### PR TITLE
Update nu-ansi-term to 0.50

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -39,7 +39,7 @@ bytes = "1.2.0"
 argh = "0.1.8"
 
 # sloggish example
-nu-ansi-term = "0.46.0"
+nu-ansi-term = "0.50.0"
 humantime = "2.1.0"
 log = "0.4.17"
 

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -49,7 +49,7 @@ once_cell = { optional = true, version = "1.13.0" }
 
 # fmt
 tracing-log = { path = "../tracing-log", version = "0.2", optional = true, default-features = false, features = ["log-tracer", "std"] }
-nu-ansi-term = { version = "0.46.0", optional = true }
+nu-ansi-term = { version = "0.50.0", optional = true }
 time = { version = "0.3.2", features = ["formatting"], optional = true }
 
 # only required by the json feature


### PR DESCRIPTION
## Motivation

`tracing-subscriber` indirectly depends on both `windows-sys` and `winapi`, It would be good to remove the `winapi` dependency as that is no longer maintained.

## Solution

Update `nu-ansi-term`.