### PR TITLE
core: add `portable-atomic` support

### DIFF
--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.63.0"
 [features]
 default = ["std"]
 alloc = ["portable-atomic-util?/alloc"]
-std = ["once_cell", "alloc"]
+std = ["once_cell", "alloc", "portable-atomic-util?/std"]
 portable-atomic = ["dep:portable-atomic-util", "once_cell?/portable-atomic"]
 
 [badges]

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -26,14 +26,16 @@ rust-version = "1.63.0"
 
 [features]
 default = ["std"]
-alloc = []
+alloc = ["portable-atomic-util?/alloc"]
 std = ["once_cell", "alloc"]
+portable-atomic = ["dep:portable-atomic-util", "once_cell?/portable-atomic"]
 
 [badges]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
 once_cell = { version = "1.13.0", optional = true }
+portable-atomic-util = { version = "0.2.4", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tracing-core/src/collect.rs
+++ b/tracing-core/src/collect.rs
@@ -4,6 +4,12 @@ use crate::{span, Dispatch, Event, LevelFilter, Metadata};
 use core::any::{Any, TypeId};
 use core::ptr::NonNull;
 
+#[cfg(all(feature = "alloc", not(feature = "portable-atomic")))]
+use alloc::sync::Arc;
+
+#[cfg(all(feature = "alloc", feature = "portable-atomic"))]
+use portable_atomic_util::Arc;
+
 /// Trait representing the functions required to collect trace data.
 ///
 /// Crates that provide implementations of methods for collecting or recording
@@ -772,7 +778,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl<C> Collect for alloc::sync::Arc<C>
+impl<C> Collect for Arc<C>
 where
     C: Collect + ?Sized,
 {

--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -552,7 +552,6 @@ impl Dispatch {
             // Workaround for a lack of support for unsized coercion in non-first-party types.
             // See https://github.com/rust-lang/rust/issues/18598
             let boxed: Box<dyn Collect + Send + Sync> = Box::<C>::new(collector);
-            
             Arc::from(boxed)
         };
 


### PR DESCRIPTION
## Motivation

- Fixes #3173

## Solution

- Added `portable-atomic-util` as an optional dependency gated behind a new feature, `portable-atomic` to `tracing-core`
- When `portable-atomic` is enabled, switched uses of `Arc` and `Weak` away from `alloc::sync` to `portable_atomic_util`.
- Added workaround for a lack of support for [unsized coercion](https://github.com/rust-lang/rust/issues/18598) in custom types. I've included a comment linking to this issue explaining the missing functionality.

## Notes

I'm currently working on `no_std` support for the [Bevy Game Engine](https://github.com/bevyengine/bevy/issues/15460), which includes targeting embedded devices without full native support for atomics, such as the RP2040 Raspberry Pi Pico. Using `portable-atomic`, users can provide a fallback implementation for atomics to libraries (typically through `critical-section`), allowing libraries to depend on atomics even on unsupported platforms. This PR would allow using `tracing` on more platforms without sacrificing ergonomics or performance on existing ones.

This is my first time contributing to `tracing`, so please reach out if there's anything I can do to help with reviewing and merging this change!