### PR TITLE
subscriber: add span display configuration for compact formatter

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -549,6 +549,34 @@ where
         }
     }
 
+    /// Sets whether or not the current span context is displayed.
+    ///
+    /// When enabled (the default), the formatter will include the current span
+    /// name and fields in the formatted output.
+    pub fn with_current_span(
+        self,
+        display_current_span: bool,
+    ) -> Layer<S, N, format::Format<L, T>, W> {
+        Layer {
+            fmt_event: self.fmt_event.with_current_span(display_current_span),
+            ..self
+        }
+    }
+
+    /// Sets whether or not span lists are displayed.
+    ///
+    /// When enabled (the default), the formatter will include fields from all
+    /// spans in the current span context in the formatted output.
+    pub fn with_span_list(
+        self,
+        display_span_list: bool,
+    ) -> Layer<S, N, format::Format<L, T>, W> {
+        Layer {
+            fmt_event: self.fmt_event.with_span_list(display_span_list),
+            ..self
+        }
+    }
+
     /// Sets the layer being built to use a [less verbose formatter][super::format::Compact].
     pub fn compact(self) -> Layer<S, N, format::Format<format::Compact, T>, W>
     where

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -733,6 +733,34 @@ where
         }
     }
 
+    /// Sets whether or not the current span context is displayed.
+    ///
+    /// When enabled (the default), the formatter will include the current span
+    /// name and fields in the formatted output.
+    pub fn with_current_span(
+        self,
+        display_current_span: bool,
+    ) -> SubscriberBuilder<N, format::Format<L, T>, F, W> {
+        SubscriberBuilder {
+            inner: self.inner.with_current_span(display_current_span),
+            ..self
+        }
+    }
+
+    /// Sets whether or not span lists are displayed.
+    ///
+    /// When enabled (the default), the formatter will include fields from all
+    /// spans in the current span context in the formatted output.
+    pub fn with_span_list(
+        self,
+        display_span_list: bool,
+    ) -> SubscriberBuilder<N, format::Format<L, T>, F, W> {
+        SubscriberBuilder {
+            inner: self.inner.with_span_list(display_span_list),
+            ..self
+        }
+    }
+
     /// Sets the subscriber being built to use a less verbose formatter.
     ///
     /// See [`format::Compact`].


### PR DESCRIPTION
Add `with_current_span` and `with_span_list` configuration methods to allow users to control whether span context and span field lists are included in formatted output. This is similar to how the JSON formatter already works. 


## Motivation

The logs can get polluting when using with tracing (see https://github.com/tokio-rs/tracing/issues/1481#issuecomment-1916073517).  I wanted to allow exclusion of spans, similar to how JSON formatter works. This doesn't seem to be implemented for the Compact formatter.  

## Solution

- Add `display_current_span` and `display_span_list` fields to Format struct
- Implement configuration methods on Format, Layer, and SubscriberBuilder
- Modify compact formatter to respect new configuration options
- Add comprehensive tests for all configuration combinations
- Maintain backward compatibility with default values of true
