### PR TITLE
chore: fix Rust 1.84.0 lints and errors (#3202)

### DIFF
--- a/tracing-attributes/tests/ui/async_instrument.stderr
+++ b/tracing-attributes/tests/ui/async_instrument.stderr
@@ -28,7 +28,10 @@ error[E0277]: `(&str,)` doesn't implement `std::fmt::Display`
   --> tests/ui/async_instrument.rs:14:1
    |
 14 | #[tracing::instrument]
-   | ^^^^^^^^^^^^^^^^^^^^^^ `(&str,)` cannot be formatted with the default formatter
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | `(&str,)` cannot be formatted with the default formatter
+   | return type was inferred to be `(&str,)` here
    |
    = help: the trait `std::fmt::Display` is not implemented for `(&str,)`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -1186,7 +1186,7 @@ impl io::Write for WriteAdaptor<'_> {
             .write_str(s)
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
-        Ok(s.as_bytes().len())
+        Ok(s.len())
     }
 
     fn flush(&mut self) -> io::Result<()> {


### PR DESCRIPTION
Backport of #3202.