### PR TITLE
tracing-subscriber: bump `matchers` to 0.2.0

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -42,7 +42,7 @@ tracing-core = { path = "../tracing-core", version = "0.2", default-features = f
 
 # only required by the `env-filter` feature
 tracing = { optional = true, path = "../tracing", version = "0.2", default-features = false }
-matchers = { optional = true, version = "0.1.0" }
+matchers = { optional = true, version = "0.2.0" }
 regex = { optional = true, version = "1.6.0", default-features = false, features = ["std", "unicode-case", "unicode-perl"] }
 smallvec = { optional = true, version = "1.9.0" }
 once_cell = { optional = true, version = "1.13.0" }


### PR DESCRIPTION
## Motivation

Looking to get rid of a duplicate dependency due to using an older version of `matchers` ( getting rid of a duplicate version of `regex-automata`, specifically).

## Solution

Well... update `matchers`. :)