### PR TITLE
Avoid checking dispatcher settings twice in `tracing::enabled`

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1009,6 +1009,7 @@ pub mod __macro_support {
     /// by the `tracing` macros, but it is not part of the stable versioned API.
     /// Breaking changes to this module may occur in small-numbered versions
     /// without warning.
+    #[inline]
     pub fn __is_enabled(meta: &Metadata<'static>, interest: Interest) -> bool {
         interest.is_always() || crate::dispatcher::get_default(|default| default.enabled(meta))
     }

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -1228,12 +1228,7 @@ macro_rules! enabled {
                 fields: $($fields)*
             };
             let interest = __CALLSITE.interest();
-            if !interest.is_never() && $crate::__macro_support::__is_enabled(__CALLSITE.metadata(), interest) {
-                let meta = __CALLSITE.metadata();
-                $crate::dispatcher::get_default(|current| current.enabled(meta))
-            } else {
-                false
-            }
+            !interest.is_never() && $crate::__macro_support::__is_enabled(__CALLSITE.metadata(), interest)
         } else {
             false
         }


### PR DESCRIPTION
## Motivation

The `__is_enabled` function already checks the current dispatcher, so unless I'm missing something, there's no need to check it again after. I also added `#[inline]` to `__is_enabled` because I noticed the second `get_default` check was being inlined, but it wasn't anymore after removing it.