### PR TITLE
fix 'cargo test' for tracing-error

### DIFF
--- a/tracing-error/Cargo.toml
+++ b/tracing-error/Cargo.toml
@@ -39,6 +39,12 @@ traced-error = []
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3.0", default-features = false, features = ["registry", "fmt"] }
 tracing = { path = "../tracing", version = "0.1.35", default-features = false, features = ["std"] }
 
+[dev-dependencies.tracing]
+path = "../tracing"
+version = "0.1"
+features = ["attributes"]
+default-features = false
+
 [badges]
 maintenance = { status = "experimental" }
 


### PR DESCRIPTION
Without this I get the error:
```
error[E0433]: failed to resolve: could not find `instrument` in `tracing`
   --> tracing-error/src/backtrace.rs:90:12
    |
 90 | #[tracing::instrument]
    |            ^^^^^^^^^^ could not find `instrument` in `tracing`
    |
note: found an item that was configured out
   --> tracing/src/lib.rs:974:29
    |
971 | #[cfg(feature = "attributes")]
    |       ---------------------- the item is gated behind the `attributes` feature
...
974 | pub use tracing_attributes::instrument;
    |                             ^^^^^^^^^^

error: aborting due to 1 previous error
```

## Motivation

We would like to run the test suite in Debian when we package this software.

## Solution

Import the needed dependency.

based on: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/tracing-error/debian/patches/fix-unit-tests.patch?ref_type=heads