### PR TITLE
Implement Value for Cow<T> where T: Value

### DIFF
--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -567,6 +567,18 @@ where
     }
 }
 
+impl<'a, T: 'a + ToOwned + ?Sized> crate::sealed::Sealed for std::borrow::Cow<'a, T> where T: Value {}
+
+impl<'a, T: 'a + ToOwned + ?Sized> Value for std::borrow::Cow<'a, T>
+where
+    T: Value,
+{
+    #[inline]
+    fn record(&self, key: &Field, visitor: &mut dyn Visit) {
+        self.as_ref().record(key, visitor)
+    }
+}
+
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl crate::sealed::Sealed for alloc::string::String {}


### PR DESCRIPTION
This implements `Value` for `Cow<'a, T>` where `T: Value`.

## Motivation

This is one part of https://github.com/tokio-rs/tracing/issues/726. I also recently ran into this personally when trying to record a field of type `Option<Cow<str>>`.
