### PR TITLE
tracing-subscriber: link init docs in description of tracing-log feature flag

### DIFF
--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -67,7 +67,8 @@
 //! ### Optional Dependencies
 //!
 //! - [`tracing-log`]: Enables better formatting for events emitted by `log`
-//!   macros in the `fmt` subscriber. Enabled by default.
+//!   macros in the `fmt` subscriber. Enabled by default. See [util::SubscriberInitExt] for
+//!   details.
 //! - [`time`][`time` crate]: Enables support for using the [`time` crate] for timestamp
 //!   formatting in the `fmt` subscriber.
 //! - [`smallvec`]: Causes the `EnvFilter` type to use the `smallvec` crate (rather


### PR DESCRIPTION
## Motivation

When updating my project after a time of inactivity, I reviewed feature flags of `tracing_subscriber`, and decided to enable the `tracing-log` feature. This, inevitably lead to a panic in my wrapper, which has function like so:

```rust
pub fn init_short_logs(filter: impl Into<EnvFilter>) {
    tracing_subscriber::fmt()
        .with_env_filter(filter)
        .with_span_events(FmtSpan::CLOSE)
        .with_writer(std::io::stdout)
        .compact()
        .init();
}
```

## Solution

To reduce future confusion, this PR adds a link to [`tracing_subscriber::util::SubscriberInitExt`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/util/trait.SubscriberInitExt.html) in the description of the feature flag.