### PR TITLE
ci: pin Rust to 1.81 for `wasm32-unknown-unknown` tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -269,8 +269,10 @@ jobs:
         - tracing
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@stable
+    - name: Install Rust 1.81
+      uses: dtolnay/rust-toolchain@stable
       with:
+        toolchain: 1.81
         target: wasm32-unknown-unknown
     - name: install test runner for wasm
       uses: taiki-e/install-action@wasm-pack

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,7 +3,7 @@ name = "tracing-examples"
 version = "0.0.0"
 publish = false
 edition = "2018"
-rust-version = "1.63.0"
+rust-version = "1.64.0"
 
 [features]
 default = []


### PR DESCRIPTION
## Motivation

There is an incompatibility with the version of Node available on our
test runners and wasm32 in Rust 1.82 (#3123).

## Solution

To unblock the CI, this change pins Rust to 1.81 for the tests using the
`wasm32-unknown-unknown` target. This is the same strategy used in Tokio
to mitigate tokio-rs/tokio#6910 until a more permanent fix can be put in
place.

This change also bumps the MSRV on the `tracing-examples` crate from
1.63.0 to 1.64.0 to avoid triggering a lint about the MSRV after a
change in Tokio 1.41.0 which bumps the required Rust version for the
`try_join!` macro. The Tokio MSRV is 1.70 now, so needing this bump for
the examples seems reasonable.