### PR TITLE
subscriber: skip span fields instead of panicking when FormattedFields is missing

### DIFF
--- a/tracing-subscriber/src/fmt/format/json.rs
+++ b/tracing-subscriber/src/fmt/format/json.rs
@@ -163,9 +163,15 @@ where
         let mut serializer = serializer.serialize_map(None)?;
 
         let ext = self.0.extensions();
-        let data = ext
-            .get::<FormattedFields<N>>()
-            .expect("Unable to find FormattedFields in extensions; this is a bug");
+        // `FormattedFields` is normally inserted by the layer's
+        // `on_new_span` hook, but the formatter can also be invoked for
+        // spans that were created before this layer was installed
+        // (for example when a `reload::Layer` is swapped in at runtime).
+        // In that case we have no formatted fields to serialize, so emit
+        // the empty span object instead of panicking.
+        let Some(data) = ext.get::<FormattedFields<N>>() else {
+            return serializer.end();
+        };
 
         // TODO: let's _not_ do this, but this resolves
         // https://github.com/tokio-rs/tracing/issues/391.

--- a/tracing-subscriber/src/fmt/format/pretty.rs
+++ b/tracing-subscriber/src/fmt/format/pretty.rs
@@ -321,11 +321,16 @@ where
             }
 
             let ext = span.extensions();
-            let fields = &ext
-                .get::<FormattedFields<N>>()
-                .expect("Unable to find FormattedFields in extensions; this is a bug");
-            if !fields.is_empty() {
-                write!(writer, " {} {}", dimmed.paint("with"), fields)?;
+            // `FormattedFields` is normally inserted by the layer's
+            // `on_new_span` hook, but the formatter can also be invoked
+            // for spans that were created before this layer was installed
+            // (for example when a `reload::Layer` is swapped in at
+            // runtime). In that case we have no formatted fields to
+            // print, so skip the "with ..." segment instead of panicking.
+            if let Some(fields) = ext.get::<FormattedFields<N>>() {
+                if !fields.is_empty() {
+                    write!(writer, " {} {}", dimmed.paint("with"), fields)?;
+                }
             }
             writer.write_char('\n')?;
         }

--- a/tracing-subscriber/tests/reload_fmt_missing_fields.rs
+++ b/tracing-subscriber/tests/reload_fmt_missing_fields.rs
@@ -1,0 +1,42 @@
+//! Regression test for <https://github.com/tokio-rs/tracing/issues/3511>
+//!
+//! When `reload::Layer` swaps from one fmt layer variant to another (e.g.
+//! Full -> Pretty), spans that pre-date the swap have `FormattedFields<OldN>`
+//! but not `FormattedFields<NewN>`.  Emitting an event inside such a span
+//! must not panic.
+#![cfg(all(feature = "fmt", feature = "ansi", feature = "registry"))]
+
+use tracing_subscriber::{fmt, layer::SubscriberExt, reload};
+
+/// Reload from a Full-format layer to a Pretty-format layer.
+///
+/// The pre-existing span has `FormattedFields<DefaultFields>` but no
+/// `FormattedFields<Pretty>`. The old code panicked with `.expect()` on
+/// the missing extension; the fix skips the "with ..." segment instead.
+#[test]
+fn pretty_fmt_does_not_panic_on_reload_from_full() {
+    type DynLayer = Box<
+        dyn tracing_subscriber::Layer<tracing_subscriber::Registry> + Send + Sync,
+    >;
+
+    let full: DynLayer = Box::new(fmt::layer().with_writer(|| std::io::sink()));
+    let (dyn_layer, handle) = reload::Layer::new(full);
+
+    let subscriber = tracing_subscriber::registry()
+        .with(dyn_layer);
+
+    tracing_core::dispatcher::with_default(&tracing_core::Dispatch::new(subscriber), || {
+        // Span created while the Full layer is active.
+        // FormattedFields<DefaultFields> is inserted; FormattedFields<Pretty> is NOT.
+        let span = tracing::info_span!("pre_existing");
+        let _guard = span.enter();
+
+        // Swap to a Pretty layer. The existing span still has no FormattedFields<Pretty>.
+        let pretty: DynLayer =
+            Box::new(fmt::layer().pretty().with_writer(|| std::io::sink()));
+        handle.reload(pretty).expect("reload must succeed");
+
+        // Must NOT panic even though FormattedFields<Pretty> is absent on the span.
+        tracing::info!("event after swap to pretty");
+    });
+}


### PR DESCRIPTION
## Motivation

Closes #3511.

When `tracing-subscriber::reload::Layer` is used to swap a `fmt::layer()` between `.pretty()` / `.json()` / `.compact()` at runtime, the `on_new_span` hook of the new layer has *not* run for spans that were created before the reload. Those spans therefore have no `FormattedFields<N>` extension. The next event in such a span causes a panic in `pretty.rs` / `json.rs`:

```text
panicked at .../pretty.rs:326:
Unable to find FormattedFields in extensions; this is a bug
```

This affects every program using `reload::Layer` to flip pretty/compact/json formatting at runtime, see the comments on #3511 from @nduchaux (reproduction) and @mladedav ("There's usually an unwrap that could be instead an early return, at least at the fmt layers").

## Solution

Treat a missing `FormattedFields` as 'no recorded fields for this span' rather than as a programmer bug:

* `pretty.rs`: skip the `" with <fields>"` segment and still emit the trailing newline. This matches the existing behaviour for spans whose `FormattedFields` is empty.
* `json.rs`: `return serializer.end()` so the span serializes as an empty object instead of crashing the writer.

A short comment in each site explains that the missing extension is the legitimate `reload::Layer` case (not a bug) so future readers do not re-introduce the unwrap.

## Test plan

- [x] `cargo build -p tracing-subscriber --features fmt,json,registry,std`
- [x] `cargo test -p tracing-subscriber --features fmt,json,registry,std --lib pretty`, 2 passed
- [x] `cargo test -p tracing-subscriber --features fmt,json,registry,std --lib json`, 11 passed

No behaviour change on the existing happy paths; the fix only affects the previously-panicking branch.