### PR TITLE
fix: point appender symlink to correct target

### DIFF
--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -802,7 +802,7 @@ fn create_writer(
     if let Some(symlink_name) = latest_symlink_name {
         let symlink_path = directory.join(symlink_name);
         let _ = symlink::remove_symlink_file(&symlink_path);
-        symlink::symlink_file(path, symlink_path).map_err(InitError::ctx(
+        symlink::symlink_file(filename, symlink_path).map_err(InitError::ctx(
             "failed to create symlink to latest log file",
         ))?;
     }


### PR DESCRIPTION

The latest_symlink feature added to tracing-appender is creating a symlink pointing to an invalid target.

Here is a simple example that shows the issue:

```rust
use tracing_appender::rolling::{RollingFileAppender, Rotation};

fn main() {
    let file_appender = RollingFileAppender::builder()
        .rotation(Rotation::DAILY)
        .filename_prefix("myapp.log")
        .latest_symlink("myapp.log")
        .build("logs")
        .expect("initializing rolling file appender failed");

    tracing_subscriber::fmt().with_writer(file_appender).init();
}
```

and here is the resulting symlink:

```sh
$ cargo run
$ ls -l logs
lrwxrwxrwx 1 aurel aurel 25 30 juin  18:22 myapp.log -> logs/myapp.log.2026-06-30
-rw-rw-r-- 1 aurel aurel  0 30 juin  18:22 myapp.log.2026-06-30
```

Note that both the log file and the symlink are inside the `logs` directory but the symlink is pointing to `logs/myapp.log.2026-06-30` instead of `myapp.log.2026-06-30`.

This patch fixes the issue and generate the proper symlink as shown here:

```sh
$ cargo run
$ ls -l logs
lrwxrwxrwx 1 aurel aurel 20 30 juin  18:24 myapp.log -> myapp.log.2026-06-30
-rw-rw-r-- 1 aurel aurel  0 30 juin  18:24 myapp.log.2026-06-30
```