### PR TITLE
fmt: add with_event_name configuration option

### DIFF
--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -516,6 +516,16 @@ where
         }
     }
 
+    /// Sets whether or not an event's [name] is displayed.
+    ///
+    /// [name]: tracing_core::Metadata::name
+    pub fn with_event_name(self, display_event_name: bool) -> Layer<S, N, format::Format<L, T>, W> {
+        Layer {
+            fmt_event: self.fmt_event.with_event_name(display_event_name),
+            ..self
+        }
+    }
+
     /// Sets whether or not an event's level is displayed.
     pub fn with_level(self, display_level: bool) -> Layer<S, N, format::Format<L, T>, W> {
         Layer {

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -694,6 +694,20 @@ where
         }
     }
 
+    /// Sets whether or not an event's [name] is
+    /// displayed.
+    ///
+    /// [name]: tracing_core::Metadata::name
+    pub fn with_event_name(
+        self,
+        display_event_name: bool,
+    ) -> SubscriberBuilder<N, format::Format<L, T>, F, W> {
+        SubscriberBuilder {
+            inner: self.inner.with_event_name(display_event_name),
+            ..self
+        }
+    }
+
     /// Sets whether or not an event's level is displayed.
     pub fn with_level(
         self,


### PR DESCRIPTION
Fixes #2774 

## Motivation

Event names set with `event!(name: "...", ...)` are currently not shown in the output. Users sometimes want to see custom event names, like how span names are displayed.

## Solution

Added `with_event_name()` option to control display of event name:
- Shows custom event name when enabled
- Hides verbose default names like `"event src/main.rs:123"`
- Disabled by default

Example:
```rust
tracing_subscriber::fmt()
    .with_event_name(true)
    .init();

event!(name: "user_login", Level::INFO, "User logged in");
// Output: 2024-01-01 INFO app: user_login: User logged in

event!(Level::INFO, "Regular event");
// Output: 2024-01-01 INFO app: Regular event (no event name shown)
```