### PR TITLE
subscriber: recover poisoned span extensions lock instead of double-panicking

### DIFF
--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -430,11 +430,17 @@ impl<'a> SpanData<'a> for Data<'a> {
     }
 
     fn extensions(&self) -> Extensions<'_> {
-        Extensions::new(self.inner.extensions.read().expect("Mutex poisoned"))
+        // If the extensions lock was poisoned by a panic while another access
+        // to this span's extensions was in progress, recover the guard rather
+        // than panicking again. A second panic here — for example, while
+        // unwinding from the first — would abort the process. See #812.
+        Extensions::new(self.inner.extensions.read().unwrap_or_else(|l| l.into_inner()))
     }
 
     fn extensions_mut(&self) -> ExtensionsMut<'_> {
-        ExtensionsMut::new(self.inner.extensions.write().expect("Mutex poisoned"))
+        // Recover from lock poisoning rather than double-panicking; see the
+        // comment in `extensions` above and #812.
+        ExtensionsMut::new(self.inner.extensions.write().unwrap_or_else(|l| l.into_inner()))
     }
 
     #[inline]
@@ -903,5 +909,62 @@ mod tests {
 
             state.assert_closed_in_order(["child", "parent", "grandparent"]);
         });
+    }
+
+    // Regression test for https://github.com/tokio-rs/tracing/issues/812.
+    //
+    // If a panic occurs while a span's extensions are borrowed (for example,
+    // `ExtensionsMut::insert` panicking on a duplicate type), the extensions
+    // `RwLock` is poisoned. A subsequent access to that span's extensions — such
+    // as a layer's `on_exit`/`on_close` running as the first panic unwinds —
+    // must not panic *again*, because a second panic during unwinding aborts the
+    // process. The accessors recover the poisoned guard instead, so the original
+    // panic unwinds normally and can be caught.
+    #[test]
+    fn poisoned_span_extensions_do_not_double_panic() {
+        struct Marker;
+
+        struct PoisonLayer;
+        impl<S> Layer<S> for PoisonLayer
+        where
+            S: Subscriber + for<'a> LookupSpan<'a>,
+        {
+            fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
+                // The second time the same span is entered, `Marker` is already
+                // present, so `insert` panics while holding the write guard,
+                // poisoning the lock.
+                let span = ctx.span(id).expect("span must exist");
+                span.extensions_mut().insert(Marker);
+            }
+
+            fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
+                // Re-borrow the (now poisoned) extensions while unwinding from
+                // the `on_enter` panic. Before the fix this double-panicked and
+                // aborted the process.
+                let span = ctx.span(id).expect("span must exist");
+                let _ = span.extensions();
+            }
+        }
+
+        let subscriber = PoisonLayer.with_subscriber(Registry::default());
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            with_default(subscriber, || {
+                let span = tracing::info_span!("poisoned");
+                span.in_scope(|| {
+                    // Entering the same span again triggers the duplicate-insert
+                    // panic in `on_enter`.
+                    span.in_scope(|| {});
+                });
+            });
+        }));
+
+        // The duplicate-insert panic must propagate and be caught here. If the
+        // poisoned-lock access in `on_exit` had panicked again, the process
+        // would have aborted instead of reaching this assertion.
+        assert!(
+            result.is_err(),
+            "the duplicate-insert panic should unwind and be caught, not abort"
+        );
     }
 }

--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -430,10 +430,14 @@ impl<'a> SpanData<'a> for Data<'a> {
     }
 
     fn extensions(&self) -> Extensions<'_> {
-        // If the extensions lock was poisoned by a panic while another access
-        // to this span's extensions was in progress, recover the guard rather
-        // than panicking again. A second panic here — for example, while
-        // unwinding from the first — would abort the process. See #812.
+        // If the extensions lock was poisoned by a panic while another access to
+        // this span's extensions was in progress, recover the guard rather than
+        // panicking again: a second panic here — e.g. while unwinding from the
+        // first — would abort the process (see #812). Recovering is sound because
+        // the extensions are a plain typemap whose lock can only be poisoned
+        // *after* a completed map mutation (`ExtensionsMut::insert`'s assertion,
+        // or a stored value's `Drop`), so the recovered map is always
+        // structurally consistent.
         Extensions::new(self.inner.extensions.read().unwrap_or_else(|l| l.into_inner()))
     }
 
@@ -920,6 +924,10 @@ mod tests {
     // must not panic *again*, because a second panic during unwinding aborts the
     // process. The accessors recover the poisoned guard instead, so the original
     // panic unwinds normally and can be caught.
+    //
+    // This only reproduces under the std `RwLock`, which poisons on panic; the
+    // `parking_lot` backend never poisons, so the scenario cannot double-panic
+    // there and this test passes trivially.
     #[test]
     fn poisoned_span_extensions_do_not_double_panic() {
         struct Marker;


### PR DESCRIPTION
## Motivation

`tracing-subscriber`'s `Registry` stores per-span [extensions] behind a `RwLock`. The `Data::extensions` / `Data::extensions_mut` accessors unwrap that lock with `.expect("Mutex poisoned")`. If a panic occurs while a span's extensions are borrowed, the lock is poisoned, and the *next* access panics again on the `.expect`. When that next access happens during unwinding — which is exactly when it tends to, since a layer's `on_exit`/`on_close` will often touch the same span's extensions as the first panic propagates — the second panic aborts the process.

The reported trigger (#812) is `ExtensionsMut::insert` panicking on a duplicate type:

```rust
fn on_enter(&self, id: &Id, ctx: Context<S>) {
    if let Some(span) = ctx.span(id) {
        let mut extensions = span.extensions_mut();
        extensions.insert(0u128); // panics on a nested entry: poisons the lock
    }
}
// elsewhere:
let span = span!(Level::INFO, "nested entries");
span.in_scope(|| span.in_scope(|| {}));
```

The duplicate-insert panic is recoverable on its own, but the poisoned-lock re-access during unwinding turns it into an unrecoverable `abort`.

## Solution

Recover the poisoned guard instead of re-panicking — the same approach already used by `DataInner::clear` in the same file:

```rust
fn extensions(&self) -> Extensions<'_> {
    Extensions::new(self.inner.extensions.read().unwrap_or_else(|l| l.into_inner()))
}
fn extensions_mut(&self) -> ExtensionsMut<'_> {
    ExtensionsMut::new(self.inner.extensions.write().unwrap_or_else(|l| l.into_inner()))
}
```

This turns the abort back into a single, catchable panic. It is sound because the extensions are a plain typemap (`HashMap<TypeId, Box<dyn Any>>`) whose lock can only be poisoned *after* a completed map mutation — `ExtensionsMut::insert`'s assertion fires after `map.insert` returns, a stored value's `Drop` runs after the structural operation, and an allocation failure aborts rather than unwinds — so the recovered map is always structurally consistent to read or further mutate.

This intentionally does **not** change `ExtensionsMut::insert`'s documented panic-on-duplicate behavior; only the cascading abort is addressed. Removing that panic is a separate, breaking change.

On the `parking_lot` backend the lock never poisons, so this is a no-op there; the change matters under the default `std` `RwLock`.

A regression test (`poisoned_span_extensions_do_not_double_panic`) reproduces the double-panic via a layer that inserts a duplicate extension in `on_enter` and re-borrows extensions in `on_exit`, and asserts the panic is caught rather than aborting.

Fixes #812

[extensions]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/registry/struct.Extensions.html