### PR TITLE
subscriber: move timing into separate subscriber layer

### DIFF
--- a/examples/examples/fmt-fmtspan.rs
+++ b/examples/examples/fmt-fmtspan.rs
@@ -1,0 +1,22 @@
+#![deny(rust_2018_idioms)]
+
+use tracing_subscriber::{fmt::format::FmtSpan, prelude::*, subscribe::CollectExt};
+#[path = "fmt/yak_shave.rs"]
+mod yak_shave;
+
+fn main() {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::timing::TimingSubscriber::default())
+        .with(tracing_subscriber::FmtSubscriber::new().with_span_events(FmtSpan::FULL))
+        .init();
+
+    let number_of_yaks = 3;
+    // this creates a new event, outside of any spans.
+    tracing::info!(number_of_yaks, "preparing to shave yaks");
+
+    let number_shaved = yak_shave::shave_all(number_of_yaks);
+    tracing::info!(
+        all_yaks_shaved = number_shaved == number_of_yaks,
+        "yak shaving completed."
+    );
+}

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1630,24 +1630,6 @@ impl Default for FmtSpanConfig {
     }
 }
 
-pub(super) struct TimingDisplay(pub(super) u64);
-impl Display for TimingDisplay {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut t = self.0 as f64;
-        for unit in ["ns", "µs", "ms", "s"].iter() {
-            if t < 10.0 {
-                return write!(f, "{:.2}{}", t, unit);
-            } else if t < 100.0 {
-                return write!(f, "{:.1}{}", t, unit);
-            } else if t < 1000.0 {
-                return write!(f, "{:.0}{}", t, unit);
-            }
-            t /= 1000.0;
-        }
-        write!(f, "{:.0}s", t * 1000.0)
-    }
-}
-
 #[cfg(test)]
 pub(super) mod test {
     use crate::fmt::{test::MockMakeWriter, time::FormatTime};

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -202,6 +202,7 @@ pub mod time;
 #[cfg_attr(docsrs, doc(cfg(all(feature = "fmt", feature = "std"))))]
 pub mod writer;
 pub use fmt_subscriber::{FmtContext, FormattedFields, Subscriber};
+pub mod timing;
 
 use crate::subscribe::Subscribe as _;
 use crate::{

--- a/tracing-subscriber/src/fmt/timing.rs
+++ b/tracing-subscriber/src/fmt/timing.rs
@@ -1,0 +1,155 @@
+//! A subscriber that tracks the time spent in each span.
+
+use core::time::Duration;
+use std::time::Instant;
+
+use tracing::Collect;
+use tracing_core::span::{self, Attributes};
+
+use crate::{registry::LookupSpan, subscribe::Context, Subscribe};
+
+/// A subscriber that tracks the time spent in each span.
+///
+/// This subscriber records the time spent in each span, storing the timing data in the span's
+/// extensions. The subscriber records the time spent in each span as either "idle" time, when the
+/// span is not executing, or "busy" time, when the span is executing. The subscriber records the
+/// time spent in each span as a [`Timing`] resource, which can be accessed by other subscribers.
+#[derive(Debug, Default)]
+pub struct TimingSubscriber;
+
+/// A resource tracking the idle and busy time spent in each span.
+///
+/// This is used by the [`TimingSubscriber`] to track the time spent in each span.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Timing {
+    state: State,
+    idle: Duration,
+    busy: Duration,
+    last: Instant,
+}
+
+impl Default for Timing {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+enum State {
+    /// The span is closed.
+    ///
+    /// No further timing information will be recorded.
+    Closed,
+    #[default]
+    /// The span is currently idle.
+    ///
+    /// Timing information will be recorded when the span becomes busy or closed.
+    Idle,
+    /// The span is currently busy.
+    ///
+    /// Timing information will be recorded when the span becomes idle or closed.
+    Busy,
+}
+
+impl Timing {
+    /// Create a new `Timing` resource.
+    fn new() -> Self {
+        Self {
+            state: State::Idle,
+            idle: Duration::ZERO,
+            busy: Duration::ZERO,
+            last: Instant::now(),
+        }
+    }
+
+    /// Record that the span has become idle.
+    fn enter(&mut self) {
+        if self.state == State::Busy {
+            return;
+        }
+        let now = Instant::now();
+        self.idle += now.duration_since(self.last);
+        self.last = now;
+        self.state = State::Busy;
+    }
+
+    /// Record that the span has become busy.
+    fn exit(&mut self) {
+        if self.state == State::Idle {
+            return;
+        }
+        let now = Instant::now();
+        self.busy += now.duration_since(self.last);
+        self.last = now;
+        self.state = State::Idle;
+    }
+
+    /// Record that the span has been closed.
+    fn close(&mut self) {
+        match self.state {
+            State::Idle => self.idle += Instant::now().duration_since(self.last),
+            State::Busy => self.busy += Instant::now().duration_since(self.last),
+            State::Closed => {}
+        }
+        self.state = State::Closed;
+    }
+
+    /// Get the idle time spent in this span.
+    pub fn idle(&self) -> Duration {
+        self.idle
+    }
+
+    /// Get the busy time spent in this span.
+    pub fn busy(&self) -> Duration {
+        self.busy
+    }
+
+    /// Get the total time spent in this span.
+    pub fn total(&self) -> Duration {
+        self.idle + self.busy
+    }
+}
+
+impl<C> Subscribe<C> for TimingSubscriber
+where
+    C: Collect + for<'a> LookupSpan<'a>,
+{
+    /// Records that a new span has been created.
+    fn on_new_span(&self, _attrs: &Attributes<'_>, id: &span::Id, ctx: Context<'_, C>) {
+        let span = ctx.span(id).expect("span not found");
+        let mut extensions = span.extensions_mut();
+        extensions.insert(Timing::new());
+    }
+
+    /// Records that a span has been entered.
+    ///
+    /// The subscriber records the time spent in the span as "idle" time, as the span is not
+    /// executing.
+    fn on_enter(&self, id: &span::Id, ctx: Context<'_, C>) {
+        let span = ctx.span(id).expect("span not found");
+        let mut extensions = span.extensions_mut();
+        let timings = extensions.get_mut::<Timing>().expect("timings not found");
+        timings.enter();
+    }
+
+    /// Records that a span has been exited.
+    ///
+    /// The subscriber records the time spent in the span as "busy" time, as the span is executing.
+    fn on_exit(&self, id: &span::Id, ctx: Context<'_, C>) {
+        let span = ctx.span(id).expect("span not found");
+        let mut extensions = span.extensions_mut();
+        let timings = extensions.get_mut::<Timing>().expect("timings not found");
+        timings.exit();
+    }
+
+    /// Records that a span has been closed.
+    ///
+    /// The subscriber records the time spent in the span as either "idle" time or "busy" time, as
+    /// the span is not executing.
+    fn on_close(&self, id: span::Id, ctx: Context<'_, C>) {
+        let span = ctx.span(&id).expect("span not found");
+        let mut extensions = span.extensions_mut();
+        let timings = extensions.get_mut::<Timing>().expect("timings not found");
+        timings.close();
+    }
+}


### PR DESCRIPTION
Moves the Timing logic out from fmt::Subcriber into its own layer.

## Motivation

This allows for the timing subscriber logic to be composed and used by
any subscriber rather than just users of the fmt subscriber. I'd like this
info to be available as part of some ideas for a new Ratatui tracing layer
I'm thinking about.

## Solution

A new subscriber (TimingSubscriber) that stores Timing in the span extensions
Updated the on_close logic in fmt::Subsciber to use this and removed all
the code that otherwise dealt with timing.

The expectation is that this subscriber would be composed when there's need to
record any timing data.

TODO: work out how to properly configure the fmt subscriber to use the
timing subscriber as a layer (or otherwise make it easy to compose this 
layer)

Questions:
- is this a good idea?
- what should be the backwards compat story for this?
- should this have a quanta implementation instead of Instant::now, and should that be feature flagged, or just defaulted (ping @tobz for some advice)

Fixes: https://github.com/tokio-rs/tracing/issues/2946
Replaces: https://github.com/tokio-rs/tracing/pull/3038

