### PR TITLE
attributes: support recording error as `std::error::Error`

### DIFF
--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -10,7 +10,7 @@ use syn::{
 };
 
 use crate::{
-    attr::{Field, Fields, FormatMode, InstrumentArgs, Level},
+    attr::{ErrFormatMode, Field, Fields, InstrumentArgs, Level, RetFormatMode},
     MaybeItemFn, MaybeItemFnRef,
 };
 
@@ -240,11 +240,14 @@ fn gen_block<B: ToTokens>(
         Some(event_args) => {
             let level_tokens = event_args.level(Level::Error);
             match event_args.mode {
-                FormatMode::Default | FormatMode::Display => Some(quote!(
+                ErrFormatMode::Default | ErrFormatMode::Display => Some(quote!(
                     tracing::event!(target: #target, #level_tokens, error = %e)
                 )),
-                FormatMode::Debug => Some(quote!(
+                ErrFormatMode::Debug => Some(quote!(
                     tracing::event!(target: #target, #level_tokens, error = ?e)
+                )),
+                ErrFormatMode::StdError => Some(quote!(
+                    tracing::event!(target: #target, #level_tokens, error = &e as &dyn ::std::error::Error)
                 )),
             }
         }
@@ -255,10 +258,10 @@ fn gen_block<B: ToTokens>(
         Some(event_args) => {
             let level_tokens = event_args.level(args_level);
             match event_args.mode {
-                FormatMode::Display => Some(quote!(
+                RetFormatMode::Display => Some(quote!(
                     tracing::event!(target: #target, #level_tokens, return = %x)
                 )),
-                FormatMode::Default | FormatMode::Debug => Some(quote!(
+                RetFormatMode::Default | RetFormatMode::Debug => Some(quote!(
                     tracing::event!(target: #target, #level_tokens, return = ?x)
                 )),
             }

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -296,6 +296,17 @@ mod expand;
 /// }
 /// ```
 ///
+/// Also, an error that implements `std::error::Error` can be recorded in a way that preserves
+/// the chain of causes by writing `err(StdError)`:
+///
+/// ```
+/// # use tracing_attributes::instrument;
+/// #[instrument(err(StdError))]
+/// fn my_function(arg: usize) -> Result<(), std::io::Error> {
+///     Ok(())
+/// }
+/// ```
+///
 /// If a `target` is specified, both the `ret` and `err` arguments will emit outputs to
 /// the declared target (or the default channel if `target` is not specified).
 ///


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

While `tracing::event!` macro accepts a value that implements `std::error::Error` trait (that is, [`tracing::Value` trait is implemented for `dyn std::error::Error`](https://docs.rs/tracing/0.1.40/tracing/trait.Value.html#impl-Value-for-dyn+Error), there is no way to achieve the same thing when afunction annotated with `#[tracing::instrument]` returns an error which implements `std::error::Error`; all we can do using the instrument attribute macro is either:

- `event!(error = %e)` (corresponds to `err` or `err(Display)`)
- `event!(error = ?e)` (corresponds to `err(Debug)`)

The lack of support of recording errors as `std::error::Error` becomes more apparent especially when we want to integrate them with OpenTelemetry. The tracing-opentelemetry crate provides a bridge layer, where [it generates OTel's event](https://github.com/tokio-rs/tracing-opentelemetry/blob/7c1fc95904b71cf98751480b413064f3108b93f4/src/layer.rs#L297) that the chain of error causes based on a passed value implementing `std::error::Error` in accordance with [Semantic Conventions for Exceptions on Spans](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/). It would be really helpful in troubleshooting an error if its virtual stack trace was recorded and viewable in OTel-compatible tracing platform. 


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Added a new notation `err(StdError)` to the `instrument` attribute macro. This works in a very similar way to the existing `err(Display)` or `err(Debug)`, with a difference that the returned error is converted into `&dyn std::error::Error` before being passed to the `event!` macro.

## Consideration

It is very usual especially in application layer (as opposed to library layer) that error types are represented as the one provided by third party crates such as `anyhow` or `eyre`. Since the error types provided by them don't implement `std::error::Error`, we won't be able to use `err(StdError)` if an instrumented function returns, for example, `anyhow::Error`.

```rust
// This doesn't compile
#[tracing::instrument(err(StdError))]
fn foo() -> Result<(), anyhow::Error> {
    Ok(())
}
```

To support these types, I think the most straightforward approach would be to introduce another notation like `err(AsRefStdError)` that calls `.as_ref()` on the returned error before casting it into a trait object (note that `AsRef<dyn std::error::Error>` is implemented for third party error types). We could maybe revisit and consider how to deal with this case later.

### Ref

#2648 pointed out that the instrument macro supports recording errors using either `Display` or `Debug`, which doesn't really work well with OTel's semantic conventions on exceptions.