### PR TITLE
feat(tracing-subscriber): add TokioUptime FormatTime implementation

### DIFF
--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -36,6 +36,9 @@ valuable = ["tracing-core/valuable", "valuable_crate", "valuable-serde", "tracin
 # Enables support for local time when using the `time` crate timestamp
 # formatters.
 local-time = ["time/local-offset"]
+# Enables support for local time when using the `tokio` timestamp
+# formatters.
+tokio-time = ["tokio/time"]
 nu-ansi-term = ["dep:nu-ansi-term"]
 # For backwards compatibility only
 regex = []
@@ -64,6 +67,8 @@ tracing-serde = { path = "../tracing-serde", version = "0.2.0", optional = true 
 # opt-in deps
 parking_lot = { version = "0.12.1", optional = true }
 chrono = { version = "0.4.26", default-features = false, features = ["clock", "std"], optional = true }
+tokio = { version = "1", optional = true }
+
 
 # registry
 sharded-slab = { version = "0.1.4", optional = true }

--- a/tracing-subscriber/src/fmt/time/mod.rs
+++ b/tracing-subscriber/src/fmt/time/mod.rs
@@ -32,6 +32,13 @@ pub use chrono_crate::ChronoLocal;
 #[cfg_attr(docsrs, doc(cfg(feature = "chrono")))]
 pub use chrono_crate::ChronoUtc;
 
+#[cfg(feature = "tokio-time")]
+mod tokio;
+
+#[cfg(feature = "tokio-time")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio-time")))]
+pub use self::tokio::{tokio_uptime, TokioUptime};
+
 /// A type that can measure and format the current time.
 ///
 /// This trait is used by `Format` to include a timestamp with each `Event` when it is logged.

--- a/tracing-subscriber/src/fmt/time/tokio.rs
+++ b/tracing-subscriber/src/fmt/time/tokio.rs
@@ -1,0 +1,49 @@
+use crate::fmt::format::Writer;
+
+/// Retrieve and print the relative elapsed tokio time since an epoch.
+///
+/// In non-paused tokio environments and when used outside of a tokio runtime,
+/// the epoch is the current time. See [`tokio::time::Instant`] for more info.
+///
+/// The `Default` implementation for `Uptime` makes the epoch the current time.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct TokioUptime {
+    epoch: tokio::time::Instant,
+}
+
+impl Default for TokioUptime {
+    fn default() -> Self {
+        TokioUptime {
+            epoch: tokio::time::Instant::now(),
+        }
+    }
+}
+
+impl From<tokio::time::Instant> for TokioUptime {
+    fn from(epoch: tokio::time::Instant) -> Self {
+        TokioUptime { epoch }
+    }
+}
+
+impl super::FormatTime for TokioUptime {
+    fn format_time(&self, w: &mut Writer<'_>) -> std::fmt::Result {
+        let e = self.epoch.elapsed();
+        write!(w, "{:4}.{:09}s", e.as_secs(), e.subsec_nanos())
+    }
+}
+
+/// Returns a new [`TokioUptime`] timestamp provider.
+///
+/// With this timer, timestamps will be formatted with the amount of time
+/// elapsed in the tokio runtime since the timestamp provider was constructed.
+///
+/// This can then be configured further to determine how timestamps should be
+/// configured.
+///
+/// This is equivalent to calling
+/// ```no_run
+/// tracing_subscriber::fmt::time::TokioUptime::default()
+/// ```
+pub fn tokio_uptime() -> TokioUptime {
+    TokioUptime::default()
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->
Resolves https://github.com/tokio-rs/tracing/issues/3492.

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Useful for logging within simulators which pause and manipulate the time within tokio runtimes, such as turmoil. This would allow for printing out time while still having deterministic log outputs. This would also be useful to log out time-shift when testing communication between multiple cooperating paused runtimes, like how turmoil treats servers.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I added the TokioUptime FormatTime implementation, behind the feature flag tokio-time, which is equivalent to Uptime except when in a tokio runtime which has had its time paused. Tokio will only be pulled in as a dependency when the tokio-time flag is set.