### PR TITLE
chore: prepare tracing-attributes 0.1.30

### DIFF
--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.30 (June 17, 2025)
+
+### Fixed
+
+- Fix `tracing::instrument` regression around shadowing ([#3311])
+
+[#3311]: https://github.com/tokio-rs/tracing/pull/3311
+
 # 0.1.29 (June 6, 2025)
 
 ### Changed

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -5,7 +5,7 @@ name = "tracing-attributes"
 # - Update doc url in README.md.
 # - Update CHANGELOG.md.
 # - Create "tracing-attributes-0.1.x" git tag.
-version = "0.1.29"
+version = "0.1.30"
 authors = [
     "Tokio Contributors <team@tokio.rs>",
     "Eliza Weisman <eliza@buoyant.io>",

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -18,7 +18,7 @@ Macro attributes for application-level tracing.
 [crates-badge]: https://img.shields.io/crates/v/tracing-attributes.svg
 [crates-url]: https://crates.io/crates/tracing-attributes
 [docs-badge]: https://docs.rs/tracing-attributes/badge.svg
-[docs-url]: https://docs.rs/tracing-attributes/0.1.29
+[docs-url]: https://docs.rs/tracing-attributes/0.1.30
 [docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
 [docs-v0.2.x-url]: https://tracing.rs/tracing_attributes
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -47,7 +47,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing-attributes = "0.1.29"
+tracing-attributes = "0.1.30"
 ```
 
 


### PR DESCRIPTION
# 0.1.30 (June 17, 2025)

### Fixed

- Fix `tracing::instrument` regression around shadowing ([#3311])

[#3311]: https://github.com/tokio-rs/tracing/pull/3311