### PR TITLE
Let `dead_code` lint work on `#[instrument]`ed functions

### DIFF
--- a/tracing-attributes/tests/async_fn.rs
+++ b/tracing-attributes/tests/async_fn.rs
@@ -30,14 +30,17 @@ async fn test_ret_impl_trait_err(n: i32) -> Result<impl Iterator<Item = i32>, &'
 }
 
 #[instrument]
+#[allow(dead_code)]
 async fn test_async_fn_empty() {}
 
 #[instrument]
+#[allow(dead_code)]
 async unsafe fn test_async_unsafe_fn_empty() {}
 
 // Reproduces a compile error when an instrumented function body contains inner
 // attributes (https://github.com/tokio-rs/tracing/issues/2294).
 #[deny(unused_variables)]
+#[allow(dead_code, clippy::mixed_attributes_style)]
 #[instrument]
 async fn repro_async_2294() {
     #![allow(unused_variables)]
@@ -50,6 +53,7 @@ async fn repro_async_2294() {
 // with the rustfmt-generated formatting, the lint will not be triggered!
 #[rustfmt::skip]
 #[deny(clippy::suspicious_else_formatting)]
+#[allow(dead_code)]
 async fn repro_1613(var: bool) {
     println!(
         "{}",
@@ -61,6 +65,7 @@ async fn repro_1613(var: bool) {
 // and https://github.com/rust-lang/rust-clippy/issues/7760
 #[instrument]
 #[deny(clippy::suspicious_else_formatting)]
+#[allow(dead_code)]
 async fn repro_1613_2() {
     // hello world
     // else

--- a/tracing-attributes/tests/dead_code.rs
+++ b/tracing-attributes/tests/dead_code.rs
@@ -1,0 +1,10 @@
+use tracing_attributes::instrument;
+
+#[deny(unfulfilled_lint_expectations)]
+#[expect(dead_code)]
+#[instrument]
+fn unused() {}
+
+#[expect(dead_code)]
+#[instrument]
+async fn unused_async() {}

--- a/tracing-attributes/tests/err.rs
+++ b/tracing-attributes/tests/err.rs
@@ -15,6 +15,7 @@ fn err() -> Result<u8, TryFromIntError> {
 }
 
 #[instrument(err)]
+#[allow(dead_code)]
 fn err_suspicious_else() -> Result<u8, TryFromIntError> {
     {}
     u8::try_from(1234)

--- a/tracing-attributes/tests/instrument.rs
+++ b/tracing-attributes/tests/instrument.rs
@@ -6,6 +6,7 @@ use tracing_mock::*;
 // Reproduces a compile error when an instrumented function body contains inner
 // attributes (https://github.com/tokio-rs/tracing/issues/2294).
 #[deny(unused_variables)]
+#[allow(dead_code, clippy::mixed_attributes_style)]
 #[instrument]
 fn repro_2294() {
     #![allow(unused_variables)]
@@ -317,6 +318,7 @@ fn user_tracing_module() {
 
     // Reproduces https://github.com/tokio-rs/tracing/issues/3119
     #[instrument(fields(f = Empty))]
+    #[allow(dead_code)]
     fn my_fn() {
         assert_eq!("test", tracing::my_other_fn());
     }

--- a/tracing-attributes/tests/ui/async_instrument.rs
+++ b/tracing-attributes/tests/ui/async_instrument.rs
@@ -10,7 +10,6 @@ async fn simple_mismatch() -> String {
     ""
 }
 
-// FIXME: this span is still pretty poor
 #[tracing::instrument]
 async fn opaque_unsatisfied() -> impl std::fmt::Display {
     ("",)

--- a/tracing-attributes/tests/ui/async_instrument.stderr
+++ b/tracing-attributes/tests/ui/async_instrument.stderr
@@ -25,77 +25,80 @@ note: return type inferred to be `String` here
    |                               ^^^^^^
 
 error[E0277]: `(&str,)` doesn't implement `std::fmt::Display`
-  --> tests/ui/async_instrument.rs:14:1
+  --> tests/ui/async_instrument.rs:14:57
    |
-14 | #[tracing::instrument]
-   | ^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | `(&str,)` cannot be formatted with the default formatter
-   | return type was inferred to be `(&str,)` here
+14 |   async fn opaque_unsatisfied() -> impl std::fmt::Display {
+   |  _________________________________________________________-
+15 | |     ("",)
+16 | | }
+   | | ^
+   | | |
+   | |_`(&str,)` cannot be formatted with the default formatter
+   |   return type was inferred to be `(&str,)` here
    |
    = help: the trait `std::fmt::Display` is not implemented for `(&str,)`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in the attribute macro `tracing::instrument` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `(&str,)` doesn't implement `std::fmt::Display`
-  --> tests/ui/async_instrument.rs:15:34
+  --> tests/ui/async_instrument.rs:14:34
    |
-15 | async fn opaque_unsatisfied() -> impl std::fmt::Display {
+14 | async fn opaque_unsatisfied() -> impl std::fmt::Display {
    |                                  ^^^^^^^^^^^^^^^^^^^^^^ `(&str,)` cannot be formatted with the default formatter
    |
    = help: the trait `std::fmt::Display` is not implemented for `(&str,)`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
 
 error[E0308]: mismatched types
-  --> tests/ui/async_instrument.rs:23:5
+  --> tests/ui/async_instrument.rs:22:5
    |
-23 |     ""
+22 |     ""
    |     ^^ expected `Wrapper<_>`, found `&str`
    |
    = note: expected struct `Wrapper<_>`
            found reference `&'static str`
 note: return type inferred to be `Wrapper<_>` here
-  --> tests/ui/async_instrument.rs:22:36
+  --> tests/ui/async_instrument.rs:21:36
    |
-22 | async fn mismatch_with_opaque() -> Wrapper<impl std::fmt::Display> {
+21 | async fn mismatch_with_opaque() -> Wrapper<impl std::fmt::Display> {
    |                                    ^^^^^^^
 help: try wrapping the expression in `Wrapper`
    |
-23 |     Wrapper("")
+22 |     Wrapper("")
    |     ++++++++  +
 
 error[E0308]: mismatched types
-  --> tests/ui/async_instrument.rs:29:16
+  --> tests/ui/async_instrument.rs:28:16
    |
-29 |         return "";
+28 |         return "";
    |                ^^ expected `()`, found `&str`
    |
 note: return type inferred to be `()` here
-  --> tests/ui/async_instrument.rs:27:10
+  --> tests/ui/async_instrument.rs:26:10
    |
-27 | async fn early_return_unit() {
+26 | async fn early_return_unit() {
    |          ^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> tests/ui/async_instrument.rs:36:16
+  --> tests/ui/async_instrument.rs:35:16
    |
-36 |         return "";
+35 |         return "";
    |                ^^- help: try using a conversion method: `.to_string()`
    |                |
    |                expected `String`, found `&str`
    |
 note: return type inferred to be `String` here
-  --> tests/ui/async_instrument.rs:34:28
+  --> tests/ui/async_instrument.rs:33:28
    |
-34 | async fn early_return() -> String {
+33 | async fn early_return() -> String {
    |                            ^^^^^^
 
 error[E0308]: mismatched types
-  --> tests/ui/async_instrument.rs:42:35
+  --> tests/ui/async_instrument.rs:40:1
    |
-42 |   async fn extra_semicolon() -> i32 {
-   |  ___________________________________^
-43 | |     1;
-   | |      - help: remove this semicolon to return this value
-44 | | }
-   | |_^ expected `i32`, found `()`
+40 | #[tracing::instrument]
+   | ^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `()`
+41 | async fn extra_semicolon() -> i32 {
+42 |     1;
+   |      - help: remove this semicolon to return this value
+   |
+   = note: this error originates in the attribute macro `tracing::instrument` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
## Motivation

`#[instrument]`ed functions never trigger a `dead_code` lint.

Closes (partially?) #1366

## Solution

Include all of the input tokens in the output. In particular, the brace tokens surrounding the function body, the parenthesis surrounding the function parameters, and the angle brackets surrounding the generics must be included.

Prior art: https://github.com/andrewhickman/fn-error-context/commit/cfa749aaef91157bae8d3a984e6650bc00f6af68
