### PR TITLE
Update `nu-ansi-term`

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -50,7 +50,7 @@ once_cell = { optional = true, version = "1.13.0" }
 
 # fmt
 tracing-log = { path = "../tracing-log", version = "0.2", optional = true, default-features = false, features = ["log-tracer", "std"] }
-nu-ansi-term = { version = "0.46.0", optional = true }
+nu-ansi-term = { version = "0.50.0", optional = true }
 time = { version = "0.3.2", features = ["formatting"], optional = true }
 
 # only required by the json feature


### PR DESCRIPTION
When using `tracing-subscriber` and https://github.com/davidbarsky/tracing-tree, 2 copies are compiled in due to differing version requirements. I checked and `nu-ansi-term`'s min rust version is lower than `tracing`'s, so this should be fine to bump.