### PR TITLE
subscriber: Change Writer's `with_ansi*` accessors to pub

### DIFF
--- a/tracing-subscriber/src/fmt/format/mod.rs
+++ b/tracing-subscriber/src/fmt/format/mod.rs
@@ -420,12 +420,6 @@ pub struct Format<F = Full, T = SystemTime> {
 // === impl Writer ===
 
 impl<'writer> Writer<'writer> {
-    // TODO(eliza): consider making this a public API?
-    // We may not want to do that if we choose to expose specialized
-    // constructors instead (e.g. `from_string` that stores whether the string
-    // is empty...?)
-    //(@kaifastromai) I suppose having dedicated constructors may have certain benefits
-    // but I am not privy to the larger direction of tracing/subscriber.
     /// Create a new [`Writer`] from any type that implements [`fmt::Write`].
     ///
     /// The returned `Writer` value may be passed as an argument to methods
@@ -446,12 +440,11 @@ impl<'writer> Writer<'writer> {
         }
     }
 
-    // TODO(eliza): consider making this a public API?
-    pub(crate) fn with_ansi(self, is_ansi: bool) -> Self {
+    pub fn with_ansi(self, is_ansi: bool) -> Self {
         Self { is_ansi, ..self }
     }
 
-    pub(crate) fn with_ansi_sanitization(self, ansi_sanitization: bool) -> Self {
+    pub fn with_ansi_sanitization(self, ansi_sanitization: bool) -> Self {
         Self {
             ansi_sanitization,
             ..self


### PR DESCRIPTION
This PR changes the scope of the `with_ansi*` accessors in the `Writer` class from `pub(crate)` to `pub`. 

## Motivation

Our software's workflow maps a subscriber's events to a `Writer` class for writing stdout and stderr to an HTML file. While the subscriber layer itself can set `with_ansi_sanitization` to false (thereby giving us "clean" output), the writer instead holds its own state. This caused some confusion when the `Writer` ended up writing codes, when the output to the console did not.

```
let report_layer = tracing_subscriber::fmt::layer()
                .with_target(print_target)
                .with_writer(report_writer)
                .pretty()
                .with_ansi(true)
                .map_event_format(move |e| {
                    let f = e
                        .with_ansi(true)
                        .with_source_location(print_source_location);
                    FormatHtml::new(f, converter) // <-- This holds a Writer
                })
                .with_ansi_sanitization(false);   // <-- which makes this useless in the Writer context
```


## Solution

Make the accessors public so that we can modify the `Writer` behavior to match the layer from which it is mapped. Happy to hear other solutions, but given the discussion in the file, it seems like this may have been on your minds anyway.