### PR TITLE
fix: do not compare references to pointers to compare pointers

### DIFF
--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -448,7 +448,7 @@ impl Eq for Metadata<'_> {}
 impl PartialEq for Metadata<'_> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        if core::ptr::eq(&self, &other) {
+        if core::ptr::eq(self, other) {
             true
         } else if cfg!(not(debug_assertions)) {
             // In a well-behaving application, two `Metadata` can be assumed to


### PR DESCRIPTION
`self` and `other` are references, and the `ptr::eq()` call intends to determine if they designate the same object. Putting them behind another level of reference will always return `false`, as those short-lived references will be compared instead.

## Solution

Remove the extra references.

As this is only an optimization which was missed, it is not possible to design a test which failed before this PR and succeeds after.