### PR TITLE
chore: explain new branch set up on `v0.1.x` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 [Website](https://tokio.rs) |
 [Chat](https://discord.gg/EeF3cQw) | [Documentation (master branch)](https://tracing-rs.netlify.com/)
 
+# The `v0.1.x` branch is no longer in use. For the versions of `tracing` released to crates.io, please see [main](https://github.com/tokio-rs/tracing/tree/main). For the pre-release development version of `tracing`, please see [v0.2.x](https://github.com/tokio-rs/tracing/tree/v0.2.x).
+
 ## Overview
 
 `tracing` is a framework for instrumenting Rust programs to collect


### PR DESCRIPTION
Explain that `v0.1.x` is no longer in use and direct users to `main` for
the released crates and `v0.2.x` for the pre-release versions.