### PR TITLE
chore: prepare tracing-mock 0.1.0-beta.3

### DIFF
--- a/tracing-mock/CHANGELOG.md
+++ b/tracing-mock/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 0.1.0-beta.3 (November 28, 2025)
+
+#### Important
+
+The previous release [0.1.0-beta.2] was yanked as it depended explicitly on
+[tracing-0.1.42], which was yanked due to a breaking change (see [#3424] for
+details). This release contains all the changes from the previous release, plus
+an update to the newer version of `tracing`.
+
+### Changed
+
+- `tracing`: updated to 0.1.43 ([#3427])
+
+[#3424]: https://github.com/tokio-rs/tracing/pull/3424
+[#3427]: https://github.com/tokio-rs/tracing/pull/3427
+[0.1.0-beta.2]: https://github.com/tokio-rs/tracing/releases/tag/tracing-mock-0.1.0-beta.2
+[tracing-0.1.42]: https://github.com/tokio-rs/tracing/releases/tag/tracing-0.1.42
+
 # 0.1.0-beta.2 (November 26, 2025)
 
 ### Added
@@ -9,9 +27,9 @@
 
 - `tracing`: updated to 0.1.42 ([#3418])
 
-[#3415]: https://github.com/tokio-rs/tracing/pull/#3415
-[#3416]: https://github.com/tokio-rs/tracing/pull/#3416
-[#3418]: https://github.com/tokio-rs/tracing/pull/#3418
+[#3415]: https://github.com/tokio-rs/tracing/pull/3415
+[#3416]: https://github.com/tokio-rs/tracing/pull/3416
+[#3418]: https://github.com/tokio-rs/tracing/pull/3418
 
 # 0.1.0-beta.1 (November 29, 2024)
 

--- a/tracing-mock/Cargo.toml
+++ b/tracing-mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-mock"
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "Hayden Stainsby <hds@caffeineconcepts.com>",

--- a/tracing-mock/README.md
+++ b/tracing-mock/README.md
@@ -16,9 +16,9 @@ Utilities for testing [`tracing`] and crates that uses it.
 [Documentation][docs-v0.2.x-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-mock.svg
-[crates-url]: https://crates.io/crates/tracing-mock/0.1.0-beta.2
+[crates-url]: https://crates.io/crates/tracing-mock/0.1.0-beta.3
 [docs-badge]: https://docs.rs/tracing-mock/badge.svg
-[docs-url]: https://docs.rs/tracing-mock/0.1.0-beta.2
+[docs-url]: https://docs.rs/tracing-mock/0.1.0-beta.3
 [docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
 [docs-v0.2.x-url]: https://tracing.rs/tracing_mock
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -57,14 +57,14 @@ To do so, add the following to `Cargo.toml`:
 
 ```toml
 [dependencies]
-tracing-mock = "= 0.1.0-beta.2"
+tracing-mock = "= 0.1.0-beta.3"
 ```
 
 [tracing-spans]: https://docs.rs/tracing/0.1/tracing/#spans
 [tracing-events]: https://docs.rs/tracing/0.1/tracing/#events
 [tracing-subscriber]: https://docs.rs/tracing/0.1/tracing/trait.Subscriber.html
-[mock-subscriber-mod]: https://docs.rs/tracing-mock/0.1.0-beta.2/tracing_mock/subscriber/index.html
-[`MockSubscriber`]: https://docs.rs/tracing-mock/0.1.0-beta.2/tracing_mock/subscriber/struct.MockSubscriber.html
+[mock-subscriber-mod]: https://docs.rs/tracing-mock/0.1.0-beta.3/tracing_mock/subscriber/index.html
+[`MockSubscriber`]: https://docs.rs/tracing-mock/0.1.0-beta.3/tracing_mock/subscriber/struct.MockSubscriber.html
 
 ## Examples
 


### PR DESCRIPTION
# 0.1.0-beta.3 (November 28, 2025)

#### Important

The previous release [0.1.0-beta.2] was yanked as it depended explicitly on
[tracing-0.1.42], which was yanked due to a breaking change (see [#3424] for
details). This release contains all the changes from the previous release, plus
an update to the newer version of `tracing`.

### Changed

- `tracing`: updated to 0.1.43 ([#3427])

[#3424]: https://github.com/tokio-rs/tracing/pull/3424
[#3427]: https://github.com/tokio-rs/tracing/pull/3427
[0.1.0-beta.2]: https://github.com/tokio-rs/tracing/releases/tag/tracing-mock-0.1.0-beta.2
[tracing-0.1.42]: https://github.com/tokio-rs/tracing/releases/tag/tracing-0.1.42