### PR TITLE
subscriber: use state machine to parse `EnvFilter` directives

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.63.0"
 default = ["smallvec", "fmt", "ansi", "tracing-log", "std"]
 alloc = ["tracing-core/alloc", "portable-atomic-util?/alloc"]
 std = ["alloc", "tracing-core/std"]
-env-filter = ["matchers", "regex", "once_cell", "tracing", "std", "thread_local"]
+env-filter = ["matchers", "once_cell", "tracing", "std", "thread_local"]
 fmt = ["registry", "std"]
 ansi = ["fmt", "nu-ansi-term"]
 registry = ["sharded-slab", "thread_local", "std"]
@@ -39,6 +39,8 @@ critical-section = ["tracing-core/critical-section", "tracing?/critical-section"
 # formatters.
 local-time = ["time/local-offset"]
 nu-ansi-term = ["dep:nu-ansi-term"]
+# For backwards compatibility only
+regex = []
 
 [dependencies]
 tracing-core = { path = "../tracing-core", version = "0.2", default-features = false }
@@ -46,7 +48,6 @@ tracing-core = { path = "../tracing-core", version = "0.2", default-features = f
 # only required by the `env-filter` feature
 tracing = { optional = true, path = "../tracing", version = "0.2", default-features = false }
 matchers = { optional = true, version = "0.1.0" }
-regex = { optional = true, version = "1.6.0", default-features = false, features = ["std", "unicode-case", "unicode-perl"] }
 smallvec = { optional = true, version = "1.9.0" }
 once_cell = { optional = true, version = "1.13.0" }
 


### PR DESCRIPTION
Intended to fix #3174. Have not done any benchmarks yet -- suggestions on how best to approach that are welcome.

This is a little bit more code, but IMO maybe slightly more readable?

It's correct enough that it passes the tests, there might be edge cases that aren't covered but those should be easy to solve.