### PR TITLE
chore: explain new branch set up on `v0.2.x` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 [Website](https://tokio.rs) |
 [Chat](https://discord.gg/EeF3cQw) | [Documentation (master branch)](https://tracing-rs.netlify.com/)
 
-# The master branch is the pre-release, development version of `tracing`. Please see the [v0.1.x](https://github.com/tokio-rs/tracing/tree/v0.1.x) branch for the versions of `tracing` released to crates.io.
+# The `v0.2.x` branch is the pre-release, development version of `tracing`. Please see the [main](https://github.com/tokio-rs/tracing/tree/main) branch for the versions of `tracing` released to crates.io.
 
 ## Overview
 


### PR DESCRIPTION
Explain that `v0.2.x` is the pre-release, development version of tracing
and direct users to `main` for the released crates.