### PR TITLE
chore: fix Rust 1.85.0 lints and errors

### DIFF
--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -517,11 +517,17 @@ pub struct PriorityMappings {
 impl PriorityMappings {
     /// Returns the default priority mappings:
     ///
-    /// - [`tracing::Level::ERROR`]: [`Priority::Error`] (3)
-    /// - [`tracing::Level::WARN`]: [`Priority::Warning`] (4)
-    /// - [`tracing::Level::INFO`]: [`Priority::Notice`] (5)
-    /// - [`tracing::Level::DEBUG`]: [`Priority::Informational`] (6)
-    /// - [`tracing::Level::TRACE`]: [`Priority::Debug`] (7)
+    /// - [`tracing::Level::ERROR`][]: [`Priority::Error`] (3)
+    /// - [`tracing::Level::WARN`][]: [`Priority::Warning`] (4)
+    /// - [`tracing::Level::INFO`][]: [`Priority::Notice`] (5)
+    /// - [`tracing::Level::DEBUG`][]: [`Priority::Informational`] (6)
+    /// - [`tracing::Level::TRACE`][]: [`Priority::Debug`] (7)
+    ///
+    /// [`tracing::Level::ERROR`]: tracing_core::Level::ERROR
+    /// [`tracing::Level::WARN`]: tracing_core::Level::WARN
+    /// [`tracing::Level::INFO`]: tracing_core::Level::INFO
+    /// [`tracing::Level::DEBUG`]: tracing_core::Level::DEBUG
+    /// [`tracing::Level::TRACE`]: tracing_core::Level::TRACE
     pub fn new() -> PriorityMappings {
         Self {
             error: Priority::Error,

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -92,9 +92,9 @@
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [`log`]: https://crates.io/crates/log
 //! [`env_logger` crate]: https://crates.io/crates/env-logger
-//! [`tracing::Collector`]: tracing::Collect
+//! [`tracing::Collector`]: tracing_core::Collect
 //! [`tracing::Event`]: tracing_core::Event
-//! [`Collect`]: tracing::Collect
+//! [`Collect`]: tracing_core::Collect
 //! [flags]: https://docs.rs/tracing/latest/tracing/#crate-feature-flags
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -122,6 +122,7 @@
 //! [`Collect`]: tracing_core::collect::Collect
 //! [collector]: tracing_core::collect::Collect
 //! [`EnvFilter`]: filter::EnvFilter
+//! [`tracing`]: https://crates.io/crates/tracing
 //! [`tracing-log`]: https://crates.io/crates/tracing-log
 //! [`smallvec`]: https://crates.io/crates/smallvec
 //! [`env_logger` crate]: https://crates.io/crates/env_logger

--- a/tracing/src/collect.rs
+++ b/tracing/src/collect.rs
@@ -30,8 +30,6 @@ where
 ///
 /// Note: Libraries should *NOT* call `set_global_default()`! That will cause conflicts when
 /// executables try to set them later.
-///
-/// [span]: super::span
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "std", feature = "alloc"))))]
 pub fn set_global_default<C>(collector: C) -> Result<(), SetGlobalDefaultError>


### PR DESCRIPTION
## Motivation

We had some broken link formatting in the `tracing-journald` docs which
clippy picked up (the text looked like a link definition, but wasn't
meant to be). 

## Solution

The incorrect links have now been corrected. They have to link to the
`tracing-core` crate because `tracing-journald` doesn't depend on
`tracing` directly.

Fixes for a broken link in the `tracing-subscriber` main page and
correcting the link to `Collect` from `tracing-log` (which also doesn't
depend on `tracing` directly) were also included.
