### PR TITLE
Add missing `dyn` keyword in `Visit` documentation code sample

### DIFF
--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -240,7 +240,7 @@ pub struct Iter {
 ///         self.sum += value as i64;
 ///     }
 ///
-///     fn record_debug(&mut self, _field: &Field, _value: &fmt::Debug) {
+///     fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {
 ///         // Do nothing
 ///     }
 /// }


### PR DESCRIPTION
## Motivation
Fix typo in documentation

## Solution
Added a missing `dyn` keyword in the `Visit` trait documentation code sample
