### PR TITLE
appender: gate symlink support to platforms that support it

### DIFF
--- a/tracing-appender/Cargo.toml
+++ b/tracing-appender/Cargo.toml
@@ -24,7 +24,6 @@ rust-version = "1.63.0"
 crossbeam-channel = "0.5.6"
 time = { version = "0.3.2", default-features = false, features = ["formatting", "parsing"] }
 parking_lot = { optional = true, version = "0.12.1" }
-symlink = "0.1.0"
 thiserror = "2"
 
 [dependencies.tracing-subscriber]
@@ -32,6 +31,13 @@ path = "../tracing-subscriber"
 version = "0.3.18"
 default-features = false
 features = ["fmt", "std"]
+
+# Symbolic links (used by the `latest_symlink` builder option) are only
+# available on some platforms, so the `symlink` dependency is gated to those
+# targets. On others (such as `wasm32`) the option is a no-op and the crate
+# still builds.
+[target.'cfg(any(unix, windows, target_os = "redox"))'.dependencies]
+symlink = "0.1.0"
 
 [dev-dependencies]
 criterion = { version = "0.3.6", default-features = false }

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -800,14 +800,38 @@ fn create_writer(
     })?;
 
     if let Some(symlink_name) = latest_symlink_name {
-        let symlink_path = directory.join(symlink_name);
-        let _ = symlink::remove_symlink_file(&symlink_path);
-        symlink::symlink_file(path, symlink_path).map_err(InitError::ctx(
-            "failed to create symlink to latest log file",
-        ))?;
+        update_latest_symlink(directory, &path, symlink_name)?;
     }
 
     Ok(new_file)
+}
+
+/// Updates the "latest" symbolic link to point at the most recent log file.
+///
+/// Symbolic links are only available on some platforms. On targets where they
+/// are not supported (such as `wasm32`), the `symlink` crate is not a
+/// dependency and this is a no-op, so the `latest_symlink` builder option has
+/// no effect there.
+#[cfg(any(unix, windows, target_os = "redox"))]
+fn update_latest_symlink(
+    directory: &Path,
+    target: &Path,
+    symlink_name: &str,
+) -> Result<(), InitError> {
+    let symlink_path = directory.join(symlink_name);
+    let _ = symlink::remove_symlink_file(&symlink_path);
+    symlink::symlink_file(target, symlink_path).map_err(InitError::ctx(
+        "failed to create symlink to latest log file",
+    ))
+}
+
+#[cfg(not(any(unix, windows, target_os = "redox")))]
+fn update_latest_symlink(
+    _directory: &Path,
+    _target: &Path,
+    _symlink_name: &str,
+) -> Result<(), InitError> {
+    Ok(())
 }
 
 fn parse_date_from_filename(
@@ -1362,6 +1386,7 @@ mod test {
         );
     }
 
+    #[cfg(any(unix, windows, target_os = "redox"))]
     #[test]
     fn test_latest_symlink() {
         use std::sync::{Arc, Mutex};


### PR DESCRIPTION
## Motivation

`tracing-appender` 0.2.5 added the `latest_symlink` builder option (#3447), which
depends on the [`symlink`](https://crates.io/crates/symlink) crate. That crate
only defines `symlink_file` and `remove_symlink_file` on `unix`, `windows`, and
`redox`, so on other targets — notably `wasm32-unknown-unknown` — the appender no
longer compiles:

```
error[E0425]: cannot find function `remove_symlink_file` in crate `symlink`
   --> tracing-appender/src/rolling.rs:804:26
    |
804 |         let _ = symlink::remove_symlink_file(&symlink_path);
    |                          ^^^^^^^^^^^^^^^^^^^ not found in `symlink`
note: found an item that was configured out
    |
133 | #[cfg(any(target_os = "redox", unix, windows))]
```

tracing-appender 0.2.4 built fine on `wasm32`; 0.2.5 regressed.

Fixes: #3536

## Solution

Gate the `symlink` dependency to the platforms that support symbolic links, and
gate the code that uses it the same way:

- In `Cargo.toml`, move `symlink` into
  `[target.'cfg(any(unix, windows, target_os = "redox"))'.dependencies]`.
- In `rolling.rs`, extract the symlink logic from `create_writer` into an
  `update_latest_symlink` helper with two `cfg`-gated definitions: the real one
  for symlink-capable targets, and a no-op for the rest. `test_latest_symlink`
  is gated the same way.

On platforms without symbolic-link support, `latest_symlink` is now a no-op (the
log file is still written; no symlink is created), and the crate compiles again.
The existing `test-build-wasm` CI job builds `tracing-appender` for `wasm32`.