### PR TITLE
docs: double quote will treated as a part of field value

### DIFF
--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -111,7 +111,7 @@ use tracing_core::{
 /// - `my_crate[span_a]=trace` will enable all spans and events that:
 ///    - are within the `span_a` span or named `span_a` _if_ `span_a` has the target `my_crate`,
 ///    - at the level `trace` or above.
-/// - `[span_b{name=\"bob\"}]` will enable all spans or event that:
+/// - `[span_b{name="bob"}]` will enable all spans or event that:
 ///    - have _any_ target,
 ///    - are inside a span named `span_b`,
 ///    - which has a field named `name` with value `bob`,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

The docs about env_filter about `target[span{field=value}]=level` [Directives](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives) has some type error.

the `[script{source=\"stdout\"]=trace` won't match the log below:

```log
2025-01-14T08:54:02.550867Z  INFO script{source="stdout"}: trac: output to stdout: 131
```

but `[script{source=stdout]=trace` will match. 

It seems the double quote will be part of the field's value. 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

just remove double quote and `\`