### PR TITLE
subscriber: correct spans in Directive::parse

### DIFF
--- a/tracing-subscriber/src/filter/env/directive.rs
+++ b/tracing-subscriber/src/filter/env/directive.rs
@@ -139,7 +139,8 @@ impl Directive {
 
         use ParseState::*;
         let mut state = Start;
-        for (i, c) in from.trim().char_indices() {
+        let from = from.trim();
+        for (i, c) in from.char_indices() {
             state = match (state, c) {
                 (Start, '[') => Span { span_start: i + 1 },
                 (Start, c) if !['-', ':', '_'].contains(&c) && !c.is_alphanumeric() => {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

Noticed in https://github.com/tokio-rs/tracing/pull/3243 that the main loop iterates over `from.trim().char_indices()`, but `i` is used to index into the untrimmed `from`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Reassign `from`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
