### PR TITLE
examples: bump inferno dep

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -44,7 +44,7 @@ humantime = "2.1.0"
 log = "0.4.17"
 
 # inferno example
-inferno = "0.11.6"
+inferno = "0.12.1"
 tempfile = "3.3.0"
 
 # fmt examples


### PR DESCRIPTION



## Motivation

The transitive dependency on itoa 0.4 does not compiles with stable
rust.


```
❯ cargo check --examples
    Checking serde v1.0.157
    Checking tokio v1.43.0
    Checking itoa v0.4.0
    Checking tracing-macros v0.1.0 (/Users/joshka/local/tracing/tracing-macros)
error[E0554]: `#![feature]` may not be used on the stable release channel
  --> /Users/joshka/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/itoa-0.4.0/src/lib.rs:13:31
   |
13 | #![cfg_attr(feature = "i128", feature(i128_type, i128))]
   |                               ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: the feature `i128_type` has been stable since `1.26.0` and no longer requires an attribute to enable

```

```
❯ cargo tree -i itoa@0.4.0
itoa v0.4.0
└── num-format v0.4.0
    └── inferno v0.11.6
        [dev-dependencies]
        └── tracing-examples v0.0.0 (/Users/joshka/local/tracing/examples)
```

## Solution

 Bump inferno to 0.12.1 to bring in the updated 1.0 version of itoa (this version is used by all other dependencies).