### PR TITLE
docs(span): recommend `await_holding_invalid_type` Clippy lint

### DIFF
--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -718,6 +718,29 @@ impl Span {
     ///   }
     ///   ```
     ///
+    /// # Detecting Incorrect Use With Clippy
+    ///
+    /// The Clippy [`await_holding_invalid_type`] lint can be used to detect cases
+    /// where an `Entered` or `EnteredSpan` guard is held across an `.await` point.
+    /// To use this lint, add the following configuration to your `clippy.toml`:
+    ///
+    /// ```toml
+    /// await-holding-invalid-types = [
+    ///     { path = "tracing::span::Entered", reason = "generates incorrect spans when held across 'await' points" },
+    ///     { path = "tracing::span::EnteredSpan", reason = "generates incorrect spans when held across 'await' points" },
+    /// ]
+    /// ```
+    ///
+    /// And enable the lint either in your `lib.rs`:
+    ///
+    /// ```ignore
+    /// #![warn(clippy::await_holding_invalid_type)]
+    /// ```
+    ///
+    /// Or in your `Cargo.toml` / `.clippy.toml` lints configuration.
+    ///
+    /// [`await_holding_invalid_type`]: https://rust-lang.github.io/rust-clippy/master/index.html#await_holding_invalid_type
+    ///
     /// [syntax]: https://rust-lang.github.io/async-book/01_getting_started/04_async_await_primer.html
     /// [`Span::in_scope`]: Span::in_scope()
     /// [instrument]: crate::Instrument


### PR DESCRIPTION
## Summary

- Adds a "Detecting Incorrect Use With Clippy" section to the `Span::enter` documentation
- Recommends configuring the `clippy::await_holding_invalid_type` lint to detect cases where `Entered` or `EnteredSpan` guards are held across `.await` points
- Includes example `clippy.toml` configuration and lint enablement instructions

Closes #3408

## Motivation

As noted in #3408, the `await-holding-invalid-types` Clippy lint is a better fit than `disallowed_methods` for catching incorrect usage of `Span::enter` in async code. Unlike `disallowed_methods`, this lint works correctly with `#[tracing::instrument]` (which internally uses `enter()` but safely manages the guard around await points).

## Test plan

- [ ] Verify docs render correctly with `cargo doc --open`
- [ ] Confirm the Clippy lint link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)