### PR TITLE
chore(attributes): fix UI test for instrument attribute on async fn

### DIFF
--- a/tracing-attributes/tests/ui/fail/async_instrument.stderr
+++ b/tracing-attributes/tests/ui/fail/async_instrument.stderr
@@ -14,15 +14,17 @@ error[E0308]: mismatched types
   --> tests/ui/fail/async_instrument.rs:10:5
    |
 10 |     ""
-   |     ^^- help: try using a conversion method: `.to_string()`
-   |     |
-   |     expected `String`, found `&str`
+   |     ^^ expected `String`, found `&str`
    |
 note: return type inferred to be `String` here
   --> tests/ui/fail/async_instrument.rs:9:31
    |
-9  | async fn simple_mismatch() -> String {
+ 9 | async fn simple_mismatch() -> String {
    |                               ^^^^^^
+help: try using a conversion method
+   |
+10 |     "".to_string()
+   |       ++++++++++++
 
 error[E0277]: `(&str,)` doesn't implement `std::fmt::Display`
   --> tests/ui/fail/async_instrument.rs:14:57
@@ -76,15 +78,17 @@ error[E0308]: mismatched types
   --> tests/ui/fail/async_instrument.rs:35:16
    |
 35 |         return "";
-   |                ^^- help: try using a conversion method: `.to_string()`
-   |                |
-   |                expected `String`, found `&str`
+   |                ^^ expected `String`, found `&str`
    |
 note: return type inferred to be `String` here
   --> tests/ui/fail/async_instrument.rs:33:28
    |
 33 | async fn early_return() -> String {
    |                            ^^^^^^
+help: try using a conversion method
+   |
+35 |         return "".to_string();
+   |                  ++++++++++++
 
 error[E0308]: mismatched types
   --> tests/ui/fail/async_instrument.rs:40:1


### PR DESCRIPTION
## Motivation

Due to a change in the error messages produced by rustc, one of the UI
tests for failing compilation of the `#[instrument]` attribute when
applied to async functions was failing.

## Solution

This change updates the expected output so that the test passes.
