### PR TITLE
chore: prepare tracing-appender 0.2.4

### DIFF
--- a/tracing-appender/CHANGELOG.md
+++ b/tracing-appender/CHANGELOG.md
@@ -1,3 +1,25 @@
+# 0.2.4 (November 26, 2025)
+
+### Added
+
+- Prune old files at startup ([#2966])
+- Add fallback to file creation date ([#3000])
+- Introduce weekly rotation ([#3218])
+
+### Fixed
+
+- Fix `max_files` integer underflow when set to zero ([#3348])
+
+### Documented
+
+- Update tracing-appender docs link to correct docs.rs URL ([#3325])
+
+[#2966]: https://github.com/tokio-rs/tracing/pull/#2966
+[#3000]: https://github.com/tokio-rs/tracing/pull/#3000
+[#3218]: https://github.com/tokio-rs/tracing/pull/#3218
+[#3325]: https://github.com/tokio-rs/tracing/pull/#3325
+[#3348]: https://github.com/tokio-rs/tracing/pull/#3348
+
 # 0.2.3 (November 13, 2023)
 
 This release contains several new features. It also increases the

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-appender"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
     "Zeki Sherif <zekshi@amazon.com>",
     "Tokio Contributors <team@tokio.rs>"

--- a/tracing-appender/README.md
+++ b/tracing-appender/README.md
@@ -16,9 +16,9 @@ Writers for logging events and spans
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-appender.svg
-[crates-url]: https://crates.io/crates/tracing-appender/0.2.2
+[crates-url]: https://crates.io/crates/tracing-appender/0.2.4
 [docs-badge]: https://docs.rs/tracing-appender/badge.svg
-[docs-url]: https://docs.rs/tracing-appender/0.2.2
+[docs-url]: https://docs.rs/tracing-appender/0.2.4
 [docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
 [docs-v0.2.x-url]: https://docs.rs/tracing-appender/
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg


### PR DESCRIPTION
# 0.2.4 (November 26, 2025)

### Added

- Prune old files at startup ([#2966])
- Add fallback to file creation date ([#3000])
- Introduce weekly rotation ([#3218])

### Fixed

- Fix `max_files` integer underflow when set to zero ([#3348])

### Documented

- Update tracing-appender docs link to correct docs.rs URL ([#3325])

[#2966]: https://github.com/tokio-rs/tracing/pull/#2966
[#3000]: https://github.com/tokio-rs/tracing/pull/#3000
[#3218]: https://github.com/tokio-rs/tracing/pull/#3218
[#3325]: https://github.com/tokio-rs/tracing/pull/#3325
[#3348]: https://github.com/tokio-rs/tracing/pull/#3348