### PR TITLE
tracing: Add `portable-atomic` support to other `tracing` crates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -189,6 +189,30 @@ jobs:
         esac
       shell: bash
 
+  check-portable-atomic:
+    # Run `cargo check` on platforms without full atomic support
+    name: cargo check (${{ matrix.target }} with portable-atomic)
+    needs: check
+    strategy:
+      matrix:
+        target: ["thumbv6m-none-eabi"]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: ${{ matrix.target }}
+    - name: Check tracing-core
+      run: cargo check --target ${{ matrix.target }} -p tracing-core --no-default-features --features alloc,portable-atomic,critical-section
+    - name: Check tracing-serde
+      run: cargo check --target ${{ matrix.target }} -p tracing-serde --no-default-features --features portable-atomic,critical-section
+    - name: Check tracing
+      run: cargo check --target ${{ matrix.target }} -p tracing --no-default-features --features attributes,portable-atomic,critical-section
+    - name: Check tracing-subscriber
+      run: cargo check --target ${{ matrix.target }} -p tracing-subscriber --no-default-features --features alloc,portable-atomic,critical-section
+    - name: Check tracing-futures
+      run: cargo check --target ${{ matrix.target }} -p tracing-futures --no-default-features --features portable-atomic,critical-section
+
   ### test jobs #############################################################
 
   test:

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -27,8 +27,9 @@ rust-version = "1.63.0"
 [features]
 default = ["std"]
 alloc = ["portable-atomic-util?/alloc"]
-std = ["once_cell", "alloc", "portable-atomic-util?/std"]
-portable-atomic = ["dep:portable-atomic-util", "once_cell?/portable-atomic"]
+std = ["once_cell", "alloc", "portable-atomic?/std", "portable-atomic-util?/std"]
+portable-atomic = ["dep:portable-atomic", "dep:portable-atomic-util", "once_cell?/portable-atomic"]
+critical-section = ["portable-atomic?/critical-section", "once_cell?/critical-section"]
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -36,6 +37,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 once_cell = { version = "1.13.0", optional = true }
 portable-atomic-util = { version = "0.2.4", default-features = false, optional = true }
+portable-atomic = { version = "1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -89,8 +89,14 @@ use core::{
     fmt,
     hash::{Hash, Hasher},
     ptr,
-    sync::atomic::{AtomicPtr, Ordering},
+    sync::atomic::Ordering,
 };
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic::AtomicPtr;
+
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic::AtomicPtr;
 
 type Callsites = LinkedList;
 

--- a/tracing-core/src/dispatch.rs
+++ b/tracing-core/src/dispatch.rs
@@ -140,11 +140,13 @@ use crate::{
     span, Event, LevelFilter, Metadata,
 };
 
