### PR TITLE
chore: prepare tracing-attributes 0.1.31

### DIFF
--- a/tracing-attributes/CHANGELOG.md
+++ b/tracing-attributes/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.31 (November 26, 2025)
+
+### Added
+
+- Support constant expressions as instrument field names ([#3158])
+
+[#3158]: https://github.com/tokio-rs/tracing/pull/#3158
+
 # 0.1.30 (June 17, 2025)
 
 ### Fixed

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -5,7 +5,7 @@ name = "tracing-attributes"
 # - Update doc url in README.md.
 # - Update CHANGELOG.md.
 # - Create "tracing-attributes-0.1.x" git tag.
-version = "0.1.30"
+version = "0.1.31"
 authors = [
     "Tokio Contributors <team@tokio.rs>",
     "Eliza Weisman <eliza@buoyant.io>",

--- a/tracing-attributes/README.md
+++ b/tracing-attributes/README.md
@@ -16,9 +16,9 @@ Macro attributes for application-level tracing.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-attributes.svg
-[crates-url]: https://crates.io/crates/tracing-attributes
+[crates-url]: https://crates.io/crates/tracing-attributes/0.1.31
 [docs-badge]: https://docs.rs/tracing-attributes/badge.svg
-[docs-url]: https://docs.rs/tracing-attributes/0.1.30
+[docs-url]: https://docs.rs/tracing-attributes/0.1.31
 [docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
 [docs-v0.2.x-url]: https://tracing.rs/tracing_attributes
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -47,7 +47,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing-attributes = "0.1.30"
+tracing-attributes = "0.1.31"
 ```
 
 

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.65.0"
 [dependencies]
 tracing-core = { path = "../tracing-core", version = "0.1.35", default-features = false }
 log = { version = "0.4.17", optional = true }
-tracing-attributes = { path = "../tracing-attributes", version = "0.1.29", optional = true }
+tracing-attributes = { path = "../tracing-attributes", version = "0.1.31", optional = true }
 pin-project-lite = "0.2.9"
 
 [dev-dependencies]


### PR DESCRIPTION
# 0.1.31 (November 26, 2025)

### Added

- Support constant expressions as instrument field names ([#3158])

[#3158]: https://github.com/tokio-rs/tracing/pull/#3158