### PR TITLE
macros: Remove 'r#' prefix from raw identifiers in field names

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1002,8 +1002,8 @@ pub mod span;
 pub mod __macro_support {
     pub use crate::callsite::{Callsite, Registration};
     use crate::{collect::Interest, Metadata};
-    use core::fmt;
     use core::sync::atomic::Ordering;
+    use core::{fmt, str};
 
     #[cfg(feature = "portable-atomic")]
     use portable_atomic::AtomicU8;
@@ -1014,7 +1014,7 @@ pub mod __macro_support {
     // Re-export the `core` functions that are used in macros. This allows
     // a crate to be named `core` and avoid name clashes.
     // See here: https://github.com/tokio-rs/tracing/issues/2761
-    pub use core::{concat, file, format_args, iter::Iterator, line, option::Option};
+    pub use core::{concat, file, format_args, iter::Iterator, line, option::Option, stringify};
 
     /// Callsite implementation used by macro-generated code.
     ///
@@ -1199,6 +1199,66 @@ pub mod __macro_support {
                 .field("meta", &self.meta)
                 .field("register", &self.register)
                 .field("registration", &self.registration)
+                .finish()
+        }
+    }
+
+    /// Implementation detail used for constructing FieldSet names from raw
+    /// identifiers. In `info!(..., r#type = "...")` the macro would end up
+    /// constructing a name equivalent to `FieldName(*b"type")`.
+    pub struct FieldName<const N: usize>([u8; N]);
+
+    impl<const N: usize> FieldName<N> {
+        /// Convert `"prefix.r#keyword.suffix"` to `b"prefix.keyword.suffix"`.
+        pub const fn new(input: &str) -> Self {
+            let input = input.as_bytes();
+            let mut output = [0u8; N];
+            let mut read = 0;
+            let mut write = 0;
+            while read < input.len() {
+                if read + 1 < input.len() && input[read] == b'r' && input[read + 1] == b'#' {
+                    read += 2;
+                }
+                output[write] = input[read];
+                read += 1;
+                write += 1;
+            }
+            assert!(write == N);
+            Self(output)
+        }
+
+        pub const fn as_str(&self) -> &str {
+            // SAFETY: Because of the private visibility of self.0, it must have
+            // been computed by Self::new. So these bytes are all of the bytes
+            // of some original valid UTF-8 string, but with "r#" substrings
+            // removed, which cannot have produced invalid UTF-8.
+            unsafe { str::from_utf8_unchecked(self.0.as_slice()) }
+        }
+    }
+
+    impl FieldName<0> {
+        /// For `"prefix.r#keyword.suffix"` compute `"prefix.keyword.suffix".len()`.
+        pub const fn len(input: &str) -> usize {
+            // Count occurrences of "r#"
+            let mut raw = 0;
+
+            let mut i = 0;
+            while i < input.len() {
+                if input.as_bytes()[i] == b'#' {
+                    raw += 1;
+                }
+                i += 1;
+            }
+
+            input.len() - 2 * raw
+        }
+    }
+
+    impl<const N: usize> fmt::Debug for FieldName<N> {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter
+                .debug_tuple("FieldName")
+                .field(&self.as_str())
                 .finish()
         }
     }

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -3099,9 +3099,12 @@ macro_rules! level_to_log {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __tracing_stringify {
-    ($($t:tt)*) => {
-        stringify!($($t)*)
-    };
+    ($($k:ident).+) => {{
+        const NAME: $crate::__macro_support::FieldName<{
+            $crate::__macro_support::FieldName::len($crate::__macro_support::stringify!($($k).+))
+        }> = $crate::__macro_support::FieldName::new($crate::__macro_support::stringify!($($k).+));
+        NAME.as_str()
+    }};
 }
 
 #[cfg(not(feature = "log"))]

--- a/tracing/tests/event.rs
+++ b/tracing/tests/event.rs
@@ -509,3 +509,15 @@ fn keyword_ident_in_field_name() {
     with_default(collector, || error!(crate = "tracing", "message"));
     handle.assert_finished();
 }
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn raw_ident_in_field_name() {
+    let (collector, handle) = collector::mock()
+        .event(expect::event().with_fields(expect::field("this.r#type").with_value(&"Value")))
+        .only()
+        .run_with_handle();
+
+    with_default(collector, || error!(this.r#type = "Value"));
+    handle.assert_finished();
+}

--- a/tracing/tests/event.rs
+++ b/tracing/tests/event.rs
@@ -514,7 +514,7 @@ fn keyword_ident_in_field_name() {
 #[test]
 fn raw_ident_in_field_name() {
     let (collector, handle) = collector::mock()
-        .event(expect::event().with_fields(expect::field("this.r#type").with_value(&"Value")))
+        .event(expect::event().with_fields(expect::field("this.type").with_value(&"Value")))
         .only()
         .run_with_handle();
 


### PR DESCRIPTION
## Motivation

Currently a call like `info!(..., r#type = "...")` ends up emitting a field named "r#type", which is never desirable. Previous work in https://github.com/tokio-rs/tracing/pull/2925 made the desired behavior expressible as `info!(..., type = "...")`, and even before that PR one could write it as `info!(..., "type" = "...")`.

However, when dealing with macro-generated use of tracing, we do still sometimes end up with raw identifiers. For example, if user-provided identifiers are used for both declaring (or instantiating, or accessing) a struct, and also for tracing. Something like this:

```rust
example!(name, r#type);

// expands to:

...
info!(..., name = GLOBAL.name, r#type = GLOBAL.r#type);
...
```

If we ask the user of `example!` to pass `type` (unraw), there is no way for the macro to access `GLOBAL.r#type` from that. But if we ask the user of `example!` to pass `r#type` (raw), there is no straightforward way for the macro to trace the field name as "type". The best option would have been something like:

```rust
info!(
    ...
    $(
        {
            (const {
                if let Some((b"r#", unraw)) = stringify!($field).as_bytes().split_first_chunk() {
                    unsafe { core::str::from_utf8_unchecked(unraw) }
                } else {
                    stringify!($field)
                }
            })
        } = GLOBAL.$field,
    )*
);
```

but this gets even more ridiculous when dealing with field names that are not just a single identifier. (`prefix.r#keyword.suffix`).

## Solution

`r#keyword = $value` is made equivalent to `keyword = $value`. The field will be emitted with the name "keyword", not "r#keyword" as before.