### PR TITLE
chore: prepare tracing-appender 0.2.5

### DIFF
--- a/tracing-appender/CHANGELOG.md
+++ b/tracing-appender/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 0.2.5 (April 17, 2026)
+
+### Added
+
+- Add latest symlink builder option ([#3447])
+
+### Fixed
+
+- Fix `RollingFileAppender` broken links in docs ([#3445])
+- Fix parsing of date from filename when no time is incuded ([#3471])
+
+[#3445]: https://github.com/tokio-rs/tracing/pull/3445
+[#3447]: https://github.com/tokio-rs/tracing/pull/3447
+[#3471]: https://github.com/tokio-rs/tracing/pull/3471
+
 # 0.2.4 (November 26, 2025)
 
 ### Added

--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 authors = [
     "Zeki Sherif <zekshi@amazon.com>",
     "Tokio Contributors <team@tokio.rs>"

--- a/tracing-appender/README.md
+++ b/tracing-appender/README.md
@@ -16,9 +16,9 @@ Writers for logging events and spans
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-appender.svg
-[crates-url]: https://crates.io/crates/tracing-appender/0.2.4
+[crates-url]: https://crates.io/crates/tracing-appender/0.2.5
 [docs-badge]: https://docs.rs/tracing-appender/badge.svg
-[docs-url]: https://docs.rs/tracing-appender/0.2.4
+[docs-url]: https://docs.rs/tracing-appender/0.2.5
 [docs-v0.2.x-badge]: https://img.shields.io/badge/docs-v0.2.x-blue
 [docs-v0.2.x-url]: https://docs.rs/tracing-appender/
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg


### PR DESCRIPTION
# 0.2.5 (April 17, 2026)

### Added

- Add latest symlink builder option ([#3447])

### Fixed

- Fix `RollingFileAppender` broken links in docs ([#3445])
- Fix parsing of date from filename when no time is incuded ([#3471])

[#3445]: https://github.com/tokio-rs/tracing/pull/3445
[#3447]: https://github.com/tokio-rs/tracing/pull/3447
[#3471]: https://github.com/tokio-rs/tracing/pull/3471