### PR TITLE
subscriber: update tracing-core to v0.1.33

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -39,7 +39,7 @@ local-time = ["time/local-offset"]
 nu-ansi-term = ["dep:nu-ansi-term"]
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.30", default-features = false }
+tracing-core = { path = "../tracing-core", version = "0.1.33", default-features = false }
 
 # only required by the filter feature
 tracing = { optional = true, path = "../tracing", version = "0.1.41", default-features = false }


### PR DESCRIPTION
The change #2954 was released in 0.3.19 (#3162).

Notably, it relied on features from tracing-core 0.1.33, however, the
version was never bumped. Users of the `tracing` feature of
`tracing-subscriber` would have no issue since it pulls in the higher
version transitively.

The specific feature used was implementing trait method `record_bytes`
from the `field::Visit` trait on `JsonVisitor` from the
tracing-subscriber json format module. (see linked #2945, or [ `impl
field::Visit for
JsonVisitor<'_>`](https://github.com/tokio-rs/tracing/blame/master/tracing-subscriber/src/fmt/format/json.rs#L491))

I believe this dependency mismatch requires users to manually select the
higher tracing-core version or suffer compilation failure.

This probably reflects some failure in how the tests utilize features
and intra-workspace dependencies, but, a resolution for that is beyond
my current comprehension of the project.

This PR was created based on #3176 by @nkconnor, because it looks like
our job rules don't allow non-members to run jobs on PRs against the `v0.1.x`
branch (there's no button for me to approve the run).