### PR TITLE
examples: ignore failing MSRV in tower-load example

### DIFF
--- a/examples/examples/tower-load.rs
+++ b/examples/examples/tower-load.rs
@@ -72,6 +72,8 @@ async fn main() -> Result<(), Err> {
     let svc = Server::bind(&addr).serve(svc);
     let admin = Server::bind(&admin_addr).serve(admin);
 
+    // We're fine breaking our MSRV in an example.
+    #[allow(clippy::incompatible_msrv)]
     let res = try_join!(
         tokio::spawn(load_gen(addr)),
         tokio::spawn(load_gen(addr)),


### PR DESCRIPTION
## Motivation

We're using the `try_join!` macro from tokio in the tower-load example
in the `tracing-examples` crate. With the latest version of Tokio
(1.41.0), this macro needs Rust 1.64.0 to compile.

Since an earlier version of Tokio has the same macro compiling on an
earlier version of Rust, and because this is just an example, it doesn't
make sense to bump the MSRV for this.

## Solution

The MSRV Clippy lint has been set to allow for this instance.