### PR TITLE
chore: bump thiserror to v2

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -49,7 +49,7 @@ tempfile = "3.3.0"
 
 # fmt examples
 snafu = "0.6.10"
-thiserror = "1.0.31"
+thiserror = "2"
 
 # env-filter-explorer example
 ansi-to-tui = "7.0.0"

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -24,7 +24,7 @@ rust-version = "1.53.0"
 crossbeam-channel = "0.5.5"
 time = { version = "0.3.2", default-features = false, features = ["formatting", "parsing"] }
 parking_lot = { optional = true, version = "0.12.1" }
-thiserror = "1.0.31"
+thiserror = "2"
 
 [dependencies.tracing-subscriber]
 path = "../tracing-subscriber"


### PR DESCRIPTION
## Motivation

The ecosystem has upgraded to thiserror v2, so this crate was causing duplicate dependency versions.

## Solution

Bump thiserror to v2 - https://github.com/dtolnay/thiserror/releases/tag/2.0.0
