### PR TITLE
subscriber: Add note about potential misuse of stdout to documentation

### DIFF
--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -5,7 +5,11 @@
 //! [`tracing`] is a framework for instrumenting Rust programs with context-aware,
 //! structured, event-based diagnostic information. This crate provides an
 //! implementation of the [`Collect`] trait that records `tracing`'s `Event`s
-//! and `Span`s by formatting them as text and logging them to stdout.
+//! and `Span`s by formatting them as text and logging them to **stdout**.
+//!
+//! _Note: It is not good practice to write logging information to stdout.
+//! It is recommended for most applications to set this to stderr instead, which
+//! can be done with [`CollectorBuilder::with_writer`]_
 //!
 //! # Usage
 //!


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

As noted in #2492 logging to `stdout` instead of `stderr` by default is just plain wrong.

It goes against established conventions and also increases the risk of bugs caused by mixing program output with diagnostics.

But since changing a default is (rightly) considered a breaking change this cannot be fixed until version `0.4`.


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Simply add a note to the documentation to make it very clear to users that the defaults are probably **not** what the are expecting and to discourage applications depending on `tracing-subscriber` from inheriting this default.
