### PR TITLE
chore: prepare tracing-core 0.1.33

### DIFF
--- a/tracing-core/CHANGELOG.md
+++ b/tracing-core/CHANGELOG.md
@@ -1,3 +1,36 @@
+# 0.1.33 (November 25, 2024)
+
+### Added
+
+- Add index API for `Field` ([#2820])
+- allow `&[u8]` to be recorded as event/span field ([#2954])
+
+### Changed
+
+- Bump MSRV to 1.63 ([#2793])
+- Use const `thread_local`s when possible ([#2838])
+
+### Fixed
+
+- Fix missed `register_callsite` error ([#2938])
+- Do not add `valuable/std` feature as dependency unless `valuable` is used ([#3002])
+- prefix macro calls with ::core to avoid clashing with local macros ([#3024])
+
+### Documented
+
+- Fix incorrect (incorrectly updated) docs for LevelFilter ([#2767])
+
+Thanks to new contributor @maddiemort for contributing to this release!
+
+[#2767]: https://github.com/tokio-rs/tracing/pull/2767
+[#2793]: https://github.com/tokio-rs/tracing/pull/2793
+[#2820]: https://github.com/tokio-rs/tracing/pull/2820
+[#2838]: https://github.com/tokio-rs/tracing/pull/2838
+[#2938]: https://github.com/tokio-rs/tracing/pull/2938
+[#2954]: https://github.com/tokio-rs/tracing/pull/2954
+[#3002]: https://github.com/tokio-rs/tracing/pull/3002
+[#3024]: https://github.com/tokio-rs/tracing/pull/3024
+
 # 0.1.32 (October 13, 2023)
 
 ### Documented

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-core"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.32"
+version = "0.1.33"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -16,9 +16,9 @@ Core primitives for application-level tracing.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-core.svg
-[crates-url]: https://crates.io/crates/tracing-core/0.1.31
+[crates-url]: https://crates.io/crates/tracing-core/0.1.33
 [docs-badge]: https://docs.rs/tracing-core/badge.svg
-[docs-url]: https://docs.rs/tracing-core/0.1.31
+[docs-url]: https://docs.rs/tracing-core/0.1.33
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_core
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -79,22 +79,22 @@ The following crate feature flags are available:
 
   ```toml
   [dependencies]
-  tracing-core = { version = "0.1.31", default-features = false }
+  tracing-core = { version = "0.1.33", default-features = false }
   ```
 
   **Note**:`tracing-core`'s `no_std` support requires `liballoc`.
 
 [`tracing`]: ../tracing
-[`span::Id`]: https://docs.rs/tracing-core/0.1.31/tracing_core/span/struct.Id.html
-[`Event`]: https://docs.rs/tracing-core/0.1.31/tracing_core/event/struct.Event.html
-[`Subscriber`]: https://docs.rs/tracing-core/0.1.31/tracing_core/subscriber/trait.Subscriber.html
-[`Metadata`]: https://docs.rs/tracing-core/0.1.31/tracing_core/metadata/struct.Metadata.html
-[`Callsite`]: https://docs.rs/tracing-core/0.1.31/tracing_core/callsite/trait.Callsite.html
-[`Field`]: https://docs.rs/tracing-core/0.1.31/tracing_core/field/struct.Field.html
-[`FieldSet`]: https://docs.rs/tracing-core/0.1.31/tracing_core/field/struct.FieldSet.html
-[`Value`]: https://docs.rs/tracing-core/0.1.31/tracing_core/field/trait.Value.html
-[`ValueSet`]: https://docs.rs/tracing-core/0.1.31/tracing_core/field/struct.ValueSet.html
-[`Dispatch`]: https://docs.rs/tracing-core/0.1.31/tracing_core/dispatcher/struct.Dispatch.html
+[`span::Id`]: https://docs.rs/tracing-core/0.1.33/tracing_core/span/struct.Id.html
+[`Event`]: https://docs.rs/tracing-core/0.1.33/tracing_core/event/struct.Event.html
+[`Subscriber`]: https://docs.rs/tracing-core/0.1.33/tracing_core/subscriber/trait.Subscriber.html
+[`Metadata`]: https://docs.rs/tracing-core/0.1.33/tracing_core/metadata/struct.Metadata.html
+[`Callsite`]: https://docs.rs/tracing-core/0.1.33/tracing_core/callsite/trait.Callsite.html
+[`Field`]: https://docs.rs/tracing-core/0.1.33/tracing_core/field/struct.Field.html
+[`FieldSet`]: https://docs.rs/tracing-core/0.1.33/tracing_core/field/struct.FieldSet.html
+[`Value`]: https://docs.rs/tracing-core/0.1.33/tracing_core/field/trait.Value.html
+[`ValueSet`]: https://docs.rs/tracing-core/0.1.33/tracing_core/field/struct.ValueSet.html
+[`Dispatch`]: https://docs.rs/tracing-core/0.1.33/tracing_core/dispatcher/struct.Dispatch.html
 
 ## Supported Rust Versions
 


### PR DESCRIPTION
# 0.1.33 (November 25, 2024)

### Added

- Add index API for `Field` ([#2820])
- allow `&[u8]` to be recorded as event/span field ([#2954])

### Changed

- Bump MSRV to 1.63 ([#2793])
- Use const `thread_local`s when possible ([#2838])

### Fixed

- Fix missed `register_callsite` error ([#2938])
- Do not add `valuable/std` feature as dependency unless `valuable` is used ([#3002])
- prefix macro calls with ::core to avoid clashing with local macros ([#3024])

### Documented

- Fix incorrect (incorrectly updated) docs for LevelFilter ([#2767])

Thanks to new contributor @maddiemort for contributing to this release!

[#2767]: https://github.com/tokio-rs/tracing/pull/2767
[#2793]: https://github.com/tokio-rs/tracing/pull/2793
[#2820]: https://github.com/tokio-rs/tracing/pull/2820
[#2838]: https://github.com/tokio-rs/tracing/pull/2838
[#2938]: https://github.com/tokio-rs/tracing/pull/2938
[#2954]: https://github.com/tokio-rs/tracing/pull/2954
[#3002]: https://github.com/tokio-rs/tracing/pull/3002
[#3024]: https://github.com/tokio-rs/tracing/pull/3024