### PR TITLE
core: rebuild interest cache when dropping default Dispatch

### DIFF
--- a/tracing-core/src/dispatcher.rs
+++ b/tracing-core/src/dispatcher.rs
@@ -896,7 +896,10 @@ impl Drop for DefaultGuard {
         // state -- causing a clash.
         let prev = CURRENT_STATE.try_with(|state| state.default.replace(self.0.take()));
         SCOPED_COUNT.fetch_sub(1, Ordering::Release);
-        drop(prev)
+        drop(prev);
+        // Once the dispatcher has been dropped, we need to rebuild
+        // the callsite interest cache (without this dispatch).
+        callsite::rebuild_interest_cache();
     }
 }
 
@@ -924,21 +927,26 @@ mod test {
         assert!(dispatcher.downcast_ref::<NoSubscriber>().is_some());
     }
 
-    struct TestCallsite;
-    static TEST_CALLSITE: TestCallsite = TestCallsite;
-    static TEST_META: Metadata<'static> = metadata! {
-        name: "test",
-        target: module_path!(),
-        level: Level::DEBUG,
-        fields: &[],
-        callsite: &TEST_CALLSITE,
-        kind: Kind::EVENT
-    };
+    #[cfg(feature = "std")]
+    pub mod test_callsite {
+        use super::*;
 
-    impl Callsite for TestCallsite {
-        fn set_interest(&self, _: Interest) {}
-        fn metadata(&self) -> &Metadata<'_> {
-            &TEST_META
+        struct TestCallsite;
+        static TEST_CALLSITE: TestCallsite = TestCallsite;
+        pub static TEST_META: Metadata<'static> = metadata! {
+            name: "test",
+            target: module_path!(),
+            level: Level::DEBUG,
+            fields: &[],
+            callsite: &TEST_CALLSITE,
+            kind: Kind::EVENT
+        };
+
+        impl Callsite for TestCallsite {
+            fn set_interest(&self, _: Interest) {}
+            fn metadata(&self) -> &Metadata<'_> {
+                &TEST_META
+            }
         }
     }
 
@@ -968,7 +976,7 @@ mod test {
                     0,
                     "event method called twice!"
                 );
-                Event::dispatch(&TEST_META, &TEST_META.fields().value_set(&[]))
+                Event::dispatch(&test_callsite::TEST_META, &test_callsite::TEST_META.fields().value_set(&[]))
             }
 
             fn enter(&self, _: &span::Id) {}
@@ -977,7 +985,7 @@ mod test {
         }
 
         with_default(&Dispatch::new(TestSubscriber), || {
-            Event::dispatch(&TEST_META, &TEST_META.fields().value_set(&[]))
+            Event::dispatch(&test_callsite::TEST_META, &test_callsite::TEST_META.fields().value_set(&[]))
         })
     }
 
@@ -990,8 +998,8 @@ mod test {
         fn mk_span() {
             get_default(|current| {
                 current.new_span(&span::Attributes::new(
-                    &TEST_META,
-                    &TEST_META.fields().value_set(&[]),
+                    &test_callsite::TEST_META,
+                    &test_callsite::TEST_META.fields().value_set(&[]),
                 ))
             });
         }

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -1166,8 +1166,7 @@ mod private {
 
 #[cfg(test)]
 mod test {
-    use alloc::{borrow::ToOwned, boxed::Box, string::String};
-    use std::format;
+    use alloc::{borrow::ToOwned, string::String};
 
     use super::*;
     use crate::metadata::{Kind, Level, Metadata};
@@ -1367,6 +1366,6 @@ mod test {
             use core::fmt::Write;
             write!(&mut result, "{:?}", value).unwrap();
         });
-        assert_eq!(result, format!("{}", r#"[61 62 63]" "[c0 ff ee]"#));
+        assert_eq!(result, String::from(r#"[61 62 63]" "[c0 ff ee]"#));
     }
 }

--- a/tracing-core/tests/dispatch.rs
+++ b/tracing-core/tests/dispatch.rs
@@ -2,7 +2,10 @@
 mod common;
 
 use common::*;
-use tracing_core::dispatcher::*;
+use tracing_core::{
+    callsite, dispatcher::*, field, metadata::Metadata, span, subscriber::Subscriber, Event, Kind,
+    Level,
+};
 
 #[test]
 fn set_default_dispatch() {
@@ -53,4 +56,60 @@ fn nested_set_default() {
             "set_default outer subscriber failed"
         )
     });
+}
+
+#[test]
+fn interest_cache_rebuilt_when_default_dropped() {
+    static CALLSITE: callsite::DefaultCallsite = {
+        // The values of the metadata are unimportant
+        static META: Metadata<'static> = Metadata::new(
+            "event ",
+            "module::path",
+            Level::INFO,
+            None,
+            None,
+            None,
+            field::FieldSet::new(&[], callsite::Identifier(&CALLSITE)),
+            Kind::EVENT,
+        );
+        callsite::DefaultCallsite::new(&META)
+    };
+
+    let _guard = set_default(&Dispatch::new(NeverSubscriber));
+    assert!(CALLSITE.interest().is_never());
+
+    let inner_guard = set_default(&Dispatch::new(AlwaysSubscriber));
+    assert!(CALLSITE.interest().is_sometimes());
+
+    drop(inner_guard);
+    assert!(CALLSITE.interest().is_never());
+}
+
+pub struct AlwaysSubscriber;
+impl Subscriber for AlwaysSubscriber {
+    fn enabled(&self, _: &Metadata<'_>) -> bool {
+        true
+    }
+    fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
+        span::Id::from_u64(1)
+    }
+    fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
+    fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
+    fn event(&self, _: &Event<'_>) {}
+    fn enter(&self, _: &span::Id) {}
+    fn exit(&self, _: &span::Id) {}
+}
+pub struct NeverSubscriber;
+impl Subscriber for NeverSubscriber {
+    fn enabled(&self, _: &Metadata<'_>) -> bool {
+        false
+    }
+    fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
+        span::Id::from_u64(1)
+    }
+    fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
+    fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
+    fn event(&self, _: &Event<'_>) {}
+    fn enter(&self, _: &span::Id) {}
+    fn exit(&self, _: &span::Id) {}
 }

--- a/tracing-core/tests/missed_register_callsite.rs
+++ b/tracing-core/tests/missed_register_callsite.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "std")]
 use std::{
     ptr,
     sync::atomic::{AtomicPtr, Ordering},
@@ -7,7 +8,6 @@ use std::{
 
 use tracing_core::{
     callsite::{Callsite as _, DefaultCallsite},
-    dispatcher::set_default,
     field::{FieldSet, Value},
     span, Dispatch, Event, Kind, Level, Metadata, Subscriber,
 };


### PR DESCRIPTION
## Motivation

The interest cache is rebuilt when a new `Dispatch` is created, however
when a thread-local default `Dispatch` is removed (after the guard
returned by `set_default` is dropped or after the closure passed to
`with_default` has returned), the interest cache is not rebuilt.

Since the `Dispatch` is correctly dropped, the next time the interest
cache is rebuilt, it will be correct, however that won't happen until
another `Dispatch` is created or `rebuild_interest_cache` is called by
the application code.

## Solution

This change adds an explicit call to `rebuild_interest_cache` in the
`DefaultGuard` drop implementation, after the `Dispatch` it was guarding
has already been dropped. This will cause it to be filtered out on the
next pass through the dispatchers and the correct interest to be cached
directly.