### PR TITLE
fix: `max_files` integer underflow when set to zero

### DIFF
--- a/tracing-appender/src/rolling/builder.rs
+++ b/tracing-appender/src/rolling/builder.rs
@@ -228,7 +228,7 @@ impl Builder {
     #[must_use]
     pub fn max_log_files(self, n: usize) -> Self {
         Self {
-            max_files: Some(n),
+            max_files: Some(n).filter(|&n| n > 0),
             ..self
         }
     }


### PR DESCRIPTION
## Motivation

When `max_files` set to zero, [rolling.rs:695](https://github.com/tokio-rs/tracing/blob/c01d4fd9def2fb061669a310598095c789ca0a32/tracing-appender/src/rolling.rs#L695) will cause integer underflow and panicking in debug build. In my opinion the API should prevent this from happening as "zero" is a valid `usize` value.

## Solution

Currently, in release builds, if `max_files` is set to zero, it behaves just like `u64::MAX` on `x86_64` platforms. Therefore, I decided to simply make `zero == None`, which should align with the existing behavior but without the panicking. I believe this can be considered as "non-breaking".

Feel free to advise if there a more preferred way of fixing this. Any help on how to provide tests would also be appreciated!