### PR TITLE
docs: Add `Unbug` to the list of related crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ are not maintained by the `tokio` project. These include:
 - [`reqwest-tracing`] provides a middleware to trace [`reqwest`] HTTP requests.
 - [`tracing-cloudwatch`] provides a layer that sends events to AWS CloudWatch Logs.
 - [`clippy-tracing`] provides a tool to add, remove and check for `tracing::instrument`.
+- [`Unbug`] provides helper macros for programmatically invoking debugger breakpoints
 
 (if you're the maintainer of a `tracing` ecosystem crate not in this list,
 please let us know!)
@@ -451,6 +452,7 @@ please let us know!)
 [`reqwest`]: https://crates.io/crates/reqwest
 [`tracing-cloudwatch`]: https://crates.io/crates/tracing-cloudwatch
 [`clippy-tracing`]: https://crates.io/crates/clippy-tracing
+[`Unbug`]: https://github.com/greymattergames/unbug/
 
 **Note:** that some of the ecosystem crates are currently unreleased and
 undergoing active development. They may be less stable than `tracing` and

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -818,6 +818,7 @@
 //!  - [`tracing-cloudwatch`] provides a layer that sends events to AWS CloudWatch Logs.
 //!  - [`clippy-tracing`] provides a tool to add, remove and check for `tracing::instrument`.
 //!  - [`json-subscriber`] provides a subscriber for emitting JSON logs. The output can be customized much more than with [`tracing-subscriber`]'s JSON output.
+//!  - [`Unbug`] provides helper macros for programmatically invoking debugger breakpoints
 //!
 //! If you're the maintainer of a `tracing` ecosystem crate not listed above,
 //! please let us know! We'd love to add your project to the list!
@@ -862,6 +863,7 @@
 //! [`tracing-cloudwatch`]: https://crates.io/crates/tracing-cloudwatch
 //! [`clippy-tracing`]: https://crates.io/crates/clippy-tracing
 //! [`json-subscriber`]: https://crates.io/crates/json-subscriber
+//! [`Unbug`]: https://github.com/greymattergames/unbug/
 //!
 //! <div class="example-wrap" style="display:inline-block">
 //! <pre class="ignore" style="white-space:normal;font:inherit;">


### PR DESCRIPTION
## Motivation

[As suggested on Hacker News](https://news.ycombinator.com/item?id=42194254). Unbug optionally uses Tracing's `error!` macro in the `ensure!` and `fail!` macros.

## Solution

Updated README.md and lib.rs to include a Github link.
