### PR TITLE
subscriber: cap per-layer-filter callsite interest at `sometimes`

### DIFF
--- a/tracing-subscriber/src/registry/sharded.rs
+++ b/tracing-subscriber/src/registry/sharded.rs
@@ -221,7 +221,17 @@ thread_local! {
 impl Subscriber for Registry {
     fn register_callsite(&self, _: &'static Metadata<'static>) -> Interest {
         if self.has_per_layer_filters() {
-            return FilterState::take_interest().unwrap_or_else(Interest::always);
+            // `Filtered::on_new_span`/`on_event` reads the thread-local
+            // `FilterState` written by `Filtered::enabled`. If a callsite
+            // caches `Interest::always`, the macros skip `enabled()`
+            // entirely and `on_new_span`/`on_event` reads whatever the
+            // *previous* `enabled()` call (for unrelated metadata, e.g. a
+            // bare `dispatch.enabled()` from `LogTracer`) left there —
+            // see #2519, #3516. Cap at `sometimes` so `enabled()` always
+            // runs and `FilterState` is always fresh for `did_enable`.
+            return FilterState::take_interest()
+                .filter(|i| !i.is_always())
+                .unwrap_or_else(Interest::sometimes);
         }
 
         Interest::always()

--- a/tracing-subscriber/tests/layer_filter_interests_are_cached.rs
+++ b/tracing-subscriber/tests/layer_filter_interests_are_cached.rs
@@ -12,11 +12,7 @@ fn layer_filter_interests_are_cached() {
     let seen = Arc::new(Mutex::new(HashMap::new()));
     let seen2 = seen.clone();
     let filter = filter::filter_fn(move |meta| {
-        *seen
-            .lock()
-            .unwrap()
-            .entry(meta.callsite())
-            .or_insert(0usize) += 1;
+        *seen.lock().unwrap().entry(*meta.level()).or_insert(0usize) += 1;
         meta.level() == &Level::INFO
     });
 
@@ -39,29 +35,31 @@ fn layer_filter_interests_are_cached() {
         tracing::error!("hello error");
     }
 
-    events();
-    {
-        let lock = seen2.lock().unwrap();
-        for (callsite, &count) in lock.iter() {
+    // Per-layer filters cap callsite interest at `sometimes` (#2519, #3516),
+    // so a callsite the filter accepts is re-evaluated on each dispatch.
+    // Callsites the filter rejects still cache `Interest::never` and are
+    // seen exactly once (during `register_callsite`).
+    let assert_seen = |dispatches: usize| {
+        let seen = seen2.lock().unwrap();
+        for (&level, &count) in seen.iter() {
+            let expected = if level == Level::INFO {
+                1 + dispatches
+            } else {
+                1
+            };
             assert_eq!(
-                count, 1,
-                "callsite {:?} should have been seen 1 time (after first set of events)",
-                callsite
+                count, expected,
+                "the {level:?} callsite should have been seen {expected} times \
+                 after {dispatches} dispatches",
             );
         }
-    }
+    };
 
     events();
-    {
-        let lock = seen2.lock().unwrap();
-        for (callsite, &count) in lock.iter() {
-            assert_eq!(
-                count, 1,
-                "callsite {:?} should have been seen 1 time (after second set of events)",
-                callsite
-            );
-        }
-    }
+    assert_seen(1);
+
+    events();
+    assert_seen(2);
 
     handle.assert_finished();
 }

--- a/tracing-subscriber/tests/layer_filters/main.rs
+++ b/tracing-subscriber/tests/layer_filters/main.rs
@@ -4,6 +4,7 @@ mod downcast_raw;
 mod filter_scopes;
 mod option;
 mod per_event;
+mod stale_filter_state;
 mod targets;
 mod trees;
 mod vec;

--- a/tracing-subscriber/tests/layer_filters/stale_filter_state.rs
+++ b/tracing-subscriber/tests/layer_filters/stale_filter_state.rs
@@ -1,0 +1,75 @@
+use super::*;
+
+/// Reproduces #2519: a bare `dispatch.enabled()` call that every per-layer
+/// filter rejects must not cause the *next* span — whose callsite cached
+/// `Interest::always` and therefore skips `enabled()` — to be dropped from
+/// per-layer-filtered layers.
+///
+/// The production trigger is `log::log_enabled!` via `tracing-log`'s
+/// `LogTracer`, which calls `dispatch.enabled()` with per-call dynamic
+/// metadata that bypasses callsite caching.
+#[test]
+fn always_interest_span_after_globally_rejected_enabled() {
+    // Two per-layer-filtered layers. Both enable INFO at "test" — so before
+    // this fix the Registry cached `Interest::always` for a span there
+    // (that's the precondition for the bug; with the fix it caps at
+    // `sometimes`) — and both reject DEBUG at "other".
+    let (a, a_handle) = layer::named("a")
+        .new_span(expect::span().named("before"))
+        .new_span(expect::span().named("after"))
+        .only()
+        .run_with_handle();
+    let (b, b_handle) = layer::named("b")
+        .new_span(expect::span().named("before"))
+        .new_span(expect::span().named("after"))
+        .only()
+        .run_with_handle();
+
+    let make_filter = || {
+        filter::Targets::new()
+            .with_target("test", Level::INFO)
+            .with_default(LevelFilter::OFF)
+    };
+    let sub = tracing_subscriber::registry()
+        .with(a.with_filter(make_filter()))
+        .with(b.with_filter(make_filter()));
+    let _guard = sub.set_default();
+
+    let _s1 = tracing::info_span!(target: "test", "before");
+
+    // Bare enabled() at ("other", DEBUG): both per-layer filters reject
+    // and set their FilterState bits to disabled. The caller doesn't
+    // dispatch (this is a bare enabled() query, not an event), so no on_*
+    // follows and nothing resets the bits. Mirrors what
+    // LogTracer::enabled does for a `log::log_enabled!` query.
+    struct PoisonCallsite;
+    static POISON: PoisonCallsite = PoisonCallsite;
+    impl tracing_core::Callsite for PoisonCallsite {
+        fn set_interest(&self, _: tracing_core::Interest) {}
+        fn metadata(&self) -> &tracing_core::Metadata<'_> {
+            &META
+        }
+    }
+    static META: tracing_core::Metadata<'static> = tracing_core::Metadata::new(
+        "log event",
+        "other",
+        Level::DEBUG,
+        None,
+        None,
+        None,
+        tracing_core::field::FieldSet::new(&[], tracing_core::identify_callsite!(&POISON)),
+        tracing_core::Kind::EVENT,
+    );
+    tracing::dispatcher::get_default(|d| {
+        let _ = d.enabled(&META);
+    });
+
+    // Before the fix, this span never reached either layer's on_new_span:
+    // its Interest::always callsite skipped enabled(), and
+    // Filtered::on_new_span read the stale disabled bits left by the
+    // poison enabled() call.
+    let _s2 = tracing::info_span!(target: "test", "after");
+
+    a_handle.assert_finished();
+    b_handle.assert_finished();
+}

--- a/tracing-subscriber/tests/multiple_layer_filter_interests_cached.rs
+++ b/tracing-subscriber/tests/multiple_layer_filter_interests_cached.rs
@@ -70,11 +70,16 @@ fn multiple_layer_filter_interests_are_cached() {
         tracing::error!("hello error");
     }
 
+    // Per-layer filters cap callsite interest at `sometimes` (#2519, #3516), so
+    // callsites that *any* filter accepts are re-evaluated by *every* filter on
+    // each dispatch. Only callsites rejected by all filters cache as `never`.
+    // We therefore only assert "seen once" for levels that every filter rejects
+    // (here: TRACE and DEBUG).
     events();
     {
         let lock = seen_info.lock().unwrap();
         for (&level, &count) in lock.iter() {
-            if level == Level::INFO {
+            if level <= Level::INFO {
                 continue;
             }
             assert_eq!(
@@ -86,7 +91,7 @@ fn multiple_layer_filter_interests_are_cached() {
 
         let lock = seen_warn.lock().unwrap();
         for (&level, &count) in lock.iter() {
-            if level == Level::INFO {
+            if level <= Level::INFO {
                 continue;
             }
             assert_eq!(
@@ -101,7 +106,7 @@ fn multiple_layer_filter_interests_are_cached() {
     {
         let lock = seen_info.lock().unwrap();
         for (&level, &count) in lock.iter() {
-            if level == Level::INFO {
+            if level <= Level::INFO {
                 continue;
             }
             assert_eq!(
@@ -113,7 +118,7 @@ fn multiple_layer_filter_interests_are_cached() {
 
         let lock = seen_warn.lock().unwrap();
         for (&level, &count) in lock.iter() {
-            if level == Level::INFO {
+            if level <= Level::INFO {
                 continue;
             }
             assert_eq!(

--- a/tracing-subscriber/tests/option_filter_interest_caching.rs
+++ b/tracing-subscriber/tests/option_filter_interest_caching.rs
@@ -42,12 +42,12 @@ fn none_interest_cache() {
         tracing::debug!(target: "always_interesting", x="bar");
     }
 
-    // The `None` filter is unchanging and performs no filtering, so it should
-    // be cacheable and always be interested in events. The filter fn is a
-    // non-dynamic filter fn, which means the result can be cached per callsite.
-    // The filter fn should only need to be called once, and the `Option` filter
-    // should not interfere in the caching of that result.
-    assert_eq!(times_filtered.load(Ordering::Relaxed), 1);
+    // Per-layer filters cap callsite interest at `sometimes` (#2519, #3516), so
+    // an accepted callsite is re-evaluated on every dispatch: once during
+    // `register_callsite` plus once per event. The `None` filter must not
+    // degrade caching any further than that (e.g. by forcing a callsite
+    // re-registration).
+    assert_eq!(times_filtered.load(Ordering::Relaxed), 3);
     handle_none.assert_finished();
     handle_filter_fn.assert_finished();
 }

--- a/tracing-subscriber/tests/vec_subscriber_filter_interests_cached.rs
+++ b/tracing-subscriber/tests/vec_subscriber_filter_interests_cached.rs
@@ -56,11 +56,16 @@ fn vec_layer_filter_interests_are_cached() {
         tracing::error!("hello error");
     }
 
+    // Per-layer filters cap callsite interest at `sometimes` (#2519, #3516), so
+    // callsites that *any* filter accepts are re-evaluated by *every* filter on
+    // each dispatch. Only callsites rejected by all filters cache as `never`.
+    // We therefore only assert "seen once" for levels that every filter rejects
+    // (here: TRACE and DEBUG).
     events();
     {
         let lock = seen_info.lock().unwrap();
         for (&level, &count) in lock.iter() {
-            if level == Level::INFO {
+            if level <= Level::INFO {
                 continue;
             }
             assert_eq!(
@@ -72,7 +77,7 @@ fn vec_layer_filter_interests_are_cached() {
 
         let lock = seen_warn.lock().unwrap();
         for (&level, &count) in lock.iter() {
-            if level == Level::INFO {
+            if level <= Level::INFO {
                 continue;
             }
             assert_eq!(
@@ -87,7 +92,7 @@ fn vec_layer_filter_interests_are_cached() {
     {
         let lock = seen_info.lock().unwrap();
         for (&level, &count) in lock.iter() {
-            if level == Level::INFO {
+            if level <= Level::INFO {
                 continue;
             }
             assert_eq!(
@@ -99,7 +104,7 @@ fn vec_layer_filter_interests_are_cached() {
 
         let lock = seen_warn.lock().unwrap();
         for (&level, &count) in lock.iter() {
-            if level == Level::INFO {
+            if level <= Level::INFO {
                 continue;
             }
             assert_eq!(


### PR DESCRIPTION
## Motivation

`Filtered<L, F>` carries each filter's per-call decision from `Layer::enabled` to `Layer::on_new_span`/`on_event` via the thread-local `FilterState` bitmap. That side-channel assumes `enabled()` runs immediately before `on_new_span`/`on_event` for the same metadata. When a callsite caches `Interest::always`, the `tracing` macros skip `enabled()` entirely — so `on_new_span` reads whatever the *previous* `enabled()` call (for unrelated metadata) wrote, and the span is silently dropped from every per-layer-filtered layer.

The common production trigger is `log::log_enabled!` via `tracing-log`'s `LogTracer`, which calls `dispatch.enabled()` with per-call dynamic metadata that bypasses callsite caching. Any crate that does this between two `#[instrument]`ed calls — sqlx's `QueryLogger` does after every query — leaves stale disabled bits in `FilterState`, and the next `Interest::always` span never reaches the OTel/fmt/etc. layer it was meant for.

Fixes: #2519
Refs: #3516, #2448, #2704

## Solution

`Registry::register_callsite` now caps the per-layer-filter interest sum at `Interest::sometimes`. Callsites that every per-layer filter accepts get `sometimes` instead of `always`, so `enabled()` runs on every dispatch and `FilterState` is always fresh when `did_enable` reads it. Callsites any filter rejects are unaffected (`never` if all reject, `sometimes` if mixed — same as before).

**Trade-off.** This removes the `Interest::always` fast-path for callsites every per-layer filter accepts. Those callsites now pay one `Filter::enabled()` call per dispatch instead of zero — for the common filters (`LevelFilter`, `Targets`, `EnvFilter` with static directives) that's a level compare plus a target prefix match, plus one thread-local write in `Filtered::enabled`. Stacks without per-layer filters are entirely unaffected. The four `*_interests_are_cached` tests are updated to reflect the new invariant: rejected callsites still cache as `never`; accepted callsites are re-evaluated per dispatch.

Users are already paying a comparable cost via the "add a no-op layer" workaround ([transact-rs/sqlx#3751](https://github.com/transact-rs/sqlx/issues/3751#issuecomment-4131222109)), which makes *rejected* callsites `sometimes` instead. This PR is cheaper for the typical case where rejected callsites outnumber accepted ones, and it doesn't depend on a follow-up event being dispatched to reset the bits.

**Scope.** This fixes the bare-`enabled()` trigger of #3516 — `LogTracer`, the `enabled!`/`event_enabled!` macros, or any direct `dispatch.enabled()` that isn't followed by a dispatch. It does **not** fix the re-entrancy triggers (#2448, #2704), where a layer's `on_event` emits its own event and the inner pass's `enabled()` clobbers `FilterState` bits the outer pass hasn't consumed yet. That case has `enabled()` called fresh; the staleness is from nesting, not skipping, and fixing it needs `FilterState` to be a stack (or the API rework #3516 discusses). This PR doesn't attempt that — it makes the existing mechanism sound for the non-re-entrant case at the cost of the fast-path, and leaves the deeper fix for #3516.

**Testing.** New `tests/layer_filters/stale_filter_state.rs` reproduces #2519: two per-layer-filtered layers, a span both accept (cached `always` before this PR), then a bare `dispatch.enabled()` both reject, then a second span both accept. Before this PR the second span never reached either layer's `on_new_span`; with it, both spans do.
