### PR TITLE
fix(tracing): exclude 9.5 MB of extraneous files from published package

### DIFF
--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -23,6 +23,7 @@ categories = [
 keywords = ["logging", "tracing", "metrics", "async"]
 edition = "2018"
 rust-version = "1.65.0"
+include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 
 [dependencies]
 tracing-core = { path = "../tracing-core", version = "0.1.36", default-features = false }


### PR DESCRIPTION
It seems around 9.5MB of data (0.44 MB compressed) is accidentally included in the binary in v0.1.44. v0.1.43 is 0.465 MB (.087MB compressed). This translates to around 15TB/mo of wasted bandwidth

An unreferenced `test-macros/` directory is shipped with the package. I don't see this in the GitHub repo, so I presume this was a part of a local publish. Additionally, tests and benches are shipped in the published package, and removing them removes another .158MB (.016MB compressed), or .82TB/mo

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

I have been working on [cargo diet](https://github.com/the-lean-crate/cargo-diet), whose goal is to remove extraneous files from published packages, and while working on an index for the top extra bandwidth used, I found tracing was at the top 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Republish without the `test-macros/` directory and add an explicit includes. The explicit includes will prevent similar accidental inclusions in the future

If y'all are interested, I can diet the rest of the crates in this monorepo as a followup!