### PR TITLE
chore: prepare tracing-journald 0.3.2

### DIFF
--- a/tracing-journald/CHANGELOG.md
+++ b/tracing-journald/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.3.2 (November 26, 2025)
+
+### Added
+
+- Use argv0 for syslog identifier ([#3372])
+
+[#3372]: https://github.com/tokio-rs/tracing/pull/#3372
+
 # 0.3.1 (November 29, 2024)
 
 [ [crates.io][crate-0.3.1] ] | [ [docs.rs][docs-0.3.1] ]

--- a/tracing-journald/Cargo.toml
+++ b/tracing-journald/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-journald"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/tracing-journald/README.md
+++ b/tracing-journald/README.md
@@ -8,12 +8,15 @@ Support for logging [`tracing`] events natively to [journald],
 preserving structured information.
 
 [![Crates.io][crates-badge]][crates-url]
+[![Documentation][docs-badge]][docs-url]
 [![Documentation (v0.2.x)][docs-v0.2.x-badge]][docs-v0.2.x-url]
 [![MIT licensed][mit-badge]][mit-url]
 ![maintenance status][maint-badge]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-journald.svg
-[crates-url]: https://crates.io/crates/tracing-journald
+[crates-url]: https://crates.io/crates/tracing-journald/0.3.2
+[docs-badge]: https://docs.rs/tracing-journald/badge.svg
+[docs-url]: https://docs.rs/tracing-journald/0.3.2
 [docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
 [docs-v0.2.x-url]: https://tracing.rs/tracing_journald
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg


### PR DESCRIPTION
# 0.3.2 (November 26, 2025)

### Added

- Use argv0 for syslog identifier ([#3372])

[#3372]: https://github.com/tokio-rs/tracing/pull/#3372