### PR TITLE
subscriber: fix typo in `layer` module docs

### DIFF
--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -468,7 +468,7 @@
 //! function pointer. In addition, when more control is required, the [`Filter`]
 //! trait may also be implemented for user-defined types.
 //!
-//! //! [`Option<Filter>`] also implements [`Filter`], which allows for an optional
+//! [`Option<Filter>`] also implements [`Filter`], which allows for an optional
 //! filter. [`None`](Option::None) filters out _nothing_ (that is, allows
 //! everything through). For example:
 //!


### PR DESCRIPTION
A typo fix in the `layer` module docs of `tracing-subscriber`.