### PR TITLE
Make Writer::with_ansi public

### DIFF
--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -441,8 +441,12 @@ impl<'writer> Writer<'writer> {
         }
     }
 
-    // TODO(eliza): consider making this a public API?
-    pub(crate) fn with_ansi(self, is_ansi: bool) -> Self {
+    /// Returns a new `Writer` with `is_ansi` set.
+    ///
+    /// If false, the returned `Writer` will not support ANSI escape code
+    /// output when written to by e.g. [`FormatEvent::format_event`] by a layer
+    /// that has ANSI escape codes enabled.
+    pub fn with_ansi(self, is_ansi: bool) -> Self {
         Self { is_ansi, ..self }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

I'm in the process of trying to work with `tracing_subscriber::fmt::Layer` in such a way that I can duplicate my console output from a command to a file. Specifically, I use a newtype wrapper alongside `Layer::map_event_format` to convert this output to HTML in conjunction with the `ansi-to-html` crate. 

It looks something like this:

```rust
/// A custom formatter for writing format layer events as HTML.
#[derive(Debug, Clone)]
pub struct FormatHtml<Formatter> {
    /// The inner layer.
    inner: Formatter,

    /// The converter to use to convert ANSI codes in the formatted output into HTML sequences.
    converter: ansi_to_html::Converter,
}

impl<S, N, Formatter> FormatEvent<S, N> for FormatHtml<Formatter>
where
    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
    N: for<'writer> FormatFields<'writer> + 'static,
    Formatter: FormatEvent<S, N>,
{
    fn format_event(
        &self,
        ctx: &FmtContext<'_, S, N>,
        mut writer: Writer<'_>,
        event: &Event<'_>,
    ) -> fmt::Result {
        let mut source = String::new();
        let source_writer = Writer::new(&mut source);
        self.inner.format_event(ctx, source_writer, event)?;
        self.converter
            .convert(&source)
            .map_err(|err| {
                let err = miette::Report::from_err(err);
                // eprintln is used here so that we do not get locked in an 
                // infinite loop of tracing the same error event over and 
                // over and over again.
                eprintln!("TRACING_ERROR: Event conversion {err:?}");
                std::fmt::Error
            })
            .and_then(|converted| write!(writer, "{}", &converted))
    }
}
```

The calling code for this looks something along the lines of:

```rust
// NOTE: this is incomplete since I usually write some html preamble
// to the writer via a newtype.
let report_writer = BufWriter::new(
    File::create("/tmp/sample_report.html").unwrap(),
)
.unwrap();
                                                                     
let (report_writer, _guard) =
    tracing_appender::non_blocking::NonBlocking::new(report_writer);

let converter = ansi_to_html::Converter::new()
    .skip_escape(true)
    .skip_optimize(true);

let stderr_layer = tracing_subscriber::fmt::layer()
    .with_writer(std::io::stderr)
    .pretty()
    .with_ansi(true);
                                                              
let report_layer = tracing_subscriber::fmt::layer()
    .with_writer(report_writer)
    .pretty()
    .with_ansi(true)
    .map_event_format(move |e| FormatHtml::new(e, converter));
                                                              
let registry = tracing_subscriber::Registry::default()
    .with(stderr_layer)
    .with(report_layer);
                                                              
tracing::subscriber::set_global_default(registry).unwrap();
```

However, because the default `Writer::new` implementation doesn't let you set whether or not ANSI codes can be output, I can't actually make a `Writer` in my `FormatEvent` impl that accepts ANSI output. As such, even though I'm converting via `ansi_to_html`, the `String` that intercepts the event formatter prior to conversion contains no ANSI codes. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

The solution is to just make `Writer::with_ansi` public:

```
let source_writer = Writer::new(&mut source).with_ansi(true);
```

With this, all of the above works and I get colorized HTML output of the exact same log that goes to stderr. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

cc @hawkw since there was a comment left behind to make this public.