### PR TITLE
feat(appender): Make `Rotation` and `RotationKind` derive `Copy`

### DIFF
--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -480,10 +480,10 @@ pub fn never(directory: impl AsRef<Path>, file_name: impl AsRef<Path>) -> Rollin
 /// let rotation = tracing_appender::rolling::Rotation::NEVER;
 /// # }
 /// ```
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub struct Rotation(RotationKind);
 
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
 enum RotationKind {
     Minutely,
     Hourly,


### PR DESCRIPTION
This pull requests makes the `Rotation` struct and the `RotationKind` enum derive the `Copy` trait.

## Motivation

Currently [`Builder::rotation`](https://github.com/tokio-rs/tracing/blob/9feb241133e55e70c7d4399689b8ef72f71d070f/tracing-appender/src/rolling/builder.rs#L82) expects an owned `Rotation` value. I ran into a complication where I provided this value as part of a struct which got passed as a reference and then had to clone the `Rotation` value because of it. I believe that it instead should derive the `Copy` trait so cloning wont be necessary anymore.


Because of the simplicity of the `Rotation` struct and `RotationKind` enum I think this should not cause any issues down the line.

## Solution

Derive the `Copy` trait for the `Rotation` struct and the `RotationKind` enum.
