### PR TITLE
Cross-thread future crash: Add test and partial fix

### DIFF
--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -185,6 +185,23 @@ impl Registry {
         self.spans.get(id_to_idx(id))
     }
 
+    /// Attempts to clone a span, returning `None` if the span has already been closed.
+    ///
+    /// We handle the case where a span ID on the `current_spans` stack is stale (the
+    /// span has been closed). This can happen when `span.enter()` is used across await
+    /// points and the async task migrates to a different thread.
+    fn try_clone_span(&self, id: &Id) -> Option<Id> {
+        let span = self.get(id)?;
+        // Increment ref_count only if it's > 0. This is the same pattern used by
+        // `std::sync::Arc::Weak::upgrade()`
+        span.ref_count
+            .fetch_update(Ordering::Acquire, Ordering::Relaxed, |n| {
+                if n == 0 { None } else { Some(n + 1) }
+            })
+            .ok()
+            .map(|_| id.clone())
+    }
+
     /// Returns a guard which tracks how many `Layer`s have
     /// processed an `on_close` notification via the `CLOSE_COUNT` thread-local.
     /// For additional details, see [`CloseGuard`].
@@ -239,9 +256,9 @@ impl Subscriber for Registry {
         let parent = if attrs.is_root() {
             None
         } else if attrs.is_contextual() {
-            self.current_span().id().map(|id| self.clone_span(id))
+            self.current_span().id().and_then(|id| self.try_clone_span(id))
         } else {
-            attrs.parent().map(|id| self.clone_span(id))
+            attrs.parent().and_then(|id| self.try_clone_span(id))
         };
 
         let id = self

--- a/tracing-subscriber/tests/registry_span_move_threads.rs
+++ b/tracing-subscriber/tests/registry_span_move_threads.rs
@@ -1,0 +1,117 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::mpsc;
+use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::thread;
+use tracing::{span, Level, Span};
+
+/// A future that yields once, simulating an async operation that causes
+/// the runtime to potentially reschedule the task on a different thread.
+struct YieldOnce {
+    has_been_polled: bool,
+}
+
+impl Future for YieldOnce {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.has_been_polled {
+            Poll::Ready(())
+        } else {
+            self.has_been_polled = true;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
+}
+
+/// Create a no-op waker for manual polling
+fn noop_waker() -> Waker {
+    const VTABLE: RawWakerVTable = RawWakerVTable::new(
+        |_| RawWaker::new(std::ptr::null(), &VTABLE),
+        |_| {},
+        |_| {},
+        |_| {},
+    );
+    unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
+}
+
+#[test]
+fn clone_span_of_closed_parent_should_not_panic() {
+    let subscriber = tracing_subscriber::registry();
+    tracing::subscriber::with_default(subscriber, || {
+        let span = span!(Level::INFO, "parent");
+        let guard = span.enter();
+
+        std::mem::forget(guard);
+        drop(span);
+
+        // This should NOT panic
+        let _child = span!(Level::INFO, "child");
+    });
+}
+
+fn mk_span_dropped_on_different_thread() {
+    // Channel for sending the future from main thread to worker thread
+    let (send_future, recv_future) = mpsc::channel::<Pin<Box<dyn Future<Output = ()> + Send>>>();
+    let (send_done, recv_done) = mpsc::channel::<()>();
+
+    // Use set_global_default so all threads share the same subscriber
+    let subscriber = tracing_subscriber::registry();
+    let _ = tracing::subscriber::set_global_default(subscriber);
+
+    let mut future = Box::pin(async {
+        let span = span!(Level::INFO, "parent_span");
+        let _guard = span.enter();
+
+        YieldOnce { has_been_polled: false }.await;
+
+        // Here we resume on a different thread, dropping the guard on that thread
+    });
+
+    // Poll once on main thread
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    match future.as_mut().poll(&mut cx) {
+        Poll::Pending => {
+            // Now send to worker thread which will complete the future
+            send_future.send(future).unwrap();
+        }
+        Poll::Ready(()) => panic!("Future should have yielded"),
+    }
+
+    // Worker thread, which receives the partially-polled future and completes it
+    let worker = thread::spawn(move || {
+        let mut future = recv_future.recv().unwrap();
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        match future.as_mut().poll(&mut cx) {
+            Poll::Ready(()) => {}
+            Poll::Pending => panic!("Future should have completed"),
+        }
+        // Signal main thread that we're done so it can try to create a child span
+        send_done.send(()).unwrap();
+    });
+
+    // Wait for worker to finish
+    recv_done.recv().unwrap();
+    worker.join().unwrap();
+}
+
+#[test]
+fn span_macro_after_cross_thread_span_should_not_panic() {
+    mk_span_dropped_on_different_thread();
+
+    // This should NOT panic
+    let _child = span!(Level::INFO, "child_span");
+}
+
+// FIXME: This test still fails
+
+// #[test]
+// fn current_span_after_cross_thread_span_should_not_panic() {
+//     mk_span_dropped_on_different_thread();
+
+//     // This should NOT panic
+//     Span::current();
+// }


### PR DESCRIPTION
I added a minimum-viable reproducible example for a crash that we've been hit with in production

All three tests that are added in this PR fail on the `main` branch. My change to `sharded.rs` fixes two of the three tests. I'm not sure what the best way to tackle the third failure is, so I've commented the test case out for now, hoping for an expert to jump in.

### Before
```
% cargo test --features registry --test registry_span_move_threads
    Blocking waiting for file lock on package cache
   Compiling tracing-subscriber v0.3.22 (/Users/arni/src/o2/tracing/tracing-subscriber)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.14s
     Running tests/registry_span_move_threads.rs (/Users/arni/src/o2/tracing/target/debug/deps/registry_span_move_threads-ee17f9c3abe1d864)

running 3 tests
test clone_span_of_closed_parent_should_not_panic ... FAILED
test current_span_after_cross_thread_span_should_not_panic ... FAILED
test span_macro_after_cross_thread_span_should_not_panic ... FAILED

failures:
...
```

### After

With third test commented out
```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.86s
     Running tests/registry_span_move_threads.rs (/Users/arni/src/o2/tracing/target/debug/deps/registry_span_move_threads-ee17f9c3abe1d864)

running 2 tests
test clone_span_of_closed_parent_should_not_panic ... ok
test span_macro_after_cross_thread_span_should_not_panic ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```