-use core::{
-    any::Any,
-    fmt,
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
-};
+use core::{any::Any, fmt, sync::atomic::Ordering};
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic::{AtomicBool, AtomicUsize};
+
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic::{AtomicBool, AtomicUsize};
 
 #[cfg(feature = "std")]
 use std::{

--- a/tracing-core/src/metadata.rs
+++ b/tracing-core/src/metadata.rs
@@ -1,10 +1,12 @@
 //! Metadata describing trace data.
 use super::{callsite, field};
-use core::{
-    cmp, fmt,
-    str::FromStr,
-    sync::atomic::{AtomicUsize, Ordering},
-};
+use core::{cmp, fmt, str::FromStr, sync::atomic::Ordering};
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic::AtomicUsize;
+
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic::AtomicUsize;
 
 /// Metadata describing a [span] or [event].
 ///

--- a/tracing-core/src/spin/once.rs
+++ b/tracing-core/src/spin/once.rs
@@ -1,7 +1,13 @@
 use core::cell::UnsafeCell;
 use core::fmt;
 use core::hint::spin_loop;
-use core::sync::atomic::{AtomicUsize, Ordering};
+use core::sync::atomic::Ordering;
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic::AtomicUsize;
+
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic::AtomicUsize;
 
 /// A synchronization primitive which can be used to run a one-time global
 /// initialization. Unlike its std equivalent, this is generalized so that the

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -23,8 +23,10 @@ default = ["std-future", "std"]
 futures-01 = ["futures_01", "std"]
 futures-03 = ["std-future", "futures", "futures-task", "std"]
 std-future = ["pin-project-lite"]
-tokio = ["tokio_01"]
+tokio = ["tokio_01", "dep:tokio-threadpool", "dep:mio"]
 std = ["tracing/std"]
+portable-atomic = ["tracing/portable-atomic"]
+critical-section = ["tracing/critical-section"]
 
 [dependencies]
 futures_01 = { package = "futures", version = "0.1.31", optional = true }
@@ -36,8 +38,8 @@ tokio-executor = { version = "0.1.10", optional = true }
 tokio_01 = { package = "tokio", version = "0.1.22", optional = true }
 
 # Fix minimal-versions
-tokio-threadpool = "0.1.18"
-mio = "0.6.23"
+tokio-threadpool = { version = "0.1.18", optional = true }
+mio = { version = "0.6.23", optional = true }
 
 [dev-dependencies]
 futures = "0.3.21"

--- a/tracing-macros/Cargo.toml
+++ b/tracing-macros/Cargo.toml
@@ -22,6 +22,7 @@ tracing = { path = "../tracing", version = "0.2", default-features = false }
 
 [dev-dependencies]
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3" }
+tracing = { path = "../tracing", version = "0.2", default-features = false, features = ["std"] }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/tracing-macros/Cargo.toml
+++ b/tracing-macros/Cargo.toml
@@ -18,7 +18,7 @@ license = "MIT"
 rust-version = "1.63.0"
 
 [dependencies]
-tracing = { path = "../tracing", version = "0.2", default-features = false, features = ["std"] }
+tracing = { path = "../tracing", version = "0.2", default-features = false }
 
 [dev-dependencies]
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3" }

--- a/tracing-macros/src/lib.rs
+++ b/tracing-macros/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 #[doc(hidden)]
 pub use tracing;
 

--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -21,6 +21,8 @@ rust-version = "1.63.0"
 [features]
 default = ["std"]
 std = ["serde/std", "tracing-core/std"]
+portable-atomic = ["tracing-core/portable-atomic"]
+critical-section = ["tracing-core/critical-section"]
 
 [dependencies]
 serde = { version = "1.0.139", default-features = false, features = ["alloc"] }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -25,13 +25,15 @@ rust-version = "1.63.0"
 [features]
 
 default = ["smallvec", "fmt", "ansi", "tracing-log", "std"]
-alloc = ["tracing-core/alloc"]
+alloc = ["tracing-core/alloc", "portable-atomic-util?/alloc"]
 std = ["alloc", "tracing-core/std"]
 env-filter = ["matchers", "regex", "once_cell", "tracing", "std", "thread_local"]
 fmt = ["registry", "std"]
 ansi = ["fmt", "nu-ansi-term"]
 registry = ["sharded-slab", "thread_local", "std"]
 json = ["tracing-serde", "serde", "serde_json"]
+portable-atomic = ["dep:portable-atomic-util", "tracing-core/portable-atomic", "tracing?/portable-atomic", "tracing-serde?/portable-atomic"]
+critical-section = ["tracing-core/critical-section", "tracing?/critical-section", "tracing-serde?/critical-section"]
 
 # Enables support for local time when using the `time` crate timestamp
 # formatters.
@@ -65,6 +67,9 @@ chrono = { version = "0.4.26", default-features = false, features = ["clock", "s
 # registry
 sharded-slab = { version = "0.1.4", optional = true }
 thread_local = { version = "1.1.4", optional = true }
+
+# portable-atomic
+portable-atomic-util = { version = "0.2.4", default-features = false, optional = true }
 
 [dev-dependencies]
 tracing = { path = "../tracing", version = "0.2" }

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -233,10 +233,13 @@ pub struct Scope<'a, R> {
 feature! {
     #![any(feature = "alloc", feature = "std")]
 
-    use alloc::{
-        boxed::Box,
-        sync::Arc
-    };
+    use alloc::boxed::Box;
+
+    #[cfg(feature = "portable-atomic")]
+    use portable_atomic_util::Arc;
+
+    #[cfg(not(feature = "portable-atomic"))]
+    use alloc::sync::Arc;
 
     #[cfg(not(feature = "smallvec"))]
     use alloc::vec::{self, Vec};

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -32,6 +32,7 @@ tracing-core = { path = "../tracing-core", version = "0.2", default-features = f
 log = { version = "0.4.17", optional = true }
 tracing-attributes = { path = "../tracing-attributes", version = "0.2", optional = true }
 pin-project-lite = "0.2.9"
+portable-atomic = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.3.6", default-features = false }
@@ -60,9 +61,11 @@ release_max_level_debug = []
 release_max_level_trace = []
 
 alloc = ["tracing-core/alloc"]
-std = ["tracing-core/std", "alloc"]
+std = ["tracing-core/std", "alloc", "portable-atomic?/std"]
 log-always = ["log"]
 attributes = ["tracing-attributes"]
+portable-atomic = ["dep:portable-atomic", "tracing-core/portable-atomic"]
+critical-section = ["tracing-core/critical-section", "portable-atomic?/critical-section"]
 
 [[bench]]
 name = "baseline"

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1003,7 +1003,14 @@ pub mod __macro_support {
     pub use crate::callsite::{Callsite, Registration};
     use crate::{collect::Interest, Metadata};
     use core::fmt;
-    use core::sync::atomic::{AtomicU8, Ordering};
+    use core::sync::atomic::Ordering;
+
+    #[cfg(feature = "portable-atomic")]
+    use portable_atomic::AtomicU8;
+
+    #[cfg(not(feature = "portable-atomic"))]
+    use core::sync::atomic::AtomicU8;
+
     // Re-export the `core` functions that are used in macros. This allows
     // a crate to be named `core` and avoid name clashes.
     // See here: https://github.com/tokio-rs/tracing/issues/2761


### PR DESCRIPTION
This PR expands [`portable-atomic`](https://docs.rs/portable-atomic/) utilisation within Tracing, improving platform support without breaking the existing public API.

## Motivation

Since #3199 was merged, it's now possible to bring more tracing crates to atomically challenged platforms through `portable-atomic`. Additionally, CI is not currently setup to ensure this feature behaves as expected (allowing compilation on platforms with incomplete atomic support).

## Solution

- Added `portable-atomic` support to:
  - `tracing`
  - `tracing-futures`
  - `tracing-serde`
  - `tracing-subscriber`
- Added `no_std` support to:
  - `tracing-macros`
  - `tracing-futures`
- Added CI task to catch regressions in `portable-atomic` _and_ `no_std` support.

## Notes

- A `critical-section` feature is also added to make CI testing and usage of `tracing`/etc. on atomically challenged platforms simpler.
- No additional dependencies are included in this PR, optional or otherwise. Instances of including `portable-atomic` as a dependency only occur when it would have already been included transitively via `tracing-core`'s `portable-atomic-util` dependency.
- I checked all instances of replacing `core::sync::atomic` with `portable-atomic` to ensure the public API was unaffected. As such, this is not a breaking change, since it simply adds `portable-atomic` and `critical-section` features.