### PR TITLE
Simplify callsite enabled check

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1105,28 +1105,32 @@ pub mod __macro_support {
             }
         }
 
-        /// Returns the callsite's cached Interest, or registers it for the
-        /// first time if it has not yet been registered.
+        /// Returns whether the callsite is enabled.
         ///
         /// /!\ WARNING: This is *not* a stable API! /!\
-        /// This method, and all code contained in the `__macro_support` module, is
+        /// This type, and all code contained in the `__macro_support` module, is
         /// a *private* API of `tracing`. It is exposed publicly because it is used
         /// by the `tracing` macros, but it is not part of the stable versioned API.
         /// Breaking changes to this module may occur in small-numbered versions
         /// without warning.
         #[inline]
-        pub fn interest(&'static self) -> Interest {
-            match self.interest.load(Ordering::Relaxed) {
+        pub fn is_enabled(&'static self) -> bool {
+            let interest = match self.interest.load(Ordering::Relaxed) {
                 Self::INTEREST_NEVER => Interest::never(),
                 Self::INTEREST_SOMETIMES => Interest::sometimes(),
                 Self::INTEREST_ALWAYS => Interest::always(),
                 _ => self.register(),
-            }
-        }
+            };
 
-        pub fn is_enabled(&self, interest: Interest) -> bool {
-            interest.is_always()
-                || crate::dispatch::get_default(|default| default.enabled(self.meta))
+            if interest.is_never() {
+                return false;
+            }
+
+            if interest.is_always() {
+                return true;
+            }
+
+            crate::dispatch::get_default(|default| default.enabled(self.meta))
         }
 
         #[inline]

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -31,11 +31,8 @@ macro_rules! span {
                 level: $lvl,
                 fields: $($fields)*
             };
-            let mut interest = $crate::collect::Interest::never();
-            if $crate::level_enabled!($lvl)
-                && { interest = __CALLSITE.interest(); !interest.is_never() }
-                && __CALLSITE.is_enabled(interest)
-            {
+
+            if $crate::level_enabled!($lvl) && __CALLSITE.is_enabled() {
                 let meta = __CALLSITE.metadata();
                 // span with explicit parent
                 $crate::Span::child_of(
@@ -63,11 +60,7 @@ macro_rules! span {
                 fields: $($fields)*
             };
 
-            let mut interest = $crate::collect::Interest::never();
-            if $crate::level_enabled!($lvl)
-                && { interest = __CALLSITE.interest(); !interest.is_never() }
-                && __CALLSITE.is_enabled(interest)
-            {
+            if $crate::level_enabled!($lvl)&& __CALLSITE.is_enabled() {
                 let meta = __CALLSITE.metadata();
                 // span with contextual parent
                 $crate::Span::new(
@@ -595,11 +588,7 @@ macro_rules! event {
             fields: $($fields)*
         };
 
-        let enabled = $crate::level_enabled!($lvl) && {
-            let interest = __CALLSITE.interest();
-            !interest.is_never() && __CALLSITE.is_enabled(interest)
-        };
-        if enabled {
+        if $crate::level_enabled!($lvl) && __CALLSITE.is_enabled() {
             (|value_set: $crate::field::ValueSet| {
                 $crate::__tracing_log!(
                     $lvl,
@@ -648,11 +637,8 @@ macro_rules! event {
             level: $lvl,
             fields: $($fields)*
         };
-        let enabled = $crate::level_enabled!($lvl) && {
-            let interest = __CALLSITE.interest();
-            !interest.is_never() && __CALLSITE.is_enabled(interest)
-        };
-        if enabled {
+
+        if $crate::level_enabled!($lvl) && __CALLSITE.is_enabled() {
             (|value_set: $crate::field::ValueSet| {
                 let meta = __CALLSITE.metadata();
                 // event with contextual parent
@@ -705,11 +691,7 @@ macro_rules! event {
             fields: $($fields)*
         };
 
-        let enabled = $crate::level_enabled!($lvl) && {
-            let interest = __CALLSITE.interest();
-            !interest.is_never() && __CALLSITE.is_enabled(interest)
-        };
-        if enabled {
+        if $crate::level_enabled!($lvl) && __CALLSITE.is_enabled() {
             (|value_set: $crate::field::ValueSet| {
                 $crate::__tracing_log!(
                     $lvl,
@@ -758,11 +740,7 @@ macro_rules! event {
             fields: $($fields)*
         };
 
-        let enabled = $crate::level_enabled!($lvl) && {
-            let interest = __CALLSITE.interest();
-            !interest.is_never() && __CALLSITE.is_enabled(interest)
-        };
-        if enabled {
+        if $crate::level_enabled!($lvl) && __CALLSITE.is_enabled() {
             (|value_set: $crate::field::ValueSet| {
                 $crate::__tracing_log!(
                     $lvl,
@@ -810,11 +788,8 @@ macro_rules! event {
             level: $lvl,
             fields: $($fields)*
         };
-        let enabled = $crate::level_enabled!($lvl) && {
-            let interest = __CALLSITE.interest();
-            !interest.is_never() && __CALLSITE.is_enabled(interest)
-        };
-        if enabled {
+
+        if $crate::level_enabled!($lvl) && __CALLSITE.is_enabled() {
             (|value_set: $crate::field::ValueSet| {
                 let meta = __CALLSITE.metadata();
                 // event with contextual parent
@@ -865,11 +840,8 @@ macro_rules! event {
             level: $lvl,
             fields: $($fields)*
         };
-        let enabled = $crate::level_enabled!($lvl) && {
-            let interest = __CALLSITE.interest();
-            !interest.is_never() && __CALLSITE.is_enabled(interest)
-        };
-        if enabled {
+
+        if $crate::level_enabled!($lvl) && __CALLSITE.is_enabled() {
             (|value_set: $crate::field::ValueSet| {
                 let meta = __CALLSITE.metadata();
                 // event with contextual parent
@@ -1195,8 +1167,8 @@ macro_rules! enabled {
                 level: $lvl,
                 fields: $($fields)*
             };
-            let interest = __CALLSITE.interest();
-            if !interest.is_never() && __CALLSITE.is_enabled(interest)  {
+
+            if __CALLSITE.is_enabled()  {
                 let meta = __CALLSITE.metadata();
                 $crate::dispatch::get_default(|current| current.enabled(meta))
             } else {


### PR DESCRIPTION
Small refactor to simplify the callsite enabled check in the macros. In particular, it is a bit confusing that the `interest.is_never()` condition is in the macro while the `interest.is_always()` condition is in `is_enabled`.