### PR TITLE
chore: prepare tracing-mock 0.1.0-beta.2

### DIFF
--- a/tracing-mock/CHANGELOG.md
+++ b/tracing-mock/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 0.1.0-beta.2 (November 26, 2025)
+
+### Added
+
+- Add `on_register_dispatch` expectation for subscriber and layer mocks ([#3415])
+- Add doctests for `on_register_dispatch` negative cases ([#3416])
+
+### Changed
+
+- `tracing`: updated to 0.1.42 ([#3418])
+
+[#3415]: https://github.com/tokio-rs/tracing/pull/#3415
+[#3416]: https://github.com/tokio-rs/tracing/pull/#3416
+[#3418]: https://github.com/tokio-rs/tracing/pull/#3418
+
 # 0.1.0-beta.1 (November 29, 2024)
 
 [ [crates.io][crate-0.1.0-beta.1] ] | [ [docs.rs][docs-0.1.0-beta.1] ]

--- a/tracing-mock/Cargo.toml
+++ b/tracing-mock/Cargo.toml
@@ -1,10 +1,6 @@
-## BIG SCARY NOTE
-# This Cargo.toml does not match the repo conventions YET
-# Before releasing to crates.io: make it so!
-
 [package]
 name = "tracing-mock"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "Hayden Stainsby <hds@caffeineconcepts.com>",

--- a/tracing-mock/README.md
+++ b/tracing-mock/README.md
@@ -16,9 +16,9 @@ Utilities for testing [`tracing`] and crates that uses it.
 [Documentation][docs-v0.2.x-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-mock.svg
-[crates-url]: https://crates.io/crates/tracing-mock
+[crates-url]: https://crates.io/crates/tracing-mock/0.1.0-beta.2
 [docs-badge]: https://docs.rs/tracing-mock/badge.svg
-[docs-url]: https://docs.rs/tracing-mock/latest
+[docs-url]: https://docs.rs/tracing-mock/0.1.0-beta.2
 [docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
 [docs-v0.2.x-url]: https://tracing.rs/tracing_mock
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -57,14 +57,14 @@ To do so, add the following to `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing-mock = "= 0.1.0-beta.1"
+tracing-mock = "= 0.1.0-beta.2"
 ```
 
 [tracing-spans]: https://docs.rs/tracing/0.1/tracing/#spans
 [tracing-events]: https://docs.rs/tracing/0.1/tracing/#events
 [tracing-subscriber]: https://docs.rs/tracing/0.1/tracing/trait.Subscriber.html
-[mock-subscriber-mod]: https://docs.rs/tracing-mock/0.1.0-beta.1/tracing_mock/subscriber/index.html
-[`MockSubscriber`]: https://docs.rs/tracing-mock/0.1.0-beta.1/tracing_mock/subscriber/struct.MockSubscriber.html
+[mock-subscriber-mod]: https://docs.rs/tracing-mock/0.1.0-beta.2/tracing_mock/subscriber/index.html
+[`MockSubscriber`]: https://docs.rs/tracing-mock/0.1.0-beta.2/tracing_mock/subscriber/struct.MockSubscriber.html
 
 ## Examples
 


### PR DESCRIPTION
# 0.1.0-beta.2 (November 26, 2025)

### Added

- Add `on_register_dispatch` expectation for subscriber and layer mocks ([#3415])
- Add doctests for `on_register_dispatch` negative cases ([#3416])

### Changed

- `tracing`: updated to 0.1.42 ([#3418])

[#3415]: https://github.com/tokio-rs/tracing/pull/#3415
[#3416]: https://github.com/tokio-rs/tracing/pull/#3416
[#3418]: https://github.com/tokio-rs/tracing/pull/#3418