### PR TITLE
Correctly state dependency on JsonFields.

### DIFF
--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -119,10 +119,9 @@ where
     Span: Subscriber + for<'lookup> crate::registry::LookupSpan<'lookup>,
     N: for<'writer> FormatFields<'writer> + 'static;
 
-impl<Span, N> serde::ser::Serialize for SerializableContext<'_, '_, Span, N>
+impl<Span> serde::ser::Serialize for SerializableContext<'_, '_, Span, JsonFields>
 where
     Span: Subscriber + for<'lookup> crate::registry::LookupSpan<'lookup>,
-    N: for<'writer> FormatFields<'writer> + 'static,
 {
     fn serialize<Ser>(&self, serializer_o: Ser) -> Result<Ser::Ok, Ser::Error>
     where
@@ -149,10 +148,9 @@ where
     Span: for<'lookup> crate::registry::LookupSpan<'lookup>,
     N: for<'writer> FormatFields<'writer> + 'static;
 
-impl<Span, N> serde::ser::Serialize for SerializableSpan<'_, '_, Span, N>
+impl<Span> serde::ser::Serialize for SerializableSpan<'_, '_, Span, JsonFields>
 where
     Span: for<'lookup> crate::registry::LookupSpan<'lookup>,
-    N: for<'writer> FormatFields<'writer> + 'static,
 {
     fn serialize<Ser>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error>
     where
@@ -162,7 +160,7 @@ where
 
         let ext = self.0.extensions();
         let data = ext
-            .get::<FormattedFields<N>>()
+            .get::<FormattedFields<JsonFields>>()
             .expect("Unable to find FormattedFields in extensions; this is a bug");
 
         // TODO: let's _not_ do this, but this resolves
@@ -210,15 +208,14 @@ where
     }
 }
 
-impl<S, N, T> FormatEvent<S, N> for Format<Json, T>
+impl<S, T> FormatEvent<S, JsonFields> for Format<Json, T>
 where
     S: Subscriber + for<'lookup> LookupSpan<'lookup>,
-    N: for<'writer> FormatFields<'writer> + 'static,
     T: FormatTime,
 {
     fn format_event(
         &self,
-        ctx: &FmtContext<'_, S, N>,
+        ctx: &FmtContext<'_, S, JsonFields>,
         mut writer: Writer<'_>,
         event: &Event<'_>,
     ) -> fmt::Result
@@ -248,7 +245,7 @@ where
                 serializer.serialize_entry("level", &meta.level().as_serde())?;
             }
 
-            let format_field_marker: std::marker::PhantomData<N> = std::marker::PhantomData;
+            let format_field_marker: std::marker::PhantomData<JsonFields> = std::marker::PhantomData;
 
             let current_span = if self.format.display_current_span || self.format.display_span_list
             {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Currently, passing `format().json()` to the `event_format` method of `SubscriberBuilder` without also calling `.json()` on the `SubscriberBuilder` results in either a runtime panic (in debug mode) or missing information from the log output (in release mode). See #3327 for more details including reproducer code and output.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This change corrects the code to state that it is only implemented for the `JsonFields` formatter, instead of being generic across formatters. If the user does not call `.json()` on the `SubscriberBuilder` before passing `format().json()` to `event_format()` they will see the following compiler error, which IMO is preferable to a runtime error:

```
error[E0277]: the trait bound `Format<Json>: FormatEvent<Registry, DefaultFields>` is not satisfied
    --> src/main.rs:5:24
     |
5    |     fmt().event_format(fmt::format().json()).init();
     |           ------------ ^^^^^^^^^^^^^^^^^^^^ the trait `FormatEvent<Registry, DefaultFields>` is not implemented for `Format<Json>`
     |           |
     |           required by a bound introduced by this call
     |
     = help: the following other types implement trait `FormatEvent<S, N>`:
               `Format<Compact, T>` implements `FormatEvent<S, N>`
               `Format<Json, T>` implements `FormatEvent<S, JsonFields>`
               `Format<Pretty, T>` implements `FormatEvent<C, N>`
               `Format<tracing_subscriber::fmt::format::Full, T>` implements `FormatEvent<S, N>`
note: required by a bound in `SubscriberBuilder::<N, E, F, W>::event_format`
    --> /home/user/repositories/tracing/tracing-subscriber/src/fmt/mod.rs:1014:13
     |
1012 |     pub fn event_format<E2>(self, fmt_event: E2) -> SubscriberBuilder<N, E2, F, W>
     |            ------------ required by a bound in this associated function
1013 |     where
1014 |         E2: FormatEvent<Registry, N> + 'static,
     |             ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `SubscriberBuilder::<N, E, F, W>::event_format`
help: consider removing this method call, as the receiver has type `Format` and `Format: FormatEvent<Registry, DefaultFields>` trivially holds
     |
5    -     fmt().event_format(fmt::format().json()).init();
5    +     fmt().event_format(fmt::format()).init();
     |

error[E0599]: the method `init` exists for struct `SubscriberBuilder<DefaultFields, Format<Json>>`, but its trait bounds were not satisfied
   --> src/main.rs:5:46
    |
5   |     fmt().event_format(fmt::format().json()).init();
    |                                              ^^^^ method cannot be called on `SubscriberBuilder<DefaultFields, Format<Json>>` due to unsatisfied trait bounds
    |
   ::: /home/user/repositories/tracing/tracing-subscriber/src/fmt/format/mod.rs:401:1
    |
401 | pub struct Format<F = Full, T = SystemTime> {
    | ------------------------------------------- doesn't satisfy `Format<Json>: FormatEvent<Registry, DefaultFields>`
    |
    = note: the following trait bounds were not satisfied:
            `Format<Json>: FormatEvent<Registry, DefaultFields>`

Some errors have detailed explanations: E0277, E0599.
For more information about an error, try `rustc --explain E0277`.
```

As noted in the commit message this improves the situation but I think more work needs to be done. A full resolution would involve either implementing the JSON code for the `DefaultFields` formatter as well (and by extension all future formatters added to the project), improving the error message so that the compiler recommends calling `.json()` on the `SubscriberBuilder`, or making the `SubscriberBuilder` automatically use `JsonFields` when using the JSON output format.