### PR TITLE
Enable suppport for Valuable in instrument macro

### DIFF
--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -35,6 +35,9 @@ proc-macro = true
 # This feature flag is no longer necessary.
 async-await = []
 
+# Enable experimental support for valuable crate
+valuable = ["tracing/valuable"]
+
 [dependencies]
 proc-macro2 = "1.0.60"
 syn = { version = "2.0", default-features = false, features = [
@@ -65,3 +68,11 @@ maintenance = { status = "experimental" }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+# enable unstable features in the documentation
+rustdoc-args = ["--cfg", "docsrs", "--cfg", "tracing_unstable"]
+# it's necessary to _also_ pass `--cfg tracing_unstable` to rustc, or else
+# dependencies will not be enabled, and the docs build will fail.
+rustc-args = ["--cfg", "tracing_unstable"]

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -36,7 +36,7 @@ proc-macro = true
 async-await = []
 
 # Enable experimental support for valuable crate
-valuable = ["tracing/valuable"]
+valuable = []
 
 [dependencies]
 proc-macro2 = "1.0.60"
@@ -52,7 +52,7 @@ syn = { version = "2.0", default-features = false, features = [
 quote = "1.0.20"
 
 [dev-dependencies]
-tracing = { path = "../tracing", version = "0.1.42" }
+tracing = { path = "../tracing", version = "0.1.42", features = ["valuable"] }
 tracing-mock = { path = "../tracing-mock" }
 tokio-test = "0.4.2"
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3.0", features = [

--- a/tracing-attributes/src/attr.rs
+++ b/tracing-attributes/src/attr.rs
@@ -171,6 +171,13 @@ impl EventArgs {
     }
 }
 
+#[cfg(all(tracing_unstable, feature = "valuable"))]
+const FORMATTING_MODE_ERR: &str =
+    "unknown event formatting mode, expected either `Debug`, `Valuable` or `Display`";
+#[cfg(not(all(tracing_unstable, feature = "valuable")))]
+const FORMATTING_MODE_ERR: &str =
+    "unknown event formatting mode, expected either `Debug` or `Display`";
+
 impl Parse for EventArgs {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         if !input.peek(syn::token::Paren) {
@@ -179,28 +186,26 @@ impl Parse for EventArgs {
         let content;
         let _ = syn::parenthesized!(content in input);
         let mut result = Self::default();
-        let mut parse_one_arg =
-            || {
-                let lookahead = content.lookahead1();
-                if lookahead.peek(kw::level) {
-                    if result.level.is_some() {
-                        return Err(content.error("expected only a single `level` argument"));
-                    }
-                    result.level = Some(content.parse()?);
-                } else if result.mode != FormatMode::default() {
-                    return Err(content.error("expected only a single format argument"));
-                } else if let Some(ident) = content.parse::<Option<Ident>>()? {
-                    match ident.to_string().as_str() {
-                        "Debug" => result.mode = FormatMode::Debug,
-                        "Display" => result.mode = FormatMode::Display,
-                        _ => return Err(syn::Error::new(
-                            ident.span(),
-                            "unknown event formatting mode, expected either `Debug` or `Display`",
-                        )),
-                    }
+        let mut parse_one_arg = || {
+            let lookahead = content.lookahead1();
+            if lookahead.peek(kw::level) {
+                if result.level.is_some() {
+                    return Err(content.error("expected only a single `level` argument"));
                 }
-                Ok(())
-            };
+                result.level = Some(content.parse()?);
+            } else if result.mode != FormatMode::default() {
+                return Err(content.error("expected only a single format argument"));
+            } else if let Some(ident) = content.parse::<Option<Ident>>()? {
+                match ident.to_string().as_str() {
+                    "Debug" => result.mode = FormatMode::Debug,
+                    "Display" => result.mode = FormatMode::Display,
+                    #[cfg(all(tracing_unstable, feature = "valuable"))]
+                    "Valuable" => result.mode = FormatMode::Valuable,
+                    _ => return Err(syn::Error::new(ident.span(), FORMATTING_MODE_ERR)),
+                }
+            }
+            Ok(())
+        };
         parse_one_arg()?;
         if !content.is_empty() {
             if content.lookahead1().peek(Token![,]) {
@@ -301,6 +306,8 @@ pub(crate) enum FormatMode {
     Default,
     Display,
     Debug,
+    #[cfg(all(tracing_unstable, feature = "valuable"))]
+    Valuable,
 }
 
 #[derive(Clone, Debug)]

--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -275,6 +275,10 @@ fn gen_block<B: ToTokens>(
                 FormatMode::Debug => Some(quote!(
                     ::tracing::event!(target: #target, #level_tokens, error = ?e)
                 )),
+                #[cfg(all(tracing_unstable, feature = "valuable"))]
+                FormatMode::Valuable => Some(quote!(::tracing::event!(
+                    target: #target, #level_tokens, error = ::tracing::field::valuable(&e),
+                ))),
             }
         }
         _ => None,
@@ -290,6 +294,10 @@ fn gen_block<B: ToTokens>(
                 FormatMode::Default | FormatMode::Debug => Some(quote!(
                     ::tracing::event!(target: #target, #level_tokens, return = ?x)
                 )),
+                #[cfg(all(tracing_unstable, feature = "valuable"))]
+                FormatMode::Valuable => Some(quote!(::tracing::event!(
+                    target: #target, #level_tokens, return = ::tracing::field::valuable(&x),
+                ))),
             }
         }
         _ => None,

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -52,6 +52,18 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 //!
+//! ## Experimental features
+//!
+//! The [`#[instrument]`][instrument] attribute supports the experimental
+//! `valuable` cargo feature to allow recording both the return value and the
+//! error values returned in the [`variant@Result::Err`] variant using the
+//! [valuable::Valuable][`Valuable`] trait. To take advantage of this feature
+//! you also need to enable [unstable features] of the [`tracing`] crate.
+//!
+//! [`Valuable`]: https://docs.rs/valuable/latest/valuable/trait.Valuable.html
+//! [unstable features]:
+//! https://docs.rs/tracing/latest/tracing/index.html#unstable-features
+//!
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/logo-type.png",
     html_favicon_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/favicon.ico",
@@ -465,6 +477,20 @@ mod expand;
 /// }
 /// ```
 ///
+/// If the experimental support for the [`valuable`] crate is enabled using the `valuable` cargo
+/// feature, and the return type implements the [`Valuable` trait] it can be recorded using the
+/// [`tracing::field::valuable`] implementation, by writing `ret(Valuable)`:
+///
+/// ```
+/// # use tracing_attributes::instrument;
+/// #[instrument(ret(Valuable))]
+/// fn my_function() -> i32 {
+///     42
+/// }
+/// ```
+/// **Note**: To enable support for [`valuable`] you must first enable unstable tracing features.
+/// See [unstable features] documentation of the `tracing` crate.
+///
 /// If the function returns a `Result<T, E>` and `E` implements `std::fmt::Display`, adding
 /// `err` or `err(Display)` will emit error events when the function returns `Err`:
 ///
@@ -500,6 +526,21 @@ mod expand;
 ///     Ok(())
 /// }
 /// ```
+///
+/// For error values that implement the [`Valuable` trait] it is also possible to record them as a
+/// [`Valuable` trait] using the experimental [`valuable`] support by writing `err(Valuable)`:
+///
+/// ```
+/// # use tracing_attributes::instrument;
+/// # use std::error::Error;
+/// #[instrument(err(Valuable))]
+/// fn my_function(arg: usize) -> Result<(), &'static dyn Error> {
+///     Ok(())
+/// }
+/// ```
+///
+/// **Note**: this requires enabling both the `valuable` cargo feature and [unstable features]
+/// of the `tracing` crate.
 ///
 /// If a `target` is specified, both the `ret` and `err` arguments will emit outputs to
 /// the declared target (or the default channel if `target` is not specified).
@@ -572,6 +613,10 @@ mod expand;
 /// [`Level`]: https://docs.rs/tracing/latest/tracing/struct.Level.html
 /// [`Level::TRACE`]: https://docs.rs/tracing/latest/tracing/struct.Level.html#associatedconstant.TRACE
 /// [`Level::ERROR`]: https://docs.rs/tracing/latest/tracing/struct.Level.html#associatedconstant.ERROR
+/// [unstable features]: https://docs.rs/tracing/latest/tracing/#unstable-features
+/// [`valuable`]: https://docs.rs/valuable/latest/valuable/
+/// [`Valuable` trait]: https://docs.rs/valuable/latest/valuable/trait.Valuable.html
+/// [`tracing::field::valuable`]: https://docs.rs/tracing/latest/tracing/field/fn.valuable.html
 #[proc_macro_attribute]
 pub fn instrument(
     args: proc_macro::TokenStream,

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -482,11 +482,13 @@ mod expand;
 /// [`tracing::field::valuable`] implementation, by writing `ret(Valuable)`:
 ///
 /// ```
+/// # #[cfg(all(tracing_unstable, feature = "valuable"))] {
 /// # use tracing_attributes::instrument;
 /// #[instrument(ret(Valuable))]
 /// fn my_function() -> i32 {
 ///     42
 /// }
+/// # }
 /// ```
 /// **Note**: To enable support for [`valuable`] you must first enable unstable tracing features.
 /// See [unstable features] documentation of the `tracing` crate.
@@ -531,12 +533,14 @@ mod expand;
 /// [`Valuable` trait] using the experimental [`valuable`] support by writing `err(Valuable)`:
 ///
 /// ```
+/// # #[cfg(all(tracing_unstable, feature = "valuable"))] {
 /// # use tracing_attributes::instrument;
 /// # use std::error::Error;
 /// #[instrument(err(Valuable))]
 /// fn my_function(arg: usize) -> Result<(), &'static dyn Error> {
 ///     Ok(())
 /// }
+/// # }
 /// ```
 ///
 /// **Note**: this requires enabling both the `valuable` cargo feature and [unstable features]

--- a/tracing-attributes/tests/ret.rs
+++ b/tracing-attributes/tests/ret.rs
@@ -306,3 +306,220 @@ fn test_dbg_warn() {
     with_default(subscriber, ret_dbg_warn);
     handle.assert_finished();
 }
+
+#[cfg(all(tracing_unstable, feature = "valuable"))]
+mod valuable {
+    use tracing::{subscriber::with_default, Level};
+    use tracing_attributes::instrument;
+    use tracing_mock::{expect, subscriber};
+
+    #[instrument(ret(Valuable))]
+    fn ret_valuable_info() -> i32 {
+        42
+    }
+
+    #[test]
+    fn test_ret_valuable_info() {
+        let span = expect::span()
+            .named("ret_valuable_info")
+            .at_level(Level::INFO);
+
+        let (subscriber, handle) = subscriber::mock()
+            .new_span(span.clone())
+            .enter(span.clone())
+            .event(
+                expect::event()
+                    .with_fields(expect::field("return").with_value(&tracing::field::valuable(&42)))
+                    .at_level(Level::INFO),
+            )
+            .exit(span.clone())
+            .drop_span(span)
+            .only()
+            .run_with_handle();
+
+        with_default(subscriber, ret_valuable_info);
+        handle.assert_finished();
+    }
+
+    #[instrument(err(Valuable), ret(Valuable))]
+    fn ret_err_valuable_ok() -> Result<u8, String> {
+        Ok(0)
+    }
+
+    #[test]
+    fn test_ret_err_valuable_ok() {
+        let span = expect::span()
+            .named("ret_err_valuable_ok")
+            .at_level(Level::INFO);
+
+        let (subscriber, handle) = subscriber::mock()
+            .new_span(span.clone())
+            .enter(span.clone())
+            .event(
+                expect::event()
+                    .with_fields(
+                        expect::field("return").with_value(&tracing::field::valuable(&0u8)),
+                    )
+                    .at_level(Level::INFO),
+            )
+            .exit(span.clone())
+            .drop_span(span)
+            .only()
+            .run_with_handle();
+
+        with_default(subscriber, || ret_err_valuable_ok().ok());
+        handle.assert_finished();
+    }
+
+    #[instrument(err(Valuable), ret(Valuable))]
+    fn ret_err_valuable_err() -> Result<u8, String> {
+        Err("Error".to_string())
+    }
+
+    #[test]
+    fn test_ret_err_valuable_err() {
+        let span = expect::span()
+            .named("ret_err_valuable_err")
+            .at_level(Level::INFO);
+
+        let (subscriber, handle) = subscriber::mock()
+            .new_span(span.clone())
+            .enter(span.clone())
+            .event(
+                expect::event()
+                    .with_fields(
+                        expect::field("error")
+                            .with_value(&tracing::field::valuable(&String::from("Error"))),
+                    )
+                    .at_level(Level::ERROR),
+            )
+            .exit(span.clone())
+            .drop_span(span)
+            .only()
+            .run_with_handle();
+
+        with_default(subscriber, || ret_err_valuable_err().err());
+        handle.assert_finished();
+    }
+
+    #[instrument(err(Valuable), ret(Debug))]
+    fn ret_dbg_err_valuable_ok() -> Result<u8, String> {
+        Ok(10)
+    }
+
+    #[test]
+    fn test_ret_dbg_err_valuabe_ok() {
+        let span = expect::span()
+            .named("ret_dbg_err_valuable_ok")
+            .at_level(Level::INFO);
+
+        let (subscriber, handle) = subscriber::mock()
+            .new_span(span.clone())
+            .enter(span.clone())
+            .event(
+                expect::event()
+                    .with_fields(
+                        expect::field("return").with_value(&tracing::field::valuable(&10u8)),
+                    )
+                    .at_level(Level::INFO),
+            )
+            .exit(span.clone())
+            .drop_span(span)
+            .only()
+            .run_with_handle();
+
+        with_default(subscriber, || ret_dbg_err_valuable_ok().ok());
+        handle.assert_finished();
+    }
+
+    #[instrument(err(Valuable), ret(Debug))]
+    fn ret_dbg_err_valuable_err() -> Result<u8, String> {
+        Err("Failure".to_string())
+    }
+
+    #[test]
+    fn test_ret_dbg_err_valuabe_err() {
+        let span = expect::span()
+            .named("ret_dbg_err_valuable_err")
+            .at_level(Level::INFO);
+
+        let (subscriber, handle) = subscriber::mock()
+            .new_span(span.clone())
+            .enter(span.clone())
+            .event(
+                expect::event()
+                    .with_fields(
+                        expect::field("error")
+                            .with_value(&tracing::field::valuable(&String::from("Failure"))),
+                    )
+                    .at_level(Level::ERROR),
+            )
+            .exit(span.clone())
+            .drop_span(span)
+            .only()
+            .run_with_handle();
+
+        with_default(subscriber, || ret_dbg_err_valuable_err().err());
+        handle.assert_finished();
+    }
+
+    #[instrument(err(Valuable))]
+    fn err_valuable() -> Result<u8, String> {
+        Err("Valuable".to_string())
+    }
+
+    #[test]
+    fn test_err_valuable() {
+        let span = expect::span().named("err_valuable").at_level(Level::INFO);
+
+        let (subscriber, handle) = subscriber::mock()
+            .new_span(span.clone())
+            .enter(span.clone())
+            .event(
+                expect::event()
+                    .with_fields(
+                        expect::field("error")
+                            .with_value(&tracing::field::valuable(&String::from("Valuable"))),
+                    )
+                    .at_level(Level::ERROR),
+            )
+            .exit(span.clone())
+            .drop_span(span)
+            .only()
+            .run_with_handle();
+
+        with_default(subscriber, || err_valuable().err());
+        handle.assert_finished();
+    }
+
+    #[instrument(err(Valuable, level = "info"))]
+    fn err_valuable_info() -> Result<u8, String> {
+        Err("Info-Valuable".to_string())
+    }
+
+    #[test]
+    fn test_err_valuable_info() {
+        let span = expect::span()
+            .named("err_valuable_info")
+            .at_level(Level::INFO);
+
+        let (subscriber, handle) = subscriber::mock()
+            .new_span(span.clone())
+            .enter(span.clone())
+            .event(
+                expect::event()
+                    .with_fields(
+                        expect::field("error")
+                            .with_value(&tracing::field::valuable(&String::from("Info-Valuable"))),
+                    )
+                    .at_level(Level::INFO),
+            )
+            .exit(span.clone())
+            .drop_span(span)
+            .only()
+            .run_with_handle();
+
+        with_default(subscriber, || err_valuable_info().err());
+        handle.assert_finished();
+    }
+}

--- a/tracing-attributes/tests/ret.rs
+++ b/tracing-attributes/tests/ret.rs
@@ -402,13 +402,16 @@ mod valuable {
         handle.assert_finished();
     }
 
+    #[derive(Debug)]
+    struct NotValuable;
+
     #[instrument(err(Valuable), ret(Debug))]
-    fn ret_dbg_err_valuable_ok() -> Result<u8, String> {
-        Ok(10)
+    fn ret_dbg_err_valuable_ok() -> Result<NotValuable, String> {
+        Ok(NotValuable)
     }
 
     #[test]
-    fn test_ret_dbg_err_valuabe_ok() {
+    fn test_ret_dbg_err_valuable_ok() {
         let span = expect::span()
             .named("ret_dbg_err_valuable_ok")
             .at_level(Level::INFO);
@@ -419,7 +422,7 @@ mod valuable {
             .event(
                 expect::event()
                     .with_fields(
-                        expect::field("return").with_value(&tracing::field::valuable(&10u8)),
+                        expect::field("return").with_value(&tracing::field::debug(&NotValuable)),
                     )
                     .at_level(Level::INFO),
             )
@@ -438,7 +441,7 @@ mod valuable {
     }
 
     #[test]
-    fn test_ret_dbg_err_valuabe_err() {
+    fn test_ret_dbg_err_valuable_err() {
         let span = expect::span()
             .named("ret_dbg_err_valuable_err")
             .at_level(Level::INFO);

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -62,7 +62,7 @@ async-await = []
 std = ["tracing-core/std"]
 log-always = ["log"]
 attributes = ["tracing-attributes"]
-valuable = ["tracing-core/valuable"]
+valuable = ["tracing-core/valuable", "tracing-attributes?/valuable"]
 
 [[bench]]
 name = "baseline"


### PR DESCRIPTION
Extend the `instrument` macro to support recording the return and the error values using the `valuable::Valuable` implementation by writing `ret(Valuable)` and `err(Valuable)` respectively.

## Motivation
Tracing already comes with `valuable` support today for various fields. This can be either done through `value.as_value()` directy or by means of calling `tracing::field::valuable(value)`. However, it does not currently support recording return or error fields when using the `#[instrument(err)]` or `#[instrument(ret)]` values. Proposed change introduces this support.

This will further be used by the `tracing-opentelemetry` to record the `exception.type` field when the error value implements the `Valuable` trait and will allow serialization with `Valuable` for return types.

## Solution
The proposal here is pretty simple: add support for `err(Valuable)` and `ret(Valuable)`, guarded behind the `valuable` feature flag and also hidden behind the unstable cfg as per current `tracing` implementation.

Additional context in [Tokio Discord](https://discord.com/channels/500028886025895936/974721015999516672/1447533064640008294).