### PR TITLE
subscriber: Replace OFF with None in empty Vec max_level_hint

### DIFF
--- a/tracing-subscriber/src/layer/mod.rs
+++ b/tracing-subscriber/src/layer/mod.rs
@@ -705,6 +705,7 @@ use core::any::TypeId;
 feature! {
     #![feature = "alloc"]
     use alloc::boxed::Box;
+    use core::cmp::Reverse;
     use core::ops::{Deref, DerefMut};
 }
 
@@ -1828,17 +1829,11 @@ feature! {
         }
 
         fn max_level_hint(&self) -> Option<LevelFilter> {
-            // Default to `OFF` if there are no inner layers.
-            let mut max_level = LevelFilter::OFF;
-            for l in self {
-                // NOTE(eliza): this is slightly subtle: if *any* layer
-                // returns `None`, we have to return `None`, assuming there is
-                // no max level hint, since that particular layer cannot
-                // provide a hint.
-                let hint = l.max_level_hint()?;
-                max_level = core::cmp::max(hint, max_level);
-            }
-            Some(max_level)
+            // NOTE(eliza): if *any* layer returns `None`, we have to return `None`, assuming there
+            // is no max level hint, since that particular layer cannot provide a hint.
+            let max_opt_level = self.iter().map(|l| l.max_level_hint().map(Reverse)).min();
+            // If Vec is empty, this will shortcircuit with `None`, which is desired.
+            Some(max_opt_level??.0)
         }
 
         fn on_record(&self, span: &span::Id, values: &span::Record<'_>, ctx: Context<'_, S>) {

--- a/tracing-subscriber/tests/layer_filters/vec.rs
+++ b/tracing-subscriber/tests/layer_filters/vec.rs
@@ -117,5 +117,5 @@ fn all_filtered_max_level_hint() {
 fn empty_vec() {
     // Just a None means everything is off
     let subscriber = tracing_subscriber::registry().with(Vec::<MockLayer>::new());
-    assert_eq!(subscriber.max_level_hint(), Some(LevelFilter::OFF));
+    assert_eq!(subscriber.max_level_hint(), None);
 }

--- a/tracing-subscriber/tests/vec.rs
+++ b/tracing-subscriber/tests/vec.rs
@@ -7,7 +7,7 @@ use tracing_subscriber::prelude::*;
 fn just_empty_vec() {
     // Just a None means everything is off
     let subscriber = tracing_subscriber::registry().with(Vec::<LevelFilter>::new());
-    assert_eq!(subscriber.max_level_hint(), Some(LevelFilter::OFF));
+    assert_eq!(subscriber.max_level_hint(), None);
 }
 
 #[test]


### PR DESCRIPTION
The expected behavior of adding an empty Vec as Layer is that it does nothing. Right now, it adds a LevelFilter::OFF rule, thus supressing other layers.

This change makes max_level_hint return None, which doesn't supress other layers, following expected behavior.

* Fixes #3563
* This is a breaking change (no API change, but observable behavior)

## Motivation

* Fixes #3563

## Solution

We return `None` when the vec is empty.

### Details

The one-liner: cute solution, but might not be obvious how it works at first glance:

* We want the highest level filter for `LevelFilter`, but we want the `None` case to be even higher priority than other.
* **Problem**: the `Ord` impl of `Option` makes `None` the lowest possible value. **Solution**: We use `min` instead of `max`!
* **Problem**: But then our ordering is invalid for `LevelFilter`. **Solution**: We use `.map(Reverse)` so that `min` for `LevelFilter` is equivalent to `max`!
* We just have to unwrap the whole thing at the end with `Some(x??.0)`