### PR TITLE
tracing: revert "make `valueset` macro sanitary"

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -2971,6 +2971,9 @@ macro_rules! valueset {
     ($fields:expr, $($kvs:tt)+) => {
         {
             #[allow(unused_imports)]
+            // This import statement CANNOT be removed as it will break existing use cases.
+            // See #831, #2332, #3424 for the last times we tried.
+            use $crate::field::{debug, display, Value};
             $fields.value_set_all($crate::valueset!(
                 @ { },
                 $($kvs)+

--- a/tracing/tests/macros.rs
+++ b/tracing/tests/macros.rs
@@ -42,6 +42,12 @@ fn span() {
     span!(Level::DEBUG, "foo", bar.baz = %2);
     span!(Level::DEBUG, "foo");
     span!(Level::DEBUG, "bar",);
+    span!(
+        Level::DEBUG,
+        "bar",
+        foo = display("foo"),
+        quux = debug(::std::option::Option::Some(2))
+    );
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -58,6 +64,11 @@ fn trace_span() {
     trace_span!("foo", bar.baz = %2);
     trace_span!("bar");
     trace_span!("bar",);
+    trace_span!(
+        "bar",
+        foo = display("foo"),
+        quux = debug(::std::option::Option::Some(2))
+    );
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -74,6 +85,11 @@ fn debug_span() {
     debug_span!("foo", bar.baz = %2);
     debug_span!("bar");
     debug_span!("bar",);
+    debug_span!(
+        "bar",
+        foo = display("foo"),
+        quux = debug(::std::option::Option::Some(2))
+    );
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -90,6 +106,11 @@ fn info_span() {
     info_span!("foo", bar.baz = %2);
     info_span!("bar");
     info_span!("bar",);
+    info_span!(
+        "bar",
+        foo = display("foo"),
+        quux = debug(::std::option::Option::Some(2))
+    );
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -106,6 +127,11 @@ fn warn_span() {
     warn_span!("foo", bar.baz = %2);
     warn_span!("bar");
     warn_span!("bar",);
+    warn_span!(
+        "bar",
+        foo = display("foo"),
+        quux = debug(::std::option::Option::Some(2))
+    );
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -122,6 +148,11 @@ fn error_span() {
     error_span!("foo", bar.baz = %2);
     error_span!("bar");
     error_span!("bar",);
+    error_span!(
+        "bar",
+        foo = display("foo"),
+        quux = debug(::std::option::Option::Some(2))
+    );
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -452,6 +483,11 @@ fn event() {
     event!(Level::DEBUG, ?foo);
     event!(Level::DEBUG, %foo);
     event!(Level::DEBUG, foo);
+    event!(
+        Level::DEBUG,
+        foo = display("foo"),
+        quux = debug(::std::option::Option::Some(2))
+    );
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -621,9 +657,7 @@ fn trace() {
     trace!(target: "foo_events", %foo, true, "message");
     trace!(name: "foo", target: "foo_events", ?foo, true, "message");
     trace!(name: "foo", target: "foo_events", %foo, true, "message");
-    let debug = "debug";
-    let display = "display";
-    trace!("{debug:?} {display:?}");
+    trace!(foo = display("foo"), quux = debug(foo));
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -691,9 +725,7 @@ fn debug() {
     debug!(target: "foo_events", %foo, true, "message");
     debug!(name: "foo", target: "foo_events", ?foo, true, "message");
     debug!(name: "foo", target: "foo_events", %foo, true, "message");
-    let debug = "debug";
-    let display = "display";
-    debug!("{debug:?} {display:?}");
+    debug!(foo = display("foo"), quux = debug(foo));
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -761,9 +793,7 @@ fn info() {
     info!(target: "foo_events", %foo, true, "message");
     info!(name: "foo", target: "foo_events", ?foo, true, "message");
     info!(name: "foo", target: "foo_events", %foo, true, "message");
-    let debug = "debug";
-    let display = "display";
-    info!("{debug:?} {display:?}");
+    info!(foo = display("foo"), quux = debug(foo));
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -831,9 +861,7 @@ fn warn() {
     warn!(target: "foo_events", %foo, true, "message");
     warn!(name: "foo", target: "foo_events", ?foo, true, "message");
     warn!(name: "foo", target: "foo_events", %foo, true, "message");
-    let debug = "debug";
-    let display = "display";
-    warn!("{debug:?} {display:?}");
+    warn!(foo = display("foo"), quux = debug(foo));
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -901,9 +929,7 @@ fn error() {
     error!(target: "foo_events", %foo, true, "message");
     error!(name: "foo", target: "foo_events", ?foo, true, "message");
     error!(name: "foo", target: "foo_events", %foo, true, "message");
-    let debug = "debug";
-    let display = "display";
-    error!("{debug:?} {display:?}");
+    error!(foo = display("foo"), quux = debug(foo));
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]


### PR DESCRIPTION
## Motivation

The change merged in #3382 caused a breaking change when released. This
is because users of the tracing macros depend on being able to use a
bare `debug` or `display` function within the macro itself, for example:

```rust
tracing::info!(foo = debug(foo), bar = display(bar));
```

## Solution

This change reverts the breaking part of the original commit, which is
removing the import statement from the `valueset!` macro. However, it
leaves the change to use full module paths inside the macro. E.g.
`$crate::field::debug`. This is best practice, and so worth keeping.

This change also adds a nice warning comment above the import statement
to try and avoid another break happening in the future (because this
isn't the first time that this has happened). It also adds explicit
tests for the use of bare `debug` and `display` usage with the same end.
