### PR TITLE
tracing-subscriber: remove clone_span on enter

### DIFF
--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -287,21 +287,15 @@ impl Collect for Registry {
     fn event(&self, _: &Event<'_>) {}
 
     fn enter(&self, id: &span::Id) {
-        if self
-            .current_spans
+        self.current_spans
             .get_or_default()
             .borrow_mut()
-            .push(id.clone())
-        {
-            self.clone_span(id);
-        }
+            .push(id.clone());
     }
 
     fn exit(&self, id: &span::Id) {
         if let Some(spans) = self.current_spans.get() {
-            if spans.borrow_mut().pop(id) {
-                dispatch::get_default(|dispatch| dispatch.try_close(id.clone()));
-            }
+            spans.borrow_mut().pop(id);
         }
     }
 

--- a/tracing-subscriber/src/registry/stack.rs
+++ b/tracing-subscriber/src/registry/stack.rs
@@ -17,10 +17,9 @@ pub(crate) struct SpanStack {
 
 impl SpanStack {
     #[inline]
-    pub(super) fn push(&mut self, id: Id) -> bool {
+    pub(super) fn push(&mut self, id: Id) {
         let duplicate = self.stack.iter().any(|i| i.id == id);
         self.stack.push(ContextId { id, duplicate });
-        !duplicate
     }
 
     #[inline]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

I briefly discussed this on Discord. At work, we enabled continuous profiling which gives us a flamegraph on our production workloads. Inspecting one of our hot-paths, I was surprised to see Span::enter being a significant percent of the samples.

This is currently using `tracing-subscriber = "0.3.19"`.

Concrete numbers:
7.7% of samples were found within the stacktrace of a `Span::enter`.
Of those samples, 22.8% were inside `clone_span`.
Collectively, that's 1.8% of total CPU time spent in `clone_span` as a result of `Span::enter`.

![Screenshot 2025-05-27 at 21 28 44](https://github.com/user-attachments/assets/9f10e242-791e-416c-bddb-e32a3b3efbca)

These numbers don't surprise me. Our hot-loop of our service is a modified copy_bidirectional. Each poll will often be very short, so the `Span::enter` will take a not insignificant percentage of the time. And since it's only IO that can wake the task, tokio will likely move it around threads depending on which thread happened to be the driver, so any atomic operations (eg a fetch_add) will likely be a cache miss.

The rest of the time of `clone_span` seems to be within our various layers, we can address those somewhere else.

When looking through the code, I couldn't find a _good_ justification for `enter` to need `clone_span`. I understand it might be defensive programming - someone can use the `Collect` api without using `tracing::Span`, and they can use it incorrectly. It would thus prevent some panics on exit (a layer using LookupSpan on exit and unwrapping) which would better prevent double-panics on drop handling during a panic. However, I see no unsafe code relying on spans definitely being alive during exit, and when using `tracing::Span::enter` which I think is the blessed case, the invariant that the span is alive during `exit` is upheld.

## Solution

Remove `clone_span` from `enter`, remove `try_close` from `exit`.
