### PR TITLE
tracing-subscriber: optimise span fields serialisation

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -31,7 +31,7 @@ env-filter = ["matchers", "once_cell", "tracing", "std", "thread_local", "dep:re
 fmt = ["registry", "std"]
 ansi = ["fmt", "nu-ansi-term"]
 registry = ["sharded-slab", "thread_local", "std"]
-json = ["tracing-serde", "serde", "serde_json", "serde/derive"]
+json = ["tracing-serde", "serde", "serde_json"]
 valuable = ["tracing-core/valuable", "valuable_crate", "valuable-serde", "tracing-serde/valuable"]
 # Enables support for local time when using the `time` crate timestamp
 # formatters.

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     registry::LookupSpan,
 };
-use serde::{ser::SerializeMap, Deserialize, Deserializer as _, Serialize, Serializer as _};
+use serde::{ser::SerializeMap, Deserializer as _, Serializer as _};
 use serde_json::{Deserializer, Serializer};
 use std::{
     collections::BTreeMap,
@@ -395,15 +395,6 @@ impl<'a> FormatFields<'a> for JsonFields {
     }
 }
 
-#[derive(Serialize, Deserialize)]
-#[serde(untagged)]
-enum SpanFieldsValue<'a> {
-    /// String which could be borrowed directly from the input json
-    Borrowed(&'a str),
-    /// Any other value
-    Owned(serde_json::Value),
-}
-
 /// The [serde::de::Visitor] which moves entries from one map to another.
 struct SerializeMapVisitor<'a, S: SerializeMap>(&'a mut S);
 
@@ -415,7 +406,7 @@ impl<'de, S: SerializeMap> serde::de::Visitor<'de> for SerializeMapVisitor<'_, S
     }
 
     fn visit_map<A: serde::de::MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
-        while let Some((key, value)) = map.next_entry::<&str, SpanFieldsValue<'_>>()? {
+        while let Some((key, value)) = map.next_entry::<&str, serde_json::Value>()? {
             self.0
                 .serialize_entry(key, &value)
                 .map_err(serde::de::Error::custom)?;


### PR DESCRIPTION
Move formatted fields from Span to json log without storing them in an intermediate `serde_json::Value` by using a smart `serde` visitor.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

Current `serde::ser::Serialize` implementation for `SerializableSpan` parses the entire `FormattedFields` string into `serde_json::Value` to fix https://github.com/tokio-rs/tracing/issues/391, but there is no need to create an intermediate object just to move json fields from one json string to another.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Instead this PR introduces a new `SerializeMapVisitor` struct implementing `serde::de::Visitor` trait to move all json fields from `Deserializer` to `Serializer` as json object is being parsed.

I assume here that `FormattedFields` should always contain a json object.

`FormattedFields` is still parsed using `serde`. But instead of deserialising it into one big `serde_json::Value`, I iterate over it's entriesusing a custom `serde::de::Visitor`.

`FormattedFields` keys are always parsed as `&str`. This could fail if any of the keys contains escape sequences, i.e. `{"boo\\"bar":"baz"}`. But I don't think this corner case is worth being supported.

`FormattedFields` values are parsed as `serde_json::Value`. I tried being smart there, but it didn't work as expected (see comments below).

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
