### PR TITLE
chore: prepare tracing 0.1.41

### DIFF
--- a/tracing-mock/Cargo.toml
+++ b/tracing-mock/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.63.0"
 publish = false
 
 [dependencies]
-tracing = { path = "../tracing", version = "0.1.35", features = ["std", "attributes"], default-features = false }
+tracing = { path = "../tracing", version = "0.1.41", features = ["std", "attributes"], default-features = false }
 tracing-core = { path = "../tracing-core", version = "0.1.28", default-features = false }
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry"], optional = true }
 

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -42,7 +42,7 @@ nu-ansi-term = ["dep:nu-ansi-term"]
 tracing-core = { path = "../tracing-core", version = "0.1.30", default-features = false }
 
 # only required by the filter feature
-tracing = { optional = true, path = "../tracing", version = "0.1.35", default-features = false }
+tracing = { optional = true, path = "../tracing", version = "0.1.41", default-features = false }
 matchers = { optional = true, version = "0.1.0" }
 regex = { optional = true, version = "1.6.0", default-features = false, features = ["std", "unicode-case", "unicode-perl"] }
 smallvec = { optional = true, version = "1.9.0" }
@@ -71,7 +71,7 @@ valuable_crate = { package = "valuable", version = "0.1.0", optional = true, def
 valuable-serde = { version = "0.1.0", optional = true, default-features = false }
 
 [dev-dependencies]
-tracing = { path = "../tracing", version = "0.1.35" }
+tracing = { path = "../tracing", version = "0.1.41" }
 tracing-mock = { path = "../tracing-mock", features = ["tracing-subscriber"] }
 log = "0.4.17"
 tracing-log = { path = "../tracing-log", version = "0.2.0" }

--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,4 +1,57 @@
-# 0.1.40
+# 0.1.41 (November 27, 2024)
+
+[ [crates.io][crate-0.1.41] ] | [ [docs.rs][docs-0.1.41] ]
+
+This release updates the `tracing-core` dependency to [v0.1.33][core-0.1.33] and
+the `tracing-attributes` dependency to [v0.1.28][attrs-0.1.28].
+
+### Added
+
+- **core**: Add index API for `Field` ([#2820])
+- **core**: Allow `&[u8]` to be recorded as event/span field ([#2954])
+
+### Changed
+
+- Bump MSRV to 1.63 ([#2793])
+- **core**: Use const `thread_local`s when possible ([#2838])
+
+### Fixed
+
+- Removed core imports in macros ([#2762])
+- **attributes**: Added missing RecordTypes for instrument ([#2781])
+- **attributes**: Change order of async and unsafe modifier ([#2864])
+- Fix missing field prefixes ([#2878])
+- **attributes**: Extract match scrutinee ([#2880])
+- Fix non-simple macro usage without message ([#2879])
+- Fix event macros with constant field names in the first position ([#2883])
+- Allow field path segments to be keywords ([#2925])
+- **core**: Fix missed `register_callsite` error ([#2938])
+- **attributes**: Support const values for `target` and `name` ([#2941])
+- Prefix macro calls with ::core to avoid clashing with local macros ([#3024])
+
+[#2762]: https://github.com/tokio-rs/tracing/pull/2762
+[#2781]: https://github.com/tokio-rs/tracing/pull/2781
+[#2793]: https://github.com/tokio-rs/tracing/pull/2793
+[#2820]: https://github.com/tokio-rs/tracing/pull/2820
+[#2838]: https://github.com/tokio-rs/tracing/pull/2838
+[#2864]: https://github.com/tokio-rs/tracing/pull/2864
+[#2878]: https://github.com/tokio-rs/tracing/pull/2878
+[#2879]: https://github.com/tokio-rs/tracing/pull/2879
+[#2880]: https://github.com/tokio-rs/tracing/pull/2880
+[#2883]: https://github.com/tokio-rs/tracing/pull/2883
+[#2925]: https://github.com/tokio-rs/tracing/pull/2925
+[#2938]: https://github.com/tokio-rs/tracing/pull/2938
+[#2941]: https://github.com/tokio-rs/tracing/pull/2941
+[#2954]: https://github.com/tokio-rs/tracing/pull/2954
+[#3024]: https://github.com/tokio-rs/tracing/pull/3024
+[attrs-0.1.28]:
+    https://github.com/tokio-rs/tracing/releases/tag/tracing-attributes-0.1.28
+[core-0.1.33]:
+    https://github.com/tokio-rs/tracing/releases/tag/tracing-core-0.1.33
+[docs-0.1.41]: https://docs.rs/tracing/0.1.41/tracing/
+[crate-0.1.41]: https://crates.io/crates/tracing/0.1.41
+
+# 0.1.40 (October 19, 2023)
 
 This release fixes a potential stack use-after-free in the
 `Instrument::into_inner` method. Only uses of this method are affected by this

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.40"
+version = "0.1.41"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -250,7 +250,7 @@ my_future
 is as long as the future's.
 
 The second, and preferred, option is through the
-[`#[instrument]`](https://docs.rs/tracing/0.1.38/tracing/attr.instrument.html)
+[`#[instrument]`](https://docs.rs/tracing/0.1.41/tracing/attr.instrument.html)
 attribute:
 
 ```rust
@@ -297,7 +297,7 @@ span.in_scope(|| {
 // Dropping the span will close it, indicating that it has ended.
 ```
 
-The [`#[instrument]`](https://docs.rs/tracing/0.1.38/tracing/attr.instrument.html) attribute macro
+The [`#[instrument]`](https://docs.rs/tracing/0.1.41/tracing/attr.instrument.html) attribute macro
 can reduce some of this boilerplate:
 
 ```rust


### PR DESCRIPTION
# 0.1.41 (November 27, 2024)

[ [crates.io][crate-0.1.41] ] | [ [docs.rs][docs-0.1.41] ]

This release updates the `tracing-core` dependency to [v0.1.33][core-0.1.33] and
the `tracing-attributes` dependency to [v0.1.28][attrs-0.1.28].

### Added

- **core**: Add index API for `Field` ([#2820])
- **core**: Allow `&[u8]` to be recorded as event/span field ([#2954])

### Changed

- Bump MSRV to 1.63 ([#2793])
- **core**: Use const `thread_local`s when possible ([#2838])

### Fixed

- Removed core imports in macros ([#2762])
- **attributes**: Added missing RecordTypes for instrument ([#2781])
- **attributes**: Change order of async and unsafe modifier ([#2864])
- Fix missing field prefixes ([#2878])
- **attributes**: Extract match scrutinee ([#2880])
- Fix non-simple macro usage without message ([#2879])
- Fix event macros with constant field names in the first position ([#2883])
- Allow field path segments to be keywords ([#2925])
- **core**: Fix missed `register_callsite` error ([#2938])
- **attributes**: Support const values for `target` and `name` ([#2941])
- Prefix macro calls with ::core to avoid clashing with local macros ([#3024])

[#2762]: https://github.com/tokio-rs/tracing/pull/2762
[#2781]: https://github.com/tokio-rs/tracing/pull/2781
[#2793]: https://github.com/tokio-rs/tracing/pull/2793
[#2820]: https://github.com/tokio-rs/tracing/pull/2820
[#2838]: https://github.com/tokio-rs/tracing/pull/2838
[#2864]: https://github.com/tokio-rs/tracing/pull/2864
[#2878]: https://github.com/tokio-rs/tracing/pull/2878
[#2879]: https://github.com/tokio-rs/tracing/pull/2879
[#2880]: https://github.com/tokio-rs/tracing/pull/2880
[#2883]: https://github.com/tokio-rs/tracing/pull/2883
[#2925]: https://github.com/tokio-rs/tracing/pull/2925
[#2938]: https://github.com/tokio-rs/tracing/pull/2938
[#2941]: https://github.com/tokio-rs/tracing/pull/2941
[#2954]: https://github.com/tokio-rs/tracing/pull/2954
[#3024]: https://github.com/tokio-rs/tracing/pull/3024
[attrs-0.1.28]:
    https://github.com/tokio-rs/tracing/releases/tag/tracing-attributes-0.1.28
[core-0.1.33]:
    https://github.com/tokio-rs/tracing/releases/tag/tracing-core-0.1.33
[docs-0.1.41]: https://docs.rs/tracing/0.1.41/tracing/
[crate-0.1.41]: https://crates.io/crates/tracing/0.1.41
