### PR TITLE
chore: prepare tracing-subscriber 0.3.21

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,10 +1,48 @@
+# 0.3.21 (November 26, 2025)
+
+### Fixed
+
+- Change registry exit to decrement local span ref only ([#3331])
+- Make Layered propagate `on_register_dispatch` ([#3379])
+
+### Changed
+
+- `tracing`: updated to 0.1.42 ([#3418])
+
+### Performance
+
+- Remove `clone_span` on enter ([#3289]) 
+
+### Documented
+
+- Fix a few small things in the format module ([#3339])
+- Fix extra closing brace in layer docs ([#3350])
+- Fix link in `FmtSpan` docs ([#3411])
+
+[#3289]: https://github.com/tokio-rs/tracing/pull/#3289
+[#3331]: https://github.com/tokio-rs/tracing/pull/#3331
+[#3339]: https://github.com/tokio-rs/tracing/pull/#3339
+[#3350]: https://github.com/tokio-rs/tracing/pull/#3350
+[#3379]: https://github.com/tokio-rs/tracing/pull/#3379
+[#3411]: https://github.com/tokio-rs/tracing/pull/#3411
+[#3418]: https://github.com/tokio-rs/tracing/pull/#3418
+
 # 0.3.20 (August 29, 2025)
 
 [ [crates.io][crate-0.3.20] ] | [ [docs.rs][docs-0.3.20] ]
 
 ### Fixed
 
-- Escape ANSI escape sequences in logs
+- Escape ANSI escape sequences in logs ([#3368])
+
+### Added
+
+- Implement `Clone` for `EnvFilter` ([#3360])
+
+[#3360]: https://github.com/tokio-rs/tracing/pull/#3360
+[#3368]: https://github.com/tokio-rs/tracing/pull/#3368
+[docs-0.3.20]: https://docs.rs/tracing-subscriber/0.3.20/tracing_subscriber/
+[crate-0.3.20]: https://crates.io/crates/tracing-subscriber/0.3.20
 
 # 0.3.19 (November 29, 2024)
 

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.21"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -29,9 +29,9 @@ application authors using `tracing` to instrument their applications.
 [tracing]: https://github.com/tokio-rs/tracing/tree/main/tracing
 [tracing-fmt]: https://github.com/tokio-rs/tracing/tree/main/tracing-subscriber
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
-[crates-url]: https://crates.io/crates/tracing-subscriber
+[crates-url]: https://crates.io/crates/tracing-subscriber/0.3.21
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/latest
+[docs-url]: https://docs.rs/tracing-subscriber/0.3.21
 [docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
 [docs-v0.2.x-url]: https://tracing.rs/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg


### PR DESCRIPTION
# 0.3.21 (November 26, 2025)

### Fixed

- Change registry exit to decrement local span ref only ([#3331])
- Make Layered propagate `on_register_dispatch` ([#3379])

### Changed

- `tracing`: updated to 0.1.42 ([#3418])

### Performance

- Remove `clone_span` on enter ([#3289]) 

### Documented

- Fix a few small things in the format module ([#3339])
- Fix extra closing brace in layer docs ([#3350])
- Fix link in `FmtSpan` docs ([#3411])

[#3289]: https://github.com/tokio-rs/tracing/pull/#3289
[#3331]: https://github.com/tokio-rs/tracing/pull/#3331
[#3339]: https://github.com/tokio-rs/tracing/pull/#3339
[#3350]: https://github.com/tokio-rs/tracing/pull/#3350
[#3379]: https://github.com/tokio-rs/tracing/pull/#3379
[#3411]: https://github.com/tokio-rs/tracing/pull/#3411
[#3418]: https://github.com/tokio-rs/tracing/pull/#3418