### PR TITLE
chore: run `tracing-subscriber` tests with all features

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -287,6 +287,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
+    - name: install cargo-nextest
+      uses: taiki-e/install-action@nextest
     - name: "Test log support"
       run: cargo test
     - name: "Test static max level"
@@ -303,6 +305,14 @@ jobs:
       # as rustdoc isn't aware of cargo's feature flags.
     - name: "Test tracing-subscriber with all features disabled"
       run: cargo test --lib --tests --no-default-features
+    - name: "Fix chrono version to 0.4.41"
+      run: cargo update -p chrono --precise 0.4.41
+    - name: "Test tracing-subscriber with all features enabled"
+      run: cargo nextest run --profile ci --all-features -p tracing-subscriber
+    - name: "Test tracing-subscriber docs with all features enabled"
+      run: cargo test --doc --all-features -p tracing-subscriber
+    - name: "Test tracing-mock with all features enabled"
+      run: cargo test --all-features -p tracing-mock
 
   # all required checks except for the main test run (which we only require
   # specific matrix combinations from)

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -81,7 +81,7 @@ tracing-log = { path = "../tracing-log", version = "0.2.0" }
 criterion = { version = "0.3.6", default-features = false }
 regex = { version = "1", default-features = false, features = ["std"] }
 tracing-futures = { path = "../tracing-futures", version = "0.2.0", default-features = false, features = ["std-future", "std"] }
-tokio = { version = "1", features = ["rt", "macros"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 # Enable the `time` crate's `macros` feature, for examples.
 time = { version = "0.3.2", features = ["formatting", "macros"] }
 


### PR DESCRIPTION
## Motivation

While investigating #3405, we found that some tests are not being run on
CI. Specifically the `tracing-subscriber` tests that depend on
non-default features.

## Solution

This change adds 2 new `run` commands to the `test-features-stable` CI
job, one with `nextest` and another for the doc tests.

There is also 1 more `run` command to run the `tracing-mock` tests with
all features (which is just `tracing-subscriber` right now, but safer to
set all).