### PR TITLE
subscriber: don't abort in release when cloning a closed span

### DIFF
--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -314,7 +314,13 @@ impl Subscriber for Registry {
         // calls to `try_close`: we have to ensure that all threads have
         // dropped their refs to the span before the span is closed.
         let refs = span.ref_count.fetch_add(1, Ordering::Relaxed);
-        assert_ne!(
+        // If the reference count was zero, the span has already been closed and
+        // this clone would resurrect it. This only happens through incorrect API
+        // usage, most commonly holding a span open across an `.await` point (see
+        // issue #3514). It produces incorrect traces, but it must not abort the
+        // program, so this is only a debug assertion: release builds tolerate the
+        // resurrected span rather than panicking.
+        debug_assert_ne!(
             refs, 0,
             "tried to clone a span ({:?}) that already closed.\n\
              This error message may indicate that a Span was held open across an \
@@ -902,6 +908,45 @@ mod tests {
             drop(span3);
 
             state.assert_closed_in_order(["child", "parent", "grandparent"]);
+        });
+    }
+
+    // Regression test for https://github.com/tokio-rs/tracing/issues/3514.
+    //
+    // A span whose reference count has already reached zero can still be cloned
+    // via `Span::current`, for example when a span is incorrectly held open
+    // across an `.await` point. This used to abort the process via `assert_ne!`;
+    // it is now a `debug_assert_ne!`, so release builds tolerate the (incorrect
+    // but non-fatal) resurrected span instead of panicking, while debug builds
+    // still surface the misuse.
+    #[test]
+    fn clone_span_with_zero_ref_count_does_not_abort_in_release() {
+        let dispatch = dispatcher::Dispatch::new(Registry::default());
+        dispatcher::with_default(&dispatch, || {
+            let span = tracing::info_span!("held across await");
+            let id = span.id().expect("a registry span must have an ID");
+            // Dropping the only handle brings the reference count to zero. With
+            // a bare `Registry` (no layers), the slab entry is not cleared, so
+            // the span data remains reachable with a zero reference count: the
+            // exact state that triggers #3514.
+            drop(span);
+
+            let cloned =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| dispatch.clone_span(&id)));
+
+            if cfg!(debug_assertions) {
+                // Debug builds keep the assertion to surface the misuse.
+                assert!(
+                    cloned.is_err(),
+                    "cloning a closed span should hit the debug assertion in debug builds",
+                );
+            } else {
+                // Release builds must not panic; the clone returns the same ID.
+                assert_eq!(
+                    cloned.expect("cloning a closed span must not panic in release builds"),
+                    id,
+                );
+            }
         });
     }
 }

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -314,12 +314,12 @@ impl Subscriber for Registry {
         // calls to `try_close`: we have to ensure that all threads have
         // dropped their refs to the span before the span is closed.
         let refs = span.ref_count.fetch_add(1, Ordering::Relaxed);
-        // If the reference count was zero, the span has already been closed and
-        // this clone would resurrect it. This only happens through incorrect API
-        // usage, most commonly holding a span open across an `.await` point (see
-        // issue #3514). It produces incorrect traces, but it must not abort the
-        // program, so this is only a debug assertion: release builds tolerate the
-        // resurrected span rather than panicking.
+        // A zero reference count here means the span was already closed, which
+        // can only happen through incorrect API usage, most commonly holding a
+        // span open across an `.await` point (see issue #3514). That is a bug in
+        // the caller, but it must not abort the program, so this is a debug
+        // assertion rather than a hard one: debug builds surface the misuse,
+        // while release builds keep running instead of panicking.
         debug_assert_ne!(
             refs, 0,
             "tried to clone a span ({:?}) that already closed.\n\
@@ -916,9 +916,12 @@ mod tests {
     // A span whose reference count has already reached zero can still be cloned
     // via `Span::current`, for example when a span is incorrectly held open
     // across an `.await` point. This used to abort the process via `assert_ne!`;
-    // it is now a `debug_assert_ne!`, so release builds tolerate the (incorrect
-    // but non-fatal) resurrected span instead of panicking, while debug builds
-    // still surface the misuse.
+    // it is now a `debug_assert_ne!`, so release builds keep running instead of
+    // panicking, while debug builds still surface the misuse.
+    //
+    // Note: only the release branch below distinguishes this fix from the old
+    // `assert_ne!` -- under `cargo test` (debug) both panic, so this must be run
+    // with `cargo test --release` to exercise the non-aborting path.
     #[test]
     fn clone_span_with_zero_ref_count_does_not_abort_in_release() {
         let dispatch = dispatcher::Dispatch::new(Registry::default());

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -313,23 +313,13 @@ impl Subscriber for Registry {
         // always at least 1. The only synchronization necessary is between
         // calls to `try_close`: we have to ensure that all threads have
         // dropped their refs to the span before the span is closed.
-        let refs = span.ref_count.fetch_add(1, Ordering::Relaxed);
-        // A zero reference count here means the span was already closed, which
-        // can only happen through incorrect API usage, most commonly holding a
-        // span open across an `.await` point (see issue #3514). That is a bug in
-        // the caller, but it must not abort the program, so this is a debug
-        // assertion rather than a hard one: debug builds surface the misuse,
-        // while release builds keep running instead of panicking.
-        debug_assert_ne!(
-            refs, 0,
-            "tried to clone a span ({:?}) that already closed.\n\
-             This error message may indicate that a Span was held open across an \
-             await point.\nSee the documentation \
-             (https://docs.rs/tracing/latest/tracing/span/struct.EnteredSpan.html#in-asynchronous-code) \
-             for more details.\n\
-            ",
-            id
-        );
+        //
+        // If the reference count was already zero, the span has been closed and
+        // this clone resurrects it. This only happens through incorrect API
+        // usage, such as holding a span open across an `.await` point (see issue
+        // #3514). It may produce incorrect traces, but it must not abort the
+        // program, so we deliberately tolerate it rather than panicking.
+        span.ref_count.fetch_add(1, Ordering::Relaxed);
         id.clone()
     }
 
@@ -913,20 +903,16 @@ mod tests {
 
     // Regression test for https://github.com/tokio-rs/tracing/issues/3514.
     //
-    // A span whose reference count has already reached zero can still be cloned
-    // via `Span::current`, for example when a span is incorrectly held open
-    // across an `.await` point. This used to abort the process via `assert_ne!`;
-    // it is now a `debug_assert_ne!`, so release builds keep running instead of
-    // panicking, while debug builds still surface the misuse.
-    //
-    // Note: only the release branch below distinguishes this fix from the old
-    // `assert_ne!` -- under `cargo test` (debug) both panic, so this must be run
-    // with `cargo test --release` to exercise the non-aborting path.
+    // Cloning a span whose reference count has already reached zero must not
+    // panic. That state arises through incorrect API usage, such as holding a
+    // span open across an `.await` point; here it is reproduced directly by
+    // dropping a span's only handle and then cloning its ID, which keeps the
+    // behavior under test explicit rather than relying on an actual await.
     #[test]
-    fn clone_span_with_zero_ref_count_does_not_abort_in_release() {
+    fn clone_span_with_zero_ref_count_does_not_panic() {
         let dispatch = dispatcher::Dispatch::new(Registry::default());
         dispatcher::with_default(&dispatch, || {
-            let span = tracing::info_span!("held across await");
+            let span = tracing::info_span!("span");
             let id = span.id().expect("a registry span must have an ID");
             // Dropping the only handle brings the reference count to zero. With
             // a bare `Registry` (no layers), the slab entry is not cleared, so
@@ -934,22 +920,9 @@ mod tests {
             // exact state that triggers #3514.
             drop(span);
 
-            let cloned =
-                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| dispatch.clone_span(&id)));
-
-            if cfg!(debug_assertions) {
-                // Debug builds keep the assertion to surface the misuse.
-                assert!(
-                    cloned.is_err(),
-                    "cloning a closed span should hit the debug assertion in debug builds",
-                );
-            } else {
-                // Release builds must not panic; the clone returns the same ID.
-                assert_eq!(
-                    cloned.expect("cloning a closed span must not panic in release builds"),
-                    id,
-                );
-            }
+            // Cloning the now-closed span must not panic, and must return the
+            // same ID.
+            assert_eq!(dispatch.clone_span(&id), id);
         });
     }
 }


### PR DESCRIPTION
## Motivation

`Registry::clone_span` asserts via `assert_ne!` that a span's reference count is
non-zero before incrementing it. Holding a span open across an `.await` point —
incorrect, but easy to do by accident — can leave a stale entry on the span
stack after the span's reference count has reached zero. A later `Span::current()`
then calls `clone_span` on the now-closed span, and the `assert_ne!` aborts the
worker thread, **even in release builds**:

```
thread 'tokio-rt-worker' panicked at .../registry/sharded.rs:
assertion `left != right` failed: tried to clone a span (Id(...)) that already closed
```

This started when #3289 removed the `clone_span`/`try_close` balancing from the
`Registry`'s `enter`/`exit` — that change didn't account for spans entered
across `.await` points. Entering a span across an await point is incorrect usage,
but it should not crash the program.

Fixes: #3514

## Solution

Downgrade the assertion to `debug_assert_ne!`, as suggested in the issue: debug
builds still surface the misuse during development, while release builds keep
running instead of aborting. Keeping the `fetch_add` leaves the reference count
balanced, so a later `try_close` still removes the span normally.

A regression test reproduces the zero-reference-count clone against a bare
`Registry` and checks the debug-vs-release behavior. Note that only the release
branch distinguishes this fix from the previous `assert_ne!` (both panic under
debug), so it must be run with `cargo test --release` to exercise the
non-aborting path.