### PR TITLE
fix(subscriber): panic when reloading Filtered

### DIFF
--- a/tracing-subscriber/src/filter/layer_filters/mod.rs
+++ b/tracing-subscriber/src/filter/layer_filters/mod.rs
@@ -730,6 +730,11 @@ where
         self.layer.on_layer(subscriber);
     }
 
+    fn on_reload_layer(&mut self, subscriber: &S) {
+        self.id = MagicPlfDowncastMarker(subscriber.register_filter_immut());
+        self.layer.on_reload_layer(subscriber);
+    }
+
     // TODO(eliza): can we figure out a nice way to make the `Filtered` layer
     // not call `is_enabled_for` in hooks that the inner layer doesn't actually
     // have real implementations of? probably not...

--- a/tracing-subscriber/src/layer/layered.rs
+++ b/tracing-subscriber/src/layer/layered.rs
@@ -257,6 +257,11 @@ where
         self.inner.on_layer(subscriber);
     }
 
+    fn on_reload_layer(&mut self, subscriber: &S) {
+        self.layer.on_reload_layer(subscriber);
+        self.inner.on_reload_layer(subscriber);
+    }
+
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         self.pick_interest(self.layer.register_callsite(metadata), || {
             self.inner.register_callsite(metadata)
@@ -396,6 +401,11 @@ where
     #[cfg(all(feature = "registry", feature = "std"))]
     fn register_filter(&mut self) -> FilterId {
         self.inner.register_filter()
+    }
+
+    #[cfg(all(feature = "registry", feature = "std"))]
+    fn register_filter_immut(&self) -> FilterId {
+        self.inner.register_filter_immut()
     }
 }
 

--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -786,6 +786,30 @@ where
         let _ = subscriber;
     }
 
+    /// Performs late initialization when a `Layer` is reloaded into a [`Subscriber`].
+    ///
+    /// This is similar to [`Layer::on_layer`], but is intended for use when a
+    /// `Layer` is dynamically reloaded via [`reload`](crate::reload), rather than
+    /// attached to a subscriber during initial construction.
+    ///
+    /// Unlike `on_layer`, this method receives a shared (`&`) reference to the
+    /// [`Subscriber`], allowing it to be called in contexts where the subscriber
+    /// is already in use and cannot be mutated. This is useful for registering
+    /// internal state (e.g., with [`register_filter_immut`]) that would otherwise
+    /// require a mutable subscriber.
+    ///
+    /// Like `on_layer`, `Layer` implementations that wrap other layers (such as
+    /// [`Filtered`] or [`Layered`]) MUST ensure that their inner layers'
+    /// `on_reload_layer` methods are called during reload, if applicable.
+    ///
+    /// [`Subscriber`]: tracing::Subscriber
+    /// [`Filtered`]: crate::filter::Filtered
+    /// [`Layered`]: crate::layer::Layered
+    /// [`register_filter_immut`]: crate::registry::LookupSpan::register_filter_immut
+    fn on_reload_layer(&mut self, subscriber: &S) {
+        let _ = subscriber;
+    }
+
     /// Registers a new callsite with this layer, returning whether or not
     /// the layer is interested in being notified about the callsite, similarly
     /// to [`Subscriber::register_callsite`].
@@ -1568,6 +1592,12 @@ where
         }
     }
 
+    fn on_reload_layer(&mut self, subscriber: &S) {
+        if let Some(ref mut layer) = self {
+            layer.on_reload_layer(subscriber);
+        }
+    }
+
     #[inline]
     fn on_register_dispatch(&self, subscriber: &Dispatch) {
         if let Some(ref layer) = self {
@@ -1698,6 +1728,11 @@ feature! {
             }
 
             #[inline]
+            fn on_reload_layer(&mut self, subscriber: &S) {
+                self.deref_mut().on_reload_layer(subscriber);
+            }
+
+            #[inline]
             fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
                 self.deref().on_new_span(attrs, id, ctx)
             }
@@ -1789,6 +1824,12 @@ feature! {
         fn on_layer(&mut self, subscriber: &mut S) {
             for l in self {
                 l.on_layer(subscriber);
+            }
+        }
+
+        fn on_reload_layer(&mut self, subscriber: &S) {
+            for l in self {
+                l.on_reload_layer(subscriber);
             }
         }
 

--- a/tracing-subscriber/src/registry/mod.rs
+++ b/tracing-subscriber/src/registry/mod.rs
@@ -151,6 +151,32 @@ pub trait LookupSpan<'a> {
             std::any::type_name::<Self>()
         )
     }
