### PR TITLE
appender: fix parsing of date from filename when no time is incuded

### DIFF
--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -1360,6 +1360,7 @@ mod test {
             created,
             Some(SystemTime::UNIX_EPOCH + Duration::seconds(1580551260))
         );
+    }
 
     #[test]
     fn test_latest_symlink() {


### PR DESCRIPTION
## Motivation

On filesystems where `std::fs::Metadata::created`
is unsupported, `RollingFileAppender` falls back
to parsing the creation date from the log filename.
However, `PrimitiveDateTime::parse` fails with
`InsufficientInformation` for daily and weekly
rotations because the filename lacks time
components.

## Solution

Replace the direct `time::PrimitiveDateTime::parse`
call with a `time::parsing::Parsed`-based approach
that defaults missing hour to midnight (00:00:00),
allowing date-only filenames to be parsed
successfully.

Fixes: #3470