### PR TITLE
Remove the additional virtual spans `ThreadId(xxx)-{thread_name}` for tracing-flame

### DIFF
--- a/tracing-flame/src/lib.rs
+++ b/tracing-flame/src/lib.rs
@@ -136,7 +136,6 @@
 
 use error::Error;
 use error::Kind;
-use once_cell::sync::Lazy;
 use std::cell::Cell;
 use std::fmt;
 use std::fmt::Write as _;
@@ -157,10 +156,8 @@ use tracing_subscriber::Subscribe;
 
 mod error;
 
-static START: Lazy<Instant> = Lazy::new(Instant::now);
-
 thread_local! {
-    static LAST_EVENT: Cell<Instant> = Cell::new(*START);
+    static LAST_EVENT: Cell<Option<Instant>> = Cell::new(None);
 
     static THREAD_NAME: String = {
         let thread = std::thread::current();
@@ -264,7 +261,6 @@ where
     pub fn new(writer: W) -> Self {
         // Initialize the start used by all threads when initializing the
         // LAST_EVENT when constructing the subscriber
-        let _unused = *START;
         Self {
             out: Arc::new(Mutex::new(writer)),
             config: Default::default(),
@@ -387,13 +383,17 @@ where
     W: Write + 'static,
 {
     fn on_enter(&self, id: &span::Id, ctx: Context<'_, C>) {
-        let samples = self.time_since_last_event();
+        let Some(samples) = self.time_since_last_event() else {
+            return;
+        };
 
         let first = ctx.span(id).expect("expected: span id exists in registry");
 
         if !self.config.empty_samples && first.parent().is_none() {
             return;
         }
+
+        let Some(second) = first.parent() else { return };
 
         let mut stack = String::new();
 
@@ -403,12 +403,9 @@ where
             stack += "all-threads";
         }
 
-        if let Some(second) = first.parent() {
-            for parent in second.scope().from_root() {
-                stack += ";";
-                write(&mut stack, parent, &self.config)
-                    .expect("expected: write to String never fails");
-            }
+        for parent in second.scope().from_root() {
+            stack += ";";
+            write(&mut stack, parent, &self.config).expect("expected: write to String never fails");
         }
 
         write!(&mut stack, " {}", samples.as_nanos())
@@ -436,7 +433,9 @@ where
             };
         }
 
-        let samples = self.time_since_last_event();
+        let samples = self
+            .time_since_last_event()
+            .expect("expected: LAST_EVENT has been initialized");
         let first = expect!(ctx.span(id), "expected: span id exists in registry");
 
         let mut stack = String::new();
@@ -468,16 +467,16 @@ where
     C: Collect + for<'span> LookupSpan<'span>,
     W: Write + 'static,
 {
-    fn time_since_last_event(&self) -> Duration {
+    fn time_since_last_event(&self) -> Option<Duration> {
         let now = Instant::now();
 
         let prev = LAST_EVENT.with(|e| {
             let prev = e.get();
-            e.set(now);
+            e.set(Some(now));
             prev
         });
 
-        now - prev
+        prev.map(|prev| now - prev)
     }
 }
 


### PR DESCRIPTION
## Motivation

`tracing-flame` generates a "virtual span" named `ThreadId(xxx)-{thread_name}` to identify the location of a thread within a span. When the time outside a span is large, the span of actual interest to users might appear exceedingly small.

The issue at hand is illustrated in the following example: 

```rust
use std::thread::sleep;
use std::time::Duration;
use tracing::{span, Level};
use tracing_flame::FlameSubscriber;
use tracing_subscriber::{prelude::*, registry::Registry};

#[test]
fn capture_supported() {
    {
        let tmp_dir = tempfile::Builder::new()
            .prefix("tracing-flamegraph-test-")
            .tempdir()
            .expect("failed to create tempdir");
        let (flame_layer, _guard) = FlameSubscriber::with_file("./tracing.folded").unwrap();

        let subscriber = Registry::default().with(flame_layer);

        tracing::collect::set_global_default(subscriber).expect("Could not set global default");

        // long sleep!!!!
        sleep(Duration::from_millis(5000));

        {
            let span = span!(Level::ERROR, "outer");
            let _guard = span.enter();
            sleep(Duration::from_millis(10));
        }

        tmp_dir.close().expect("failed to delete tempdir");
    }
}

```

Pay attention to the line commented as `long sleep`, where the code spends much longer outside the "outer" span, which is what users are primarily concerned with.

The flame-graph spawned from the previous code looks something like this:

![CleanShot 2024-09-28 at 17 22 17@2x](https://github.com/user-attachments/assets/cd869221-37ec-45ec-8745-6bbdd408651b)

As you can see, the `outer` span appears barely noticeable.

## Solution

We could remove the additional "virtual span" that is deemed unnecessary. Consequently, the flame graph for the above example ought to look more like this:

![CleanShot 2024-09-28 at 17 24 46@2x](https://github.com/user-attachments/assets/3d1651c0-2465-47c4-a428-898e6a0275a4)


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
