### PR TITLE
journald: Fix a broken markdown anchor in README.md

### DIFF
--- a/tracing-journald/README.md
+++ b/tracing-journald/README.md
@@ -4,7 +4,7 @@
 
 # tracing-journald
 
-Support for logging [`tracing`][tracing] events natively to [journald],
+Support for logging [`tracing`] events natively to [journald],
 preserving structured information.
 
 [![Crates.io][crates-badge]][crates-url]


### PR DESCRIPTION
README.md unnecessarily used an anchor reference which, additionally, was broken.

This PR removes the additional anchor which causes the link to work again.

## Motivation

My OCD makes me want to fix all broken things that I see and I just couldn't stand looking at the broken anchor.

## Solution

I've removed superfluous anchor. This change is best verified using GitHub's "View File" feature.

Have a nice day! :wave: 
