### PR TITLE
chore: prepare tracing-core 0.1.36

### DIFF
--- a/tracing-core/CHANGELOG.md
+++ b/tracing-core/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.36 (December 18, 2025)
+
+- Fix `record_all` panic ([#3432])
+
+[#3432]: https://github.com/tokio-rs/tracing/pull/3432
+
 # 0.1.35 (November 26, 2025)
 
 ### Added

--- a/tracing-core/Cargo.toml
+++ b/tracing-core/Cargo.toml
@@ -6,7 +6,7 @@ name = "tracing-core"
 # - Update doc url in README.md.
 # - Update CHANGELOG.md.
 # - Create "tracing-core-0.1.x" git tag.
-version = "0.1.35"
+version = "0.1.36"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tracing-core/README.md
+++ b/tracing-core/README.md
@@ -16,9 +16,9 @@ Core primitives for application-level tracing.
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-core.svg
-[crates-url]: https://crates.io/crates/tracing-core/0.1.35
+[crates-url]: https://crates.io/crates/tracing-core/0.1.36
 [docs-badge]: https://docs.rs/tracing-core/badge.svg
-[docs-url]: https://docs.rs/tracing-core/0.1.35
+[docs-url]: https://docs.rs/tracing-core/0.1.36
 [docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
 [docs-v0.2.x-url]: https://tracing.rs/tracing_core
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -79,22 +79,22 @@ The following crate feature flags are available:
 
   ```toml
   [dependencies]
-  tracing-core = { version = "0.1.35", default-features = false }
+  tracing-core = { version = "0.1.36", default-features = false }
   ```
 
   **Note**:`tracing-core`'s `no_std` support requires `liballoc`.
 
 [`tracing`]: ../tracing
-[`span::Id`]: https://docs.rs/tracing-core/0.1.35/tracing_core/span/struct.Id.html
-[`Event`]: https://docs.rs/tracing-core/0.1.35/tracing_core/event/struct.Event.html
-[`Subscriber`]: https://docs.rs/tracing-core/0.1.35/tracing_core/subscriber/trait.Subscriber.html
-[`Metadata`]: https://docs.rs/tracing-core/0.1.35/tracing_core/metadata/struct.Metadata.html
-[`Callsite`]: https://docs.rs/tracing-core/0.1.35/tracing_core/callsite/trait.Callsite.html
-[`Field`]: https://docs.rs/tracing-core/0.1.35/tracing_core/field/struct.Field.html
-[`FieldSet`]: https://docs.rs/tracing-core/0.1.35/tracing_core/field/struct.FieldSet.html
-[`Value`]: https://docs.rs/tracing-core/0.1.35/tracing_core/field/trait.Value.html
-[`ValueSet`]: https://docs.rs/tracing-core/0.1.35/tracing_core/field/struct.ValueSet.html
-[`Dispatch`]: https://docs.rs/tracing-core/0.1.35/tracing_core/dispatcher/struct.Dispatch.html
+[`span::Id`]: https://docs.rs/tracing-core/0.1.36/tracing_core/span/struct.Id.html
+[`Event`]: https://docs.rs/tracing-core/0.1.36/tracing_core/event/struct.Event.html
+[`Subscriber`]: https://docs.rs/tracing-core/0.1.36/tracing_core/subscriber/trait.Subscriber.html
+[`Metadata`]: https://docs.rs/tracing-core/0.1.36/tracing_core/metadata/struct.Metadata.html
+[`Callsite`]: https://docs.rs/tracing-core/0.1.36/tracing_core/callsite/trait.Callsite.html
+[`Field`]: https://docs.rs/tracing-core/0.1.36/tracing_core/field/struct.Field.html
+[`FieldSet`]: https://docs.rs/tracing-core/0.1.36/tracing_core/field/struct.FieldSet.html
+[`Value`]: https://docs.rs/tracing-core/0.1.36/tracing_core/field/trait.Value.html
+[`ValueSet`]: https://docs.rs/tracing-core/0.1.36/tracing_core/field/struct.ValueSet.html
+[`Dispatch`]: https://docs.rs/tracing-core/0.1.36/tracing_core/dispatcher/struct.Dispatch.html
 
 ## Supported Rust Versions
 

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -25,7 +25,7 @@ edition = "2018"
 rust-version = "1.65.0"
 
 [dependencies]
-tracing-core = { path = "../tracing-core", version = "0.1.35", default-features = false }
+tracing-core = { path = "../tracing-core", version = "0.1.36", default-features = false }
 log = { version = "0.4.17", optional = true }
 tracing-attributes = { path = "../tracing-attributes", version = "0.1.31", optional = true }
 pin-project-lite = "0.2.9"


### PR DESCRIPTION
# 0.1.36 (December 18, 2025)

- Fix `record_all` panic ([#3432])

[#3432]: https://github.com/tokio-rs/tracing/pull/3432