### PR TITLE
chore: fix docs and explain new branch set up on `v0.1.x` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ![Tracing — Structured, application-level diagnostics][splash]
 
-[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/splash.svg
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
-[![Documentation (master)][docs-master-badge]][docs-master-url]
+[![Documentation (v0.2.x)][docs-v0.2.x-badge]][docs-v0.2.x-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][actions-badge]][actions-url]
 [![Discord chat][discord-badge]][discord-url]
@@ -13,8 +13,8 @@
 [crates-url]: https://crates.io/crates/tracing
 [docs-badge]: https://docs.rs/tracing/badge.svg
 [docs-url]: https://docs.rs/tracing
-[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
-[docs-master-url]: https://tracing.rs
+[docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
+[docs-v0.2.x-url]: https://tracing.rs
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [actions-badge]: https://github.com/tokio-rs/tracing/workflows/CI/badge.svg
@@ -23,13 +23,21 @@
 [discord-url]: https://discord.gg/EeF3cQw
 
 [Website](https://tokio.rs) |
-[Chat](https://discord.gg/EeF3cQw) | [Documentation (master branch)](https://tracing-rs.netlify.com/)
+[Chat](https://discord.gg/EeF3cQw)
 
 ## Overview
 
 `tracing` is a framework for instrumenting Rust programs to collect
 structured, event-based diagnostic information. `tracing` is maintained by the
 Tokio project, but does _not_ require the `tokio` runtime to be used.
+
+### Branch set-up
+
+- [`main`](https://github.com/tokio-rs/tracing/tree/main) - Default branch, crates.io releases are done from this branch. This was previously the
+  `v0.1.x` branch.
+- [`v0.2.x`](https://github.com/tokio-rs/tracing/tree/v0.2.x) - Branch containing the as-yet unreleased 0.2 version of `tracing-core`, `tracing`, and
+  all the other tracing crates that depend on these versions. This was previously the `master`
+  branch.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 [Website](https://tokio.rs) |
 [Chat](https://discord.gg/EeF3cQw)
 
+# The `v0.1.x` branch is no longer in use. For the versions of `tracing` released to crates.io, please see [main](https://github.com/tokio-rs/tracing/tree/main). For the pre-release development version of `tracing`, please see [v0.2.x](https://github.com/tokio-rs/tracing/tree/v0.2.x).
+
 ## Overview
 
 `tracing` is a framework for instrumenting Rust programs to collect

--- a/tracing-appender/README.md
+++ b/tracing-appender/README.md
@@ -1,6 +1,6 @@
 ![Tracing — Structured, application-level diagnostics][splash]
 
-[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/splash.svg
 
 # tracing-appender
 
@@ -8,7 +8,7 @@ Writers for logging events and spans
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
-[![Documentation (master)][docs-master-badge]][docs-master-url]
+[![Documentation (v0.2.x)][docs-v0.2.x-badge]][docs-v0.2.x-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][actions-badge]][actions-url]
 [![Discord chat][discord-badge]][discord-url]
@@ -19,8 +19,8 @@ Writers for logging events and spans
 [crates-url]: https://crates.io/crates/tracing-appender/0.2.2
 [docs-badge]: https://docs.rs/tracing-appender/badge.svg
 [docs-url]: https://docs.rs/tracing-appender/0.2.2
-[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
-[docs-master-url]: https://tracing.rs/tracing-appender
+[docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
+[docs-v0.2.x-url]: https://tracing.rs/tracing-appender
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: ../LICENSE
 [actions-badge]: https://github.com/tokio-rs/tracing/workflows/CI/badge.svg

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -4,13 +4,13 @@
 //!
 //! [`tracing`][tracing] is a framework for structured, event-based diagnostic information.
 //! `tracing-appender` allows events and spans to be recorded in a non-blocking manner through
-//! a dedicated logging thread. It also provides a [`RollingFileAppender`][file_appender] that can
+//! a dedicated logging thread. It also provides a [`RollingFileAppender`] that can
 //! be used with _or_ without the non-blocking writer.
 //!
 //! *Compiler support: [requires `rustc` 1.63+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
-//! [file_appender]: rolling::RollingFileAppender
+//! [`RollingFileAppender`]: rolling::RollingFileAppender
 //! [tracing]: https://docs.rs/tracing/
 //!
 //! # Usage
@@ -136,7 +136,7 @@
 //! long as doing so complies with this policy.
 //!
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
+    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
 )]
 #![cfg_attr(docsrs, deny(rustdoc::broken_intra_doc_links))]

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -1,6 +1,6 @@
 //! A rolling file appender.
 //!
-//! Creates a new log file at a fixed frequency as defined by [`Rotation`][self::Rotation].
+//! Creates a new log file at a fixed frequency as defined by [`Rotation`].
 //! Logs will be written to this file for the duration of the period and will automatically roll over
 //! to the newly created log file once the time period has elapsed.
 //!
@@ -116,9 +116,9 @@ impl RollingFileAppender {
     /// Creates a new `RollingFileAppender`.
     ///
     /// A `RollingFileAppender` will have a fixed rotation whose frequency is
-    /// defined by [`Rotation`][self::Rotation]. The `directory` and
-    /// `file_name_prefix` arguments determine the location and file name's _prefix_
-    /// of the log file. `RollingFileAppender` will automatically append the current date
+    /// defined by [`Rotation`]. The `directory` and `file_name_prefix`
+    /// arguments determine the location and file name's _prefix_ of the log
+    /// file. `RollingFileAppender` will automatically append the current date
     /// and hour (UTC format) to the file name.
     ///
     /// Alternatively, a `RollingFileAppender` can be constructed using one of the following helpers:
@@ -340,9 +340,9 @@ pub fn hourly(
 /// a non-blocking, daily file appender.
 ///
 /// A `RollingFileAppender` has a fixed rotation whose frequency is
-/// defined by [`Rotation`][self::Rotation]. The `directory` and
-/// `file_name_prefix` arguments determine the location and file name's _prefix_
-/// of the log file. `RollingFileAppender` automatically appends the current date in UTC.
+/// defined by [`Rotation`]. The `directory` and `file_name_prefix`
+/// arguments determine the location and file name's _prefix_ of the log file.
+/// `RollingFileAppender` automatically appends the current date in UTC.
 ///
 /// # Examples
 ///
@@ -376,9 +376,9 @@ pub fn daily(
 /// a non-blocking, weekly file appender.
 ///
 /// A `RollingFileAppender` has a fixed rotation whose frequency is
-/// defined by [`Rotation`][self::Rotation]. The `directory` and
-/// `file_name_prefix` arguments determine the location and file name's _prefix_
-/// of the log file. `RollingFileAppender` automatically appends the current date in UTC.
+/// defined by [`Rotation`]. The `directory` and `file_name_prefix` arguments
+/// determine the location and file name's _prefix_ of the log file.
+/// `RollingFileAppender` automatically appends the current date in UTC.
 ///
 /// # Examples
 ///

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -4,7 +4,7 @@ name = "tracing-attributes"
 # - Remove path dependencies
 # - Update doc url in README.md.
 # - Update CHANGELOG.md.
-# - Create "v0.1.x" git tag.
+# - Create "tracing-attributes-0.1.x" git tag.
 version = "0.1.28"
 authors = [
     "Tokio Contributors <team@tokio.rs>",

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -1,6 +1,6 @@
 ![Tracing — Structured, application-level diagnostics][splash]
 
-[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/splash.svg
 
 # tracing-attributes
 
@@ -8,7 +8,7 @@ Macro attributes for application-level tracing.
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
-[![Documentation (master)][docs-master-badge]][docs-master-url]
+[![Documentation (v0.2.x)][docs-v0.2.x-badge]][docs-v0.2.x-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][actions-badge]][actions-url]
 [![Discord chat][discord-badge]][discord-url]
@@ -19,8 +19,8 @@ Macro attributes for application-level tracing.
 [crates-url]: https://crates.io/crates/tracing-attributes
 [docs-badge]: https://docs.rs/tracing-attributes/badge.svg
 [docs-url]: https://docs.rs/tracing-attributes/0.1.28
-[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
-[docs-master-url]: https://tracing-rs.netlify.com/tracing_attributes
+[docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
+[docs-v0.2.x-url]: https://tracing.rs/tracing_attributes
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [actions-badge]: https://github.com/tokio-rs/tracing/workflows/CI/badge.svg

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -53,7 +53,7 @@
 //! long as doing so complies with this policy.
 //!
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
+    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
 )]
 #![cfg_attr(docsrs, deny(rustdoc::broken_intra_doc_links))]

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -5,7 +5,7 @@ name = "tracing-core"
 # - Update html_root_url.
 # - Update doc url in README.md.
 # - Update CHANGELOG.md.
-# - Create "v0.1.x" git tag.
+# - Create "tracing-core-0.1.x" git tag.
 version = "0.1.33"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -1,6 +1,6 @@
 ![Tracing — Structured, application-level diagnostics][splash]
 
-[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/splash.svg
 
 # tracing-core
 
@@ -8,7 +8,7 @@ Core primitives for application-level tracing.
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
-[![Documentation (master)][docs-master-badge]][docs-master-url]
+[![Documentation (v0.2.x)][docs-v0.2.x-badge]][docs-v0.2.x-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][actions-badge]][actions-url]
 [![Discord chat][discord-badge]][discord-url]
@@ -19,8 +19,8 @@ Core primitives for application-level tracing.
 [crates-url]: https://crates.io/crates/tracing-core/0.1.33
 [docs-badge]: https://docs.rs/tracing-core/badge.svg
 [docs-url]: https://docs.rs/tracing-core/0.1.33
-[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
-[docs-master-url]: https://tracing-rs.netlify.com/tracing_core
+[docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
+[docs-v0.2.x-url]: https://tracing.rs/tracing_core
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [actions-badge]: https://github.com/tokio-rs/tracing/workflows/CI/badge.svg

--- a/tracing-core/src/callsite.rs
+++ b/tracing-core/src/callsite.rs
@@ -93,7 +93,7 @@
 //! [always]: crate::subscriber::Interest::always
 //! [sometimes]: crate::subscriber::Interest::sometimes
 //! [never]: crate::subscriber::Interest::never
-//! [`Dispatch`]: crate::dispatch::Dispatch
+//! [`Dispatch`]: crate::dispatcher::Dispatch
 //! [macros]: https://docs.rs/tracing/latest/tracing/#macros
 //! [instrument]: https://docs.rs/tracing/latest/tracing/attr.instrument.html
 use crate::stdlib::{
@@ -301,7 +301,7 @@ impl DefaultCallsite {
     /// See the [documentation on callsite registration][reg-docs] for details
     /// on the global callsite registry.
     ///
-    /// [`Callsite`]: crate::callsite::Callsite
+    /// [`tracing_core::callsite::register`]: crate::callsite::register
     /// [reg-docs]: crate::callsite#registering-callsites
     #[inline(never)]
     // This only happens once (or if the cached interest value was corrupted).

--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -155,7 +155,7 @@ pub struct Dispatch {
 /// `WeakDispatch` is a version of [`Dispatch`] that holds a non-owning reference
 /// to a [`Subscriber`].
 ///
-/// The Subscriber` may be accessed by calling [`WeakDispatch::upgrade`],
+/// The `Subscriber` may be accessed by calling [`WeakDispatch::upgrade`],
 /// which returns an `Option<Dispatch>`. If all [`Dispatch`] clones that point
 /// at the `Subscriber` have been dropped, [`WeakDispatch::upgrade`] will return
 /// `None`. Otherwise, it will return `Some(Dispatch)`.
@@ -244,14 +244,13 @@ pub struct DefaultGuard(Option<Dispatch>);
 ///
 /// <pre class="ignore" style="white-space:normal;font:inherit;">
 ///     <strong>Note</strong>: This function required the Rust standard library.
-///     <code>no_std</code> users should use <a href="../fn.set_global_default.html">
+///     <code>no_std</code> users should use <a href="fn.set_global_default.html">
 ///     <code>set_global_default</code></a> instead.
 /// </pre>
 ///
 /// [span]: super::span
 /// [`Subscriber`]: super::subscriber::Subscriber
 /// [`Event`]: super::event::Event
-/// [`set_global_default`]: super::set_global_default
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn with_default<T>(dispatcher: &Dispatch, f: impl FnOnce() -> T) -> T {
@@ -268,11 +267,11 @@ pub fn with_default<T>(dispatcher: &Dispatch, f: impl FnOnce() -> T) -> T {
 ///
 /// <pre class="ignore" style="white-space:normal;font:inherit;">
 ///     <strong>Note</strong>: This function required the Rust standard library.
-///     <code>no_std</code> users should use <a href="../fn.set_global_default.html">
+///     <code>no_std</code> users should use <a href="fn.set_global_default.html">
 ///     <code>set_global_default</code></a> instead.
 /// </pre>
 ///
-/// [`set_global_default`]: super::set_global_default
+/// [`set_global_default`]: set_global_default
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[must_use = "Dropping the guard unregisters the dispatcher."]
@@ -676,7 +675,7 @@ impl Dispatch {
     /// [`Subscriber`]: super::subscriber::Subscriber
     /// [`drop_span`]: super::subscriber::Subscriber::drop_span
     /// [`new_span`]: super::subscriber::Subscriber::new_span
-    /// [`try_close`]: Entered::try_close()
+    /// [`try_close`]: Self::try_close()
     #[inline]
     #[deprecated(since = "0.1.2", note = "use `Dispatch::try_close` instead")]
     pub fn drop_span(&self, id: span::Id) {

--- a/tracing-core/src/lib.rs
+++ b/tracing-core/src/lib.rs
@@ -117,7 +117,7 @@
 //! [`tokio-rs/tracing`]: https://github.com/tokio-rs/tracing
 //! [`tracing`]: https://crates.io/crates/tracing
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
+    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
 )]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/tracing-error/README.md
+++ b/tracing-error/README.md
@@ -1,6 +1,6 @@
 ![Tracing — Structured, application-level diagnostics][splash]
 
-[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/splash.svg
 
 # tracing-error
 
@@ -9,20 +9,20 @@ information.
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
-[![Documentation (master)][docs-master-badge]][docs-master-url]
+[![Documentation (v0.2.x)][docs-v0.2.x-badge]][docs-v0.2.x-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][actions-badge]][actions-url]
 [![Discord chat][discord-badge]][discord-url]
 ![maintenance status][maint-badge]
 
-[Documentation (release)][docs-url] | [Documentation (master)][docs-master-url] | [Chat][discord-url]
+[Documentation (release)][docs-url] | [Documentation (v0.2.x)][docs-v0.2.x-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-error.svg
 [crates-url]: https://crates.io/crates/tracing-error/0.2.1
 [docs-badge]: https://docs.rs/tracing-error/badge.svg
 [docs-url]: https://docs.rs/tracing-error/0.2.1/tracing_error
-[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
-[docs-master-url]: https://tracing-rs.netlify.com/tracing_error
+[docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
+[docs-v0.2.x-url]: https://tracing.rs/tracing_error
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [actions-badge]: https://github.com/tokio-rs/tracing/workflows/CI/badge.svg

--- a/tracing-error/src/lib.rs
+++ b/tracing-error/src/lib.rs
@@ -180,7 +180,7 @@
 //!
 #![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
+    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
 )]
 #![allow(clippy::needless_doctest_main)]

--- a/tracing-flame/README.md
+++ b/tracing-flame/README.md
@@ -1,6 +1,6 @@
 ![Tracing — Structured, application-level diagnostics][splash]
 
-[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/splash.svg
 
 # tracing-flame
 
@@ -9,7 +9,7 @@ and flamecharts with [`inferno`]
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
-[![Documentation (master)][docs-master-badge]][docs-master-url]
+[![Documentation (v0.2.x)][docs-v0.2.x-badge]][docs-v0.2.x-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][actions-badge]][actions-url]
 [![Discord chat][discord-badge]][discord-url]
@@ -131,13 +131,13 @@ terms or conditions.
 [`FlameLayer`]: https://docs.rs/tracing-flame/*/tracing_flame/struct.FlameLayer.html
 [`FlushGuard`]: https://docs.rs/tracing-flame/*/tracing_flame/struct.FlushGuard.html
 [`inferno-flamegraph`]: https://docs.rs/inferno/0.9.5/inferno/index.html#producing-a-flame-graph
-[`tracing`]: https://github.com/tokio-rs/tracing/tree/master/tracing
+[`tracing`]: https://github.com/tokio-rs/tracing/tree/main/tracing
 [crates-badge]: https://img.shields.io/crates/v/tracing-flame.svg
 [crates-url]: https://crates.io/crates/tracing-flame
 [docs-badge]: https://docs.rs/tracing-flame/badge.svg
 [docs-url]: https://docs.rs/tracing-flame/0.2.6
-[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
-[docs-master-url]: https://tracing-rs.netlify.com/tracing_flame
+[docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
+[docs-v0.2.x-url]: https://tracing.rs/tracing_flame
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [actions-badge]: https://github.com/tokio-rs/tracing/workflows/CI/badge.svg

--- a/tracing-flame/src/lib.rs
+++ b/tracing-flame/src/lib.rs
@@ -107,7 +107,7 @@
 //! long as doing so complies with this policy.
 //!
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
+    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
 )]
 #![cfg_attr(docsrs, deny(rustdoc::broken_intra_doc_links))]

--- a/tracing-futures/README.md
+++ b/tracing-futures/README.md
@@ -1,6 +1,6 @@
 ![Tracing — Structured, application-level diagnostics][splash]
 
-[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/splash.svg
 
 # tracing-futures
 
@@ -8,7 +8,7 @@ Utilities for instrumenting futures-based code with [`tracing`].
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
-[![Documentation (master)][docs-master-badge]][docs-master-url]
+[![Documentation (v0.2.x)][docs-v0.2.x-badge]][docs-v0.2.x-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][actions-badge]][actions-url]
 [![Discord chat][discord-badge]][discord-url]
@@ -20,8 +20,8 @@ Utilities for instrumenting futures-based code with [`tracing`].
 [crates-url]: https://crates.io/crates/tracing-futures/0.2.5
 [docs-badge]: https://docs.rs/tracing-futures/badge.svg
 [docs-url]: https://docs.rs/tracing-futures/0.2.5/tracing_futures
-[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
-[docs-master-url]: https://tracing-rs.netlify.com/tracing_futures
+[docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
+[docs-v0.2.x-url]: https://tracing.rs/tracing_futures
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [actions-badge]: https://github.com/tokio-rs/tracing/workflows/CI/badge.svg

--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -71,8 +71,8 @@
 //! long as doing so complies with this policy.
 //!
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
-    html_favicon_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/favicon.ico",
+    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/logo-type.png",
+    html_favicon_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/favicon.ico",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
 )]
 #![warn(

--- a/tracing-journald/README.md
+++ b/tracing-journald/README.md
@@ -1,6 +1,6 @@
 ![Tracing — Structured, application-level diagnostics][splash]
 
-[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/splash.svg
 
 # tracing-journald
 
@@ -8,14 +8,14 @@ Support for logging [`tracing`] events natively to [journald],
 preserving structured information.
 
 [![Crates.io][crates-badge]][crates-url]
-[![Documentation (master)][docs-master-badge]][docs-master-url]
+[![Documentation (v0.2.x)][docs-v0.2.x-badge]][docs-v0.2.x-url]
 [![MIT licensed][mit-badge]][mit-url]
 ![maintenance status][maint-badge]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-journald.svg
 [crates-url]: https://crates.io/crates/tracing-journald
-[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
-[docs-master-url]: https://tracing-rs.netlify.com/tracing_journald
+[docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
+[docs-v0.2.x-url]: https://tracing.rs/tracing_journald
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [maint-badge]: https://img.shields.io/badge/maintenance-experimental-blue.svg

--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -32,7 +32,7 @@
 //! long as doing so complies with this policy.
 //!
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
+    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
 )]
 #![cfg_attr(docsrs, deny(rustdoc::broken_intra_doc_links))]
@@ -68,7 +68,7 @@ mod socket;
 /// - `DEBUG` => Informational (6)
 /// - `TRACE` => Debug (7)
 ///
-/// These mappings can be changed with [`Subscriber::with_priority_mappings`].
+/// These mappings can be changed with [`Layer::with_priority_mappings`].
 ///
 /// The standard journald `CODE_LINE` and `CODE_FILE` fields are automatically emitted. A `TARGET`
 /// field is emitted containing the event's target.

--- a/tracing-log/README.md
+++ b/tracing-log/README.md
@@ -1,6 +1,6 @@
 ![Tracing — Structured, application-level diagnostics][splash]
 
-[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/splash.svg
 
 # tracing-log
 
@@ -8,7 +8,7 @@
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
-[![Documentation (master)][docs-master-badge]][docs-master-url]
+[![Documentation (v0.2.x)][docs-v0.2.x-badge]][docs-v0.2.x-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][actions-badge]][actions-url]
 [![Discord chat][discord-badge]][discord-url]
@@ -21,8 +21,8 @@
 [crates-url]: https://crates.io/crates/tracing-log
 [docs-badge]: https://docs.rs/tracing-log/badge.svg
 [docs-url]: https://docs.rs/tracing-log
-[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
-[docs-master-url]: https://tracing-rs.netlify.com/tracing_log
+[docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
+[docs-v0.2.x-url]: https://tracing.rs/tracing_log
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [actions-badge]: https://github.com/tokio-rs/tracing/workflows/CI/badge.svg

--- a/tracing-log/src/lib.rs
+++ b/tracing-log/src/lib.rs
@@ -95,7 +95,7 @@
 //! [flags]: https://docs.rs/tracing/latest/tracing/#crate-feature-flags
 //! [`Builder::with_interest_cache`]: log_tracer::Builder::with_interest_cache
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
+    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]

--- a/tracing-mock/README.md
+++ b/tracing-mock/README.md
@@ -1,6 +1,6 @@
 ![Tracing — Structured, application-level diagnostics][splash]
 
-[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/splash.svg
 
 # tracing-mock
 
@@ -8,21 +8,21 @@ Utilities for testing [`tracing`] and crates that uses it.
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
-[![Documentation (master)][docs-master-badge]][docs-master-url]
+[![Documentation (v0.2.x)][docs-v0.2.x-badge]][docs-v0.2.x-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][actions-badge]][actions-url]
 [![Discord chat][discord-badge]][discord-url]
 
-[Documentation][docs-master-url] | [Chat][discord-url]
+[Documentation][docs-v0.2.x-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-mock.svg
 [crates-url]: https://crates.io/crates/tracing-mock
 [docs-badge]: https://docs.rs/tracing-mock/badge.svg
 [docs-url]: https://docs.rs/tracing-mock/latest
-[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
-[docs-master-url]: https://tracing.rs/tracing_mock
+[docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
+[docs-v0.2.x-url]: https://tracing.rs/tracing_mock
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
-[mit-url]: https://github.com/tokio-rs/tracing/blob/master/tracing-mock/LICENSE
+[mit-url]: https://github.com/tokio-rs/tracing/blog/main/tracing-mock/LICENSE
 [actions-badge]: https://github.com/tokio-rs/tracing/workflows/CI/badge.svg
 [actions-url]:https://github.com/tokio-rs/tracing/actions?query=workflow%3ACI
 [discord-badge]: https://img.shields.io/discord/500028886025895936?logo=discord&label=discord&logoColor=white

--- a/tracing-mock/src/lib.rs
+++ b/tracing-mock/src/lib.rs
@@ -7,8 +7,8 @@
     deny(rustdoc::broken_intra_doc_links),
 )]
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
-    html_favicon_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/favicon.ico",
+    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/logo-type.png",
+    html_favicon_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/favicon.ico",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
 )]
 #![warn(

--- a/tracing-serde/README.md
+++ b/tracing-serde/README.md
@@ -1,18 +1,18 @@
 ![Tracing — Structured, application-level diagnostics][splash]
 
-[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/splash.svg
 
 # tracing-serde
 
 An adapter for serializing [`tracing`] types using [`serde`].
 
 [![Documentation][docs-badge]][docs-url]
-[![Documentation (master)][docs-master-badge]][docs-master-url]
+[![Documentation (v0.2.x)][docs-v0.2.x-badge]][docs-v0.2.x-url]
 
 [docs-badge]: https://docs.rs/tracing-serde/badge.svg
 [docs-url]: https://docs.rs/tracing-serde
-[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
-[docs-master-url]: https://tracing-rs.netlify.com/tracing_serde
+[docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
+[docs-v0.2.x-url]: https://tracing.rs/tracing_serde
 
 ## Overview
 

--- a/tracing-serde/src/lib.rs
+++ b/tracing-serde/src/lib.rs
@@ -3,12 +3,12 @@
 //! An adapter for serializing [`tracing`] types using [`serde`].
 //!
 //! [![Documentation][docs-badge]][docs-url]
-//! [![Documentation (master)][docs-master-badge]][docs-master-url]
+//! [![Documentation (v0.2.x)][docs-v0.2.x-badge]][docs-v0.2.x-url]
 //!
 //! [docs-badge]: https://docs.rs/tracing-serde/badge.svg
 //! [docs-url]: https://docs.rs/tracing-serde
-//! [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
-//! [docs-master-url]: https://tracing-rs.netlify.com/tracing_serde
+//! [docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
+//! [docs-v0.2.x-url]: https://tracing.rs/tracing_serde
 //!
 //! ## Overview
 //!
@@ -162,7 +162,7 @@
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [`serde`]: https://crates.io/crates/serde
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
+    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -1,6 +1,6 @@
 ![Tracing — Structured, application-level diagnostics][splash]
 
-[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/splash.svg
 
 # tracing-subscriber
 
@@ -18,7 +18,7 @@ application authors using `tracing` to instrument their applications.
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
-[![Documentation (master)][docs-master-badge]][docs-master-url]
+[![Documentation (v0.2.x)][docs-v0.2.x-badge]][docs-v0.2.x-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][actions-badge]][actions-url]
 [![Discord chat][discord-badge]][discord-url]
@@ -26,14 +26,14 @@ application authors using `tracing` to instrument their applications.
 
 [Documentation][docs-url] | [Chat][discord-url]
 
-[tracing]: https://github.com/tokio-rs/tracing/tree/master/tracing
-[tracing-fmt]: https://github.com/tokio-rs/tracing/tree/master/tracing-subscriber
+[tracing]: https://github.com/tokio-rs/tracing/tree/main/tracing
+[tracing-fmt]: https://github.com/tokio-rs/tracing/tree/main/tracing-subscriber
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
 [crates-url]: https://crates.io/crates/tracing-subscriber
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
 [docs-url]: https://docs.rs/tracing-subscriber/latest
-[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
-[docs-master-url]: https://tracing-rs.netlify.com/tracing_subscriber
+[docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
+[docs-v0.2.x-url]: https://tracing.rs/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [actions-badge]: https://github.com/tokio-rs/tracing/workflows/CI/badge.svg

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -321,8 +321,8 @@ impl<S, N, E, W> Layer<S, N, E, W> {
     /// whether or not other crates in the dependency graph enable the "ansi"
     /// feature flag.
     ///
-    /// [`with_ansi`]: Subscriber::with_ansi
-    /// [`set_ansi`]: Subscriber::set_ansi
+    /// [`with_ansi`]: Layer::with_ansi
+    /// [`set_ansi`]: Layer::set_ansi
     pub fn with_ansi(self, ansi: bool) -> Self {
         #[cfg(not(feature = "ansi"))]
         if ansi {

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -864,7 +864,7 @@ impl<T> Format<Json, T> {
     /// ```ignore,json
     /// {"timestamp":"Feb 20 11:28:15.096","level":"INFO","target":"mycrate", "message":"some message", "key": "value"}
     /// ```
-    /// See [`Json`][super::format::Json].
+    /// See [`Json`].
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub fn flatten_event(mut self, flatten_event: bool) -> Format<Json, T> {

--- a/tracing-subscriber/src/fmt/time/time_crate.rs
+++ b/tracing-subscriber/src/fmt/time/time_crate.rs
@@ -167,7 +167,7 @@ impl<F: Formattable> LocalTime<F> {
     /// [`time` crate]: time
     /// [`Formattable`]: time::formatting::Formattable
     /// [well-known formats]: time::format_description::well_known
-    /// [`format_description!`]: time::macros::format_description!
+    /// [`format_description!`]: https://docs.rs/time/0.3/time/macros/macro.format_description.html
     /// [`time::format_description::parse`]: time::format_description::parse()
     /// [`time` book]: https://time-rs.github.io/book/api/format-description.html
     pub fn new(format: F) -> Self {
@@ -284,7 +284,7 @@ impl<F: Formattable> UtcTime<F> {
     /// [`time` crate]: time
     /// [`Formattable`]: time::formatting::Formattable
     /// [well-known formats]: time::format_description::well_known
-    /// [`format_description!`]: time::macros::format_description!
+    /// [`format_description!`]: https://docs.rs/time/0.3/time/macros/macro.format_description.html
     /// [`time::format_description::parse`]: time::format_description::parse
     /// [`time` book]: https://time-rs.github.io/book/api/format-description.html
     pub fn new(format: F) -> Self {
@@ -440,7 +440,7 @@ impl<F: time::formatting::Formattable> OffsetTime<F> {
     /// [`Formattable`]: time::formatting::Formattable
     /// [local offset]: time::UtcOffset::current_local_offset()
     /// [well-known formats]: time::format_description::well_known
-    /// [`format_description!`]: time::macros::format_description
+    /// [`format_description!`]: https://docs.rs/time/0.3/time/macros/macro.format_description.html
     /// [`time::format_description::parse`]: time::format_description::parse
     /// [`time` book]: https://time-rs.github.io/book/api/format-description.html
     pub fn new(offset: time::UtcOffset, format: F) -> Self {

--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -468,9 +468,9 @@
 //! function pointer. In addition, when more control is required, the [`Filter`]
 //! trait may also be implemented for user-defined types.
 //!
-//! //! [`Option<Filter>`] also implements [`Filter`], which allows for an optional
-//! filter. [`None`](Option::None) filters out _nothing_ (that is, allows
-//! everything through). For example:
+//! [`Option<Filter>`] also implements [`Filter`], which allows for an optional
+//! filter. [`None`] filters out _nothing_ (that is, allows everything through). For
+//! example:
 //!
 //! ```rust
 //! # use tracing_subscriber::{filter::filter_fn, Layer};

--- a/tracing-subscriber/src/lib.rs
+++ b/tracing-subscriber/src/lib.rs
@@ -162,7 +162,7 @@
 //! [`liballoc`]: https://doc.rust-lang.org/alloc/index.html
 //! [`libstd`]: https://doc.rust-lang.org/std/index.html
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
+    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
 )]
 #![cfg_attr(

--- a/tracing-subscriber/src/reload.rs
+++ b/tracing-subscriber/src/reload.rs
@@ -272,7 +272,7 @@ impl<L, S> Layer<L, S> {
     /// Returns a `Handle` that can be used to reload the wrapped [`Layer`] or [`Filter`].
     ///
     /// [`Layer`]: crate::layer::Layer
-    /// [`Filter`]: crate::filter::Filter
+    /// [`Filter`]: crate::layer::Filter
     pub fn handle(&self) -> Handle<L, S> {
         Handle {
             inner: Arc::downgrade(&self.inner),

--- a/tracing-test/README.md
+++ b/tracing-test/README.md
@@ -1,22 +1,22 @@
 ![Tracing — Structured, application-level diagnostics][splash]
 
-[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/splash.svg
 
 # tracing-test
 
 Utilities for testing [`tracing`][tracing] and crates that uses it.
 
-[![Documentation (master)][docs-master-badge]][docs-master-url]
+[![Documentation (v0.2.x)][docs-v0.2.x-badge]][docs-v0.2.x-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][actions-badge]][actions-url]
 [![Discord chat][discord-badge]][discord-url]
 
-[Documentation][docs-master-url] | [Chat][discord-url]
+[Documentation][docs-v0.2.x-url] | [Chat][discord-url]
 
-[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
-[docs-master-url]: https://tracing-rs.netlify.com/tracing_mock
+[docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
+[docs-v0.2.x-url]: https://tracing.rs/tracing_mock
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
-[mit-url]: https://github.com/tokio-rs/tracing/blob/master/tracing-test/LICENSE
+[mit-url]: https://github.com/tokio-rs/tracing/blog/main/tracing-test/LICENSE
 [actions-badge]: https://github.com/tokio-rs/tracing/workflows/CI/badge.svg
 [actions-url]:https://github.com/tokio-rs/tracing/actions?query=workflow%3ACI
 [discord-badge]: https://img.shields.io/discord/500028886025895936?logo=discord&label=discord&logoColor=white

--- a/tracing-tower/src/lib.rs
+++ b/tracing-tower/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
+    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
 )]
 #![warn(

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -4,7 +4,7 @@ name = "tracing"
 # - Remove path dependencies
 # - Update doc url in README.md.
 # - Update CHANGELOG.md.
-# - Create "v0.1.x" git tag
+# - Create "tracing-0.1.x" git tag
 version = "0.1.41"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -1,6 +1,6 @@
 ![Tracing — Structured, application-level diagnostics][splash]
 
-[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/splash.svg
+[splash]: https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/splash.svg
 
 # tracing
 
@@ -8,7 +8,7 @@ Application-level tracing for Rust.
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
-[![Documentation (master)][docs-master-badge]][docs-master-url]
+[![Documentation (v0.2.x)][docs-v0.2.x-badge]][docs-v0.2.x-url]
 [![MIT licensed][mit-badge]][mit-url]
 [![Build Status][actions-badge]][actions-url]
 [![Discord chat][discord-badge]][discord-url]
@@ -19,8 +19,8 @@ Application-level tracing for Rust.
 [crates-url]: https://crates.io/crates/tracing
 [docs-badge]: https://docs.rs/tracing/badge.svg
 [docs-url]: https://docs.rs/tracing
-[docs-master-badge]: https://img.shields.io/badge/docs-master-blue
-[docs-master-url]: https://tracing-rs.netlify.com/tracing
+[docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
+[docs-v0.2.x-url]: https://tracing.rs/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 [actions-badge]: https://github.com/tokio-rs/tracing/workflows/CI/badge.svg
@@ -437,12 +437,12 @@ undergoing active development. They may be less stable than `tracing` and
 
 [`log`]: https://docs.rs/log/0.4.6/log/
 [`tokio-rs/tracing`]: https://github.com/tokio-rs/tracing
-[`tracing-futures`]: https://github.com/tokio-rs/tracing/tree/master/tracing-futures
-[`tracing-subscriber`]: https://github.com/tokio-rs/tracing/tree/master/tracing-subscriber
-[`tracing-log`]: https://github.com/tokio-rs/tracing/tree/master/tracing-log
+[`tracing-futures`]: https://github.com/tokio-rs/tracing/tree/main/tracing-futures
+[`tracing-subscriber`]: https://github.com/tokio-rs/tracing/tree/main/tracing-subscriber
+[`tracing-log`]: https://github.com/tokio-rs/tracing/tree/main/tracing-log
 [`env_logger`]: https://crates.io/crates/env_logger
 [`FmtSubscriber`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Subscriber.html
-[`examples`]: https://github.com/tokio-rs/tracing/tree/master/examples
+[`examples`]: https://github.com/tokio-rs/tracing/tree/main/examples
 
 ## Supported Rust Versions
 

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -193,7 +193,7 @@
 //! You can find more examples showing how to use this crate [here][examples].
 //!
 //! [RAII]: https://github.com/rust-unofficial/patterns/blob/main/src/patterns/behavioural/RAII.md
-//! [examples]: https://github.com/tokio-rs/tracing/tree/master/examples
+//! [examples]: https://github.com/tokio-rs/tracing/tree/main/examples
 //!
 //! ### Events
 //!
@@ -915,7 +915,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
+    html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
 )]
 #![warn(

--- a/tracing/src/subscriber.rs
+++ b/tracing/src/subscriber.rs
@@ -33,7 +33,6 @@ where
 /// Note: Libraries should *NOT* call `set_global_default()`! That will cause conflicts when
 /// executables try to set them later.
 ///
-/// [span]: super::span
 /// [`Subscriber`]: super::subscriber::Subscriber
 /// [`Event`]: super::event::Event
 pub fn set_global_default<S>(subscriber: S) -> Result<(), SetGlobalDefaultError>


### PR DESCRIPTION
Port #3295 to the (now legacy) `v0.1.x` branch. This is to fix the
Netlify jobs which are now running here.

Explain that `v0.1.x` is no longer in use and direct users to `main` for
the released crates and `v0.2.x` for the pre-release versions.