### PR TITLE
added tokio task id behind feature

### DIFF
--- a/examples/examples/tokio-task-id.rs
+++ b/examples/examples/tokio-task-id.rs
@@ -13,9 +13,9 @@
 /// Example output:
 ///
 /// ```not_rust
-/// Jul 17 00:38:07.177  INFO TaskId(02) task_info: i=9
-/// Jul 17 00:38:07.177  INFO            task 1 TaskId(03) task_info: i=9
-/// Jul 17 00:38:07.177  INFO large name task 2 TaskId(04) task_info: i=9
+/// 2026-04-15T20:27:00.900174Z  INFO Id(11) tokio_task_id: i=1
+/// 2026-04-15T20:27:00.900224Z  INFO Id(12) tokio_task_id: i=1
+/// 2026-04-15T20:27:00.902561Z  INFO Id(12) tokio_task_id: i=2
 /// ```
 use std::time::Duration;
 use tracing::info;

--- a/examples/examples/tokio-task-id.rs
+++ b/examples/examples/tokio-task-id.rs
@@ -1,0 +1,50 @@
+#![deny(rust_2018_idioms)]
+/// This is a example showing how tokio task id can be displayed when
+/// formatting events with `tracing_subscriber::fmt`. This is useful
+/// as the task ID makes it easier to trace activity back to the
+/// specific asynchronous task that produced the log.
+///
+/// You can run this example by running the following command in a terminal
+///
+/// ```
+/// cargo run --features tokio-task-id --example tokio-task-id
+/// ```
+///
+/// Example output:
+///
+/// ```not_rust
+/// Jul 17 00:38:07.177  INFO TaskId(02) task_info: i=9
+/// Jul 17 00:38:07.177  INFO            task 1 TaskId(03) task_info: i=9
+/// Jul 17 00:38:07.177  INFO large name task 2 TaskId(04) task_info: i=9
+/// ```
+use std::time::Duration;
+use tracing::info;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        // enable tokio task id to be emitted
+        .with_tokio_task_ids(true)
+        .init();
+
+    let do_one_work = async {
+        for i in 1..10 {
+            info!(i);
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+    };
+
+    let do_other_work = async {
+        for i in 1..20 {
+            info!(i);
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    };
+
+    let task_one = tokio::task::spawn(do_one_work);
+    let task_two = tokio::task::spawn(do_other_work);
+
+    let _ = task_one.await;
+    let _ = task_two.await;
+}

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -79,7 +79,6 @@ tokio = { version = "1", optional = true, features = ["rt"] }
 valuable_crate = { package = "valuable", version = "0.1.0", optional = true, default-features = false }
 valuable-serde = { version = "0.1.0", optional = true, default-features = false }
 
-
 [dev-dependencies]
 tracing = { path = "../tracing", version = "0.1.43" }
 tracing-mock = { path = "../tracing-mock", features = ["tracing-subscriber"] }

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -40,6 +40,9 @@ nu-ansi-term = ["dep:nu-ansi-term"]
 # For backwards compatibility only
 regex = []
 
+# tokio task id
+tokio-task-id = ["tokio"]
+
 [dependencies]
 tracing-core = { path = "../tracing-core", version = "0.1.35", default-features = false }
 
@@ -69,9 +72,13 @@ chrono = { version = "0.4.26", default-features = false, features = ["clock", "s
 sharded-slab = { version = "0.1.4", optional = true }
 thread_local = { version = "1.1.4", optional = true }
 
+# tokio task id
+tokio = { version = "1", optional = true, features = ["rt"] }
+
 [target.'cfg(tracing_unstable)'.dependencies]
 valuable_crate = { package = "valuable", version = "0.1.0", optional = true, default-features = false }
 valuable-serde = { version = "0.1.0", optional = true, default-features = false }
+
 
 [dev-dependencies]
 tracing = { path = "../tracing", version = "0.1.43" }

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -570,6 +570,20 @@ where
         }
     }
 
+    /// Sets whether or not the [tokio task ID] of the current tokio task is displayed
+    /// when formatting events.
+    ///
+    /// [tokio task ID]: tokio::task::Id
+    pub fn with_tokio_task_ids(
+        self,
+        display_tokio_task_id: bool,
+    ) -> Layer<S, N, format::Format<L, T>, W> {
+        Layer {
+            fmt_event: self.fmt_event.with_tokio_task_ids(display_tokio_task_id),
+            ..self
+        }
+    }
+
     /// Sets the layer being built to use a [less verbose formatter][super::format::Compact].
     pub fn compact(self) -> Layer<S, N, format::Format<format::Compact, T>, W>
     where

--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -323,6 +323,17 @@ where
                     .serialize_entry("threadId", &format!("{:?}", std::thread::current().id()))?;
             }
 
+            #[cfg(feature = "tokio-task-id")]
+            if self.display_tokio_task_id {
+                let current_tokio_task_id = tokio::task::try_id();
+                match current_tokio_task_id {
+                    Some(id) => {
+                        serializer.serialize_entry("tokioTaskId", &format!("{:?}", id))?;
+                    }
+                    None => {}
+                }
+            }
+
             serializer.end()
         };
 

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -415,7 +415,7 @@ pub struct Format<F = Full, T = SystemTime> {
     pub(crate) display_thread_name: bool,
     pub(crate) display_filename: bool,
     pub(crate) display_line_number: bool,
-    pub(crate) display_tokio_task_id: bool, // Sen: https://github.com/tokio-rs/tracing/pull/818/changes#diff-3d2a515301e5ac498f093147c3e5faf9ce86650d03770531e7435f48ad03db0c
+    pub(crate) display_tokio_task_id: bool,
 }
 
 // === impl Writer ===
