### PR TITLE
docs: fix extra closing brace in rendered doc

### DIFF
--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -67,7 +67,7 @@
 //! # fn new() -> Self { Self {} }
 //! # }
 //! # impl MySubscriber {
-//! # fn new() -> Self { Self { }}
+//! # fn new() -> Self { Self {} }
 //! # }
 //!
 //! let subscriber = MySubscriber::new()
@@ -107,7 +107,7 @@
 //! #   fn enabled(&self, _: &Metadata) -> bool { false }
 //! #   fn enter(&self, _: &Id) {}
 //! #   fn exit(&self, _: &Id) {}
-//! }
+//! # }
 //! # impl MyLayer {
 //! # fn new() -> Self { Self {} }
 //! # }
@@ -118,7 +118,7 @@
 //! # fn new() -> Self { Self {} }
 //! # }
 //! # impl MySubscriber {
-//! # fn new() -> Self { Self { }}
+//! # fn new() -> Self { Self {} }
 //! # }
 //!
 //! let subscriber = MySubscriber::new()


### PR DESCRIPTION
## Motivation

Noticed that there is an extra closing brace while reading the rendered documentation.
<img width="1222" height="863" alt="image" src="https://github.com/user-attachments/assets/e04b0eb1-0a86-4684-85d6-99835ffa4985" />


## Solution

Straightforward fix.
