### PR TITLE
Add `impl Copy` to Id in span.rs

### DIFF
--- a/tracing-core/src/span.rs
+++ b/tracing-core/src/span.rs
@@ -13,7 +13,7 @@ use crate::{field, Metadata};
 ///
 /// [collector]: super::collect::Collect
 /// [`new_span`]: super::collect::Collect::new_span
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Id(NonZeroU64);
 
 /// Attributes provided to a collector describing a new span when it is


### PR DESCRIPTION
Reasoning: 
- wrapped type is Copy: https://doc.rust-lang.org/std/num/type.NonZeroU32.html
- simplifies passing around (parent) span Id

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
