### PR TITLE
tracing: update core to 0.1.34 and attributes to 0.1.29

### DIFF
--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -25,9 +25,9 @@ edition = "2018"
 rust-version = "1.65.0"
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.33", default-features = false }
+tracing-core = { path = "../tracing-core", version = "0.1.34", default-features = false }
 log = { version = "0.4.17", optional = true }
-tracing-attributes = { path = "../tracing-attributes", version = "0.1.28", optional = true }
+tracing-attributes = { path = "../tracing-attributes", version = "0.1.29", optional = true }
 pin-project-lite = "0.2.9"
 
 [dev-dependencies]


### PR DESCRIPTION
Updates the main `tracing` crate with the newly released versions of
`tracing-core` and `tracing-attributes`.