### PR TITLE
feat(tracing-appender): add the ability for `RollingFileAppender` to use the local time

### DIFF
--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -20,6 +20,10 @@ keywords = ["logging", "tracing", "file-appender", "non-blocking-writer"]
 edition = "2018"
 rust-version = "1.63.0"
 
+[features]
+# Enables support for using the local timezone when rotating log files.
+local-time = ["time/local-offset"]
+
 [dependencies]
 crossbeam-channel = "0.5.6"
 time = { version = "0.3.2", default-features = false, features = ["formatting", "parsing"] }

--- a/tracing-appender/src/lib.rs
+++ b/tracing-appender/src/lib.rs
@@ -140,7 +140,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/tokio-rs/tracing/main/assets/favicon.ico",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
 )]
-#![cfg_attr(docsrs, deny(rustdoc::broken_intra_doc_links))]
+#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -87,6 +87,8 @@ pub use builder::{Builder, InitError};
 pub struct RollingFileAppender {
     state: Inner,
     writer: RwLock<File>,
+    #[cfg(feature = "local-time")]
+    clock: ClockKind,
     #[cfg(test)]
     now: Box<dyn Fn() -> OffsetDateTime + Send + Sync>,
 }
@@ -110,6 +112,39 @@ struct Inner {
     rotation: Rotation,
     next_date: AtomicUsize,
     max_files: Option<usize>,
+}
+
+/// Specifies which clock is used for determining rotation times and formatting
+/// dates in log file names.
+///
+/// By default [`RollingFileAppender`] uses UTC. Use [`Builder::use_local_time`]
+/// to switch to the system's local timezone.
+#[cfg(feature = "local-time")]
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) enum ClockKind {
+    /// Use UTC for rotation and file naming (the defualt).
+    #[default]
+    Utc,
+    /// Use the system's local timezone for rotation and file naming.
+    ///
+    /// # Caveats
+    ///
+    /// Determining the local UTC offset may fail on some platforms.
+    /// When the local offset cannot be determined, the appender falls back
+    /// to UTC silently.
+    Local,
+}
+
+#[cfg(feature = "local-time")]
+impl ClockKind {
+    pub(crate) fn now(&self) -> OffsetDateTime {
+        match self {
+            ClockKind::Utc => OffsetDateTime::now_utc(),
+            ClockKind::Local => {
+                OffsetDateTime::now_local().unwrap_or_else(|_| OffsetDateTime::now_utc())
+            }
+        }
+    }
 }
 
 // === impl RollingFileAppender ===
@@ -193,9 +228,16 @@ impl RollingFileAppender {
             ref suffix,
             ref latest_symlink,
             ref max_files,
+            #[cfg(feature = "local-time")]
+            ref clock,
         } = builder;
         let directory = directory.as_ref().to_path_buf();
+
+        #[cfg(feature = "local-time")]
+        let now = clock.now();
+        #[cfg(not(feature = "local-time"))]
         let now = OffsetDateTime::now_utc();
+
         let (state, writer) = Inner::new(
             now,
             rotation.clone(),
@@ -208,8 +250,22 @@ impl RollingFileAppender {
         Ok(Self {
             state,
             writer,
+            #[cfg(feature = "local-time")]
+            clock: *clock,
             #[cfg(test)]
-            now: Box::new(OffsetDateTime::now_utc),
+            now: {
+                #[cfg(feature = "local-time")]
+                {
+                    Box::new({
+                        let clock = *clock;
+                        move || clock.now()
+                    })
+                }
+                #[cfg(not(feature = "local-time"))]
+                {
+                    Box::new(OffsetDateTime::now_utc)
+                }
+            },
         })
     }
 
@@ -219,7 +275,13 @@ impl RollingFileAppender {
         return (self.now)();
 
         #[cfg(not(test))]
-        OffsetDateTime::now_utc()
+        {
+            #[cfg(feature = "local-time")]
+            return self.clock.now();
+
+            #[cfg(not(feature = "local-time"))]
+            return OffsetDateTime::now_utc();
+        }
     }
 }
 
@@ -259,12 +321,16 @@ impl<'a> tracing_subscriber::fmt::writer::MakeWriter<'a> for RollingFileAppender
 
 impl fmt::Debug for RollingFileAppender {
     // This manual impl is required because of the `now` field (only present
-    // with `cfg(test)`), which is not `Debug`...
+    // with `cfg(test)`), which is not `Debug`. Also for the `clock` field
+    // which is behind the `local-time` feature.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RollingFileAppender")
-            .field("state", &self.state)
-            .field("writer", &self.writer)
-            .finish()
+        let mut d = f.debug_struct("RollingFileAppender");
+        let d = d.field("state", &self.state).field("writer", &self.writer);
+
+        #[cfg(feature = "local-time")]
+        let d = d.field("clock", &self.clock);
+
+        d.finish()
     }
 }
 
