### PR TITLE
chore: prepare tracing 0.1.44

### DIFF
--- a/tracing/CHANGELOG.md
+++ b/tracing/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.1.44 (December 18, 2025)
+
+### Fixed
+
+- Fix `record_all` panic ([#3432])
+
+### Changed
+
+- `tracing-core`: updated to 0.1.36 ([#3440])
+
+[#3432]: https://github.com/tokio-rs/tracing/pull/3432
+[#3440]: https://github.com/tokio-rs/tracing/pull/3440
+
 # 0.1.43 (November 28, 2025)
 
 #### Important

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -5,7 +5,7 @@ name = "tracing"
 # - Update doc url in README.md.
 # - Update CHANGELOG.md.
 # - Create "tracing-0.1.x" git tag
-version = "0.1.43"
+version = "0.1.44"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -16,9 +16,9 @@ Application-level tracing for Rust.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing.svg
-[crates-url]: https://crates.io/crates/tracing/0.1.43
+[crates-url]: https://crates.io/crates/tracing/0.1.44
 [docs-badge]: https://docs.rs/tracing/badge.svg
-[docs-url]: https://docs.rs/tracing/0.1.43
+[docs-url]: https://docs.rs/tracing/0.1.44
 [docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
 [docs-v0.2.x-url]: https://tracing.rs/tracing
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -250,7 +250,7 @@ my_future
 is as long as the future's.
 
 The second, and preferred, option is through the
-[`#[instrument]`](https://docs.rs/tracing/0.1.43/tracing/attr.instrument.html)
+[`#[instrument]`](https://docs.rs/tracing/0.1.44/tracing/attr.instrument.html)
 attribute:
 
 ```rust
@@ -297,7 +297,7 @@ span.in_scope(|| {
 // Dropping the span will close it, indicating that it has ended.
 ```
 
-The [`#[instrument]`](https://docs.rs/tracing/0.1.43/tracing/attr.instrument.html) attribute macro
+The [`#[instrument]`](https://docs.rs/tracing/0.1.44/tracing/attr.instrument.html) attribute macro
 can reduce some of this boilerplate:
 
 ```rust


### PR DESCRIPTION
# 0.1.44 (December 18, 2025)

### Fixed

- Fix `record_all` panic ([#3432])

### Changed

- `tracing-core`: updated to 0.1.36 ([#3440])

[#3432]: https://github.com/tokio-rs/tracing/pull/3432
[#3440]: https://github.com/tokio-rs/tracing/pull/3440