### PR TITLE
chore: fix doc issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ members = [
  # This will be ignored with Rust older than 1.74, but for now that's okay;
  # we're only using it to fix check-cfg issues that first appeared in Rust 1.80.
 [workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(flaky_tests)", "cfg(tracing_unstable)"] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(flaky_tests)", "cfg(tracing_unstable)", "cfg(unsound_local_offset)"] }

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! This crate can be used in a few ways to record spans/events:
 //!  - Using a [`RollingFileAppender`] to perform writes to a log file. This will block on writes.
-//!  - Using *any* type implementing [`std::io::Write`][write] in a non-blocking fashion.
+//!  - Using *any* type implementing [`std::io::Write`] in a non-blocking fashion.
 //!  - Using a combination of [`NonBlocking`] and [`RollingFileAppender`] to allow writes to a log file
 //!    without blocking.
 //!
@@ -48,7 +48,7 @@
 //! # }
 //! ```
 //!
-//! The file appender implements [`std::io::Write`][write]. To be used with
+//! The file appender implements [`std::io::Write`]. To be used with
 //! [`tracing_subscriber::FmtSubscriber`][fmt_subscriber], it must be combined with a
 //! [`MakeWriter`][make_writer] implementation to be able to record tracing spans/event.
 //!
@@ -68,12 +68,12 @@
 //!     .init();
 //! # }
 //! ```
-//! **Note:** `_guard` is a [`WorkerGuard`][guard] which is returned by [`tracing_appender::non_blocking`][non_blocking]
+//! **Note:** `_guard` is a [`WorkerGuard`] which is returned by [`tracing_appender::non_blocking`][non_blocking]
 //! to ensure buffered logs are flushed to their output in the case of abrupt terminations of a process.
 //! See [`WorkerGuard` module][guard] for more details.
 //!
 //! The example below demonstrates the construction of a [`tracing_appender::non_blocking`][non_blocking]
-//! writer constructed with a [`std::io::Write`][write]:
+//! writer constructed with a [`std::io::Write`]:
 //!
 //! ```rust
 //! use std::io::Error;
@@ -102,7 +102,6 @@
 //!
 //! The [`non_blocking` module][non_blocking]'s documentation provides more detail on how to use `non_blocking`.
 //!
-//! [write]: std::io::Write
 //! [non_blocking]: mod@non_blocking
 //! [guard]: non_blocking::WorkerGuard
 //! [make_writer]: tracing_subscriber::fmt::MakeWriter

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -31,9 +31,7 @@
 //! Unintentional drops of `WorkerGuard` remove the guarantee that logs will be flushed
 //! during a program's termination, in a panic or otherwise.
 //!
-//! See [`WorkerGuard`][worker_guard] for examples of using the guard.
-//!
-//! [worker_guard]: WorkerGuard
+//! See [`WorkerGuard`] for examples of using the guard.
 //!
 //! # Examples
 //!
@@ -60,12 +58,11 @@ use tracing_subscriber::fmt::MakeWriter;
 
 /// The default maximum number of buffered log lines.
 ///
-/// If [`NonBlocking`][non-blocking] is lossy, it will drop spans/events at capacity.
-/// If [`NonBlocking`][non-blocking] is _not_ lossy,
-/// backpressure will be exerted on senders, causing them to block their
-/// respective threads until there is available capacity.
+/// If [`NonBlocking`] is lossy, it will drop spans/events at capacity.
+/// If [`NonBlocking`] is _not_ lossy, backpressure will be exerted on
+/// senders, causing them to block their respective threads until there
+/// is available capacity.
 ///
-/// [non-blocking]: NonBlocking
 /// Recommended to be a power of 2.
 pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 
@@ -116,11 +113,10 @@ pub struct WorkerGuard {
 /// `NonBlocking` moves the writing out of an application's data path by sending spans and events
 /// to a dedicated logging thread.
 ///
-/// This struct implements [`MakeWriter`][make_writer] from the `tracing-subscriber`
+/// This struct implements [`MakeWriter`] from the `tracing-subscriber`
 /// crate. Therefore, it can be used with the [`tracing_subscriber::fmt`][fmt] module
 /// or with any other collector/subscriber implementation that uses the `MakeWriter` trait.
 ///
-/// [make_writer]: tracing_subscriber::fmt::MakeWriter
 /// [fmt]: mod@tracing_subscriber::fmt
 #[derive(Clone, Debug)]
 pub struct NonBlocking {
@@ -184,9 +180,7 @@ impl NonBlocking {
     }
 }
 
-/// A builder for [`NonBlocking`][non-blocking].
-///
-/// [non-blocking]: NonBlocking
+/// A builder for [`NonBlocking`].
 #[derive(Debug)]
 pub struct NonBlockingBuilder {
     buffered_lines_limit: usize,

--- a/tracing-subscriber/src/subscribe/mod.rs
+++ b/tracing-subscriber/src/subscribe/mod.rs
@@ -471,7 +471,7 @@
 //! trait may also be implemented for user-defined types.
 //!
 //! [`Option<Filter>`] also implements [`Filter`], which allows for an optional
-//! filter. [`None`](Option::None) filters out _nothing_ (that is, allows
+//! filter. [`None`] filters out _nothing_ (that is, allows
 //! everything through). For example:
 //!
 //! ```rust


### PR DESCRIPTION
## Motivation

There are a few warnings when building the docs causing failures on CI.

## Solution

This change fixes those and adds `unsound_local_offset` as an unexpeced cfg.