### PR TITLE
Remove old warnings, use more efficient methods

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -51,7 +51,7 @@ once_cell = { optional = true, version = "1.13.0" }
 # fmt
 tracing-log = { path = "../tracing-log", version = "0.2", optional = true, default-features = false, features = ["log-tracer", "std"] }
 nu-ansi-term = { version = "0.46.0", optional = true }
-time = { version = "0.3.2", features = ["formatting"], optional = true }
+time = { version = "0.3.38", features = ["formatting"], optional = true }
 
 # only required by the json feature
 serde_json = { version = "1.0.82", optional = true }
@@ -76,7 +76,7 @@ regex = { version = "1.6.0", default-features = false, features = ["std"] }
 tracing-futures = { path = "../tracing-futures", version = "0.3", default-features = false, features = ["std-future", "std"] }
 tokio = { version = "1.20.0", features = ["rt", "macros"] }
 # Enable the `time` crate's `macros` feature, for examples.
-time = { version = "0.3.2", features = ["formatting", "macros"] }
+time = { version = "0.3.38", features = ["formatting", "macros"] }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/tracing-subscriber/src/fmt/time/mod.rs
+++ b/tracing-subscriber/src/fmt/time/mod.rs
@@ -13,7 +13,7 @@ mod time_crate;
 pub use time_crate::UtcTime;
 
 #[cfg(feature = "local-time")]
-#[cfg_attr(docsrs, doc(cfg(all(unsound_local_offset, feature = "local-time"))))]
+#[cfg_attr(docsrs, doc(cfg(feature = "local-time")))]
 pub use time_crate::LocalTime;
 
 /// [`chrono`]-based implementation for [`FormatTime`].


### PR DESCRIPTION
Since `time` 0.3.37, `--cfg unsound_local_offset` was removed in favor of requiring manual method calls to update `$TZ`. As effectively no one changes `$TZ`, this means that any calls requiring the local offset generally work as expected. For this reason, I have removed the now-outdated warnings and doc cfgs.

Additionally, I have switched the UTC version to use the newly-introduced `UtcDateTime` from `time` 0.3.38. I left (and split) the helper method, though this can be inlined if preferable. There is possibly a minor performance difference by using `UtcDateTime`, but I did so moreso because it's idiomatic to use the best type for the job.

Side note, why not use `#![feature(doc_auto_cfg)]`? This would render the majority of manual declarations redundant.