### PR TITLE
chore: prepare tracing-error 0.2.1

### DIFF
--- a/tracing-error/CHANGELOG.md
+++ b/tracing-error/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 0.2.1 (November 29, 2024)
+
+[ [crates.io][crate-0.2.1] ] | [ [docs.rs][docs-0.2.1] ]
+
+### Changed
+
+- Bump MSRV to 1.63 ([#2793])
+
+### Documented
+
+- Use intra-doc links instead of relative file paths ([#2068])
+- More intra-doc links ([#2077])
+- Add missing backtick to `prelude` docs ([#2120])
+
+[#2068]: https://github.com/tokio-rs/tracing/pull/2068
+[#2077]: https://github.com/tokio-rs/tracing/pull/2077
+[#2120]: https://github.com/tokio-rs/tracing/pull/2120
+[#2793]: https://github.com/tokio-rs/tracing/pull/2793
+[docs-0.2.1]: https://docs.rs/tracing-error/0.2.1/tracing_error/
+[crate-0.2.1]: https://crates.io/crates/tracing-error/0.2.1
+
 # 0.2.0 (October 23, 2021)
 
 This is a breaking change release in order to update the `tracing-subscriber`

--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -8,7 +8,7 @@ name = "tracing-error"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "Jane Lusby <jlusby@yaah.dev>",

--- a/tracing-error/README.md
+++ b/tracing-error/README.md
@@ -18,9 +18,9 @@ information.
 [Documentation (release)][docs-url] | [Documentation (master)][docs-master-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-error.svg
-[crates-url]: https://crates.io/crates/tracing-error/0.2.0
+[crates-url]: https://crates.io/crates/tracing-error/0.2.1
 [docs-badge]: https://docs.rs/tracing-error/badge.svg
-[docs-url]: https://docs.rs/tracing-error/0.2.0/tracing_error
+[docs-url]: https://docs.rs/tracing-error/0.2.1/tracing_error
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_error
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -234,5 +234,5 @@ terms or conditions.
 [subscriber layer]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/trait.Layer.html
 [`tracing`]: https://docs.rs/tracing
 [`std::error::Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
-[`SpanTrace`]: https://docs.rs/tracing-error/0.2.0/tracing_error/struct.SpanTrace.html
-[`ErrorLayer`]: https://docs.rs/tracing-error/0.2.0/tracing_error/struct.ErrorLayer.html
+[`SpanTrace`]: https://docs.rs/tracing-error/0.2.1/tracing_error/struct.SpanTrace.html
+[`ErrorLayer`]: https://docs.rs/tracing-error/0.2.1/tracing_error/struct.ErrorLayer.html


### PR DESCRIPTION
# 0.2.1 (November 29, 2024)

[ [crates.io][crate-0.2.1] ] | [ [docs.rs][docs-0.2.1] ]

### Changed

- Bump MSRV to 1.63 ([#2793])

### Documented

- Use intra-doc links instead of relative file paths ([#2068])
- More intra-doc links ([#2077])
- Add missing backtick to `prelude` docs ([#2120])

[#2068]: https://github.com/tokio-rs/tracing/pull/2068
[#2077]: https://github.com/tokio-rs/tracing/pull/2077
[#2120]: https://github.com/tokio-rs/tracing/pull/2120
[#2793]: https://github.com/tokio-rs/tracing/pull/2793
[docs-0.2.1]: https://docs.rs/tracing-error/0.2.1/tracing_error/
[crate-0.2.1]: https://crates.io/crates/tracing-error/0.2.1