### PR TITLE
docs: add `tracing-oslog` to related crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ are not maintained by the `tokio` project. These include:
 - [`tracing-cloudwatch`] provides a layer that sends events to AWS CloudWatch Logs.
 - [`tracing-subscriber-reload-arcswap`] provides a lock-free alternative to `tracing_subscriber::reload::Layer` using `arc-swap`.
 - [`clippy-tracing`] provides a tool to add, remove and check for `tracing::instrument`.
+- [`tracing-oslog`] provides a layer for reporting traces to Apple's logging framework.
 
 (if you're the maintainer of a `tracing` ecosystem crate not in this list,
 please let us know!)
@@ -468,6 +469,7 @@ please let us know!)
 [`tracing-cloudwatch`]: https://crates.io/crates/tracing-cloudwatch
 [`tracing-subscriber-reload-arcswap`]: https://crates.io/crates/tracing-subscriber-reload-arcswap
 [`clippy-tracing`]: https://crates.io/crates/clippy-tracing
+[`tracing-oslog`]: https://crates.io/crates/tracing-oslog
 
 **Note:** that some of the ecosystem crates are currently unreleased and
 undergoing active development. They may be less stable than `tracing` and

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -757,6 +757,7 @@
 //!  - [`tracing-cloudwatch`] provides a layer that sends events to AWS CloudWatch Logs.
 //!  - [`clippy-tracing`] provides a tool to add, remove and check for `tracing::instrument`.
 //!  - [`json-subscriber`] provides a subscriber for emitting JSON logs. The output can be customized much more than with [`tracing-subscriber`]'s JSON output.
+//!  - [`tracing-oslog`] provides a layer for reporting traces to Apple's logging framework.
 //!
 //! If you're the maintainer of a `tracing` ecosystem crate not listed above,
 //! please let us know! We'd love to add your project to the list!
@@ -801,6 +802,7 @@
 //! [`tracing-cloudwatch`]: https://crates.io/crates/tracing-cloudwatch
 //! [`clippy-tracing`]: https://crates.io/crates/clippy-tracing
 //! [`json-subscriber`]: https://crates.io/crates/json-subscriber
+//! [`tracing-oslog`]: https://crates.io/crates/tracing-oslog
 //!
 //! <pre class="ignore" style="white-space:normal;font:inherit;">
 //!     <strong>Note</strong>: Some of these ecosystem crates are currently


### PR DESCRIPTION
This is used by e.g. `bevy_log` to improve the logging experience on iOS in particular (getting access to stdout/stderr is harder there).