### PR TITLE
tracing: fix "name / parent" variant of `event!`

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -759,7 +759,7 @@ macro_rules! event {
 
         let enabled = $crate::level_enabled!($lvl) && {
             let interest = __CALLSITE.interest();
-            !interest.is_never() && __CALLSITE.is_enabled(interest)
+            !interest.is_never() && $crate::__macro_support::__is_enabled(__CALLSITE.metadata(), interest)
         };
         if enabled {
             (|value_set: $crate::field::ValueSet| {

--- a/tracing/tests/macros.rs
+++ b/tracing/tests/macros.rs
@@ -527,6 +527,13 @@ fn locals_no_message() {
         ?data,
     );
     event!(
+        name: "foo",
+        parent: ::core::option::Option::None,
+        Level::WARN,
+        private_data,
+        ?data,
+    );
+    event!(
         target: "app_events",
         Level::WARN,
         private_data,
@@ -570,6 +577,7 @@ fn trace() {
     trace!({ foo = ?2, bar.baz = %78 }, "quux");
     trace!(name: "foo", foo = 3, bar.baz = 2, quux = false);
     trace!(name: "foo", target: "foo_events", foo = 3, bar.baz = 2, quux = false);
+    trace!(name: "foo", parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
     trace!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     trace!(target: "foo_events", foo = 3, bar.baz = 3,);
     trace!(target: "foo_events", "foo");
@@ -636,6 +644,7 @@ fn debug() {
     debug!({ foo = ?2, bar.baz = %78 }, "quux");
     debug!(name: "foo", foo = 3, bar.baz = 2, quux = false);
     debug!(name: "foo", target: "foo_events", foo = 3, bar.baz = 2, quux = false);
+    debug!(name: "foo", parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
     debug!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     debug!(target: "foo_events", foo = 3, bar.baz = 3,);
     debug!(target: "foo_events", "foo");
@@ -702,6 +711,7 @@ fn info() {
     info!({ foo = ?2, bar.baz = %78 }, "quux");
     info!(name: "foo", foo = 3, bar.baz = 2, quux = false);
     info!(name: "foo", target: "foo_events", foo = 3, bar.baz = 2, quux = false);
+    info!(name: "foo", parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
     info!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     info!(target: "foo_events", foo = 3, bar.baz = 3,);
     info!(target: "foo_events", "foo");
@@ -768,6 +778,7 @@ fn warn() {
     warn!({ foo = ?2, bar.baz = %78 }, "quux");
     warn!(name: "foo", foo = 3, bar.baz = 2, quux = false);
     warn!(name: "foo", target: "foo_events", foo = 3, bar.baz = 2, quux = false);
+    warn!(name: "foo", parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
     warn!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     warn!(target: "foo_events", foo = 3, bar.baz = 3,);
     warn!(target: "foo_events", "foo");
@@ -834,6 +845,7 @@ fn error() {
     error!({ foo = ?2, bar.baz = %78 }, "quux");
     error!(name: "foo", foo = 3, bar.baz = 2, quux = false);
     error!(name: "foo", target: "foo_events", foo = 3, bar.baz = 2, quux = false);
+    error!(name: "foo", parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
     error!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     error!(target: "foo_events", foo = 3, bar.baz = 3,);
     error!(target: "foo_events", "foo");


### PR DESCRIPTION
## Motivation

In the case of an event with a name and a parent, the change in #2083
to use a free function instead of a method for `is_enabled` was not
applied. This particular variant was also not covered by any tests,
which is how this error slipped through CI.

## Solution

This change fixes the `is_enabled` call and adds additional test
coverage for this macros case.

This change was originally submitted by @Mododo in #2983, but we have an
issue where first-time contributor PRs to the `v0.1.x` branch don't
trigger CI and we can't trigger it manually, so it needed to be
recreated.
