### PR TITLE
chore: prepare tracing-subscriber 0.3.23

### DIFF
--- a/tracing-subscriber/CHANGELOG.md
+++ b/tracing-subscriber/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.3.23 (March 13, 2026)
+
+### Fixed
+
+- Allow ansi sanitization to be disabled ([#3484])
+
+[#3484]: https://github.com/tokio-rs/tracing/pull/3484
+
 # 0.3.22 (November 28, 2025)
 
 #### Important

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 authors = [
     "Eliza Weisman <eliza@buoyant.io>",
     "David Barsky <me@davidbarsky.com>",

--- a/tracing-subscriber/README.md
+++ b/tracing-subscriber/README.md
@@ -29,9 +29,9 @@ application authors using `tracing` to instrument their applications.
 [tracing]: https://github.com/tokio-rs/tracing/tree/main/tracing
 [tracing-fmt]: https://github.com/tokio-rs/tracing/tree/main/tracing-subscriber
 [crates-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg
-[crates-url]: https://crates.io/crates/tracing-subscriber/0.3.22
+[crates-url]: https://crates.io/crates/tracing-subscriber/0.3.23
 [docs-badge]: https://docs.rs/tracing-subscriber/badge.svg
-[docs-url]: https://docs.rs/tracing-subscriber/0.3.22
+[docs-url]: https://docs.rs/tracing-subscriber/0.3.23
 [docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
 [docs-v0.2.x-url]: https://tracing.rs/tracing_subscriber
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg


### PR DESCRIPTION
# 0.3.23 (March 13, 2026)

### Fixed

- Allow ansi sanitization to be disabled ([#3484])

[#3484]: https://github.com/tokio-rs/tracing/pull/3484