### PR TITLE
tracing: fix perf regression when release_max_level_* not set

### DIFF
--- a/tracing/src/level_filters.rs
+++ b/tracing/src/level_filters.rs
@@ -66,21 +66,36 @@ pub use tracing_core::{metadata::ParseLevelFilterError, LevelFilter};
 pub const STATIC_MAX_LEVEL: LevelFilter = get_max_level_inner();
 
 const fn get_max_level_inner() -> LevelFilter {
-    if cfg!(not(debug_assertions)) {
-        if cfg!(feature = "release_max_level_off") {
-            LevelFilter::OFF
-        } else if cfg!(feature = "release_max_level_error") {
-            LevelFilter::ERROR
-        } else if cfg!(feature = "release_max_level_warn") {
-            LevelFilter::WARN
-        } else if cfg!(feature = "release_max_level_info") {
-            LevelFilter::INFO
-        } else if cfg!(feature = "release_max_level_debug") {
-            LevelFilter::DEBUG
-        } else {
-            // Same as branch cfg!(feature = "release_max_level_trace")
-            LevelFilter::TRACE
-        }
+    if cfg!(all(
+        not(debug_assertions),
+        feature = "release_max_level_off"
+    )) {
+        LevelFilter::OFF
+    } else if cfg!(all(
+        not(debug_assertions),
+        feature = "release_max_level_error"
+    )) {
+        LevelFilter::ERROR
+    } else if cfg!(all(
+        not(debug_assertions),
+        feature = "release_max_level_warn"
+    )) {
+        LevelFilter::WARN
+    } else if cfg!(all(
+        not(debug_assertions),
+        feature = "release_max_level_info"
+    )) {
+        LevelFilter::INFO
+    } else if cfg!(all(
+        not(debug_assertions),
+        feature = "release_max_level_debug"
+    )) {
+        LevelFilter::DEBUG
+    } else if cfg!(all(
+        not(debug_assertions),
+        feature = "release_max_level_trace"
+    )) {
+        LevelFilter::TRACE
     } else if cfg!(feature = "max_level_off") {
         LevelFilter::OFF
     } else if cfg!(feature = "max_level_error") {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

This PR fixes perf regression (binary size and instruction counts) existed in tracing > 0.1.37 in case if `release_max_level_*` feature was not set.

## Solution

Regression was introduced in #2553, where logic was unintentionally changed: before pr, in case if  `release_max_level_*` wasn't set, log level from `max_level_*` was used, but after it was unconditionally set to trace level.

See additional info in https://github.com/tokio-rs/tracing/pull/2553#issuecomment-3262310405

