### PR TITLE
Backport everything up to May 2025

### DIFF
--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -453,7 +453,7 @@ impl RecordType {
                 if path
                     .segments
                     .iter()
-                    .last()
+                    .next_back()
                     .map(|path_segment| {
                         let ident = path_segment.ident.to_string();
                         Self::TYPES_FOR_VALUE.iter().any(|&t| t == ident)

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -25,15 +25,15 @@
 //! features with other crates in the asynchronous ecosystem:
 //!
 //! - `tokio`: Enables compatibility with the `tokio` crate, including
-//!    [`Instrument`] and [`WithSubscriber`] implementations for
-//!    `tokio::executor::Executor`, `tokio::runtime::Runtime`, and
-//!    `tokio::runtime::current_thread`. Enabled by default.
+//!   [`Instrument`] and [`WithSubscriber`] implementations for
+//!   `tokio::executor::Executor`, `tokio::runtime::Runtime`, and
+//!   `tokio::runtime::current_thread`. Enabled by default.
 //! - `tokio-executor`: Enables compatibility with the `tokio-executor`
-//!    crate, including [`Instrument`] and [`WithSubscriber`]
-//!    implementations for types implementing `tokio_executor::Executor`.
-//!    This is intended primarily for use in crates which depend on
-//!    `tokio-executor` rather than `tokio`; in general the `tokio` feature
-//!    should be used instead.
+//!   crate, including [`Instrument`] and [`WithSubscriber`]
+//!   implementations for types implementing `tokio_executor::Executor`.
+//!   This is intended primarily for use in crates which depend on
+//!   `tokio-executor` rather than `tokio`; in general the `tokio` feature
+//!   should be used instead.
 //! - `std-future`: Enables compatibility with `std::future::Future`.
 //! - `futures-01`: Enables compatibility with version 0.1.x of the [`futures`]
 //!   crate.

--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -515,11 +515,17 @@ pub struct PriorityMappings {
 impl PriorityMappings {
     /// Returns the default priority mappings:
     ///
-    /// - [`tracing::Level::ERROR`]: [`Priority::Error`] (3)
-    /// - [`tracing::Level::WARN`]: [`Priority::Warning`] (4)
-    /// - [`tracing::Level::INFO`]: [`Priority::Notice`] (5)
-    /// - [`tracing::Level::DEBUG`]: [`Priority::Informational`] (6)
-    /// - [`tracing::Level::TRACE`]: [`Priority::Debug`] (7)
+    /// - [`tracing::Level::ERROR`][]: [`Priority::Error`] (3)
+    /// - [`tracing::Level::WARN`][]: [`Priority::Warning`] (4)
+    /// - [`tracing::Level::INFO`][]: [`Priority::Notice`] (5)
+    /// - [`tracing::Level::DEBUG`][]: [`Priority::Informational`] (6)
+    /// - [`tracing::Level::TRACE`][]: [`Priority::Debug`] (7)
+    ///
+    /// [`tracing::Level::ERROR`]: tracing_core::Level::ERROR
+    /// [`tracing::Level::WARN`]: tracing_core::Level::WARN
+    /// [`tracing::Level::INFO`]: tracing_core::Level::INFO
+    /// [`tracing::Level::DEBUG`]: tracing_core::Level::DEBUG
+    /// [`tracing::Level::TRACE`]: tracing_core::Level::TRACE
     pub fn new() -> PriorityMappings {
         Self {
             error: Priority::Error,

--- a/tracing-subscriber/src/filter/env/mod.rs
+++ b/tracing-subscriber/src/filter/env/mod.rs
@@ -56,16 +56,16 @@ use tracing_core::{
 /// Each component (`target`, `span`, `field`, `value`, and `level`) will be covered in turn.
 ///
 /// - `target` matches the event or span's target. In general, this is the module path and/or crate name.
-///    Examples of targets `h2`, `tokio::net`, or `tide::server`. For more information on targets,
-///    please refer to [`Metadata`]'s documentation.
+///   Examples of targets `h2`, `tokio::net`, or `tide::server`. For more information on targets,
+///   please refer to [`Metadata`]'s documentation.
 /// - `span` matches on the span's name. If a `span` directive is provided alongside a `target`,
-///    the `span` directive will match on spans _within_ the `target`.
+///   the `span` directive will match on spans _within_ the `target`.
 /// - `field` matches on [fields] within spans. Field names can also be supplied without a `value`
-///    and will match on any [`Span`] or [`Event`] that has a field with that name.
-///    For example: `[span{field=\"value\"}]=debug`, `[{field}]=trace`.
+///   and will match on any [`Span`] or [`Event`] that has a field with that name.
+///   For example: `[span{field=\"value\"}]=debug`, `[{field}]=trace`.
 /// - `value` matches on the value of a span's field. If a value is a numeric literal or a bool,
-///    it will match _only_ on that value. Otherwise, this filter matches the
-///    [`std::fmt::Debug`] output from the value.
+///   it will match _only_ on that value. Otherwise, this filter matches the
+///   [`std::fmt::Debug`] output from the value.
 /// - `level` sets a maximum verbosity level accepted by this directive.
 ///
 /// When a field value directive (`[{<FIELD NAME>=<FIELD_VALUE>}]=...`) matches a

--- a/tracing-subscriber/src/filter/layer_filters/mod.rs
+++ b/tracing-subscriber/src/filter/layer_filters/mod.rs
@@ -135,7 +135,7 @@ impl FilterMap {
 /// 2. If all the bits are set, then every per-layer filter has decided it
 ///    doesn't want to enable that span or event. In that case, the
 ///    `Registry`'s `enabled` method will return `false`, so that
-///     recording a span or event can be skipped entirely.
+///    recording a span or event can be skipped entirely.
 #[derive(Debug)]
 pub(crate) struct FilterState {
     enabled: Cell<FilterMap>,

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -442,22 +442,22 @@ where
     /// The following options are available:
     ///
     /// - `FmtSpan::NONE`: No events will be synthesized when spans are
-    ///    created, entered, exited, or closed. Data from spans will still be
-    ///    included as the context for formatted events. This is the default.
+    ///   created, entered, exited, or closed. Data from spans will still be
+    ///   included as the context for formatted events. This is the default.
     /// - `FmtSpan::NEW`: An event will be synthesized when spans are created.
     /// - `FmtSpan::ENTER`: An event will be synthesized when spans are entered.
     /// - `FmtSpan::EXIT`: An event will be synthesized when spans are exited.
     /// - `FmtSpan::CLOSE`: An event will be synthesized when a span closes. If
-    ///    [timestamps are enabled][time] for this formatter, the generated
-    ///    event will contain fields with the span's _busy time_ (the total
-    ///    time for which it was entered) and _idle time_ (the total time that
-    ///    the span existed but was not entered).
+    ///   [timestamps are enabled][time] for this formatter, the generated
+    ///   event will contain fields with the span's _busy time_ (the total
+    ///   time for which it was entered) and _idle time_ (the total time that
+    ///   the span existed but was not entered).
     /// - `FmtSpan::ACTIVE`: Events will be synthesized when spans are entered
-    ///    or exited.
+    ///   or exited.
     /// - `FmtSpan::FULL`: Events will be synthesized whenever a span is
-    ///    created, entered, exited, or closed. If timestamps are enabled, the
-    ///    close event will contain the span's busy and idle time, as
-    ///    described above.
+    ///   created, entered, exited, or closed. If timestamps are enabled, the
+    ///   close event will contain the span's busy and idle time, as
+    ///   described above.
     ///
     /// The options can be enabled in any combination. For instance, the following
     /// will synthesize events whenever spans are created and closed:

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -36,9 +36,9 @@
 //!
 //! For example:
 //! - Setting `RUST_LOG=debug` enables all `Span`s and `Event`s
-//!     set to the log level `DEBUG` or higher
+//!   set to the log level `DEBUG` or higher
 //! - Setting `RUST_LOG=my_crate=trace` enables `Span`s and `Event`s
-//!     in `my_crate` at all log levels
+//!   in `my_crate` at all log levels
 //!
 //! **Note**: This should **not** be called by libraries. Libraries should use
 //! [`tracing`] to publish `tracing` `Event`s.
@@ -570,22 +570,22 @@ where
     /// The following options are available:
     ///
     /// - `FmtSpan::NONE`: No events will be synthesized when spans are
-    ///    created, entered, exited, or closed. Data from spans will still be
-    ///    included as the context for formatted events. This is the default.
+    ///   created, entered, exited, or closed. Data from spans will still be
+    ///   included as the context for formatted events. This is the default.
     /// - `FmtSpan::NEW`: An event will be synthesized when spans are created.
     /// - `FmtSpan::ENTER`: An event will be synthesized when spans are entered.
     /// - `FmtSpan::EXIT`: An event will be synthesized when spans are exited.
     /// - `FmtSpan::CLOSE`: An event will be synthesized when a span closes. If
-    ///    [timestamps are enabled][time] for this formatter, the generated
-    ///    event will contain fields with the span's _busy time_ (the total
-    ///    time for which it was entered) and _idle time_ (the total time that
-    ///    the span existed but was not entered).
+    ///   [timestamps are enabled][time] for this formatter, the generated
+    ///   event will contain fields with the span's _busy time_ (the total
+    ///   time for which it was entered) and _idle time_ (the total time that
+    ///   the span existed but was not entered).
     /// - `FmtSpan::ACTIVE`: An event will be synthesized when spans are entered
-    ///    or exited.
+    ///   or exited.
     /// - `FmtSpan::FULL`: Events will be synthesized whenever a span is
-    ///    created, entered, exited, or closed. If timestamps are enabled, the
-    ///    close event will contain the span's busy and idle time, as
-    ///    described above.
+    ///   created, entered, exited, or closed. If timestamps are enabled, the
+    ///   close event will contain the span's busy and idle time, as
+    ///   described above.
     ///
     /// The options can be enabled in any combination. For instance, the following
     /// will synthesize events whenever spans are created and closed:

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -153,6 +153,7 @@
 //! [`tracing`]: https://docs.rs/tracing/latest/tracing
 //! [`EnvFilter`]: filter::EnvFilter
 //! [`fmt`]: mod@fmt
+//! [`tracing`]: https://crates.io/crates/tracing
 //! [`tracing-log`]: https://crates.io/crates/tracing-log
 //! [`smallvec`]: https://crates.io/crates/smallvec
 //! [`env_logger` crate]: https://crates.io/crates/env_logger

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -710,7 +710,7 @@
 //!    `tracing-subscriber`'s `FmtSubscriber`, you don't need to depend on
 //!    `tracing-log` directly.
 //!  - [`tracing-appender`] provides utilities for outputting tracing data,
-//!     including a file appender and non blocking writer.
+//!    including a file appender and non blocking writer.
 //!
 //! Additionally, there are also several third-party crates which are not
 //! maintained by the `tokio` project. These include:


### PR DESCRIPTION
## Motivation

It's probably time to get a release of the core tracing crates out.

## Solution

Backport all the missing changes since the last large backport: #3144

## Checklist

The list is in `git log` order and should be completed from bottom to top. Commits
marked with `(X)` and no checkbox were already backported. Commits marked
with `(S)` have been skipped on purpose.

- [ ] 2025-05-15 906f00ce examples: add env-filter-explorer example (#3233) 
- [ ] 2025-05-13 9c28e64d macros: Remove 'r#' prefix from raw identifiers in field names (#3130) 
- [ ] 2025-05-08 28561e05 subscriber: use state machine to parse `EnvFilter` directives (#3243) 
- [ ] 2025-04-30 c54aa4e0 subscriber: increase `EnvFilter` test coverage (#3262) 
- [ ] 2025-04-10 dfc2c8b8 chore: fix Rust 1.86.0 lints (#3253) 
- [ ] 2025-04-10 8941592c tracing: add `portable-atomic` support to other `tracing` crates (#3246) 
- [ ] 2025-03-31 7a3ddfb0 core: add `portable-atomic` support (#3199) 
- [ ] 2025-03-27 d6505ca8 tracing: add `record_all!` macro for recording multiple values in one call (#3227) 
- [X] 2025-03-24 c400b75b chore: fix Rust 1.85.0 lints and errors (#3240) 
- [X] 2025-01-24 b4868674 chore: fix Rust 1.84.0 lints and errors (#3202) 
- [ ] 2024-12-02 b02a700b subscriber: skip padding when skipping `log.*` fields in `DefaultVisitor` (#2980) 
- [ ] 2024-12-01 ce32540c docs: add link to a stream recording by @jonhoo (#3106) 
- [ ] 2024-12-01 71b63478 chore: corrected typos in the example readme (#2718) 
- [ ] 2024-12-01 66cafe59 chore: remove outdated release instructions (#3154) 
- [ ] 2024-11-30 d1260a48 fix: Update incorrect tracing-futures feature docs (#2802) 
- [ ] 2024-11-30 93c533b5 Update README.md docs link (#3145) 