### PR TITLE
chore: prepare tracing-serde 0.2.0

### DIFF
--- a/tracing-serde/CHANGELOG.md
+++ b/tracing-serde/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 0.2.0 (November 27, 2024)
+
+[ [crates.io][crate-0.2.0] ] | [ [docs.rs][docs-0.2.0] ]
+
+<a id = "0.2.0-breaking"></a>
+### Breaking Changes 
+
+- Correct SerializeField definition and doc formatting ([#3040])
+  `SerializeField` has gained a generic lifetime parameter.
+
+### Fixed
+
+- Implement `AsSerde` for `FieldSet` ([#2241])
+- [**breaking**](#0.2.0-breaking) Correct SerializeField definition and doc formatting ([#3040])
+
+### Changed
+
+- Bump MSRV to 1.63 ([#2793])
+
+[#2241]: https://github.com/tokio-rs/tracing/pull/2241
+[#3040]: https://github.com/tokio-rs/tracing/pull/3040
+[docs-0.2.0]: https://docs.rs/tracing-serde/0.2.0/tracing-serde/
+[crate-0.2.0]: https://crates.io/crates/tracing-serde/0.2.0
+
 # 0.1.3 (February 4, 2022)
 
 This release adds *experimental* support for recording structured field

--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-serde"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 edition = "2018"

--- a/tracing-serde/README.md
+++ b/tracing-serde/README.md
@@ -47,7 +47,7 @@ First, add this to your `Cargo.toml`:
 ```toml
 [dependencies]
 tracing = "0.1"
-tracing-serde = "0.1"
+tracing-serde = "0.2"
 ```
 
 Next, add this to your crate:

--- a/tracing-serde/src/lib.rs
+++ b/tracing-serde/src/lib.rs
@@ -43,7 +43,7 @@
 //! ```toml
 //! [dependencies]
 //! tracing = "0.1"
-//! tracing-serde = "0.1"
+//! tracing-serde = "0.2"
 //! ```
 //!
 //! Next, add this to your crate:

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -56,7 +56,7 @@ time = { version = "0.3.2", features = ["formatting"], optional = true }
 # only required by the json feature
 serde_json = { version = "1.0.82", optional = true }
 serde = { version = "1.0.140", optional = true }
-tracing-serde = { path = "../tracing-serde", version = "0.1.3", optional = true }
+tracing-serde = { path = "../tracing-serde", version = "0.2.0", optional = true }
 
 # opt-in deps
 parking_lot = { version = "0.12.1", optional = true }


### PR DESCRIPTION
# 0.2.0 (November 27, 2024)

[ [crates.io][crate-0.2.0] ] | [ [docs.rs][docs-0.2.0] ]

<a id = "0.2.0-breaking"></a>
### Breaking Changes 

- Correct SerializeField definition and doc formatting ([#3040])
  `SerializeField` has gained a generic lifetime parameter.

### Fixed

- Implement `AsSerde` for `FieldSet` ([#2241])
- [**breaking**](#0.2.0-breaking) Correct SerializeField definition and doc formatting ([#3040])

### Changed

- Bump MSRV to 1.63 ([#2793])

[#2241]: https://github.com/tokio-rs/tracing/pull/2241
[#3040]: https://github.com/tokio-rs/tracing/pull/3040
[docs-0.2.0]: https://docs.rs/tracing-serde/0.2.0/tracing-serde/
[crate-0.2.0]: https://crates.io/crates/tracing-serde/0.2.0