### PR TITLE
subscriber: make EnvFilter Builder::env_var_name public

### DIFF
--- a/tracing-subscriber/src/filter/env/builder.rs
+++ b/tracing-subscriber/src/filter/env/builder.rs
@@ -340,7 +340,30 @@ impl Builder {
         filter
     }
 
-    fn env_var_name(&self) -> &str {
+    /// Returns the name of the environment variable read by the
+    /// [`from_env`], [`from_env_lossy`], and [`try_from_env`] methods.
+    ///
+    /// If a custom name was configured via [`with_env_var`], that name is
+    /// returned. Otherwise, the default of [`EnvFilter::DEFAULT_ENV`]
+    /// (`RUST_LOG`) is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tracing_subscriber::filter::EnvFilter;
+    ///
+    /// let builder = EnvFilter::builder();
+    /// assert_eq!(builder.env_var_name(), EnvFilter::DEFAULT_ENV);
+    ///
+    /// let builder = EnvFilter::builder().with_env_var("MY_APP_LOG");
+    /// assert_eq!(builder.env_var_name(), "MY_APP_LOG");
+    /// ```
+    ///
+    /// [`from_env`]: Self::from_env
+    /// [`from_env_lossy`]: Self::from_env_lossy
+    /// [`try_from_env`]: Self::try_from_env
+    /// [`with_env_var`]: Self::with_env_var
+    pub fn env_var_name(&self) -> &str {
         self.env.as_deref().unwrap_or(EnvFilter::DEFAULT_ENV)
     }
 }


### PR DESCRIPTION
## Motivation

`tracing_subscriber::filter::EnvFilter::builder()` returns a `Builder` whose configured environment-variable name (set by `with_env_var`, defaulting to `EnvFilter::DEFAULT_ENV`) is currently inaccessible to external code. A downstream that wants to inspect the configured name (for example, to log a clear error when that variable holds an invalid filter string) has to either hardcode `EnvFilter::DEFAULT_ENV` (losing any custom name set via `with_env_var`) or reimplement the builder's fallback logic.

The motivating use case came up in Bevy's `LogPlugin` (bevyengine/bevy#13897), which wants to surface a diagnostic when the user-configured `RUST_LOG`-equivalent variable contains invalid directives, but cannot reach the configured name through the builder.

## Solution

Flip the existing `fn env_var_name(&self) -> &str` on `Builder` from private to `pub`, with rustdoc describing the precedence between `with_env_var` and `EnvFilter::DEFAULT_ENV`, plus a short example:

```rust
use tracing_subscriber::filter::EnvFilter;

let builder = EnvFilter::builder();
assert_eq!(builder.env_var_name(), EnvFilter::DEFAULT_ENV);

let builder = EnvFilter::builder().with_env_var("MY_APP_LOG");
assert_eq!(builder.env_var_name(), "MY_APP_LOG");
```

The implementation is unchanged. This is a purely additive change to the public API surface. No new fields are exposed; `Builder::env` stays private, so the builder keeps exclusive control over how the name is stored.

Closes #3009.
