### PR TITLE
chore: prepare tracing 0.1.43

### DIFF
--- a/tracing-mock/Cargo.toml
+++ b/tracing-mock/Cargo.toml
@@ -25,7 +25,7 @@ edition = "2018"
 rust-version = "1.65.0"
 
 [dependencies]
-tracing = { path = "../tracing", version = "0.1.42", features = ["std", "attributes"], default-features = false }
+tracing = { path = "../tracing", version = "0.1.43", features = ["std", "attributes"], default-features = false }
 tracing-core = { path = "../tracing-core", version = "0.1.28", default-features = false }
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3", default-features = false, features = ["registry"], optional = true }
 

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -44,7 +44,7 @@ regex = []
 tracing-core = { path = "../tracing-core", version = "0.1.35", default-features = false }
 
 # only required by the filter feature
-tracing = { optional = true, path = "../tracing", version = "0.1.42", default-features = false }
+tracing = { optional = true, path = "../tracing", version = "0.1.43", default-features = false }
 matchers = { optional = true, version = "0.2.0" }
 # required to have matchers::BuildError implement std::error::Error
 regex-automata = { optional = true, version = "0.4", default-features = false, features = ["std"] }
@@ -74,7 +74,7 @@ valuable_crate = { package = "valuable", version = "0.1.0", optional = true, def
 valuable-serde = { version = "0.1.0", optional = true, default-features = false }
 
 [dev-dependencies]
-tracing = { path = "../tracing", version = "0.1.42" }
+tracing = { path = "../tracing", version = "0.1.43" }
 tracing-mock = { path = "../tracing-mock", features = ["tracing-subscriber"] }
 log = "0.4.17"
 tracing-log = { path = "../tracing-log", version = "0.2.0" }

--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 0.1.43 (November 28, 2025)
+
+#### Important
+
+The previous release [0.1.42] was yanked because [#3382] was a breaking change.
+See further details in [#3424]. This release contains all the changes from that
+version, plus a revert for the problematic part of the breaking PR.
+
+### Fixed
+
+- Revert "make `valueset` macro sanitary" ([#3425])
+
+[#3382]: https://github.com/tokio-rs/tracing/pull/3382
+[#3424]: https://github.com/tokio-rs/tracing/pull/3424
+[#3425]: https://github.com/tokio-rs/tracing/pull/3425
+[0.1.42]: https://github.com/tokio-rs/tracing/releases/tag/tracing-0.1.42
+
 # 0.1.42 (November 26, 2025)
 
 ### Important
@@ -30,17 +47,17 @@ be used outside of `tracing` macros.
 
 - **core**: Add missing `dyn` keyword in `Visit` documentation code sample ([#3387])
 
-[#2983]: https://github.com/tokio-rs/tracing/pull/#2983
-[#3130]: https://github.com/tokio-rs/tracing/pull/#3130
-[#3158]: https://github.com/tokio-rs/tracing/pull/#3158
-[#3227]: https://github.com/tokio-rs/tracing/pull/#3227
-[#3373]: https://github.com/tokio-rs/tracing/pull/#3373
-[#3374]: https://github.com/tokio-rs/tracing/pull/#3374
-[#3382]: https://github.com/tokio-rs/tracing/pull/#3382
-[#3387]: https://github.com/tokio-rs/tracing/pull/#3387
-[#3398]: https://github.com/tokio-rs/tracing/pull/#3398
-[#3414]: https://github.com/tokio-rs/tracing/pull/#3414
-[#3417]: https://github.com/tokio-rs/tracing/pull/#3417
+[#2983]: https://github.com/tokio-rs/tracing/pull/2983
+[#3130]: https://github.com/tokio-rs/tracing/pull/3130
+[#3158]: https://github.com/tokio-rs/tracing/pull/3158
+[#3227]: https://github.com/tokio-rs/tracing/pull/3227
+[#3373]: https://github.com/tokio-rs/tracing/pull/3373
+[#3374]: https://github.com/tokio-rs/tracing/pull/3374
+[#3382]: https://github.com/tokio-rs/tracing/pull/3382
+[#3387]: https://github.com/tokio-rs/tracing/pull/3387
+[#3398]: https://github.com/tokio-rs/tracing/pull/3398
+[#3414]: https://github.com/tokio-rs/tracing/pull/3414
+[#3417]: https://github.com/tokio-rs/tracing/pull/3417
 [`Span::record_all`]: https://docs.rs/tracing/0.1.41/tracing/struct.Span.html#method.record_all
 
 # 0.1.41 (November 27, 2024)

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -5,7 +5,7 @@ name = "tracing"
 # - Update doc url in README.md.
 # - Update CHANGELOG.md.
 # - Create "tracing-0.1.x" git tag
-version = "0.1.42"
+version = "0.1.43"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -16,9 +16,9 @@ Application-level tracing for Rust.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.42
+[crates-url]: https://crates.io/crates/tracing/0.1.43
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.42
+[docs-url]: https://docs.rs/tracing/0.1.43
 [docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
 [docs-v0.2.x-url]: https://tracing.rs/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -250,7 +250,7 @@ my_future
 is as long as the future's.
 
 The second, and preferred, option is through the
-[`#[instrument]`](https://docs.rs/tracing/0.1.42/tracing/attr.instrument.html)
+[`#[instrument]`](https://docs.rs/tracing/0.1.43/tracing/attr.instrument.html)
 attribute:
 
 ```rust
@@ -297,7 +297,7 @@ span.in_scope(|| {
 // Dropping the span will close it, indicating that it has ended.
 ```
 
-The [`#[instrument]`](https://docs.rs/tracing/0.1.42/tracing/attr.instrument.html) attribute macro
+The [`#[instrument]`](https://docs.rs/tracing/0.1.43/tracing/attr.instrument.html) attribute macro
 can reduce some of this boilerplate:
 
 ```rust


### PR DESCRIPTION
# 0.1.43 (November 28, 2025)

#### Important

The previous release [0.1.42] was yanked because [#3382] was a breaking change.
See further details in [#3424]. This release contains all the changes from that
version, plus a revert for the problematic part of the breaking PR.

### Fixed

- Revert "make `valueset` macro sanitary" ([#3425])

[#3382]: https://github.com/tokio-rs/tracing/pull/3382
[#3424]: https://github.com/tokio-rs/tracing/pull/3424
[#3425]: https://github.com/tokio-rs/tracing/pull/3425
[0.1.42]: https://github.com/tokio-rs/tracing/releases/tag/tracing-0.1.42