### PR TITLE
chore: prepare tracing-attributes 0.1.28

### DIFF
--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,3 +1,29 @@
+# 0.1.28 (November 26, 2024)
+
+### Changed
+
+- Bump MSRV to 1.63 ([#2793])
+
+### Fixed
+
+- Added missing RecordTypes for instrument ([#2781])
+- Change order of async and unsafe modifier ([#2864])
+- Extract match scrutinee ([#2880])
+- Allow field path segments to be keywords ([#2925])
+- Support const values for `target` and `name` ([#2941])
+
+### Documented
+
+- Fix backporting error in attributes ([#2780])
+
+[#2780]: https://github.com/tokio-rs/tracing/pull/2780
+[#2781]: https://github.com/tokio-rs/tracing/pull/2781
+[#2793]: https://github.com/tokio-rs/tracing/pull/2793
+[#2864]: https://github.com/tokio-rs/tracing/pull/2864
+[#2880]: https://github.com/tokio-rs/tracing/pull/2880
+[#2925]: https://github.com/tokio-rs/tracing/pull/2925
+[#2941]: https://github.com/tokio-rs/tracing/pull/2941
+
 # 0.1.27 (October 13, 2023)
 
 ### Changed

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-attributes"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.27"
+version = "0.1.28"
 authors = [
     "Tokio Contributors <team@tokio.rs>",
     "Eliza Weisman <eliza@buoyant.io>",

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -18,7 +18,7 @@ Macro attributes for application-level tracing.
 [crates-badge]: https://img.shields.io/crates/v/tracing-attributes.svg
 [crates-url]: https://crates.io/crates/tracing-attributes
 [docs-badge]: https://docs.rs/tracing-attributes/badge.svg
-[docs-url]: https://docs.rs/tracing-attributes/0.1.26
+[docs-url]: https://docs.rs/tracing-attributes/0.1.28
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_attributes
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -47,7 +47,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing-attributes = "0.1.26"
+tracing-attributes = "0.1.28"
 ```
 
 


### PR DESCRIPTION
# 0.1.28 (November 26, 2024)

### Changed

- Bump MSRV to 1.63 ([#2793])

### Fixed

- Added missing RecordTypes for instrument ([#2781])
- Change order of async and unsafe modifier ([#2864])
- Extract match scrutinee ([#2880])
- Allow field path segments to be keywords ([#2925])
- Support const values for `target` and `name` ([#2941])

### Documented

- Fix backporting error in attributes ([#2780])

[#2780]: https://github.com/tokio-rs/tracing/pull/2780
[#2781]: https://github.com/tokio-rs/tracing/pull/2781
[#2793]: https://github.com/tokio-rs/tracing/pull/2793
[#2864]: https://github.com/tokio-rs/tracing/pull/2864
[#2880]: https://github.com/tokio-rs/tracing/pull/2880
[#2925]: https://github.com/tokio-rs/tracing/pull/2925
[#2941]: https://github.com/tokio-rs/tracing/pull/2941