### PR TITLE
chore: fix 'clippy::manual_option_zip' in tracing-error

### DIFF
--- a/tracing-error/src/backtrace.rs
+++ b/tracing-error/src/backtrace.rs
@@ -205,10 +205,7 @@ impl fmt::Display for SpanTrace {
                 try_bool!(write!(f, "\n           with {}", fields), err);
             }
 
-            if let Some((file, line)) = metadata
-                .file()
-                .and_then(|file| metadata.line().map(|line| (file, line)))
-            {
+            if let Some((file, line)) = metadata.file().zip(metadata.line()) {
                 try_bool!(write!(f, "\n             at {}:{}", file, line), err);
             }
 
@@ -240,11 +237,7 @@ impl fmt::Debug for SpanTrace {
                     write!(f, ", fields: {:?}", self.fields)?;
                 }
 
-                if let Some((file, line)) = self
-                    .metadata
-                    .file()
-                    .and_then(|file| self.metadata.line().map(|line| (file, line)))
-                {
+                if let Some((file, line)) = self.metadata.file().zip(self.metadata.line()) {
                     write!(f, ", file: {:?}, line: {:?}", file, line)?;
                 }
 


### PR DESCRIPTION
## Motivation

CI `warnings` job (clippy) is failing with `error: manual implementation of "Option::zip"` for Rust 1.96.0.
e.g. https://github.com/tokio-rs/tracing/actions/runs/25983660191/job/78456844423?pr=3534

```
error: manual implementation of `Option::zip`
   --> tracing-error/src/backtrace.rs:208:41
    |
208 |               if let Some((file, line)) = metadata
    |  _________________________________________^
209 | |                 .file()
210 | |                 .and_then(|file| metadata.line().map(|line| (file, line)))
    | |__________________________________________________________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#manual_option_zip
    = note: `-D clippy::manual-option-zip` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_option_zip)]`
help: use
    |
208 ~             if let Some((file, line)) = metadata
209 +                 .file().zip(metadata.line())
```


## Solution

Apply the suggestion by Clippy and format the code (cargo fmt --all).