### PR TITLE
subscriber: update matchers

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -43,7 +43,7 @@ tracing-core = { path = "../tracing-core", version = "0.2", default-features = f
 
 # only required by the `env-filter` feature
 tracing = { optional = true, path = "../tracing", version = "0.2", default-features = false }
-matchers = { optional = true, version = "0.1.0" }
+matchers = { optional = true, version = "0.2.0" }
 regex = { optional = true, version = "1.6.0", default-features = false, features = ["std", "unicode-case", "unicode-perl"] }
 smallvec = { optional = true, version = "1.9.0" }
 once_cell = { optional = true, version = "1.13.0" }

--- a/tracing-subscriber/src/filter/env/field.rs
+++ b/tracing-subscriber/src/filter/env/field.rs
@@ -234,7 +234,7 @@ impl ValueMatch {
     /// This returns an error if the string didn't contain a valid `bool`,
     /// `u64`, `i64`, or `f64` literal, and couldn't be parsed as a regular
     /// expression.
-    fn parse_regex(s: &str) -> Result<Self, matchers::Error> {
+    fn parse_regex(s: &str) -> Result<Self, matchers::BuildError> {
         s.parse::<bool>()
             .map(ValueMatch::Bool)
             .or_else(|_| s.parse::<u64>().map(ValueMatch::U64))
@@ -279,7 +279,7 @@ impl fmt::Display for ValueMatch {
 // === impl MatchPattern ===
 
 impl FromStr for MatchPattern {
-    type Err = matchers::Error;
+    type Err = matchers::BuildError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let matcher = Pattern::new_anchored(s)?;
         Ok(Self {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

`regex-automata` appears multiple times in the dependency tree for `tracing-subscriber`.
(v0.1.10 for matchers and `current` for regex itself)


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Update `matchers` to `0.2.0`, which depends on the current `regex-automata`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