@@ -1170,7 +1236,13 @@ mod test {
             let clock = clock.clone();
             Box::new(move || *clock.lock().unwrap())
         };
-        let appender = RollingFileAppender { state, writer, now };
+        let appender = RollingFileAppender {
+            state,
+            writer,
+            #[cfg(feature = "local-time")]
+            clock: ClockKind::Utc,
+            now,
+        };
         let default = tracing_subscriber::fmt()
             .without_time()
             .with_level(false)
@@ -1253,7 +1325,13 @@ mod test {
             let clock = clock.clone();
             Box::new(move || *clock.lock().unwrap())
         };
-        let appender = RollingFileAppender { state, writer, now };
+        let appender = RollingFileAppender {
+            state,
+            writer,
+            #[cfg(feature = "local-time")]
+            clock: ClockKind::Utc,
+            now,
+        };
         let default = tracing_subscriber::fmt()
             .without_time()
             .with_level(false)
@@ -1404,6 +1482,8 @@ mod test {
         let mut appender = RollingFileAppender {
             state,
             writer,
+            #[cfg(feature = "local-time")]
+            clock: ClockKind::Utc,
             now: now_fn,
         };
 
@@ -1423,5 +1503,107 @@ mod test {
         // Verify the symlink is functional
         let content = fs::read_to_string(&symlink_path).expect("failed to read through symlink");
         assert_eq!("test\n", content);
+    }
+
+    #[cfg(feature = "local-time")]
+    #[test]
+    fn test_local_time_filename_uses_local_date() {
+        // The filename should reflect the local date, not necessarily UTC.
+        // We can't control the timezone in a unit test, but we CAN verify
+        // that the generated filename matches what ClockKind::Local.now()
+        // produces right now.
+        let directory = tempfile::tempdir().expect("failed to create tempdir");
+        let appender = RollingFileAppender::builder()
+            .rotation(Rotation::DAILY)
+            .filename_prefix("local_date")
+            .filename_suffix("log")
+            .use_local_time()
+            .build(directory.path())
+            .expect("failed to build appender");
+
+        let now = ClockKind::Local.now();
+        let expected_date = appender.state.join_date(&now);
+
+        let dir_contents = fs::read_dir(directory.path()).expect("Failed to read directory");
+        let filenames: Vec<String> = dir_contents
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+
+        assert!(
+            filenames.iter().any(|f| f == &expected_date),
+            "Expected a file named {:?}, found {:?}",
+            expected_date,
+            filenames
+        );
+    }
+
+    #[cfg(feature = "local-time")]
+    #[test]
+    fn test_local_time_rotations() {
+        use std::sync::{Arc, Mutex};
+
+        let format = format_description::parse(
+            "[year]-[month]-[day] [hour]:[minute]:[second] [offset_hour \
+     sign:mandatory]:[offset_minute]:[offset_second]",
+        )
+        .unwrap();
+
+        // Use a time with a non-zero offset to prove the offset is preserved
+        // in filenames.
+        let now = OffsetDateTime::parse("2026-04-24 08:30:00 +08:00:00", &format).unwrap();
+
+        let directory = tempfile::tempdir().expect("failed to create tempdir");
+        let (state, writer) = Inner::new(
+            now,
+            Rotation::DAILY,
+            directory.path(),
+            Some("offset_test".to_string()),
+            Some("log".to_string()),
+            None,
+            None,
+        )
+        .unwrap();
+
+        // The initial file should use the date as seen in the +08:00 offset
+        // (2026-04-24), NOT the UTC date.
+        let expected_filename = state.join_date(&now);
+        assert!(
+            expected_filename.contains("2026-04-24"),
+            "Filename should contain local date 2026-04-24, got: {}",
+            expected_filename
+        );
+
+        let clock = Arc::new(Mutex::new(now));
+        let now_fn = {
+            let clock = clock.clone();
+            Box::new(move || *clock.lock().unwrap())
+        };
+        let mut appender = RollingFileAppender {
+            state,
+            writer,
+            clock: ClockKind::Local,
+            now: now_fn,
+        };
+
+        write_to_log(&mut appender, "day 1");
+
+        // Advance past midnight in +08:00 (16:00 UTC = 00:00 +08:00 next day)
+        *clock.lock().unwrap() =
+            OffsetDateTime::parse("2026-04-25 00:05:00 +08:00:00", &format).unwrap();
+
+        write_to_log(&mut appender, "day 2");
+
+        // Should now have two files
+        let dir_contents: Vec<_> = fs::read_dir(directory.path())
+            .expect("Failed to read dir")
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(
+            dir_contents.len(),
+            2,
+            "Expected 2 log files after rotation, found {}",
+            dir_contents.len()
+        );
     }
 }

