### PR TITLE
core: add missing const

### DIFF
--- a/tracing-core/src/sync.rs
+++ b/tracing-core/src/sync.rs
@@ -11,7 +11,7 @@ pub(crate) struct Mutex<T> {
 }
 
 impl<T> Mutex<T> {
-    pub(crate) fn new(data: T) -> Self {
+    pub(crate) const fn new(data: T) -> Self {
         Self {
             inner: crate::spin::Mutex::new(data),
         }


### PR DESCRIPTION
I used auto-merge in #3314 and it merged despite CI failing...
