### PR TITLE
docs(subscriber): fix pretty ANSI and env-filter documentation

### DIFF
--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -655,16 +655,12 @@ impl<F, T> Format<F, T> {
     /// # Options
     ///
     /// [`Format::with_ansi`] can be used to disable ANSI terminal escape codes (which enable
-    /// formatting such as colors, bold, italic, etc) in event formatting. However, a field
-    /// formatter must be manually provided to avoid ANSI in the formatting of parent spans, like
-    /// so:
+    /// formatting such as colors, bold, italic, etc) in event and field formatting:
     ///
     /// ```
-    /// # use tracing_subscriber::fmt::format;
     /// tracing_subscriber::fmt()
     ///    .pretty()
     ///    .with_ansi(false)
-    ///    .fmt_fields(format::PrettyFields::new().with_ansi(false))
     ///    // ... other settings ...
     ///    .init();
     /// ```

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -29,8 +29,14 @@
 //!
 //! ## Filtering Events with Environment Variables
 //!
-//! The default subscriber installed by `init` enables you to filter events
-//! at runtime using environment variables (using the [`EnvFilter`]).
+//! The subscriber installed by [`init`] enables you to filter events at runtime
+//! using environment variables (using the [`EnvFilter`]) when the `env-filter`
+//! feature is enabled. Configuring a subscriber with [`fmt()`] does **not**
+//! enable an [`EnvFilter`] by default; call [`.with_env_filter(...)`][with_env_filter]
+//! explicitly if you need `RUST_LOG` filtering.
+//!
+//! [`init`]: crate::fmt::init
+//! [with_env_filter]: SubscriberBuilder::with_env_filter
 //!
 //! The filter syntax is a superset of the [`env_logger`] syntax.
 //!

--- a/tracing-subscriber/src/fmt/time/time_crate.rs
+++ b/tracing-subscriber/src/fmt/time/time_crate.rs
@@ -8,15 +8,13 @@ use time::{format_description::well_known, formatting::Formattable, OffsetDateTi
 ///
 /// <div class="example-wrap" style="display:inline-block">
 /// <pre class="compile_fail" style="white-space:normal;font:inherit;">
-///     <strong>Warning</strong>: The <a href = "https://docs.rs/time/0.3/time/"><code>time</code>
-///     crate</a> must be compiled with <code>--cfg unsound_local_offset</code> in order to use
-///     local timestamps. When this cfg is not enabled, local timestamps cannot be recorded, and
+///     <strong>Warning</strong>: Recording local timestamps uses
+///     [`OffsetDateTime::now_local`], which may fail if the local offset cannot be determined
+///     (for example, in some multi-threaded contexts). When local time cannot be recorded,
 ///     events will be logged without timestamps.
 ///
-///    Alternatively, [`OffsetTime`] can log with a local offset if it is initialized early.
-///
-///    See the <a href="https://docs.rs/time/0.3.4/time/#feature-flags"><code>time</code>
-///    documentation</a> for more details.
+///     Alternatively, [`OffsetTime`] can log with a fixed local offset if it is initialized
+///     early in the program's lifecycle (recommended for production use).
 /// </pre></div>
 ///
 /// [local time]: time::OffsetDateTime::now_local


### PR DESCRIPTION
## Summary
- Drop deprecated `PrettyFields::with_ansi` from the `Format::pretty` example.
- Clarify that `fmt::init()` enables `EnvFilter` (with `env-filter`) but `fmt()` does not unless configured.

Fixes #2268
Fixes #1357