### PR TITLE
chore: fix new Clippy lints in Rust 1.83.0

### DIFF
--- a/examples/examples/counters.rs
+++ b/examples/examples/counters.rs
@@ -28,7 +28,7 @@ struct Count<'a> {
     counters: RwLockReadGuard<'a, HashMap<String, AtomicUsize>>,
 }
 
-impl<'a> Visit for Count<'a> {
+impl Visit for Count<'_> {
     fn record_i64(&mut self, field: &Field, value: i64) {
         if let Some(counter) = self.counters.get(field.name()) {
             if value > 0 {

--- a/examples/examples/sloggish/sloggish_subscriber.rs
+++ b/examples/examples/sloggish/sloggish_subscriber.rs
@@ -86,7 +86,7 @@ struct Event<'a> {
 
 struct ColorLevel<'a>(&'a Level);
 
-impl<'a> fmt::Display for ColorLevel<'a> {
+impl fmt::Display for ColorLevel<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self.0 {
             Level::TRACE => Color::Purple.paint("TRACE"),
@@ -116,7 +116,7 @@ impl Visit for Span {
     }
 }
 
-impl<'a> Visit for Event<'a> {
+impl Visit for Event<'_> {
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
         write!(
             &mut self.stderr,

--- a/tracing-appender/benches/bench.rs
+++ b/tracing-appender/benches/bench.rs
@@ -18,7 +18,7 @@ impl NoOpWriter {
     }
 }
 
-impl<'a> MakeWriter<'a> for NoOpWriter {
+impl MakeWriter<'_> for NoOpWriter {
     type Writer = NoOpWriter;
 
     fn make_writer(&self) -> Self::Writer {

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -70,7 +70,7 @@ pub use builder::{Builder, InitError};
 ///
 /// // Log all events to a rolling log file.
 /// let logfile = tracing_appender::rolling::hourly("/logs", "myapp-logs");
-
+///
 /// // Log `INFO` and above to stdout.
 /// let stdout = std::io::stdout.with_max_level(tracing::Level::INFO);
 ///

--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -772,7 +772,7 @@ struct IdentAndTypesRenamer<'a> {
     idents: Vec<(Ident, Ident)>,
 }
 
-impl<'a> VisitMut for IdentAndTypesRenamer<'a> {
+impl VisitMut for IdentAndTypesRenamer<'_> {
     // we deliberately compare strings because we want to ignore the spans
     // If we apply clippy's lint, the behavior changes
     #[allow(clippy::cmp_owned)]
@@ -801,7 +801,7 @@ struct AsyncTraitBlockReplacer<'a> {
     patched_block: Block,
 }
 
-impl<'a> VisitMut for AsyncTraitBlockReplacer<'a> {
+impl VisitMut for AsyncTraitBlockReplacer<'_> {
     fn visit_block_mut(&mut self, i: &mut Block) {
         if i == self.block {
             *i = self.patched_block.clone();

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -879,7 +879,7 @@ impl<'a> Entered<'a> {
 }
 
 #[cfg(feature = "std")]
-impl<'a> Drop for Entered<'a> {
+impl Drop for Entered<'_> {
     #[inline]
     fn drop(&mut self) {
         self.0.can_enter.set(true);

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -387,7 +387,7 @@ where
 
 struct HexBytes<'a>(&'a [u8]);
 
-impl<'a> fmt::Debug for HexBytes<'a> {
+impl fmt::Debug for HexBytes<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_char('[')?;
 
@@ -407,13 +407,13 @@ impl<'a> fmt::Debug for HexBytes<'a> {
 
 // ===== impl Visit =====
 
-impl<'a, 'b> Visit for fmt::DebugStruct<'a, 'b> {
+impl Visit for fmt::DebugStruct<'_, '_> {
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
         self.field(field.name(), value);
     }
 }
 
-impl<'a, 'b> Visit for fmt::DebugMap<'a, 'b> {
+impl Visit for fmt::DebugMap<'_, '_> {
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
         self.entry(&format_args!("{}", field), value);
     }
@@ -641,9 +641,9 @@ where
     }
 }
 
-impl<'a> crate::sealed::Sealed for fmt::Arguments<'a> {}
+impl crate::sealed::Sealed for fmt::Arguments<'_> {}
 
-impl<'a> Value for fmt::Arguments<'a> {
+impl Value for fmt::Arguments<'_> {
     fn record(&self, key: &Field, visitor: &mut dyn Visit) {
         visitor.record_debug(key, self)
     }
@@ -938,7 +938,7 @@ impl FieldSet {
     }
 }
 
-impl<'a> IntoIterator for &'a FieldSet {
+impl IntoIterator for &FieldSet {
     type IntoIter = Iter;
     type Item = Field;
     #[inline]
@@ -1017,7 +1017,7 @@ impl Iterator for Iter {
 
 // ===== impl ValueSet =====
 
-impl<'a> ValueSet<'a> {
+impl ValueSet<'_> {
     /// Returns an [`Identifier`] that uniquely identifies the [`Callsite`]
     /// defining the fields this `ValueSet` refers to.
     ///
@@ -1078,7 +1078,7 @@ impl<'a> ValueSet<'a> {
     }
 }
 
-impl<'a> fmt::Debug for ValueSet<'a> {
+impl fmt::Debug for ValueSet<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.values
             .iter()
@@ -1093,7 +1093,7 @@ impl<'a> fmt::Debug for ValueSet<'a> {
     }
 }
 
-impl<'a> fmt::Display for ValueSet<'a> {
+impl fmt::Display for ValueSet<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.values
             .iter()

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -191,7 +191,7 @@ pub struct Kind(u8);
 ///         // ...
 ///         # drop(span); Id::from_u64(1)
 ///     }
-
+///
 ///     fn event(&self, event: &Event<'_>) {
 ///         // ...
 ///         # drop(event);
@@ -332,7 +332,7 @@ impl<'a> Metadata<'a> {
     }
 }
 
-impl<'a> fmt::Debug for Metadata<'a> {
+impl fmt::Debug for Metadata<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut meta = f.debug_struct("Metadata");
         meta.field("name", &self.name)
@@ -440,9 +440,9 @@ impl fmt::Debug for Kind {
     }
 }
 
-impl<'a> Eq for Metadata<'a> {}
+impl Eq for Metadata<'_> {}
 
-impl<'a> PartialEq for Metadata<'a> {
+impl PartialEq for Metadata<'_> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         if core::ptr::eq(&self, &other) {

--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -227,7 +227,7 @@ impl fmt::Debug for SpanTrace {
             fields: &'a str,
         }
 
-        impl<'a> fmt::Debug for DebugSpan<'a> {
+        impl fmt::Debug for DebugSpan<'_> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(
                     f,

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -212,7 +212,7 @@ pub trait AsTrace: crate::sealed::Sealed {
     fn as_trace(&self) -> Self::Trace;
 }
 
-impl<'a> crate::sealed::Sealed for Metadata<'a> {}
+impl crate::sealed::Sealed for Metadata<'_> {}
 
 impl<'a> AsLog for Metadata<'a> {
     type Log = log::Metadata<'a>;
@@ -223,7 +223,7 @@ impl<'a> AsLog for Metadata<'a> {
             .build()
     }
 }
-impl<'a> crate::sealed::Sealed for log::Metadata<'a> {}
+impl crate::sealed::Sealed for log::Metadata<'_> {}
 
 impl<'a> AsTrace for log::Metadata<'a> {
     type Trace = Metadata<'a>;
@@ -353,7 +353,7 @@ fn loglevel_to_cs(
     }
 }
 
-impl<'a> crate::sealed::Sealed for log::Record<'a> {}
+impl crate::sealed::Sealed for log::Record<'_> {}
 
 impl<'a> AsTrace for log::Record<'a> {
     type Trace = Metadata<'a>;
@@ -464,7 +464,7 @@ pub trait NormalizeEvent<'a>: crate::sealed::Sealed {
     fn is_log(&self) -> bool;
 }
 
-impl<'a> crate::sealed::Sealed for Event<'a> {}
+impl crate::sealed::Sealed for Event<'_> {}
 
 impl<'a> NormalizeEvent<'a> for Event<'a> {
     fn normalized_metadata(&'a self) -> Option<Metadata<'a>> {
@@ -516,7 +516,7 @@ impl<'a> LogVisitor<'a> {
     }
 }
 
-impl<'a> Visit for LogVisitor<'a> {
+impl Visit for LogVisitor<'_> {
     fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {}
 
     fn record_u64(&mut self, field: &Field, value: u64) {

--- a/tracing-mock/src/field.rs
+++ b/tracing-mock/src/field.rs
@@ -527,7 +527,7 @@ pub(crate) struct CheckVisitor<'a> {
     subscriber_name: &'a str,
 }
 
-impl<'a> Visit for CheckVisitor<'a> {
+impl Visit for CheckVisitor<'_> {
     fn record_f64(&mut self, field: &Field, value: f64) {
         self.expect
             .compare_or_panic(field.name(), &value, self.ctx, self.subscriber_name)
@@ -563,7 +563,7 @@ impl<'a> Visit for CheckVisitor<'a> {
     }
 }
 
-impl<'a> CheckVisitor<'a> {
+impl CheckVisitor<'_> {
     pub(crate) fn finish(self) {
         assert!(
             self.expect.fields.is_empty(),

--- a/tracing-serde/src/fields.rs
+++ b/tracing-serde/src/fields.rs
@@ -10,13 +10,13 @@ pub trait AsMap: Sized + sealed::Sealed {
     }
 }
 
-impl<'a> AsMap for Event<'a> {}
-impl<'a> AsMap for Attributes<'a> {}
-impl<'a> AsMap for Record<'a> {}
+impl AsMap for Event<'_> {}
+impl AsMap for Attributes<'_> {}
+impl AsMap for Record<'_> {}
 
 // === impl SerializeFieldMap ===
 
-impl<'a> Serialize for SerializeFieldMap<'a, Event<'_>> {
+impl Serialize for SerializeFieldMap<'_, Event<'_>> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -29,7 +29,7 @@ impl<'a> Serialize for SerializeFieldMap<'a, Event<'_>> {
     }
 }
 
-impl<'a> Serialize for SerializeFieldMap<'a, Attributes<'_>> {
+impl Serialize for SerializeFieldMap<'_, Attributes<'_>> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -42,7 +42,7 @@ impl<'a> Serialize for SerializeFieldMap<'a, Attributes<'_>> {
     }
 }
 
-impl<'a> Serialize for SerializeFieldMap<'a, Record<'_>> {
+impl Serialize for SerializeFieldMap<'_, Record<'_>> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/tracing-serde/src/lib.rs
+++ b/tracing-serde/src/lib.rs
@@ -208,7 +208,7 @@ pub mod fields;
 #[derive(Debug)]
 pub struct SerializeField<'a>(&'a Field);
 
-impl<'a> Serialize for SerializeField<'a> {
+impl Serialize for SerializeField<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -220,7 +220,7 @@ impl<'a> Serialize for SerializeField<'a> {
 #[derive(Debug)]
 pub struct SerializeFieldSet<'a>(&'a FieldSet);
 
-impl<'a> Serialize for SerializeFieldSet<'a> {
+impl Serialize for SerializeFieldSet<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -236,7 +236,7 @@ impl<'a> Serialize for SerializeFieldSet<'a> {
 #[derive(Debug)]
 pub struct SerializeLevel<'a>(&'a Level);
 
-impl<'a> Serialize for SerializeLevel<'a> {
+impl Serialize for SerializeLevel<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -260,7 +260,7 @@ impl<'a> Serialize for SerializeLevel<'a> {
 #[derive(Debug)]
 pub struct SerializeId<'a>(&'a Id);
 
-impl<'a> Serialize for SerializeId<'a> {
+impl Serialize for SerializeId<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -274,7 +274,7 @@ impl<'a> Serialize for SerializeId<'a> {
 #[derive(Debug)]
 pub struct SerializeMetadata<'a>(&'a Metadata<'a>);
 
-impl<'a> Serialize for SerializeMetadata<'a> {
+impl Serialize for SerializeMetadata<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -297,7 +297,7 @@ impl<'a> Serialize for SerializeMetadata<'a> {
 #[derive(Debug)]
 pub struct SerializeEvent<'a>(&'a Event<'a>);
 
-impl<'a> Serialize for SerializeEvent<'a> {
+impl Serialize for SerializeEvent<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -317,7 +317,7 @@ impl<'a> Serialize for SerializeEvent<'a> {
 #[derive(Debug)]
 pub struct SerializeAttributes<'a>(&'a Attributes<'a>);
 
-impl<'a> Serialize for SerializeAttributes<'a> {
+impl Serialize for SerializeAttributes<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -340,7 +340,7 @@ impl<'a> Serialize for SerializeAttributes<'a> {
 #[derive(Debug)]
 pub struct SerializeRecord<'a>(&'a Record<'a>);
 
-impl<'a> Serialize for SerializeRecord<'a> {
+impl Serialize for SerializeRecord<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -586,17 +586,17 @@ impl<'a> AsSerde<'a> for FieldSet {
     }
 }
 
-impl<'a> self::sealed::Sealed for Event<'a> {}
+impl self::sealed::Sealed for Event<'_> {}
 
-impl<'a> self::sealed::Sealed for Attributes<'a> {}
+impl self::sealed::Sealed for Attributes<'_> {}
 
 impl self::sealed::Sealed for Id {}
 
 impl self::sealed::Sealed for Level {}
 
-impl<'a> self::sealed::Sealed for Record<'a> {}
+impl self::sealed::Sealed for Record<'_> {}
 
-impl<'a> self::sealed::Sealed for Metadata<'a> {}
+impl self::sealed::Sealed for Metadata<'_> {}
 
 impl self::sealed::Sealed for Field {}
 

--- a/tracing-subscriber/src/field/mod.rs
+++ b/tracing-subscriber/src/field/mod.rs
@@ -157,29 +157,29 @@ where
 
 // === impl RecordFields ===
 
-impl<'a> crate::sealed::Sealed<RecordFieldsMarker> for Event<'a> {}
-impl<'a> RecordFields for Event<'a> {
+impl crate::sealed::Sealed<RecordFieldsMarker> for Event<'_> {}
+impl RecordFields for Event<'_> {
     fn record(&self, visitor: &mut dyn Visit) {
         Event::record(self, visitor)
     }
 }
 
-impl<'a> crate::sealed::Sealed<RecordFieldsMarker> for Attributes<'a> {}
-impl<'a> RecordFields for Attributes<'a> {
+impl crate::sealed::Sealed<RecordFieldsMarker> for Attributes<'_> {}
+impl RecordFields for Attributes<'_> {
     fn record(&self, visitor: &mut dyn Visit) {
         Attributes::record(self, visitor)
     }
 }
 
-impl<'a> crate::sealed::Sealed<RecordFieldsMarker> for Record<'a> {}
-impl<'a> RecordFields for Record<'a> {
+impl crate::sealed::Sealed<RecordFieldsMarker> for Record<'_> {}
+impl RecordFields for Record<'_> {
     fn record(&self, visitor: &mut dyn Visit) {
         Record::record(self, visitor)
     }
 }
 
-impl<'a, F> crate::sealed::Sealed<RecordFieldsMarker> for &'a F where F: RecordFields {}
-impl<'a, F> RecordFields for &'a F
+impl<F> crate::sealed::Sealed<RecordFieldsMarker> for &F where F: RecordFields {}
+impl<F> RecordFields for &F
 where
     F: RecordFields,
 {
@@ -338,19 +338,19 @@ pub(in crate::field) mod test_util {
         }
     }
 
-    impl<'a> Visit for DebugVisitor<'a> {
+    impl Visit for DebugVisitor<'_> {
         fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
             write!(self.writer, "{}={:?}", field, value).unwrap();
         }
     }
 
-    impl<'a> VisitOutput<fmt::Result> for DebugVisitor<'a> {
+    impl VisitOutput<fmt::Result> for DebugVisitor<'_> {
         fn finish(self) -> fmt::Result {
             self.err
         }
     }
 
-    impl<'a> VisitFmt for DebugVisitor<'a> {
+    impl VisitFmt for DebugVisitor<'_> {
         fn writer(&mut self) -> &mut dyn fmt::Write {
             self.writer
         }

--- a/tracing-subscriber/src/filter/env/field.rs
+++ b/tracing-subscriber/src/filter/env/field.rs
@@ -500,7 +500,7 @@ impl SpanMatch {
     }
 }
 
-impl<'a> Visit for MatchVisitor<'a> {
+impl Visit for MatchVisitor<'_> {
     fn record_f64(&mut self, field: &Field, value: f64) {
         match self.inner.fields.get(field) {
             Some((ValueMatch::NaN, ref matched)) if value.is_nan() => {

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -1035,13 +1035,13 @@ pub struct FmtContext<'a, S, N> {
     pub(crate) event: &'a Event<'a>,
 }
 
-impl<'a, S, N> fmt::Debug for FmtContext<'a, S, N> {
+impl<S, N> fmt::Debug for FmtContext<'_, S, N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FmtContext").finish()
     }
 }
 
-impl<'cx, 'writer, S, N> FormatFields<'writer> for FmtContext<'cx, S, N>
+impl<'writer, S, N> FormatFields<'writer> for FmtContext<'_, S, N>
 where
     S: Subscriber + for<'lookup> LookupSpan<'lookup>,
     N: FormatFields<'writer> + 'static,
@@ -1055,7 +1055,7 @@ where
     }
 }
 
-impl<'a, S, N> FmtContext<'a, S, N>
+impl<S, N> FmtContext<'_, S, N>
 where
     S: Subscriber + for<'lookup> LookupSpan<'lookup>,
     N: for<'writer> FormatFields<'writer> + 'static,

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -119,7 +119,7 @@ where
     Span: Subscriber + for<'lookup> crate::registry::LookupSpan<'lookup>,
     N: for<'writer> FormatFields<'writer> + 'static;
 
-impl<'a, 'b, Span, N> serde::ser::Serialize for SerializableContext<'a, 'b, Span, N>
+impl<Span, N> serde::ser::Serialize for SerializableContext<'_, '_, Span, N>
 where
     Span: Subscriber + for<'lookup> crate::registry::LookupSpan<'lookup>,
     N: for<'writer> FormatFields<'writer> + 'static,
@@ -149,7 +149,7 @@ where
     Span: for<'lookup> crate::registry::LookupSpan<'lookup>,
     N: for<'writer> FormatFields<'writer> + 'static;
 
-impl<'a, 'b, Span, N> serde::ser::Serialize for SerializableSpan<'a, 'b, Span, N>
+impl<Span, N> serde::ser::Serialize for SerializableSpan<'_, '_, Span, N>
 where
     Span: for<'lookup> crate::registry::LookupSpan<'lookup>,
     N: for<'writer> FormatFields<'writer> + 'static,
@@ -426,7 +426,7 @@ pub struct JsonVisitor<'a> {
     writer: &'a mut dyn Write,
 }
 
-impl<'a> fmt::Debug for JsonVisitor<'a> {
+impl fmt::Debug for JsonVisitor<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!("JsonVisitor {{ values: {:?} }}", self.values))
     }
@@ -447,13 +447,13 @@ impl<'a> JsonVisitor<'a> {
     }
 }
 
-impl<'a> crate::field::VisitFmt for JsonVisitor<'a> {
+impl crate::field::VisitFmt for JsonVisitor<'_> {
     fn writer(&mut self) -> &mut dyn fmt::Write {
         self.writer
     }
 }
 
-impl<'a> crate::field::VisitOutput<fmt::Result> for JsonVisitor<'a> {
+impl crate::field::VisitOutput<fmt::Result> for JsonVisitor<'_> {
     fn finish(self) -> fmt::Result {
         let inner = || {
             let mut serializer = Serializer::new(WriteAdaptor::new(self.writer));
@@ -474,7 +474,7 @@ impl<'a> crate::field::VisitOutput<fmt::Result> for JsonVisitor<'a> {
     }
 }
 
-impl<'a> field::Visit for JsonVisitor<'a> {
+impl field::Visit for JsonVisitor<'_> {
     #[cfg(all(tracing_unstable, feature = "valuable"))]
     fn record_value(&mut self, field: &Field, value: valuable_crate::Value<'_>) {
         let value = match serde_json::to_value(valuable_serde::Serializable::new(value)) {

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -1237,7 +1237,7 @@ impl<'a> DefaultVisitor<'a> {
     }
 }
 
-impl<'a> field::Visit for DefaultVisitor<'a> {
+impl field::Visit for DefaultVisitor<'_> {
     fn record_str(&mut self, field: &Field, value: &str) {
         if self.result.is_err() {
             return;
@@ -1298,13 +1298,13 @@ impl<'a> field::Visit for DefaultVisitor<'a> {
     }
 }
 
-impl<'a> crate::field::VisitOutput<fmt::Result> for DefaultVisitor<'a> {
+impl crate::field::VisitOutput<fmt::Result> for DefaultVisitor<'_> {
     fn finish(self) -> fmt::Result {
         self.result
     }
 }
 
-impl<'a> crate::field::VisitFmt for DefaultVisitor<'a> {
+impl crate::field::VisitFmt for DefaultVisitor<'_> {
     fn writer(&mut self) -> &mut dyn fmt::Write {
         &mut self.writer
     }
@@ -1313,7 +1313,7 @@ impl<'a> crate::field::VisitFmt for DefaultVisitor<'a> {
 /// Renders an error into a list of sources, *including* the error
 struct ErrorSourceList<'a>(&'a (dyn std::error::Error + 'static));
 
-impl<'a> Display for ErrorSourceList<'a> {
+impl Display for ErrorSourceList<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut list = f.debug_list();
         let mut curr = Some(self.0);
@@ -1427,7 +1427,7 @@ impl<'a> FmtThreadName<'a> {
     }
 }
 
-impl<'a> fmt::Display for FmtThreadName<'a> {
+impl fmt::Display for FmtThreadName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use std::sync::atomic::{
             AtomicUsize,
@@ -1498,7 +1498,7 @@ impl<'a> fmt::Display for FmtLevel<'a> {
 }
 
 #[cfg(feature = "ansi")]
-impl<'a> fmt::Display for FmtLevel<'a> {
+impl fmt::Display for FmtLevel<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.ansi {
             match *self.level {
@@ -1566,7 +1566,7 @@ where
     }
 }
 
-impl<'a, F> fmt::Debug for FieldFnVisitor<'a, F> {
+impl<F> fmt::Debug for FieldFnVisitor<'_, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FieldFnVisitor")
             .field("f", &format_args!("{}", std::any::type_name::<F>()))

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -437,7 +437,7 @@ impl<'a> PrettyVisitor<'a> {
     }
 }
 
-impl<'a> field::Visit for PrettyVisitor<'a> {
+impl field::Visit for PrettyVisitor<'_> {
     fn record_str(&mut self, field: &Field, value: &str) {
         if self.result.is_err() {
             return;
@@ -497,14 +497,14 @@ impl<'a> field::Visit for PrettyVisitor<'a> {
     }
 }
 
-impl<'a> VisitOutput<fmt::Result> for PrettyVisitor<'a> {
+impl VisitOutput<fmt::Result> for PrettyVisitor<'_> {
     fn finish(mut self) -> fmt::Result {
         write!(&mut self.writer, "{}", self.style.suffix())?;
         self.result
     }
 }
 
-impl<'a> VisitFmt for PrettyVisitor<'a> {
+impl VisitFmt for PrettyVisitor<'_> {
     fn writer(&mut self) -> &mut dyn fmt::Write {
         &mut self.writer
     }

--- a/tracing-subscriber/src/fmt/time/mod.rs
+++ b/tracing-subscriber/src/fmt/time/mod.rs
@@ -86,7 +86,7 @@ pub fn uptime() -> Uptime {
     Uptime::default()
 }
 
-impl<'a, F> FormatTime for &'a F
+impl<F> FormatTime for &F
 where
     F: FormatTime,
 {

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -800,7 +800,7 @@ where
     }
 }
 
-impl<'a, W> io::Write for MutexGuardWriter<'a, W>
+impl<W> io::Write for MutexGuardWriter<'_, W>
 where
     W: io::Write,
 {
@@ -1177,7 +1177,7 @@ impl<'a> WriteAdaptor<'a> {
     }
 }
 #[cfg(any(feature = "json", feature = "time"))]
-impl<'a> io::Write for WriteAdaptor<'a> {
+impl io::Write for WriteAdaptor<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let s =
             std::str::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
@@ -1195,7 +1195,7 @@ impl<'a> io::Write for WriteAdaptor<'a> {
 }
 
 #[cfg(any(feature = "json", feature = "time"))]
-impl<'a> fmt::Debug for WriteAdaptor<'a> {
+impl fmt::Debug for WriteAdaptor<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("WriteAdaptor { .. }")
     }

--- a/tracing-subscriber/src/layer/context.rs
+++ b/tracing-subscriber/src/layer/context.rs
@@ -408,7 +408,7 @@ where
     }
 }
 
-impl<'a, S> Context<'a, S> {
+impl<S> Context<'_, S> {
     pub(crate) fn none() -> Self {
         Self {
             subscriber: None,
@@ -419,7 +419,7 @@ impl<'a, S> Context<'a, S> {
     }
 }
 
-impl<'a, S> Clone for Context<'a, S> {
+impl<S> Clone for Context<'_, S> {
     #[inline]
     fn clone(&self) -> Self {
         let subscriber = self.subscriber.as_ref().copied();

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -115,7 +115,7 @@ pub trait LookupSpan<'a> {
     /// should only implement `span_data`.
     ///
     /// [`span_data`]: LookupSpan::span_data()
-    fn span(&'a self, id: &Id) -> Option<SpanRef<'_, Self>>
+    fn span(&'a self, id: &Id) -> Option<SpanRef<'a, Self>>
     where
         Self: Sized,
     {

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -383,13 +383,13 @@ impl<'a> LookupSpan<'a> for Registry {
 
 // === impl CloseGuard ===
 
-impl<'a> CloseGuard<'a> {
+impl CloseGuard<'_> {
     pub(crate) fn set_closing(&mut self) {
         self.is_closing = true;
     }
 }
 
-impl<'a> Drop for CloseGuard<'a> {
+impl Drop for CloseGuard<'_> {
     fn drop(&mut self) {
         // If this returns with an error, we are already panicking. At
         // this point, there's nothing we can really do to recover

--- a/tracing-subscriber/tests/layer_filters/option.rs
+++ b/tracing-subscriber/tests/layer_filters/option.rs
@@ -82,7 +82,7 @@ fn none_max_level_hint() {
         .run_with_handle();
     let max_level = Level::INFO;
     let layer_filter_fn = layer_filter_fn.with_filter(
-        filter::dynamic_filter_fn(move |meta, _| return meta.level() <= &max_level)
+        filter::dynamic_filter_fn(move |meta, _| meta.level() <= &max_level)
             .with_max_level_hint(max_level),
     );
     assert_eq!(layer_filter_fn.max_level_hint(), Some(LevelFilter::INFO));
@@ -112,7 +112,7 @@ fn some_max_level_hint() {
         .only()
         .run_with_handle();
     let layer_some = layer_some.with_filter(Some(
-        filter::dynamic_filter_fn(move |meta, _| return meta.level() <= &Level::DEBUG)
+        filter::dynamic_filter_fn(move |meta, _| meta.level() <= &Level::DEBUG)
             .with_max_level_hint(Level::DEBUG),
     ));
     assert_eq!(layer_some.max_level_hint(), Some(LevelFilter::DEBUG));
@@ -122,7 +122,7 @@ fn some_max_level_hint() {
         .only()
         .run_with_handle();
     let layer_filter_fn = layer_filter_fn.with_filter(
-        filter::dynamic_filter_fn(move |meta, _| return meta.level() <= &Level::INFO)
+        filter::dynamic_filter_fn(move |meta, _| meta.level() <= &Level::INFO)
             .with_max_level_hint(Level::INFO),
     );
     assert_eq!(layer_filter_fn.max_level_hint(), Some(LevelFilter::INFO));

--- a/tracing-test/src/lib.rs
+++ b/tracing-test/src/lib.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 #[allow(missing_docs)]
-
 pub struct PollN<T, E> {
     and_return: Option<Result<T, E>>,
     finish_at: usize,

--- a/tracing/benches/shared.rs
+++ b/tracing/benches/shared.rs
@@ -83,7 +83,7 @@ struct VisitingSubscriber(Mutex<String>);
 
 struct Visitor<'a>(MutexGuard<'a, String>);
 
-impl<'a> field::Visit for Visitor<'a> {
+impl field::Visit for Visitor<'_> {
     fn record_debug(&mut self, _field: &field::Field, value: &dyn fmt::Debug) {
         let _ = write!(&mut *self.0, "{:?}", value);
     }

--- a/tracing/src/field.rs
+++ b/tracing/src/field.rs
@@ -147,7 +147,7 @@ impl AsField for Field {
     }
 }
 
-impl<'a> AsField for &'a Field {
+impl AsField for &Field {
     #[inline]
     fn as_field(&self, metadata: &Metadata<'_>) -> Option<Field> {
         if self.callsite() == metadata.callsite() {
@@ -166,5 +166,5 @@ impl AsField for str {
 }
 
 impl crate::sealed::Sealed for Field {}
-impl<'a> crate::sealed::Sealed for &'a Field {}
+impl crate::sealed::Sealed for &Field {}
 impl crate::sealed::Sealed for str {}

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -888,7 +888,6 @@ impl Span {
     /// span.record("some_field", &"hello world!");
     /// ```
     ///
-
     /// [`Subscriber::enter`]: super::subscriber::Subscriber::enter()
     /// [`Subscriber::exit`]: super::subscriber::Subscriber::exit()
     /// [`Id`]: super::Id
@@ -1556,7 +1555,7 @@ impl Deref for EnteredSpan {
     }
 }
 
-impl<'a> Drop for Entered<'a> {
+impl Drop for Entered<'_> {
     #[inline(always)]
     fn drop(&mut self) {
         self.span.do_exit()


### PR DESCRIPTION
Most of these changes are places where lifetimes were named, but can be
elided. Then a few cases where a lifetime was elided, but actually
resolves to a named lifetime. So lots of lifetimes.

This is the `v0.1.x` branch sister PR to #3164 (for the `master`
branch), since `clippy --fix` on another branch is a much better way to
apply these changes than backporting.