### PR TITLE
attributes: globally qualify attribute paths

### DIFF
--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.28 (Unreleased)
+
+### Fixed
+
+- Globally qualify attribute paths to avoid ambiguities ([#3119])
+
 # 0.1.27 (October 13, 2023)
 
 ### Changed

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-attributes"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.27"
+version = "0.1.28"
 authors = [
     "Tokio Contributors <team@tokio.rs>",
     "Eliza Weisman <eliza@buoyant.io>",

--- a/tracing-attributes/src/attr.rs
+++ b/tracing-attributes/src/attr.rs
@@ -352,7 +352,7 @@ impl ToTokens for Field {
             // `instrument` produce empty field values, so changing it now
             // is a breaking change. agh.
             let name = &self.name;
-            tokens.extend(quote!(#name = tracing::field::Empty))
+            tokens.extend(quote!(#name = ::tracing::field::Empty))
         } else {
             self.kind.to_tokens(tokens);
             self.name.to_tokens(tokens);
@@ -428,11 +428,11 @@ impl Parse for Level {
 impl ToTokens for Level {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
-            Level::Trace => tokens.extend(quote!(tracing::Level::TRACE)),
-            Level::Debug => tokens.extend(quote!(tracing::Level::DEBUG)),
-            Level::Info => tokens.extend(quote!(tracing::Level::INFO)),
-            Level::Warn => tokens.extend(quote!(tracing::Level::WARN)),
-            Level::Error => tokens.extend(quote!(tracing::Level::ERROR)),
+            Level::Trace => tokens.extend(quote!(::tracing::Level::TRACE)),
+            Level::Debug => tokens.extend(quote!(::tracing::Level::DEBUG)),
+            Level::Info => tokens.extend(quote!(::tracing::Level::INFO)),
+            Level::Warn => tokens.extend(quote!(::tracing::Level::WARN)),
+            Level::Error => tokens.extend(quote!(::tracing::Level::ERROR)),
             Level::Path(ref pat) => tokens.extend(quote!(#pat)),
         }
     }

--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -199,7 +199,7 @@ fn gen_block<B: ToTokens>(
             })
             .map(|(user_name, (real_name, record_type))| match record_type {
                 RecordType::Value => quote!(#user_name = #real_name),
-                RecordType::Debug => quote!(#user_name = tracing::field::debug(&#real_name)),
+                RecordType::Debug => quote!(#user_name = ::tracing::field::debug(&#real_name)),
             })
             .collect();
 
@@ -223,7 +223,7 @@ fn gen_block<B: ToTokens>(
 
         let custom_fields = &args.fields;
 
-        quote!(tracing::span!(
+        quote!(::tracing::span!(
             target: #target,
             #(parent: #parent,)*
             #level,
@@ -241,10 +241,10 @@ fn gen_block<B: ToTokens>(
             let level_tokens = event_args.level(Level::Error);
             match event_args.mode {
                 FormatMode::Default | FormatMode::Display => Some(quote!(
-                    tracing::event!(target: #target, #level_tokens, error = %e)
+                    ::tracing::event!(target: #target, #level_tokens, error = %e)
                 )),
                 FormatMode::Debug => Some(quote!(
-                    tracing::event!(target: #target, #level_tokens, error = ?e)
+                    ::tracing::event!(target: #target, #level_tokens, error = ?e)
                 )),
             }
         }
@@ -256,10 +256,10 @@ fn gen_block<B: ToTokens>(
             let level_tokens = event_args.level(args_level);
             match event_args.mode {
                 FormatMode::Display => Some(quote!(
-                    tracing::event!(target: #target, #level_tokens, return = %x)
+                    ::tracing::event!(target: #target, #level_tokens, return = %x)
                 )),
                 FormatMode::Default | FormatMode::Debug => Some(quote!(
-                    tracing::event!(target: #target, #level_tokens, return = ?x)
+                    ::tracing::event!(target: #target, #level_tokens, return = ?x)
                 )),
             }
         }
@@ -320,7 +320,7 @@ fn gen_block<B: ToTokens>(
             let __tracing_instrument_future = #mk_fut;
             if !__tracing_attr_span.is_disabled() {
                 #follows_from
-                tracing::Instrument::instrument(
+                ::tracing::Instrument::instrument(
                     __tracing_instrument_future,
                     __tracing_attr_span
                 )
@@ -344,7 +344,7 @@ fn gen_block<B: ToTokens>(
         // regression in case the level is enabled.
         let __tracing_attr_span;
         let __tracing_attr_guard;
-        if tracing::level_enabled!(#level) || tracing::if_log_enabled!(#level, {true} else {false}) {
+        if ::tracing::level_enabled!(#level) || ::tracing::if_log_enabled!(#level, {true} else {false}) {
             __tracing_attr_span = #span;
             #follows_from
             __tracing_attr_guard = __tracing_attr_span.enter();
@@ -724,7 +724,7 @@ impl<'block> AsyncInfo<'block> {
                     let async_attrs = &async_expr.attrs;
                     if pinned_box {
                         quote! {
-                            Box::pin(#(#async_attrs) * async move { #instrumented_block })
+                            ::std::boxed::Box::pin(#(#async_attrs) * async move { #instrumented_block })
                         }
                     } else {
                         quote! {

--- a/tracing-attributes/tests/instrument.rs
+++ b/tracing-attributes/tests/instrument.rs
@@ -252,3 +252,21 @@ fn impl_trait_return_type() {
 
     handle.assert_finished();
 }
+
+#[test]
+fn user_tracing_module() {
+    use ::tracing::field::Empty;
+
+    // Reproduces https://github.com/tokio-rs/tracing/issues/3119
+    #[instrument(fields(f = Empty))]
+    fn my_fn() {
+        assert_eq!("test", tracing::my_other_fn());
+    }
+
+    mod tracing {
+        #[allow(dead_code)]
+        pub fn my_other_fn() -> &'static str {
+            "test"
+        }
+    }
+}


### PR DESCRIPTION
Avoid ambiguities with any user-defined `tracing` modules by globally qualifying types used in the attribute-generated code e.g., `::tracing::Level`.

Fixes: #3119 for the v0.1.x crate versions.

## Motivation

We need to define helper functions for tracing within our own crates, and `tracing` is too good a name to pass up. Our helpers will mostly wrap and otherwise "hide" the `tracing` crate, but when using `#[instrument]` the generated code conflicts with our `tracing` module.

## Solution

Globally qualify any token paths e.g., `::tracing` to avoid ambiguities.