### PR TITLE
tracing: accept dotted field names as the first field with name:

### DIFF
--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -1335,14 +1335,32 @@ macro_rules! trace {
     (name: $name:expr, target: $target:expr, parent: $parent:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::TRACE, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::TRACE, { $($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::TRACE, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::TRACE, { ?$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::TRACE, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::TRACE, { %$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::TRACE, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::TRACE, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::TRACE, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::TRACE, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::TRACE, { $($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::TRACE, { ?$($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::TRACE, { %$($k).+ })
     );
     (name: $name:expr, target: $target:expr, parent: $parent:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::TRACE, {}, $($arg)+)
@@ -1352,14 +1370,32 @@ macro_rules! trace {
     (name: $name:expr, target: $target:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, target: $target, $crate::Level::TRACE, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, target: $target:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, $crate::Level::TRACE, { $($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::TRACE, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, $crate::Level::TRACE, { ?$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::TRACE, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, $crate::Level::TRACE, { %$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::TRACE, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::TRACE, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::TRACE, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::TRACE, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::TRACE, { $($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::TRACE, { ?$($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::TRACE, { %$($k).+ })
     );
     (name: $name:expr, target: $target:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, target: $target, $crate::Level::TRACE, {}, $($arg)+)
@@ -1386,14 +1422,32 @@ macro_rules! trace {
     (name: $name:expr, parent: $parent:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, parent: $parent, $crate::Level::TRACE, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, parent: $parent:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, parent: $parent, $crate::Level::TRACE, { $($k).+ $($field)* })
+    (name: $name:expr, parent: $parent:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::TRACE, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, parent: $parent, $crate::Level::TRACE, { ?$($k).+ $($field)* })
+    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::TRACE, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, parent: $parent:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, parent: $parent, $crate::Level::TRACE, { %$($k).+ $($field)* })
+    (name: $name:expr, parent: $parent:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::TRACE, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::TRACE, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::TRACE, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::TRACE, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::TRACE, { $($k).+ })
+    );
+    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::TRACE, { ?$($k).+ })
+    );
+    (name: $name:expr, parent: $parent:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::TRACE, { %$($k).+ })
     );
     (name: $name:expr, parent: $parent:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, parent: $parent, $crate::Level::TRACE, {}, $($arg)+)
@@ -1403,14 +1457,32 @@ macro_rules! trace {
     (name: $name:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, $crate::Level::TRACE, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, $crate::Level::TRACE, { $($k).+ $($field)* })
+    (name: $name:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::TRACE, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, $crate::Level::TRACE, { ?$($k).+ $($field)* })
+    (name: $name:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::TRACE, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, $crate::Level::TRACE, { %$($k).+ $($field)* })
+    (name: $name:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::TRACE, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::TRACE, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::TRACE, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::TRACE, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, $crate::Level::TRACE, { $($k).+ })
+    );
+    (name: $name:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, $crate::Level::TRACE, { ?$($k).+ })
+    );
+    (name: $name:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, $crate::Level::TRACE, { %$($k).+ })
     );
     (name: $name:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, $crate::Level::TRACE, {}, $($arg)+)
@@ -1611,14 +1683,32 @@ macro_rules! debug {
     (name: $name:expr, target: $target:expr, parent: $parent:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::DEBUG, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::DEBUG, { $($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::DEBUG, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::DEBUG, { ?$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::DEBUG, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::DEBUG, { %$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::DEBUG, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::DEBUG, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::DEBUG, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::DEBUG, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::DEBUG, { $($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::DEBUG, { ?$($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::DEBUG, { %$($k).+ })
     );
     (name: $name:expr, target: $target:expr, parent: $parent:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::DEBUG, {}, $($arg)+)
@@ -1628,14 +1718,32 @@ macro_rules! debug {
     (name: $name:expr, target: $target:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, target: $target, $crate::Level::DEBUG, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, target: $target:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, $crate::Level::DEBUG, { $($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::DEBUG, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, $crate::Level::DEBUG, { ?$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::DEBUG, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, $crate::Level::DEBUG, { %$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::DEBUG, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::DEBUG, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::DEBUG, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::DEBUG, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::DEBUG, { $($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::DEBUG, { ?$($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::DEBUG, { %$($k).+ })
     );
     (name: $name:expr, target: $target:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, target: $target, $crate::Level::DEBUG, {}, $($arg)+)
@@ -1662,14 +1770,32 @@ macro_rules! debug {
     (name: $name:expr, parent: $parent:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, parent: $parent, $crate::Level::DEBUG, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, parent: $parent:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, parent: $parent, $crate::Level::DEBUG, { $($k).+ $($field)* })
+    (name: $name:expr, parent: $parent:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::DEBUG, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, parent: $parent, $crate::Level::DEBUG, { ?$($k).+ $($field)* })
+    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::DEBUG, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, parent: $parent:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, parent: $parent, $crate::Level::DEBUG, { %$($k).+ $($field)* })
+    (name: $name:expr, parent: $parent:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::DEBUG, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::DEBUG, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::DEBUG, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::DEBUG, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::DEBUG, { $($k).+ })
+    );
+    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::DEBUG, { ?$($k).+ })
+    );
+    (name: $name:expr, parent: $parent:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::DEBUG, { %$($k).+ })
     );
     (name: $name:expr, parent: $parent:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, parent: $parent, $crate::Level::DEBUG, {}, $($arg)+)
@@ -1679,14 +1805,32 @@ macro_rules! debug {
     (name: $name:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, $crate::Level::DEBUG, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, $crate::Level::DEBUG, { $($k).+ $($field)* })
+    (name: $name:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::DEBUG, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, $crate::Level::DEBUG, { ?$($k).+ $($field)* })
+    (name: $name:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::DEBUG, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, $crate::Level::DEBUG, { %$($k).+ $($field)* })
+    (name: $name:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::DEBUG, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::DEBUG, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::DEBUG, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::DEBUG, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, $crate::Level::DEBUG, { $($k).+ })
+    );
+    (name: $name:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, $crate::Level::DEBUG, { ?$($k).+ })
+    );
+    (name: $name:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, $crate::Level::DEBUG, { %$($k).+ })
     );
     (name: $name:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, $crate::Level::DEBUG, {}, $($arg)+)
@@ -1898,14 +2042,32 @@ macro_rules! info {
     (name: $name:expr, target: $target:expr, parent: $parent:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::INFO, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::INFO, { $($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::INFO, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::INFO, { ?$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::INFO, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::INFO, { %$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::INFO, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::INFO, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::INFO, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::INFO, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::INFO, { $($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::INFO, { ?$($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::INFO, { %$($k).+ })
     );
     (name: $name:expr, target: $target:expr, parent: $parent:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::INFO, {}, $($arg)+)
@@ -1915,14 +2077,32 @@ macro_rules! info {
     (name: $name:expr, target: $target:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, target: $target, $crate::Level::INFO, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, target: $target:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, $crate::Level::INFO, { $($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::INFO, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, $crate::Level::INFO, { ?$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::INFO, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, $crate::Level::INFO, { %$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::INFO, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::INFO, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::INFO, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::INFO, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::INFO, { $($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::INFO, { ?$($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::INFO, { %$($k).+ })
     );
     (name: $name:expr, target: $target:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, target: $target, $crate::Level::INFO, {}, $($arg)+)
@@ -1949,14 +2129,32 @@ macro_rules! info {
     (name: $name:expr, parent: $parent:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, parent: $parent, $crate::Level::INFO, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, parent: $parent:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, parent: $parent, $crate::Level::INFO, { $($k).+ $($field)* })
+    (name: $name:expr, parent: $parent:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::INFO, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, parent: $parent, $crate::Level::INFO, { ?$($k).+ $($field)* })
+    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::INFO, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, parent: $parent:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, parent: $parent, $crate::Level::INFO, { %$($k).+ $($field)* })
+    (name: $name:expr, parent: $parent:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::INFO, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::INFO, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::INFO, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::INFO, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::INFO, { $($k).+ })
+    );
+    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::INFO, { ?$($k).+ })
+    );
+    (name: $name:expr, parent: $parent:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::INFO, { %$($k).+ })
     );
     (name: $name:expr, parent: $parent:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, parent: $parent, $crate::Level::INFO, {}, $($arg)+)
@@ -1966,14 +2164,32 @@ macro_rules! info {
     (name: $name:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, $crate::Level::INFO, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, $crate::Level::INFO, { $($k).+ $($field)* })
+    (name: $name:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::INFO, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, $crate::Level::INFO, { ?$($k).+ $($field)* })
+    (name: $name:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::INFO, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, $crate::Level::INFO, { %$($k).+ $($field)* })
+    (name: $name:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::INFO, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::INFO, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::INFO, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::INFO, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, $crate::Level::INFO, { $($k).+ })
+    );
+    (name: $name:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, $crate::Level::INFO, { ?$($k).+ })
+    );
+    (name: $name:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, $crate::Level::INFO, { %$($k).+ })
     );
     (name: $name:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, $crate::Level::INFO, {}, $($arg)+)
@@ -2178,14 +2394,32 @@ macro_rules! warn {
     (name: $name:expr, target: $target:expr, parent: $parent:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::WARN, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::WARN, { $($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::WARN, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::WARN, { ?$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::WARN, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::WARN, { %$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::WARN, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::WARN, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::WARN, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::WARN, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::WARN, { $($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::WARN, { ?$($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::WARN, { %$($k).+ })
     );
     (name: $name:expr, target: $target:expr, parent: $parent:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::WARN, {}, $($arg)+)
@@ -2195,14 +2429,32 @@ macro_rules! warn {
     (name: $name:expr, target: $target:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, target: $target, $crate::Level::WARN, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, target: $target:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, $crate::Level::WARN, { $($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::WARN, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, $crate::Level::WARN, { ?$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::WARN, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, $crate::Level::WARN, { %$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::WARN, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::WARN, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::WARN, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::WARN, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::WARN, { $($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::WARN, { ?$($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::WARN, { %$($k).+ })
     );
     (name: $name:expr, target: $target:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, target: $target, $crate::Level::WARN, {}, $($arg)+)
@@ -2229,14 +2481,32 @@ macro_rules! warn {
     (name: $name:expr, parent: $parent:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, parent: $parent, $crate::Level::WARN, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, parent: $parent:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, parent: $parent, $crate::Level::WARN, { $($k).+ $($field)* })
+    (name: $name:expr, parent: $parent:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::WARN, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, parent: $parent, $crate::Level::WARN, { ?$($k).+ $($field)* })
+    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::WARN, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, parent: $parent:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, parent: $parent, $crate::Level::WARN, { %$($k).+ $($field)* })
+    (name: $name:expr, parent: $parent:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::WARN, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::WARN, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::WARN, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::WARN, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::WARN, { $($k).+ })
+    );
+    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::WARN, { ?$($k).+ })
+    );
+    (name: $name:expr, parent: $parent:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::WARN, { %$($k).+ })
     );
     (name: $name:expr, parent: $parent:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, parent: $parent, $crate::Level::WARN, {}, $($arg)+)
@@ -2246,14 +2516,32 @@ macro_rules! warn {
     (name: $name:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, $crate::Level::WARN, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, $crate::Level::WARN, { $($k).+ $($field)* })
+    (name: $name:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::WARN, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, $crate::Level::WARN, { ?$($k).+ $($field)* })
+    (name: $name:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::WARN, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, $crate::Level::WARN, { %$($k).+ $($field)* })
+    (name: $name:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::WARN, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::WARN, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::WARN, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::WARN, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, $crate::Level::WARN, { $($k).+ })
+    );
+    (name: $name:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, $crate::Level::WARN, { ?$($k).+ })
+    );
+    (name: $name:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, $crate::Level::WARN, { %$($k).+ })
     );
     (name: $name:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, $crate::Level::WARN, {}, $($arg)+)
@@ -2454,14 +2742,32 @@ macro_rules! error {
     (name: $name:expr, target: $target:expr, parent: $parent:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::ERROR, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::ERROR, { $($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::ERROR, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::ERROR, { ?$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::ERROR, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::ERROR, { %$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::ERROR, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::ERROR, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::ERROR, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::ERROR, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::ERROR, { $($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::ERROR, { ?$($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, parent: $parent:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::ERROR, { %$($k).+ })
     );
     (name: $name:expr, target: $target:expr, parent: $parent:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, target: $target, parent: $parent, $crate::Level::ERROR, {}, $($arg)+)
@@ -2471,14 +2777,32 @@ macro_rules! error {
     (name: $name:expr, target: $target:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, target: $target, $crate::Level::ERROR, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, target: $target:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, $crate::Level::ERROR, { $($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::ERROR, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, $crate::Level::ERROR, { ?$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::ERROR, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, target: $target:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, target: $target, $crate::Level::ERROR, { %$($k).+ $($field)* })
+    (name: $name:expr, target: $target:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::ERROR, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::ERROR, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::ERROR, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::ERROR, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, target: $target:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::ERROR, { $($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::ERROR, { ?$($k).+ })
+    );
+    (name: $name:expr, target: $target:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, target: $target, $crate::Level::ERROR, { %$($k).+ })
     );
     (name: $name:expr, target: $target:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, target: $target, $crate::Level::ERROR, {}, $($arg)+)
@@ -2505,14 +2829,32 @@ macro_rules! error {
     (name: $name:expr, parent: $parent:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, parent: $parent, $crate::Level::ERROR, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, parent: $parent:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, parent: $parent, $crate::Level::ERROR, { $($k).+ $($field)* })
+    (name: $name:expr, parent: $parent:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::ERROR, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, parent: $parent, $crate::Level::ERROR, { ?$($k).+ $($field)* })
+    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::ERROR, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, parent: $parent:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, parent: $parent, $crate::Level::ERROR, { %$($k).+ $($field)* })
+    (name: $name:expr, parent: $parent:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::ERROR, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::ERROR, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::ERROR, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::ERROR, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, parent: $parent:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::ERROR, { $($k).+ })
+    );
+    (name: $name:expr, parent: $parent:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::ERROR, { ?$($k).+ })
+    );
+    (name: $name:expr, parent: $parent:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, parent: $parent, $crate::Level::ERROR, { %$($k).+ })
     );
     (name: $name:expr, parent: $parent:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, parent: $parent, $crate::Level::ERROR, {}, $($arg)+)
@@ -2522,14 +2864,32 @@ macro_rules! error {
     (name: $name:expr, { $($field:tt)* }, $($arg:tt)* ) => (
         $crate::event!(name: $name, $crate::Level::ERROR, { $($field)* }, $($arg)*)
     );
-    (name: $name:expr, $($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, $crate::Level::ERROR, { $($k).+ $($field)* })
+    (name: $name:expr, $($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::ERROR, { $($k).+ = $($field)* })
     );
-    (name: $name:expr, ?$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, $crate::Level::ERROR, { ?$($k).+ $($field)* })
+    (name: $name:expr, ?$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::ERROR, { ?$($k).+ = $($field)* })
     );
-    (name: $name:expr, %$($k:ident).+ $($field:tt)* ) => (
-        $crate::event!(name: $name, $crate::Level::ERROR, { %$($k).+ $($field)* })
+    (name: $name:expr, %$($k:ident).+ = $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::ERROR, { %$($k).+ = $($field)* })
+    );
+    (name: $name:expr, $($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::ERROR, { $($k).+, $($field)* })
+    );
+    (name: $name:expr, ?$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::ERROR, { ?$($k).+, $($field)* })
+    );
+    (name: $name:expr, %$($k:ident).+, $($field:tt)* ) => (
+        $crate::event!(name: $name, $crate::Level::ERROR, { %$($k).+, $($field)* })
+    );
+    (name: $name:expr, $($k:ident).+ ) => (
+        $crate::event!(name: $name, $crate::Level::ERROR, { $($k).+ })
+    );
+    (name: $name:expr, ?$($k:ident).+ ) => (
+        $crate::event!(name: $name, $crate::Level::ERROR, { ?$($k).+ })
+    );
+    (name: $name:expr, %$($k:ident).+ ) => (
+        $crate::event!(name: $name, $crate::Level::ERROR, { %$($k).+ })
     );
     (name: $name:expr, $($arg:tt)+ ) => (
         $crate::event!(name: $name, $crate::Level::ERROR, {}, $($arg)+)

--- a/tracing/tests/macros.rs
+++ b/tracing/tests/macros.rs
@@ -614,6 +614,12 @@ fn trace() {
     trace!(name: "foo", foo = 3, bar.baz = 2, quux = false);
     trace!(name: "foo", target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     trace!(name: "foo", parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
+    // Regression test for https://github.com/tokio-rs/tracing/issues/3407:
+    // a dotted field name as the *first* field after `name:` must be accepted.
+    trace!(name: "foo", bar.baz = 2, quux = false);
+    trace!(name: "foo", target: "foo_events", bar.baz = 2, quux = false);
+    trace!(name: "foo", parent: ::core::option::Option::None, bar.baz = 2, quux = false);
+    trace!(name: "foo", bar.baz = 2, "message {}", 1);
     trace!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     trace!(target: "foo_events", foo = 3, bar.baz = 3,);
     trace!(target: "foo_events", "foo");
@@ -682,6 +688,12 @@ fn debug() {
     debug!(name: "foo", foo = 3, bar.baz = 2, quux = false);
     debug!(name: "foo", target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     debug!(name: "foo", parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
+    // Regression test for https://github.com/tokio-rs/tracing/issues/3407:
+    // a dotted field name as the *first* field after `name:` must be accepted.
+    debug!(name: "foo", bar.baz = 2, quux = false);
+    debug!(name: "foo", target: "foo_events", bar.baz = 2, quux = false);
+    debug!(name: "foo", parent: ::core::option::Option::None, bar.baz = 2, quux = false);
+    debug!(name: "foo", bar.baz = 2, "message {}", 1);
     debug!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     debug!(target: "foo_events", foo = 3, bar.baz = 3,);
     debug!(target: "foo_events", "foo");
@@ -750,6 +762,12 @@ fn info() {
     info!(name: "foo", foo = 3, bar.baz = 2, quux = false);
     info!(name: "foo", target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     info!(name: "foo", parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
+    // Regression test for https://github.com/tokio-rs/tracing/issues/3407:
+    // a dotted field name as the *first* field after `name:` must be accepted.
+    info!(name: "foo", bar.baz = 2, quux = false);
+    info!(name: "foo", target: "foo_events", bar.baz = 2, quux = false);
+    info!(name: "foo", parent: ::core::option::Option::None, bar.baz = 2, quux = false);
+    info!(name: "foo", bar.baz = 2, "message {}", 1);
     info!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     info!(target: "foo_events", foo = 3, bar.baz = 3,);
     info!(target: "foo_events", "foo");
@@ -818,6 +836,12 @@ fn warn() {
     warn!(name: "foo", foo = 3, bar.baz = 2, quux = false);
     warn!(name: "foo", target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     warn!(name: "foo", parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
+    // Regression test for https://github.com/tokio-rs/tracing/issues/3407:
+    // a dotted field name as the *first* field after `name:` must be accepted.
+    warn!(name: "foo", bar.baz = 2, quux = false);
+    warn!(name: "foo", target: "foo_events", bar.baz = 2, quux = false);
+    warn!(name: "foo", parent: ::core::option::Option::None, bar.baz = 2, quux = false);
+    warn!(name: "foo", bar.baz = 2, "message {}", 1);
     warn!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     warn!(target: "foo_events", foo = 3, bar.baz = 3,);
     warn!(target: "foo_events", "foo");
@@ -886,6 +910,12 @@ fn error() {
     error!(name: "foo", foo = 3, bar.baz = 2, quux = false);
     error!(name: "foo", target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     error!(name: "foo", parent: ::core::option::Option::None, foo = 3, bar.baz = 2, quux = false);
+    // Regression test for https://github.com/tokio-rs/tracing/issues/3407:
+    // a dotted field name as the *first* field after `name:` must be accepted.
+    error!(name: "foo", bar.baz = 2, quux = false);
+    error!(name: "foo", target: "foo_events", bar.baz = 2, quux = false);
+    error!(name: "foo", parent: ::core::option::Option::None, bar.baz = 2, quux = false);
+    error!(name: "foo", bar.baz = 2, "message {}", 1);
     error!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     error!(target: "foo_events", foo = 3, bar.baz = 3,);
     error!(target: "foo_events", "foo");


### PR DESCRIPTION
## Motivation

The level macros (`trace!`, `debug!`, `info!`, `warn!`, `error!`) fail to
compile when a dotted field name (e.g. `order.id`) is the **first** field and
the `name:` specifier is used:

```rust
info!(name: "order.received.ok", order.id = 123, "order received");
// error: local ambiguity when calling macro `info`:
//        multiple parsing options: built-in NTs tt ('field') or 1 other option.
```

`event!` accepts this form, and the level macros accept it when a non-dotted
field comes first or when `name:` is omitted — it is only the `name:` arms that
reject a dotted first field.

The `name:` arms matched fields with a single coarse pattern,
`$($k:ident).+ $($field:tt)*`, with no separator between the field path and the
rest. When the first field is dotted, the `.` is ambiguous: the macro cannot
tell whether it continues the field path (`$($k).+`) or begins `$($field)*`.
The `parent:` and no-specifier arms avoid this by matching `=`/`,`-separated
fields with separate arms (as @hds noted in the issue).

Fixes: #3407

## Solution

Make the `name:` arms granular in the same way as the `parent:`/no-specifier
arms — across all five level macros and all four `name:` combinations (`name`;
`name` + `target`; `name` + `parent`; `name` + `target` + `parent`). For plain,
`?`, and `%` fields, each coarse arm becomes three:

* `$($k:ident).+ = $($field:tt)*` — `field = value`
* `$($k:ident).+, $($field:tt)*` — a shorthand field followed by more
* `$($k:ident).+` — a trailing shorthand field with no value

This resolves the ambiguity while preserving every previously-accepted form.

Adds regression tests covering a dotted first field after `name:` for each
level macro and each `name:` combination (compile-only, matching the existing
`tests/macros.rs` convention).