### PR TITLE
fmt: call nu_ansi_term::enable_ansi_support for windows

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_subscriber.rs
+++ b/tracing-subscriber/src/fmt/fmt_subscriber.rs
@@ -323,14 +323,18 @@ impl<C, N, E, W> Subscriber<C, N, E, W> {
     /// [`with_ansi`]: Subscriber::with_ansi
     /// [`set_ansi`]: Subscriber::set_ansi
     pub fn with_ansi(self, ansi: bool) -> Self {
-        #[cfg(not(feature = "ansi"))]
         if ansi {
-            const ERROR: &str =
-                "tracing-subscriber: the `ansi` crate feature is required to enable ANSI terminal colors";
-            #[cfg(debug_assertions)]
-            panic!("{}", ERROR);
-            #[cfg(not(debug_assertions))]
-            eprintln!("{}", ERROR);
+            #[cfg(not(feature = "ansi"))]
+            {
+                const ERROR: &str =
+                    "tracing-subscriber: the `ansi` crate feature is required to enable ANSI terminal colors";
+                #[cfg(debug_assertions)]
+                panic!("{}", ERROR);
+                #[cfg(not(debug_assertions))]
+                eprintln!("{}", ERROR);
+            }
+            #[cfg(target_os = "windows")]
+            nu_ansi_term::enable_ansi_support();
         }
 
         Subscriber {
@@ -571,6 +575,8 @@ where
     #[cfg(feature = "ansi")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
     pub fn pretty(self) -> Subscriber<C, format::Pretty, format::Format<format::Pretty, T>, W> {
+        #[cfg(target_os = "windows")]
+        nu_ansi_term::enable_ansi_support();
         Subscriber {
             fmt_event: self.fmt_event.pretty(),
             fmt_fields: format::Pretty::default(),

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -744,6 +744,10 @@ impl<F, T> Format<F, T> {
 
     /// Enable ANSI terminal colors for formatted output.
     pub fn with_ansi(self, ansi: bool) -> Format<F, T> {
+        if ansi {
+            #[cfg(target_os = "windows")]
+            nu_ansi_term::enable_ansi_support();
+        }
         Format {
             ansi: Some(ansi),
             ..self

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -626,6 +626,10 @@ where
     /// whether or not other crates in the dependency graph enable the "ansi"
     /// feature flag.
     pub fn with_ansi(self, ansi: bool) -> CollectorBuilder<N, format::Format<L, T>, F, W> {
+        if ansi {
+            #[cfg(target_os = "windows")]
+            nu_ansi_term::enable_ansi_support();
+        }
         CollectorBuilder {
             inner: self.inner.with_ansi(ansi),
             ..self
@@ -750,6 +754,8 @@ where
     pub fn pretty(
         self,
     ) -> CollectorBuilder<format::Pretty, format::Format<format::Pretty, T>, F, W> {
+        #[cfg(target_os = "windows")]
+        nu_ansi_term::enable_ansi_support();
         CollectorBuilder {
             filter: self.filter,
             inner: self.inner.pretty(),


### PR DESCRIPTION
To correctly enable the ansi output, we need to call `nu_ansi_term::enable_ansi_support` on windows before outputting ansi characters.

Fixes: #3068

Disclaimer: I know this is not clean at all, and I have most likely missed places where we need to enable this, but I haven't found a better option.