### PR TITLE
chore: prepare tracing-subscriber 0.3.22

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 0.3.22 (November 28, 2025)
+
+#### Important
+
+The previous release [0.3.21] was yanked as it depended explicitly on
+[tracing-0.1.42], which was yanked due to a breaking change (see [#3424] for
+details). This release contains all the changes from the previous release, plus
+an update to the newer version of `tracing`.
+
+### Changed
+
+- `tracing`: updated to 0.1.43 ([#3427])
+
+[#3424]: https://github.com/tokio-rs/tracing/pull/3424
+[#3427]: https://github.com/tokio-rs/tracing/pull/3427
+[0.3.21]: https://github.com/tokio-rs/tracing/releases/tag/tracing-subscriber-0.3.21
+[tracing-0.1.42]: https://github.com/tokio-rs/tracing/releases/tag/tracing-0.1.42
+
 # 0.3.21 (November 26, 2025)
 
 ### Fixed
@@ -19,13 +37,13 @@
 - Fix extra closing brace in layer docs ([#3350])
 - Fix link in `FmtSpan` docs ([#3411])
 
-[#3289]: https://github.com/tokio-rs/tracing/pull/#3289
-[#3331]: https://github.com/tokio-rs/tracing/pull/#3331
-[#3339]: https://github.com/tokio-rs/tracing/pull/#3339
-[#3350]: https://github.com/tokio-rs/tracing/pull/#3350
-[#3379]: https://github.com/tokio-rs/tracing/pull/#3379
-[#3411]: https://github.com/tokio-rs/tracing/pull/#3411
-[#3418]: https://github.com/tokio-rs/tracing/pull/#3418
+[#3289]: https://github.com/tokio-rs/tracing/pull/3289
+[#3331]: https://github.com/tokio-rs/tracing/pull/3331
+[#3339]: https://github.com/tokio-rs/tracing/pull/3339
+[#3350]: https://github.com/tokio-rs/tracing/pull/3350
+[#3379]: https://github.com/tokio-rs/tracing/pull/3379
+[#3411]: https://github.com/tokio-rs/tracing/pull/3411
+[#3418]: https://github.com/tokio-rs/tracing/pull/3418
 
 # 0.3.20 (August 29, 2025)
 
@@ -39,8 +57,8 @@
 
 - Implement `Clone` for `EnvFilter` ([#3360])
 
-[#3360]: https://github.com/tokio-rs/tracing/pull/#3360
-[#3368]: https://github.com/tokio-rs/tracing/pull/#3368
+[#3360]: https://github.com/tokio-rs/tracing/pull/3360
+[#3368]: https://github.com/tokio-rs/tracing/pull/3368
 [docs-0.3.20]: https://docs.rs/tracing-subscriber/0.3.20/tracing_subscriber/
 [crate-0.3.20]: https://crates.io/crates/tracing-subscriber/0.3.20
 

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.3.21"
+version = "0.3.22"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -29,9 +29,9 @@ application authors using `tracing` to instrument their applications.
 [tracing]: https://github.com/tokio-rs/tracing/tree/main/tracing
 [tracing-fmt]: https://github.com/tokio-rs/tracing/tree/main/tracing-subscriber
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
-[crates-url]: https://crates.io/crates/tracing-subscriber/0.3.21
+[crates-url]: https://crates.io/crates/tracing-subscriber/0.3.22
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.3.21
+[docs-url]: https://docs.rs/tracing-subscriber/0.3.22
 [docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
 [docs-v0.2.x-url]: https://tracing.rs/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg


### PR DESCRIPTION
# 0.3.22 (November 28, 2025)

#### Important

The previous release [0.3.21] was yanked as it depended explicitly on
[tracing-0.1.42], which was yanked due to a breaking change (see [#3424] for
details). This release contains all the changes from the previous release, plus
an update to the newer version of `tracing`.

### Changed

- `tracing`: updated to 0.1.43 ([#3427])

[#3424]: https://github.com/tokio-rs/tracing/pull/3424
[#3427]: https://github.com/tokio-rs/tracing/pull/3427
[0.3.21]: https://github.com/tokio-rs/tracing/releases/tag/tracing-subscriber-0.3.21
[tracing-0.1.42]: https://github.com/tokio-rs/tracing/releases/tag/tracing-0.1.42