### PR TITLE
Remove favicon URL from configuration

### DIFF
--- a/tracing-futures/src/lib.rs
+++ b/tracing-futures/src/lib.rs
@@ -72,7 +72,7 @@
 //!
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/logo-type.png",
-    html_favicon_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/favicon.ico",
+    html_favicon_url = "",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
 )]
 #![warn(


### PR DESCRIPTION

Changes made:
File: tracing-futures/src/lib.rs
- Old: html_favicon_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/favicon.ico"
+ New: html_favicon_url = ""

The current favicon URL seems outdated. If there's a correct URL for the project's favicon, I'll gladly update it. Otherwise, removing it to avoid potential broken links.

Let me know if there's a preferred favicon URL to use instead!