### PR TITLE
Update fmt-multiple-writers.rs example

### DIFF
--- a/examples/examples/fmt-multiple-writers.rs
+++ b/examples/examples/fmt-multiple-writers.rs
@@ -3,23 +3,29 @@
 //!
 //! An example demonstrating how `fmt::Subcriber` can write to multiple
 //! destinations (in this instance, `stdout` and a file) simultaneously.
+//! The stdout subscriber is configured with ANSI color codes, while the
+//! file subscriber is configured without them.
 
 #[path = "fmt/yak_shave.rs"]
 mod yak_shave;
 
-use std::io;
+use std::{fs, io};
 use tracing_subscriber::{fmt, subscribe::CollectExt, EnvFilter};
 
 fn main() {
     let dir = tempfile::tempdir().expect("Failed to create tempdir");
 
-    let file_appender = tracing_appender::rolling::hourly(dir, "example.log");
+    let file_appender = tracing_appender::rolling::hourly(dir.path(), "example.log");
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
 
     let collector = tracing_subscriber::registry()
         .with(EnvFilter::from_default_env().add_directive(tracing::Level::TRACE.into()))
         .with(fmt::Subscriber::new().with_writer(io::stdout))
-        .with(fmt::Subscriber::new().with_writer(non_blocking));
+        .with(
+            fmt::Subscriber::new()
+                .with_ansi(false)
+                .with_writer(non_blocking),
+        );
     tracing::collect::set_global_default(collector).expect("Unable to set a global collector");
 
     let number_of_yaks = 3;
@@ -31,4 +37,17 @@ fn main() {
         all_yaks_shaved = number_shaved == number_of_yaks,
         "yak shaving completed."
     );
+
+    // Print the log file contents to stdout since it's destroyed when the TempDir is dropped.
+    fs::read_dir(dir.path())
+        .expect("failed to read log dir")
+        .map(|r| r.unwrap().path())
+        .for_each(|log_file| {
+            println!(
+                "{:#^80}",
+                format!(" BEGIN FILE CONTENTS: {} ", log_file.display())
+            );
+            print!("{}", std::fs::read_to_string(log_file).unwrap());
+            println!("{:#^80}", " END FILE CONTENTS ");
+        });
 }


### PR DESCRIPTION
## Motivation

Related https://github.com/tokio-rs/tracing/issues/3116

A common use-case is to write colored (ANSI) logs to stdout and write non-colored logs to a file. Where that file may be forwarded to an aggregator, or viewed in an editor, which expects the contents to not have color formatting.

## Solution

This PR updates the `fmt-multiple-writers.rs` example to demonstrate this use-case.

One additional change that is not related to what is described above is the printing of the log file contents to stdout after the example has finished shaving Yaks. The motive being that the log file `TempDir` is dropped after the example has finished. Currently, the end-user doesn't have a way to inspect the contents of the file without hopping into a debugger, modifying the example to do so, or writing the file to a path that persists after execution.

## Example Output

<img width="1223" alt="Screenshot 2024-11-17 at 11 42 33 PM" src="https://github.com/user-attachments/assets/b532c36c-750b-44ea-9107-8192cf53157c">

