### PR TITLE
Nested (i.e., dotted) field name support in #[tracing::instrument]

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -210,7 +210,7 @@ mod expand;
 /// to the generated span through the `fields` argument on the
 /// `#[instrument]` macro. Strings, integers or boolean literals are accepted values
 /// for each field. The name of the field must be a single valid Rust
-/// identifier, nested (dotted) field names are not supported. Any
+/// identifier, though nested (dotted) field names are supported. Any
 /// Rust expression can be used as a field value in this manner. These
 /// expressions will be evaluated at the beginning of the function's body, so
 /// arguments to the function may be used in these expressions. Field names may

--- a/tracing-attributes/tests/instrument.rs
+++ b/tracing-attributes/tests/instrument.rs
@@ -51,7 +51,7 @@ fn override_everything() {
 
 #[test]
 fn fields() {
-    #[instrument(target = "my_target", level = "debug")]
+    #[instrument(target = "my_target", level = "debug", fields(nested.dotted.field = "foo-bar"))]
     fn my_fn(arg1: usize, arg2: bool, arg3: String) {}
 
     let span = expect::span()
@@ -70,6 +70,7 @@ fn fields() {
                     .with_value(&2usize)
                     .and(expect::field("arg2").with_value(&false))
                     .and(expect::field("arg3").with_value(&"Cool".to_string()))
+                    .and(expect::field("nested.dotted.field").with_value(&"foo-bar"))
                     .only(),
             ),
         )
@@ -82,6 +83,7 @@ fn fields() {
                     .with_value(&3usize)
                     .and(expect::field("arg2").with_value(&true))
                     .and(expect::field("arg3").with_value(&"Still Cool".to_string()))
+                    .and(expect::field("nested.dotted.field").with_value(&"foo-bar"))
                     .only(),
             ),
         )


### PR DESCRIPTION
## Motivation

I was reading the `#[tracing::instrument]` documentation, and noticed it mentioning that nested/dotted field names were _not_ supported by the macro. However, I had code written and instrumented with `#[tracing::instrument]` macros where I _was_ explicitly adding fields whose names were nested/dotted, and it all seemed to work fine/as-expected (i.e., the emitted spans had the correct field name and value, even with the dotted notation)...

## Solution

Decided to simply amend the docs to reflect that the nested/dotted field names do seem to work as of today, and modified a unit test to exercise this accordingly? That being said, I may be missing some broader context/other nuances that actually prevent this from working as-intended. If so, just let me know, am more than happy to learn and take any further actions as necessary! :sweat_smile: 
