### PR TITLE
docs: fix broken rustdoc links across tracing crates

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -451,7 +451,7 @@ mod expand;
 /// ```
 ///
 /// **Note**:  if the function returns a `Result<T, E>`, `ret` will record returned values if and
-/// only if the function returns [`Result::Ok`].
+/// only if the function returns [`Ok`](core::result::Result::Ok).
 ///
 /// By default, returned values will be recorded using their [`std::fmt::Debug`] implementations.
 /// If a returned value implements [`std::fmt::Display`], it can be recorded using its `Display`
@@ -505,7 +505,7 @@ mod expand;
 /// the declared target (or the default channel if `target` is not specified).
 ///
 /// The `ret` and `err` arguments can be combined in order to record an event if a
-/// function returns [`Result::Ok`] or [`Result::Err`]:
+/// function returns [`Ok`](core::result::Result::Ok) or [`Err`](core::result::Result::Err):
 ///
 /// ```
 /// # use tracing_attributes::instrument;

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -91,7 +91,7 @@ where
     N: for<'writer> FormatFields<'writer> + 'static,
     W: for<'writer> MakeWriter<'writer> + 'static,
 {
-    /// Sets the [event formatter][`FormatEvent`] that the layer being built will
+    /// Sets the [`FormatEvent`] implementation that the layer being built will
     /// use to format events.
     ///
     /// The event formatter may be any type implementing the [`FormatEvent`]

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -1008,7 +1008,7 @@ impl<N, E, F, W> SubscriberBuilder<N, E, F, W> {
         }
     }
 
-    /// Sets the [event formatter][`FormatEvent`] that the subscriber being built
+    /// Sets the [`FormatEvent`] implementation that the subscriber being built
     /// will use to format events that occur.
     ///
     /// The event formatter may be any type implementing the [`FormatEvent`]

--- a/tracing/src/field.rs
+++ b/tracing/src/field.rs
@@ -95,7 +95,7 @@
 //! be forwarded to the visitor's [`record_debug`] method.
 //!
 //! [`fmt::Debug`]: std::fmt::Debug
-//! [`fmt::Display`]: std::fmt::Debug
+//! [`fmt::Display`]: std::fmt::Display
 //! [`valuable`]: https://crates.io/crates/valuable
 //! [`valuable::Valuable`]: https://docs.rs/valuable/latest/valuable/trait.Valuable.html
 //! [`as_value`]: https://docs.rs/valuable/latest/valuable/trait.Valuable.html#tymethod.as_value


### PR DESCRIPTION
Fixes #2783