+
+    /// Registers a [`Filter`] for [per-layer filtering] with this
+    /// [`Subscriber`], using a shared reference.
+    ///
+    /// This method is similar to [`register_filter`], but takes `&self`
+    /// instead of `&mut self`. It is intended for use in cases where
+    /// filters must be registered after the subscriber has already been
+    /// constructed, such as when reloading a [`Layer`] dynamically.
+    ///
+    /// # Panics
+    ///
+    /// If this `Subscriber` does not support [per-layer filtering].
+    ///
+    /// [`Filter`]: crate::layer::Filter
+    /// [per-layer filtering]: crate::layer::Layer#per-layer-filtering
+    /// [`Subscriber`]: tracing_core::Subscriber
+    /// [`Layer`]: crate::layer::Layer
+    /// [`register_filter`]: Self::register_filter
+    #[cfg(feature = "registry")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "registry")))]
+    fn register_filter_immut(&self) -> FilterId {
+        panic!(
+            "{} does not currently support filters",
+            std::any::type_name::<Self>()
+        )
+    }
 }
 
 /// A stored representation of data associated with a span.

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use core::{
     cell::{self, Cell, RefCell},
-    sync::atomic::{fence, AtomicUsize, Ordering},
+    sync::atomic::{fence, AtomicU8, AtomicUsize, Ordering},
 };
 use std::thread_local;
 use tracing_core::{
@@ -93,7 +93,7 @@ use tracing_core::{
 pub struct Registry {
     spans: Pool<DataInner>,
     current_spans: ThreadLocal<RefCell<SpanStack>>,
-    next_filter_id: u8,
+    next_filter_id: AtomicU8,
 }
 
 /// Span data stored in a [`Registry`].
@@ -138,7 +138,7 @@ impl Default for Registry {
         Self {
             spans: Pool::new(),
             current_spans: ThreadLocal::new(),
-            next_filter_id: 0,
+            next_filter_id: AtomicU8::new(0),
         }
     }
 }
@@ -202,7 +202,7 @@ impl Registry {
     }
 
     pub(crate) fn has_per_layer_filters(&self) -> bool {
-        self.next_filter_id > 0
+        self.next_filter_id.load(Ordering::SeqCst) > 0
     }
 
     pub(crate) fn span_stack(&self) -> cell::Ref<'_, SpanStack> {
@@ -375,9 +375,12 @@ impl<'a> LookupSpan<'a> for Registry {
     }
 
     fn register_filter(&mut self) -> FilterId {
-        let id = FilterId::new(self.next_filter_id);
-        self.next_filter_id += 1;
-        id
+        self.register_filter_immut()
+    }
+
+    fn register_filter_immut(&self) -> FilterId {
+        let filter_id = self.next_filter_id.fetch_add(1, Ordering::SeqCst);
+        FilterId::new(filter_id)
     }
 }
 


### PR DESCRIPTION
## Motivation

Resolve [https://github.com/tokio-rs/tracing/issues/1629](https://github.com/tokio-rs/tracing/issues/1629) without introducing a breaking change.

A workaround for this issue was introduced via [`filter_mut`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.Filtered.html#method.filter_mut), which allows reloading the `Filter` of a `Filtered` layer — but it still doesn't support replacing the entire `Filtered` layer.

A [breaking change](https://github.com/tokio-rs/tracing/issues/2101) was also proposed, but it comes with some downsides:

* It cannot be included in a patch release.
* As discussed in the `Alternatives` section [here](https://github.com/tokio-rs/tracing/issues/2101), it could introduce unintended side effects.

## Solution

This change adds support for reloading filtered layers without breaking the existing API by introducing a dedicated `Handle::reload_filtered` method for reloading `Filtered` layers, and a `Layer::on_reload_layer` method for performing late initialization when a `Layer` is reloaded.

`Handle::reload_filtered` invokes the new `Layer::on_reload_layer` method on the layer. This method is responsible for registering the filter with the subscriber via `register_filter_immut`.

Unlike `register_filter`, the `register_filter_immut` function takes a shared reference to the subscriber, allowing filter registration after the subscriber has been fully initialized.

Usage examples for are included in the inline documentation.

Fixes: #1629