### PR TITLE
docs: Adding a link to a stream recording of @jonhoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ Tracing.
 * [RustConf 2019 talk][rust-conf-2019-08-video] and [slides][rust-conf-2019-08-slides], August 2019
 * [Are we observable yet? @ RustyDays talk][rusty-days-2020-08-video] and [slides][rusty-days-2020-08-slides], August 2020
 * [Crabs with instruments!][tremorcon-2021-09], September 2021
+* [Decrusting the tracing crate by Jon Gjengset][decrusting-tracing-2024-02], February 2024
 
 [bay-rust-2019-03]: https://www.youtube.com/watch?v=j_kXRg3zlec
 [rust-conf-2019-08-video]: https://www.youtube.com/watch?v=JjItsfqFIdo
@@ -487,6 +488,7 @@ Tracing.
 [custom-logging-part-1]: https://burgers.io/custom-logging-in-rust-using-tracing
 [custom-logging-part-2]: https://burgers.io/custom-logging-in-rust-using-tracing-part-2
 [tremorcon-2021-09]: https://www.youtube.com/watch?v=ZC7fyqshun8
+[decrusting-tracing-2024-02]: https://www.youtube.com/watch?v=21rtHinFA40
 
 Help us expand this list! If you've written or spoken about Tracing, or
 know of resources that aren't listed, please open a pull request adding them.


### PR DESCRIPTION
@jonhoo recorded a great resource about the crate's inner workings and included practical suggestions about patterns to follow when annotating one's code.

I added the link to the YouTube video under the "Talks" header as that seemed appropriate enough.