### PR TITLE
feat: `TracedError` impl Clone, get inner error

### DIFF
--- a/tracing-error/src/error.rs
+++ b/tracing-error/src/error.rs
@@ -181,6 +181,12 @@ where
     }
 }
 
+impl<E> std::clone::Clone for TracedError<E> where E: Clone {
+    fn clone(&self) -> Self {
+        Self { inner: self.inner.clone() }
+    }
+}
+
 impl<E> From<E> for TracedError<E>
 where
     E: Error + Send + Sync + 'static,
@@ -210,6 +216,12 @@ impl ErrorImpl<Erased> {
         // the function pointer we construct here will also retain the original type. therefore,
         // when this is consumed by the `error` method, it will be safe to call.
         unsafe { (self.vtable.object_ref)(self) }
+    }
+}
+
+impl<E> Clone for ErrorImpl<E> where E: Clone {
+    fn clone(&self) -> Self {
+        Self { vtable: self.vtable, span_trace: self.span_trace.clone(), error: self.error.clone() }
     }
 }
 

--- a/tracing-error/src/error.rs
+++ b/tracing-error/src/error.rs
@@ -179,6 +179,50 @@ where
     {
         self.map(Into::into)
     }
+
+    /// Return a reference to the original error stored within this [`TracedError`].
+    ///
+    /// ```rust
+    /// use tracing_error::TracedError;
+    /// # #[derive(Clone, Debug, PartialEq)]
+    /// # struct MyError(u64);
+    /// # impl std::fmt::Display for MyError {
+    /// #     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    /// #         write!(f, "Inner Error")
+    /// #     }
+    /// # }
+    /// # impl std::error::Error for MyError {}
+    ///
+    /// let original_err = MyError(42);
+    ///
+    /// let traced_err: TracedError<MyError> = TracedError::from(original_err.clone());
+    /// assert_eq!(traced_err.get_inner_error(), &original_err)
+    /// ```
+    pub fn get_inner_error(&self) -> &E {
+        &self.inner.error
+    }
+
+    /// Consume the [`TracedError`] and return the original error stored within.
+    ///
+    /// ```rust
+    /// use tracing_error::TracedError;
+    /// # #[derive(Clone, Debug, PartialEq)]
+    /// # struct MyError(u64);
+    /// # impl std::fmt::Display for MyError {
+    /// #     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    /// #         write!(f, "Inner Error")
+    /// #     }
+    /// # }
+    /// # impl std::error::Error for MyError {}
+    ///
+    /// let original_err = MyError(42);
+    ///
+    /// let traced_err: TracedError<MyError> = TracedError::from(original_err.clone());
+    /// assert_eq!(traced_err.to_inner_error(), original_err)
+    /// ```
+    pub fn to_inner_error(self) -> E {
+        self.inner.error
+    }
 }
 
 impl<E> std::clone::Clone for TracedError<E> where E: Clone {

--- a/tracing-error/src/error.rs
+++ b/tracing-error/src/error.rs
@@ -225,9 +225,14 @@ where
     }
 }
 
-impl<E> std::clone::Clone for TracedError<E> where E: Clone {
+impl<E> std::clone::Clone for TracedError<E>
+where
+    E: Clone,
+{
     fn clone(&self) -> Self {
-        Self { inner: self.inner.clone() }
+        Self {
+            inner: self.inner.clone(),
+        }
     }
 }
 
@@ -263,9 +268,16 @@ impl ErrorImpl<Erased> {
     }
 }
 
-impl<E> Clone for ErrorImpl<E> where E: Clone {
+impl<E> Clone for ErrorImpl<E>
+where
+    E: Clone,
+{
     fn clone(&self) -> Self {
-        Self { vtable: self.vtable, span_trace: self.span_trace.clone(), error: self.error.clone() }
+        Self {
+            vtable: self.vtable,
+            span_trace: self.span_trace.clone(),
+            error: self.error.clone(),
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

`TracedError` currently does not `impl Clone`, even if the inner error implements `Clone`.

Additionally, there is currently no way to access the inner error.

## Solution

Adds `impl Clone for TracedError` and two new methods, one for accessing the inner error by reference and one for "unwrapping" the `TracedError` entirely.