@@ -1003,7 +1003,7 @@ where
             let current_tokio_task_id = tokio::task::try_id();
             match current_tokio_task_id {
                 Some(id) => {
-                    write!(writer, "{:0>2?} ", id)?; // Sen: maybe use something like FmtThreadName as above
+                    write!(writer, "{:0>2?} ", id)?;
                 }
                 None => {}
             }
@@ -1142,7 +1142,7 @@ where
             let current_tokio_task_id = tokio::task::try_id();
             match current_tokio_task_id {
                 Some(id) => {
-                    write!(writer, "{:0>2?} ", id)?; // Sen: maybe use something like FmtThreadName as above
+                    write!(writer, "{:0>2?} ", id)?;
                 }
                 None => {}
             }

--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -415,6 +415,7 @@ pub struct Format<F = Full, T = SystemTime> {
     pub(crate) display_thread_name: bool,
     pub(crate) display_filename: bool,
     pub(crate) display_line_number: bool,
+    pub(crate) display_tokio_task_id: bool, // Sen: https://github.com/tokio-rs/tracing/pull/818/changes#diff-3d2a515301e5ac498f093147c3e5faf9ce86650d03770531e7435f48ad03db0c
 }
 
 // === impl Writer ===
@@ -623,6 +624,7 @@ impl Default for Format<Full, SystemTime> {
             display_thread_name: false,
             display_filename: false,
             display_line_number: false,
+            display_tokio_task_id: false,
         }
     }
 }
@@ -643,6 +645,7 @@ impl<F, T> Format<F, T> {
             display_thread_name: self.display_thread_name,
             display_filename: self.display_filename,
             display_line_number: self.display_line_number,
+            display_tokio_task_id: self.display_tokio_task_id,
         }
     }
 
@@ -682,6 +685,7 @@ impl<F, T> Format<F, T> {
             display_thread_name: self.display_thread_name,
             display_filename: true,
             display_line_number: true,
+            display_tokio_task_id: self.display_tokio_task_id,
         }
     }
 
@@ -713,6 +717,7 @@ impl<F, T> Format<F, T> {
             display_thread_name: self.display_thread_name,
             display_filename: self.display_filename,
             display_line_number: self.display_line_number,
+            display_tokio_task_id: self.display_tokio_task_id,
         }
     }
 
@@ -742,6 +747,7 @@ impl<F, T> Format<F, T> {
             display_thread_name: self.display_thread_name,
             display_filename: self.display_filename,
             display_line_number: self.display_line_number,
+            display_tokio_task_id: self.display_tokio_task_id,
         }
     }
 
@@ -758,6 +764,7 @@ impl<F, T> Format<F, T> {
             display_thread_name: self.display_thread_name,
             display_filename: self.display_filename,
             display_line_number: self.display_line_number,
+            display_tokio_task_id: self.display_tokio_task_id,
         }
     }
 
@@ -837,6 +844,17 @@ impl<F, T> Format<F, T> {
     pub fn with_source_location(self, display_location: bool) -> Self {
         self.with_line_number(display_location)
             .with_file(display_location)
+    }
+
+    /// Sets whether or not the [tokio task ID] of the current tokio task is displayed
+    /// when formatting events.
+    ///
+    /// [tokio task ID]: tokio::task::Id
+    pub fn with_tokio_task_ids(self, display_tokio_task_id: bool) -> Format<F, T> {
+        Format {
+            display_tokio_task_id,
+            ..self
+        }
     }
 
     #[inline]
@@ -980,6 +998,17 @@ where
             write!(writer, "{:0>2?} ", std::thread::current().id())?;
         }
 
+        #[cfg(feature = "tokio-task-id")]
+        if self.display_tokio_task_id {
+            let current_tokio_task_id = tokio::task::try_id();
+            match current_tokio_task_id {
+                Some(id) => {
+                    write!(writer, "{:0>2?} ", id)?; // Sen: maybe use something like FmtThreadName as above
+                }
+                None => {}
+            }
+        }
+
         let dimmed = writer.dimmed();
 
         if let Some(scope) = ctx.event_scope() {
@@ -1106,6 +1135,17 @@ where
 
         if self.display_thread_id {
             write!(writer, "{:0>2?} ", std::thread::current().id())?;
+        }
+
+        #[cfg(feature = "tokio-task-id")]
+        if self.display_tokio_task_id {
+            let current_tokio_task_id = tokio::task::try_id();
+            match current_tokio_task_id {
+                Some(id) => {
+                    write!(writer, "{:0>2?} ", id)?; // Sen: maybe use something like FmtThreadName as above
+                }
+                None => {}
+            }
         }
 
         let fmt_ctx = {

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -752,6 +752,20 @@ where
         }
     }
 
+    /// Sets whether or not the [tokio task ID] of the current tokio task is displayed
+    /// when formatting events.
+    ///
+    /// [tokio task ID]: tokio::task::Id
+    pub fn with_tokio_task_ids(
+        self,
+        display_tokio_task_id: bool,
+    ) -> SubscriberBuilder<N, format::Format<L, T>, F, W> {
+        SubscriberBuilder {
+            inner: self.inner.with_tokio_task_ids(display_tokio_task_id),
+            ..self
+        }
+    }
+
     /// Sets the subscriber being built to use a less verbose formatter.
     ///
     /// See [`format::Compact`].


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
Fixes #3517 


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This PR introduces optional support for including Tokio task IDs in formatted output, following the PR used for thread IDs in #818 .

- Uses `tokio::task::try_id()` to retrieve the current task ID.
- If no task ID is available, nothing is logged.
- All Tokio-related code is fully gated behind the `tokio-task-id` feature