--- a/tracing-appender/src/rolling/builder.rs
+++ b/tracing-appender/src/rolling/builder.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "local-time")]
+use super::ClockKind;
+
 use super::{RollingFileAppender, Rotation};
 use std::{io, path::Path};
 use thiserror::Error;
@@ -12,6 +15,8 @@ pub struct Builder {
     pub(super) suffix: Option<String>,
     pub(super) latest_symlink: Option<String>,
     pub(super) max_files: Option<usize>,
+    #[cfg(feature = "local-time")]
+    pub(super) clock: ClockKind,
 }
 
 /// Errors returned by [`Builder::build`].
@@ -56,6 +61,8 @@ impl Builder {
             suffix: None,
             latest_symlink: None,
             max_files: None,
+            #[cfg(feature = "local-time")]
+            clock: ClockKind::Utc,
         }
     }
 
@@ -263,6 +270,77 @@ impl Builder {
         let latest_symlink = if name.is_empty() { None } else { Some(name) };
         Self {
             latest_symlink,
+            ..self
+        }
+    }
+
+    /// Configures the appender to use the system's local timezone for rotation
+    /// scheduling and log file naming.
+    ///
+    /// By default, [`RollingFileAppender`] uses UTC for both rotation boundaries
+    /// and the date/time stamps embedded in file names. This means that, for example,
+    /// a daily-rotating appender rolls over at midnight *UTC*, which may fall in the
+    /// middle of a day in other time zones. Calling this method switches the appender
+    /// to local time so that rotation boundaries and file name date/time stamps align
+    /// with the local time.
+    ///
+    /// # Caveats
+    ///
+    /// Determining the local UTC offset may fail on some platforms. When the offset
+    /// cannot be determined, the appender **silently falls back to UTC**.
+    ///
+    /// # Examples
+    /// ```
+    /// use tracing_appender::rolling::{RollingFileAppender, Rotation};
+    ///
+    /// # fn docs() {
+    /// let appender = RollingFileAppender::builder()
+    ///     .rotation(Rotation::DAILY)
+    ///     .use_local_time()
+    ///     // ...
+    ///     .build("/var/log")
+    ///     .expect("failed to initialize rolling file appender");
+    /// # drop(appender)
+    /// # }
+    /// ```
+    #[cfg(feature = "local-time")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "local-time")))]
+    #[must_use]
+    pub fn use_local_time(self) -> Self {
+        Self {
+            clock: ClockKind::Local,
+            ..self
+        }
+    }
+
+    /// Configures the appender to use UTC for rotation scheduling and log file naming.
+    ///
+    /// This is the default behavior. This method is provided as an explicit opt-in
+    /// for readability, or to override a previously set [`use_local_time`] call.
+    ///
+    /// [`use_local_time`]: Self::use_local_time
+    ///
+    /// # Examples
+    /// ```
+    /// use tracing_appender::rolling::{RollingFileAppender, Rotation};
+    ///
+    /// # fn docs() {
+    /// let appender = RollingFileAppender::builder()
+    ///     .rotation(Rotation::DAILY)
+    ///     .use_utc() // explictly use UTC (the default)
+    ///     // ...
+    ///     .build("/var/log")
+    ///     .expect("failed to initialize rolling file appender");
+    /// # drop(appender)
+    /// # }
+    /// ```
+    ///
+    #[cfg(feature = "local-time")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "local-time")))]
+    #[must_use]
+    pub fn use_utc(self) -> Self {
+        Self {
+            clock: ClockKind::Utc,
             ..self
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->
Resolves https://github.com/tokio-rs/tracing/issues/3524, allowing the `RollingFileAppender` timezone to be configurable.

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

There may be use cases (like in the linked issue) where a user would want all of their logs to be framed within their local time zone instead of UTC. Currently, the `RollingFileAppender` always uses UTC for rolling files.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- Added a new `local-time` feature flag to `tracing-appender` to match the opt-in format used by `tracing-subscriber`.
- Created a new `ClockKind` enum for configuration.
- Updated the `rolling::Builder` with a `use_local_time()` and `use_utc()` method (by default it will use UTC formatting).
- Added 2 feature-gated unit tests for ensuring correct rolling behavior when using `ClockKind::Local`.

This feature has no breaking changes and is strictly opt-in due to `ClockKind` implementing UTC as its default variant.