### PR TITLE
chore: remove outdated release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,7 +214,7 @@ be viewed by clicking the `details` link on the
 ### Building Documentation
 
 Tracing's documentation uses nightly-only RustDoc features and lints, like
-`doc(cfg)` and `broken_intra_doc_lints`. These features are enabled by 
+`doc(cfg)` and `broken_intra_doc_lints`. These features are enabled by
 passing `--cfg docsrs` to RustDoc. Therefore, in order to build Tracing's
 documentation the same way it would be built by docs.rs, it's necessary to
 use the following command:
@@ -430,8 +430,7 @@ When releasing a new version of a crate, follow these steps:
 2. **Update Cargo metadata.** After releasing any path dependencies, update the
    `version` field in `Cargo.toml` to the new version, and the `documentation`
    field to the docs.rs URL of the new version.
-3. **Update other documentation links.** Update the `#![doc(html_root_url)]`
-   attribute in the crate's `lib.rs` and the "Documentation" link in the crate's
+3. **Update the "Documentation" link in the crate's
    `README.md` to point to the docs.rs URL of the new version.
 4. **Update the changelog for the crate.** Each crate in the Tokio repository
    has its own `CHANGELOG.md` in that crate's subdirectory. Any changes to that

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -2,9 +2,7 @@
 name = "tracing-attributes"
 # When releasing to crates.io:
 # - Remove path dependencies
-# - Update doc url
-#   - Cargo.toml
-#   - README.md
+# - Update doc url in README.md.
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
 version = "0.2.0"

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -2,7 +2,6 @@
 name = "tracing-attributes"
 # When releasing to crates.io:
 # - Remove path dependencies
-# - Update html_root_url.
 # - Update doc url
 #   - Cargo.toml
 #   - README.md

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -3,9 +3,7 @@ name = "tracing-core"
 # When releasing to crates.io:
 # - Remove path dependencies
 # - Update html_root_url.
-# - Update doc url
-#   - Cargo.toml
-#   - README.md
+# - Update doc url in README.md.
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
 version = "0.2.0"

--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -2,7 +2,6 @@
 name = "tracing-error"
 # When releasing to crates.io:
 # - Remove path dependencies
-# - Update html_root_url.
 # - Update doc url
 #   - Cargo.toml
 #   - README.md

--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -2,9 +2,7 @@
 name = "tracing-error"
 # When releasing to crates.io:
 # - Remove path dependencies
-# - Update doc url
-#   - Cargo.toml
-#   - README.md
+# - Update doc url in README.md.
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag
 version = "0.2.0"

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -2,9 +2,7 @@
 name = "tracing"
 # When releasing to crates.io:
 # - Remove path dependencies
-# - Update doc url
-#   - Cargo.toml
-#   - README.md
+# - Update doc url in README.md.
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag
 version = "0.2.0"

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -2,7 +2,6 @@
 name = "tracing"
 # When releasing to crates.io:
 # - Remove path dependencies
-# - Update html_root_url.
 # - Update doc url
 #   - Cargo.toml
 #   - README.md


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

Follow up of https://github.com/tokio-rs/tracing/commit/60c60bef62972e447414a748a95b31ff9027165b


## Solution

I have removed outdated release instructions from our document. 
