### PR TITLE
tracing-subscriber: update docs for `try_from_default_env`

### DIFF
--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -371,7 +371,7 @@ impl EnvFilter {
     /// use tracing_subscriber::EnvFilter;
     ///
     /// # fn docs() -> Result<EnvFilter, tracing_subscriber::filter::FromEnvError> {
-    /// EnvFilter::builder().try_from_env()
+    /// EnvFilter::builder().try_from_default_env()
     /// # }
     /// ```
     pub fn try_from_default_env() -> Result<Self, FromEnvError> {


### PR DESCRIPTION
The docs for the EnvFilter::try_from_default_env method reference another method.


## Motivation

The docs look confusing referencing another method instead of the one documenting.


## Solution

Change the method name being called
