### PR TITLE
tracing-appender: support rolling file using local time

### DIFF
--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -20,6 +20,11 @@ keywords = ["logging", "tracing", "file-appender", "non-blocking-writer"]
 edition = "2018"
 rust-version = "1.53.0"
 
+[features]
+
+# Enables support for rolling file using local time
+local-time = ["time/local-offset"]
+
 [dependencies]
 crossbeam-channel = "0.5.5"
 time = { version = "0.3.2", default-features = false, features = ["formatting", "parsing"] }

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -121,6 +121,10 @@
 //! # }
 //! ```
 //!
+//! ## Feature Flags
+//!
+//! - `local-time`: Enables support for rolling file using local time
+//!
 //! ## Supported Rust Versions
 //!
 //! `tracing-appender` is built against the latest stable release. The minimum supported

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -209,12 +209,19 @@ impl RollingFileAppender {
         })
     }
 
+    #[cfg(test)]
     #[inline]
     fn now(&self) -> OffsetDateTime {
-        #[cfg(test)]
-        return (self.now)();
+        (self.now)()
+    }
 
-        #[cfg(not(test))]
+    #[cfg(not(test))]
+    #[inline]
+    fn now(&self) -> OffsetDateTime {
+        #[cfg(feature = "local-time")]
+        return OffsetDateTime::now_local().unwrap_or_else(|_| OffsetDateTime::now_utc());
+
+        #[cfg(not(feature = "local-time"))]
         OffsetDateTime::now_utc()
     }
 }


### PR DESCRIPTION
## Motivation

Fixes #3102 

## Solution

Add a `local-time` feature to `tracing-appender` (just like the one in `tracing-subscriber`) to modify the behavior.
