### PR TITLE
attributes: Improve spans for body block

### DIFF
--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -84,10 +84,18 @@ pub(crate) fn gen_function<'a, B: ToTokens + 'a>(
             return __tracing_attr_fake_return;
         }
     };
+
+    // Ensure that we use the user-written {} to surround the user-written block
+    // for better proc-macro token spans for compiler error messages.
+    let mut innermost_block_tokens = TokenStream::new();
+    brace_token.surround(&mut innermost_block_tokens, |tokens| {
+        block.to_tokens(tokens);
+    });
+
     let block = quote! {
         {
             #fake_return_edge
-            { #block }
+            #innermost_block_tokens
         }
     };
 


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

`tracing::instrument` expands to something approximately like this:

```
fn name() {//^0
  {//^1
    // span
    {//^2
      if false {}
      {//^3
        // actual statements from the body
      }
    }
  }
}
```

When the actual body contains errors, rustc will use all kinds of spans to display those errors.

Currently, tracing will assign call-site spans to `^1`, `^2`, `^3` and the spans from the real `{` to `^0`. This is a problem because rustc will sometimes use the span from `^3` in syntax errors:

```
fn main() {
    let x:
}
```

```
error: expected type, found `}`
 --> src/main.rs:4:1
  |
3 |     let x:
  |          - while parsing the type for `x`
4 | }
  | ^ expected type

error: expected type, found `}`
 --> src/main.rs:1:1
  |
1 | #[tracing_attributes::instrument]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type
2 | fn main() {
3 |     let x:
  |          - while parsing the type for `x`
  |
  = note: this error originates in the attribute macro `tracing_attributes::instrument` (in Nightly builds, run with -Z macro-backtrace for more info)
```

The first error is from pre-expansion parsing, while the second error comes from post-expansion parsing and chas the bad span because rustc tries to point at the `}` character.


## Solution

By making `^3` use the user token span as well, the span of the error will improve significantly.

```
error: expected type, found `}`
 --> src/main.rs:2:11
  |
2 |   fn main() {
  |  ___________^
3 | |     let x:
  | |          - while parsing the type for `x`
4 | | }
  | |_^ expected type
```

It's still not perfect because of limitations in `proc_macro::Group` that do not allow assigning the open and close spans separately. If that ever becomes available, syn should be able to use it automatically and tracing would get the nice errors.

Because it's still not quite perfect after this change, errors will still not be deduplicated and there will be two of them.

An alternative would be to preserve the entire body, including the `{}`, verbatim without any syn-printing, which I think should be able to preserve the spans precisely. I opted against this for now as it would involve slightly more changes.