### PR TITLE
feat: support alternate sigils in macros

### DIFF
--- a/tracing-attributes/src/attr.rs
+++ b/tracing-attributes/src/attr.rs
@@ -179,28 +179,32 @@ impl Parse for EventArgs {
         let content;
         let _ = syn::parenthesized!(content in input);
         let mut result = Self::default();
-        let mut parse_one_arg =
-            || {
-                let lookahead = content.lookahead1();
-                if lookahead.peek(kw::level) {
-                    if result.level.is_some() {
-                        return Err(content.error("expected only a single `level` argument"));
-                    }
-                    result.level = Some(content.parse()?);
-                } else if result.mode != FormatMode::default() {
-                    return Err(content.error("expected only a single format argument"));
-                } else if let Some(ident) = content.parse::<Option<Ident>>()? {
-                    match ident.to_string().as_str() {
-                        "Debug" => result.mode = FormatMode::Debug,
-                        "Display" => result.mode = FormatMode::Display,
-                        _ => return Err(syn::Error::new(
+        let mut parse_one_arg = || {
+            let lookahead = content.lookahead1();
+            if lookahead.peek(kw::level) {
+                if result.level.is_some() {
+                    return Err(content.error("expected only a single `level` argument"));
+                }
+                result.level = Some(content.parse()?);
+            } else if result.mode != FormatMode::default() {
+                return Err(content.error("expected only a single format argument"));
+            } else if let Some(ident) = content.parse::<Option<Ident>>()? {
+                match ident.to_string().as_str() {
+                    "Debug" => result.mode = FormatMode::Debug,
+                    "Display" => result.mode = FormatMode::Display,
+                    "DisplayAlternate" => result.mode = FormatMode::DisplayAlternate,
+                    "DebugAlternate" => result.mode = FormatMode::DebugAlternate,
+                    _ => {
+                        return Err(syn::Error::new(
                             ident.span(),
-                            "unknown event formatting mode, expected either `Debug` or `Display`",
-                        )),
+                            "unknown event formatting mode, expected `Debug`, `Display`, \
+                             `DebugAlternate`, or `DisplayAlternate`",
+                        ))
                     }
                 }
-                Ok(())
-            };
+            }
+            Ok(())
+        };
         parse_one_arg()?;
         if !content.is_empty() {
             if content.lookahead1().peek(Token![,]) {
@@ -301,6 +305,8 @@ pub(crate) enum FormatMode {
     Default,
     Display,
     Debug,
+    DisplayAlternate,
+    DebugAlternate,
 }
 
 #[derive(Clone, Debug)]
@@ -317,6 +323,8 @@ pub(crate) struct Field {
 pub(crate) enum FieldKind {
     Debug,
     Display,
+    DebugAlternate,
+    DisplayAlternate,
     Value,
 }
 
@@ -356,7 +364,18 @@ impl ToTokens for Fields {
 impl Parse for Field {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let mut kind = FieldKind::Value;
-        if input.peek(Token![%]) {
+        if input.peek(Token![#]) {
+            input.parse::<Token![#]>()?;
+            if input.peek(Token![%]) {
+                input.parse::<Token![%]>()?;
+                kind = FieldKind::DisplayAlternate;
+            } else if input.peek(Token![?]) {
+                input.parse::<Token![?]>()?;
+                kind = FieldKind::DebugAlternate;
+            } else {
+                return Err(input.error("expected `%` or `?` after `#`"));
+            }
+        } else if input.peek(Token![%]) {
             input.parse::<Token![%]>()?;
             kind = FieldKind::Display;
         } else if input.peek(Token![?]) {
@@ -377,7 +396,18 @@ impl Parse for Field {
         };
         let value = if input.peek(Token![=]) {
             input.parse::<Token![=]>()?;
-            if input.peek(Token![%]) {
+            if input.peek(Token![#]) {
+                input.parse::<Token![#]>()?;
+                if input.peek(Token![%]) {
+                    input.parse::<Token![%]>()?;
+                    kind = FieldKind::DisplayAlternate;
+                } else if input.peek(Token![?]) {
+                    input.parse::<Token![?]>()?;
+                    kind = FieldKind::DebugAlternate;
+                } else {
+                    return Err(input.error("expected `%` or `?` after `#`"));
+                }
+            } else if input.peek(Token![%]) {
                 input.parse::<Token![%]>()?;
                 kind = FieldKind::Display;
             } else if input.peek(Token![?]) {
@@ -420,6 +450,14 @@ impl ToTokens for FieldKind {
         match self {
             FieldKind::Debug => tokens.extend(quote! { ? }),
             FieldKind::Display => tokens.extend(quote! { % }),
+            FieldKind::DebugAlternate => {
+                let pound = proc_macro2::Punct::new('#', proc_macro2::Spacing::Alone);
+                tokens.extend(quote! { #pound ? });
+            }
+            FieldKind::DisplayAlternate => {
+                let pound = proc_macro2::Punct::new('#', proc_macro2::Spacing::Alone);
+                tokens.extend(quote! { #pound % });
+            }
             _ => {}
         }
     }

--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -275,6 +275,18 @@ fn gen_block<B: ToTokens>(
                 FormatMode::Debug => Some(quote!(
                     ::tracing::event!(target: #target, #level_tokens, error = ?e)
                 )),
+                FormatMode::DisplayAlternate => {
+                    let pound = proc_macro2::Punct::new('#', proc_macro2::Spacing::Alone);
+                    Some(quote!(
+                        ::tracing::event!(target: #target, #level_tokens, error = #pound %e)
+                    ))
+                }
+                FormatMode::DebugAlternate => {
+                    let pound = proc_macro2::Punct::new('#', proc_macro2::Spacing::Alone);
+                    Some(quote!(
+                        ::tracing::event!(target: #target, #level_tokens, error = #pound ?e)
+                    ))
+                }
             }
         }
         _ => None,
@@ -290,6 +302,18 @@ fn gen_block<B: ToTokens>(
                 FormatMode::Default | FormatMode::Debug => Some(quote!(
                     ::tracing::event!(target: #target, #level_tokens, return = ?x)
                 )),
+                FormatMode::DisplayAlternate => {
+                    let pound = proc_macro2::Punct::new('#', proc_macro2::Spacing::Alone);
+                    Some(quote!(
+                        ::tracing::event!(target: #target, #level_tokens, return = #pound %x)
+                    ))
+                }
+                FormatMode::DebugAlternate => {
+                    let pound = proc_macro2::Punct::new('#', proc_macro2::Spacing::Alone);
+                    Some(quote!(
+                        ::tracing::event!(target: #target, #level_tokens, return = #pound ?x)
+                    ))
+                }
             }
         }
         _ => None,

--- a/tracing-attributes/tests/err.rs
+++ b/tracing-attributes/tests/err.rs
@@ -327,3 +327,73 @@ fn test_err_warn_info() {
     with_default(subscriber, || err_warn_info().ok());
     handle.assert_finished();
 }
+
+// Behaves similar to anyhow::Error.
+struct ChainedError;
+
+impl std::fmt::Display for ChainedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if f.alternate() {
+            write!(f, "outer: inner cause")
+        } else {
+            write!(f, "outer")
+        }
+    }
+}
+
+impl std::fmt::Debug for ChainedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if f.alternate() {
+            f.debug_struct("ChainedError")
+                .field("msg", &"outer")
+                .field("cause", &"inner cause")
+                .finish()
+        } else {
+            write!(f, "ChainedError(outer)")
+        }
+    }
+}
+
+#[instrument(err(DisplayAlternate))]
+fn err_display_alternate() -> Result<u8, ChainedError> {
+    Err(ChainedError)
+}
+
+#[test]
+fn test_err_display_alternate() {
+    let span = expect::span().named("err_display_alternate");
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(span.clone())
+        .enter(span.clone())
+        .event(expect::event().at_level(Level::ERROR).with_fields(
+            expect::field("error").with_value(&tracing::field::display_alternate(ChainedError)),
+        ))
+        .exit(span.clone())
+        .drop_span(span)
+        .only()
+        .run_with_handle();
+    with_default(subscriber, || err_display_alternate().ok());
+    handle.assert_finished();
+}
+
+#[instrument(err(DebugAlternate))]
+fn err_debug_alternate() -> Result<u8, ChainedError> {
+    Err(ChainedError)
+}
+
+#[test]
+fn test_err_debug_alternate() {
+    let span = expect::span().named("err_debug_alternate");
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(span.clone())
+        .enter(span.clone())
+        .event(expect::event().at_level(Level::ERROR).with_fields(
+            expect::field("error").with_value(&tracing::field::debug_alternate(ChainedError)),
+        ))
+        .exit(span.clone())
+        .drop_span(span)
+        .only()
+        .run_with_handle();
+    with_default(subscriber, || err_debug_alternate().ok());
+    handle.assert_finished();
+}

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -363,6 +363,14 @@ pub struct DisplayValue<T: fmt::Display>(T);
 #[derive(Clone)]
 pub struct DebugValue<T: fmt::Debug>(T);
 
+/// A `Value` which serializes using the alternate form of `fmt::Display`.
+#[derive(Clone)]
+pub struct DisplayValueAlternate<T: fmt::Display>(T);
+
+/// A `Value` which serializes using the alternate form of `fmt::Debug`.
+#[derive(Clone)]
+pub struct DebugValueAlternate<T: fmt::Debug>(T);
+
 /// Wraps a type implementing `fmt::Display` as a `Value` that can be
 /// recorded using its `Display` implementation.
 pub fn display<T>(t: T) -> DisplayValue<T>
@@ -379,6 +387,24 @@ where
     T: fmt::Debug,
 {
     DebugValue(t)
+}
+
+/// Wraps a type implementing `fmt::Display` as a `Value` that will be
+/// recorded using the alternate form.
+pub fn display_alternate<T>(t: T) -> DisplayValueAlternate<T>
+where
+    T: fmt::Display,
+{
+    DisplayValueAlternate(t)
+}
+
+/// Wraps a type implementing `fmt::Debug` as a `Value` that will be
+/// recorded using the alternate form.
+pub fn debug_alternate<T>(t: T) -> DebugValueAlternate<T>
+where
+    T: fmt::Debug,
+{
+    DebugValueAlternate(t)
 }
 
 /// Wraps a type implementing [`Valuable`] as a `Value` that
@@ -753,6 +779,50 @@ where
 impl<T: fmt::Debug> fmt::Debug for DebugValue<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+// ===== impl DisplayValueAlternate =====
+
+impl<T: fmt::Display> crate::sealed::Sealed for DisplayValueAlternate<T> {}
+
+impl<T> Value for DisplayValueAlternate<T>
+where
+    T: fmt::Display,
+{
+    fn record(&self, key: &Field, visitor: &mut dyn Visit) {
+        visitor.record_debug(key, self)
+    }
+}
+
+impl<T: fmt::Display> fmt::Debug for DisplayValueAlternate<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:#}", self.0)
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for DisplayValueAlternate<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:#}", self.0)
+    }
+}
+
+// ===== impl DebugValueAlternate =====
+
+impl<T: fmt::Debug> crate::sealed::Sealed for DebugValueAlternate<T> {}
+
+impl<T> Value for DebugValueAlternate<T>
+where
+    T: fmt::Debug,
+{
+    fn record(&self, key: &Field, visitor: &mut dyn Visit) {
+        visitor.record_debug(key, self)
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for DebugValueAlternate<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:#?}", self.0)
     }
 }
 

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -2825,6 +2825,95 @@ macro_rules! valueset_all {
     // (@{ $(,)* $($out:expr),* }, $($k:ident).+ = _, $($rest:tt)*) => {
     //     $crate::valueset_all!(@ { $($out),*, (None) }, $($rest)*)
     // };
+    (@ { $(,)* $($out:expr),* }, $($k:ident).+ = #?$val:expr, $($rest:tt)*) => {
+        $crate::valueset_all!(
+            @ { $($out),*, ($crate::__macro_support::Option::Some(&$crate::field::debug_alternate(&$val) as &dyn $crate::field::Value)) },
+            $($rest)*
+        )
+    };
+    (@ { $(,)* $($out:expr),* }, $($k:ident).+ = #?$val:expr) => {
+        $crate::valueset_all!(
+            @ { $($out),*, ($crate::__macro_support::Option::Some(&$crate::field::debug_alternate(&$val) as &dyn $crate::field::Value)) },
+        )
+    };
+    (@ { $(,)* $($out:expr),* }, $($k:ident).+ = #%$val:expr, $($rest:tt)*) => {
+        $crate::valueset_all!(
+            @ { $($out),*, ($crate::__macro_support::Option::Some(&$crate::field::display_alternate(&$val) as &dyn $crate::field::Value)) },
+            $($rest)*
+        )
+    };
+    (@ { $(,)* $($out:expr),* }, $($k:ident).+ = #%$val:expr) => {
+        $crate::valueset_all!(
+            @ { $($out),*, ($crate::__macro_support::Option::Some(&$crate::field::display_alternate(&$val) as &dyn $crate::field::Value)) },
+        )
+    };
+    (@ { $(,)* $($out:expr),* }, #?$($k:ident).+, $($rest:tt)*) => {
+        $crate::valueset_all!(
+            @ { $($out),*, ($crate::__macro_support::Option::Some(&$crate::field::debug_alternate(&$($k).+) as &dyn $crate::field::Value)) },
+            $($rest)*
+        )
+    };
+    (@ { $(,)* $($out:expr),* }, #?$($k:ident).+) => {
+        $crate::valueset_all!(
+            @ { $($out),*, ($crate::__macro_support::Option::Some(&$crate::field::debug_alternate(&$($k).+) as &dyn $crate::field::Value)) },
+        )
+    };
+    (@ { $(,)* $($out:expr),* }, #%$($k:ident).+, $($rest:tt)*) => {
+        $crate::valueset_all!(
+            @ { $($out),*, ($crate::__macro_support::Option::Some(&$crate::field::display_alternate(&$($k).+) as &dyn $crate::field::Value)) },
+            $($rest)*
+        )
+    };
+    (@ { $(,)* $($out:expr),* }, #%$($k:ident).+) => {
+        $crate::valueset_all!(
+            @ { $($out),*, ($crate::__macro_support::Option::Some(&$crate::field::display_alternate(&$($k).+) as &dyn $crate::field::Value)) },
+        )
+    };
+    (@ { $(,)* $($out:expr),* }, $k:literal = #?$val:expr, $($rest:tt)*) => {
+        $crate::valueset_all!(
+            @ { $($out),*, ($crate::__macro_support::Option::Some(&$crate::field::debug_alternate(&$val) as &dyn $crate::field::Value)) },
+            $($rest)*
+        )
+    };
+    (@ { $(,)* $($out:expr),* }, $k:literal = #?$val:expr) => {
+        $crate::valueset_all!(
+            @ { $($out),*, ($crate::__macro_support::Option::Some(&$crate::field::debug_alternate(&$val) as &dyn $crate::field::Value)) },
+        )
+    };
+    (@ { $(,)* $($out:expr),* }, $k:literal = #%$val:expr, $($rest:tt)*) => {
+        $crate::valueset_all!(
+            @ { $($out),*, ($crate::__macro_support::Option::Some(&$crate::field::display_alternate(&$val) as &dyn $crate::field::Value)) },
+            $($rest)*
+        )
+    };
+    (@ { $(,)* $($out:expr),* }, $k:literal = #%$val:expr) => {
+        $crate::valueset_all!(
+            @ { $($out),*, ($crate::__macro_support::Option::Some(&$crate::field::display_alternate(&$val) as &dyn $crate::field::Value)) },
+        )
+    };
+    (@ { $(,)* $($out:expr),* }, { $k:expr } = #?$val:expr, $($rest:tt)*) => {
+        $crate::valueset_all!(
+            @ { $($out),*, (Some(&$crate::field::debug_alternate(&$val) as &dyn $crate::field::Value)) },
+            $($rest)*
+        )
+    };
+    (@ { $(,)* $($out:expr),* }, { $k:expr } = #?$val:expr) => {
+        $crate::valueset_all!(
+            @ { $($out),*, (Some(&$crate::field::debug_alternate(&$val) as &dyn $crate::field::Value)) },
+        )
+    };
+    (@ { $(,)* $($out:expr),* }, { $k:expr } = #%$val:expr, $($rest:tt)*) => {
+        $crate::valueset_all!(
+            @ { $($out),*, (Some(&$crate::field::display_alternate(&$val) as &dyn $crate::field::Value)) },
+            $($rest)*
+        )
+    };
+    (@ { $(,)* $($out:expr),* }, { $k:expr } = #%$val:expr) => {
+        $crate::valueset_all!(
+            @ { $($out),*, (Some(&$crate::field::display_alternate(&$val) as &dyn $crate::field::Value)) },
+        )
+    };
+
     (@ { $(,)* $($out:expr),* }, $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
         $crate::valueset_all!(
             @ { $($out),*, ($crate::__macro_support::Option::Some(&$crate::field::debug(&$val) as &dyn $crate::field::Value)) },
@@ -2973,7 +3062,7 @@ macro_rules! valueset_all {
             #[allow(unused_imports)]
             // This import statement CANNOT be removed as it will break existing use cases.
             // See #831, #2332, #3424 for the last times we tried.
-            use $crate::field::{debug, display, Value};
+            use $crate::field::{debug, display, debug_alternate, display_alternate, Value};
             $fields.value_set_all($crate::valueset_all!(
                 @ { },
                 $($kvs)+
@@ -3002,6 +3091,95 @@ macro_rules! valueset {
     }};
 
     // === recursive case (more tts) ===
+
+    (@ $fields:expr, { $(,)* $(($field:expr, $out:expr)),* }, $($k:ident).+ = #?$val:expr, $($rest:tt)*) => {
+        $crate::valueset!(
+            @ $fields, { $(($field, $out)),*, ($crate::__tracing_stringify!($($k).+), $crate::field::debug_alternate(&$val)) },
+            $($rest)*
+        )
+    };
+    (@ $fields:expr, { $(,)* $(($field:expr, $out:expr)),* }, $($k:ident).+ = #?$val:expr) => {
+        $crate::valueset!(
+            @ $fields, { $(($field, $out)),*, ($crate::__tracing_stringify!($($k).+), $crate::field::debug_alternate(&$val)) },
+        )
+    };
+    (@ $fields:expr, { $(,)* $(($field:expr, $out:expr)),* }, $($k:ident).+ = #%$val:expr, $($rest:tt)*) => {
+        $crate::valueset!(
+            @ $fields, { $(($field, $out)),*, ($crate::__tracing_stringify!($($k).+), $crate::field::display_alternate(&$val)) },
+            $($rest)*
+        )
+    };
+    (@ $fields:expr, { $(,)* $(($field:expr, $out:expr)),* }, $($k:ident).+ = #%$val:expr) => {
+        $crate::valueset!(
+            @ $fields, { $(($field, $out)),*, ($crate::__tracing_stringify!($($k).+), $crate::field::display_alternate(&$val)) },
+        )
+    };
+    (@ $fields:expr, { $(,)* $(($field:expr, $out:expr)),* }, #?$($k:ident).+, $($rest:tt)*) => {
+        $crate::valueset!(
+            @ $fields, { $(($field, $out)),*, ($crate::__tracing_stringify!($($k).+), $crate::field::debug_alternate(&$($k).+)) },
+            $($rest)*
+        )
+    };
+    (@ $fields:expr, { $(,)* $(($field:expr, $out:expr)),* }, #?$($k:ident).+) => {
+        $crate::valueset!(
+            @ $fields, { $(($field, $out)),*, ($crate::__tracing_stringify!($($k).+), $crate::field::debug_alternate(&$($k).+)) },
+        )
+    };
+    (@ $fields:expr, { $(,)* $(($field:expr, $out:expr)),* }, #%$($k:ident).+, $($rest:tt)*) => {
+        $crate::valueset!(
+            @ $fields, { $(($field, $out)),*, ($crate::__tracing_stringify!($($k).+), $crate::field::display_alternate(&$($k).+)) },
+            $($rest)*
+        )
+    };
+    (@ $fields:expr, { $(,)* $(($field:expr, $out:expr)),* }, #%$($k:ident).+) => {
+        $crate::valueset!(
+            @ $fields, { $(($field, $out)),*, ($crate::__tracing_stringify!($($k).+), $crate::field::display_alternate(&$($k).+)) },
+        )
+    };
+    (@ $fields:expr, { $(,)* $(($field:expr, $out:expr)),* }, $k:literal = #?$val:expr, $($rest:tt)*) => {
+        $crate::valueset!(
+            @ $fields, { $(($field, $out)),*, ($k, $crate::field::debug_alternate(&$val)) },
+            $($rest)*
+        )
+    };
+    (@ $fields:expr, { $(,)* $(($field:expr, $out:expr)),* }, $k:literal = #?$val:expr) => {
+        $crate::valueset!(
+            @ $fields, { $(($field, $out)),*, ($k, $crate::field::debug_alternate(&$val)) },
+        )
+    };
+    (@ $fields:expr, { $(,)* $(($field:expr, $out:expr)),* }, $k:literal = #%$val:expr, $($rest:tt)*) => {
+        $crate::valueset!(
+            @ $fields, { $(($field, $out)),*, ($k, $crate::field::display_alternate(&$val)) },
+            $($rest)*
+        )
+    };
+    (@ $fields:expr, { $(,)* $(($field:expr, $out:expr)),* }, $k:literal = #%$val:expr) => {
+        $crate::valueset!(
+            @ $fields, { $(($field, $out)),*, ($k, $crate::field::display_alternate(&$val)) },
+        )
+    };
+    (@ $fields:expr, { $(,)* $(($field:expr, $out:expr)),* }, { $k:expr } = #?$val:expr, $($rest:tt)*) => {
+        $crate::valueset!(
+            @ $fields, { $(($field, $out)),*, ($k, $crate::field::debug_alternate(&$val)) },
+            $($rest)*
+        )
+    };
+    (@ $fields:expr, { $(,)* $(($field:expr, $out:expr)),* }, { $k:expr } = #?$val:expr) => {
+        $crate::valueset!(
+            @ $fields, { $(($field, $out)),*, ($k, $crate::field::debug_alternate(&$val)) },
+        )
+    };
+    (@ $fields:expr, { $(,)* $(($field:expr, $out:expr)),* }, { $k:expr } = #%$val:expr, $($rest:tt)*) => {
+        $crate::valueset!(
+            @ $fields, { $(($field, $out)),*, ($k, $crate::field::display_alternate(&$val)) },
+            $($rest)*
+        )
+    };
+    (@ $fields:expr, { $(,)* $(($field:expr, $out:expr)),* }, { $k:expr } = #%$val:expr) => {
+        $crate::valueset!(
+            @ $fields, { $(($field, $out)),*, ($k, $crate::field::display_alternate(&$val)) },
+        )
+    };
 
     (@ $fields:expr, { $(,)* $(($field:expr, $out:expr)),* }, $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
         $crate::valueset!(
@@ -3146,7 +3324,7 @@ macro_rules! valueset {
             #[allow(unused_imports)]
             // This import statement CANNOT be removed as it will break existing use cases.
             // See #831, #2332, #3424 for the last times we tried.
-            use $crate::field::{debug, display, Value};
+            use $crate::field::{debug, display, debug_alternate, display_alternate, Value};
             $fields.value_set($crate::valueset!(
                 @ $fields, { },
                 $($kvs)+
@@ -3169,6 +3347,32 @@ macro_rules! fieldset {
     };
 
     // == recursive cases (more tts) ==
+
+    (@ { $(,)* $($out:expr),* } $($k:ident).+ = #?$val:expr, $($rest:tt)*) => {
+        $crate::fieldset!(@ { $($out),*, $crate::__tracing_stringify!($($k).+) } $($rest)*)
+    };
+    (@ { $(,)* $($out:expr),* } $($k:ident).+ = #%$val:expr, $($rest:tt)*) => {
+        $crate::fieldset!(@ { $($out),*, $crate::__tracing_stringify!($($k).+) } $($rest)*)
+    };
+    (@ { $(,)* $($out:expr),* } #?$($k:ident).+, $($rest:tt)*) => {
+        $crate::fieldset!(@ { $($out),*, $crate::__tracing_stringify!($($k).+) } $($rest)*)
+    };
+    (@ { $(,)* $($out:expr),* } #%$($k:ident).+, $($rest:tt)*) => {
+        $crate::fieldset!(@ { $($out),*, $crate::__tracing_stringify!($($k).+) } $($rest)*)
+    };
+    (@ { $(,)* $($out:expr),* } $k:literal = #?$val:expr, $($rest:tt)*) => {
+        $crate::fieldset!(@ { $($out),*, $k } $($rest)*)
+    };
+    (@ { $(,)* $($out:expr),* } $k:literal = #%$val:expr, $($rest:tt)*) => {
+        $crate::fieldset!(@ { $($out),*, $k } $($rest)*)
+    };
+    (@ { $(,)* $($out:expr),* } { $k:expr } = #?$val:expr, $($rest:tt)*) => {
+        $crate::fieldset!(@ { $($out),*, $k } $($rest)*)
+    };
+    (@ { $(,)* $($out:expr),* } { $k:expr } = #%$val:expr, $($rest:tt)*) => {
+        $crate::fieldset!(@ { $($out),*, $k } $($rest)*)
+    };
+
     (@ { $(,)* $($out:expr),* } $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
         $crate::fieldset!(@ { $($out),*, $crate::__tracing_stringify!($($k).+) } $($rest)*)
     };

--- a/tracing/tests/alternate_format.rs
+++ b/tracing/tests/alternate_format.rs
@@ -1,0 +1,125 @@
+#![cfg(feature = "std")]
+
+use std::fmt;
+
+use tracing::field::{debug, debug_alternate, display, display_alternate};
+use tracing::subscriber::with_default;
+use tracing::{event, info_span, Level};
+use tracing_mock::*;
+
+// Behaves similar to anyhow::Error.
+struct ChainedError;
+
+impl fmt::Display for ChainedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "outer: inner cause")
+        } else {
+            write!(f, "outer")
+        }
+    }
+}
+
+impl fmt::Debug for ChainedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            f.debug_struct("ChainedError")
+                .field("msg", &"outer")
+                .field("cause", &"inner cause")
+                .finish()
+        } else {
+            write!(f, "ChainedError(outer)")
+        }
+    }
+}
+
+#[test]
+fn display_alternate_in_event() {
+    let (subscriber, handle) = subscriber::mock()
+        .event(
+            expect::event()
+                .with_fields(expect::field("error").with_value(&display_alternate(&ChainedError))),
+        )
+        .only()
+        .run_with_handle();
+    with_default(subscriber, || {
+        event!(Level::INFO, error = #%ChainedError);
+    });
+    handle.assert_finished();
+}
+
+#[test]
+fn display_normal_in_event() {
+    let (subscriber, handle) = subscriber::mock()
+        .event(
+            expect::event().with_fields(expect::field("error").with_value(&display(&ChainedError))),
+        )
+        .only()
+        .run_with_handle();
+    with_default(subscriber, || {
+        event!(Level::INFO, error = %ChainedError);
+    });
+    handle.assert_finished();
+}
+
+#[test]
+fn debug_alternate_in_event() {
+    let (subscriber, handle) = subscriber::mock()
+        .event(
+            expect::event()
+                .with_fields(expect::field("error").with_value(&debug_alternate(&ChainedError))),
+        )
+        .only()
+        .run_with_handle();
+    with_default(subscriber, || {
+        event!(Level::INFO, error = #?ChainedError);
+    });
+    handle.assert_finished();
+}
+
+#[test]
+fn debug_normal_in_event() {
+    let (subscriber, handle) = subscriber::mock()
+        .event(
+            expect::event().with_fields(expect::field("error").with_value(&debug(&ChainedError))),
+        )
+        .only()
+        .run_with_handle();
+    with_default(subscriber, || {
+        event!(Level::INFO, error = ?ChainedError);
+    });
+    handle.assert_finished();
+}
+
+#[test]
+fn display_alternate_shorthand() {
+    let (subscriber, handle) = subscriber::mock()
+        .event(
+            expect::event()
+                .with_fields(expect::field("error").with_value(&display_alternate(&ChainedError))),
+        )
+        .only()
+        .run_with_handle();
+    with_default(subscriber, || {
+        let error = ChainedError;
+        event!(Level::INFO, #%error);
+    });
+    handle.assert_finished();
+}
+
+#[test]
+fn alternate_in_span() {
+    let span = expect::span().named("test");
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(
+            span.clone()
+                .with_fields(expect::field("error").with_value(&display_alternate(&ChainedError))),
+        )
+        .drop_span(span)
+        .only()
+        .run_with_handle();
+    with_default(subscriber, || {
+        let _span = info_span!("test", error = #%ChainedError);
+    });
+    handle.assert_finished();
+}

--- a/tracing/tests/macros.rs
+++ b/tracing/tests/macros.rs
@@ -492,6 +492,24 @@ fn event() {
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[test]
+fn alternate_format_sigils() {
+    let foo = 1;
+    event!(Level::DEBUG, bar = #%foo);
+    event!(Level::DEBUG, bar = #?foo);
+    event!(Level::DEBUG, #%foo);
+    event!(Level::DEBUG, #?foo);
+    span!(Level::DEBUG, "test", bar = #%foo);
+    span!(Level::DEBUG, "test", bar = #?foo);
+    span!(Level::DEBUG, "test", #%foo);
+    span!(Level::DEBUG, "test", #?foo);
+    info!(bar = #%foo);
+    info!(bar = #?foo);
+    info!(#%foo);
+    info!(#?foo);
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
 fn enabled() {
     enabled!(Level::DEBUG, foo, bar.baz, quux,);
     enabled!(Level::DEBUG, message);


### PR DESCRIPTION
This adds support for the "alternate" display/debug versions of values, mirroring what `std` supports:

```rust
// Similar to println!("{:#}", bar);
info!(foo = #%bar, "test");

// Similar to println!("{:#?}", bar);
debug!(foo = #?bar, "test");
```

This is also supported in the `#[instrument]` macro:

```rust
#[instrument(err(DisplayAlternate))]
fn hello_world() -> Result<(), anyhow::Error> {
    break_stuff().context("I broke something!")?;
    Ok(())
}
```

As alluded to above and in #1311, one particularly useful case for this is `anyhow::Error`, which prints the full stack of causes in its alternate display, but only prints the top error in its standard display format.

Fixes #1311
