### PR TITLE
chore(clippy): remove the redundant `&` in layer_filters.rs

### DIFF
--- a/examples/examples/sloggish/sloggish_subscriber.rs
+++ b/examples/examples/sloggish/sloggish_subscriber.rs
@@ -256,7 +256,7 @@ impl Subscriber for SloggishSubscriber {
             "{timestamp} {level} {target}",
             timestamp = humantime::format_rfc3339_seconds(SystemTime::now()),
             level = ColorLevel(event.metadata().level()),
-            target = &event.metadata().target(),
+            target = event.metadata().target(),
         )
         .unwrap();
         let mut visitor = Event {

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -942,7 +942,7 @@ mod test {
             now: OffsetDateTime,
         }
 
-        let format = format_description::parse(
+        let format = format_description::parse_borrowed::<2>(
             "[year]-[month]-[day] [hour]:[minute]:[second] [offset_hour \
          sign:mandatory]:[offset_minute]:[offset_second]",
         )
@@ -1023,7 +1023,7 @@ mod test {
 
     #[test]
     fn test_path_concatenation() {
-        let format = format_description::parse(
+        let format = format_description::parse_borrowed::<2>(
             "[year]-[month]-[day] [hour]:[minute]:[second] [offset_hour \
          sign:mandatory]:[offset_minute]:[offset_second]",
         )
@@ -1150,7 +1150,7 @@ mod test {
         use std::sync::{Arc, Mutex};
         use tracing_subscriber::prelude::*;
 
-        let format = format_description::parse(
+        let format = format_description::parse_borrowed::<2>(
             "[year]-[month]-[day] [hour]:[minute]:[second] [offset_hour \
          sign:mandatory]:[offset_minute]:[offset_second]",
         )
@@ -1233,7 +1233,7 @@ mod test {
         use std::sync::{Arc, Mutex};
         use tracing_subscriber::prelude::*;
 
-        let format = format_description::parse(
+        let format = format_description::parse_borrowed::<2>(
             "[year]-[month]-[day] [hour]:[minute]:[second] [offset_hour \
          sign:mandatory]:[offset_minute]:[offset_second]",
         )
@@ -1370,7 +1370,7 @@ mod test {
     fn test_latest_symlink() {
         use std::sync::{Arc, Mutex};
 
-        let format = format_description::parse(
+        let format = format_description::parse_borrowed::<2>(
             "[year]-[month]-[day] [hour]:[minute]:[second] [offset_hour \
          sign:mandatory]:[offset_minute]:[offset_second]",
         )

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -559,8 +559,12 @@ impl Rotation {
 
     fn date_format(&self) -> Vec<format_description::FormatItem<'static>> {
         match *self {
-            Rotation::MINUTELY => format_description::parse_borrowed::<2>("[year]-[month]-[day]-[hour]-[minute]"),
-            Rotation::HOURLY => format_description::parse_borrowed::<2>("[year]-[month]-[day]-[hour]"),
+            Rotation::MINUTELY => {
+                format_description::parse_borrowed::<2>("[year]-[month]-[day]-[hour]-[minute]")
+            }
+            Rotation::HOURLY => {
+                format_description::parse_borrowed::<2>("[year]-[month]-[day]-[hour]")
+            }
             Rotation::DAILY => format_description::parse_borrowed::<2>("[year]-[month]-[day]"),
             Rotation::WEEKLY => format_description::parse_borrowed::<2>("[year]-[month]-[day]"),
             Rotation::NEVER => format_description::parse_borrowed::<2>("[year]-[month]-[day]"),

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -559,11 +559,11 @@ impl Rotation {
 
     fn date_format(&self) -> Vec<format_description::FormatItem<'static>> {
         match *self {
-            Rotation::MINUTELY => format_description::parse("[year]-[month]-[day]-[hour]-[minute]"),
-            Rotation::HOURLY => format_description::parse("[year]-[month]-[day]-[hour]"),
-            Rotation::DAILY => format_description::parse("[year]-[month]-[day]"),
-            Rotation::WEEKLY => format_description::parse("[year]-[month]-[day]"),
-            Rotation::NEVER => format_description::parse("[year]-[month]-[day]"),
+            Rotation::MINUTELY => format_description::parse_borrowed::<2>("[year]-[month]-[day]-[hour]-[minute]"),
+            Rotation::HOURLY => format_description::parse_borrowed::<2>("[year]-[month]-[day]-[hour]"),
+            Rotation::DAILY => format_description::parse_borrowed::<2>("[year]-[month]-[day]"),
+            Rotation::WEEKLY => format_description::parse_borrowed::<2>("[year]-[month]-[day]"),
+            Rotation::NEVER => format_description::parse_borrowed::<2>("[year]-[month]-[day]"),
         }
         .expect("Unable to create a formatter; this is a bug in tracing-appender")
     }

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -1167,7 +1167,7 @@ mod private {
 #[cfg(test)]
 mod test {
     use alloc::{borrow::ToOwned, boxed::Box, string::String};
-    use std::format;
+    use std::{format, string::ToString};
 
     use super::*;
     use crate::metadata::{Kind, Level, Metadata};
@@ -1367,6 +1367,6 @@ mod test {
             use core::fmt::Write;
             write!(&mut result, "{:?}", value).unwrap();
         });
-        assert_eq!(result, format!("{}", r#"[61 62 63]" "[c0 ff ee]"#));
+        assert_eq!(result, r#"[61 62 63]" "[c0 ff ee]"#.to_string());
     }
 }

--- a/tracing-log/src/interest_cache.rs
+++ b/tracing-log/src/interest_cache.rs
@@ -499,9 +499,9 @@ mod tests {
                 .target("dummy_2")
                 .build();
             try_cache(&metadata_1, || true);
-            assert_eq!(try_cache(&metadata_1, || { unreachable!() }), true);
+            assert!(try_cache(&metadata_1, || { unreachable!() }));
             try_cache(&metadata_2, || false);
-            assert_eq!(try_cache(&metadata_2, || { unreachable!() }), false);
+            assert!(!try_cache(&metadata_2, || { unreachable!() }));
         })
         .join()
         .unwrap();
@@ -521,7 +521,7 @@ mod tests {
                 .build();
 
             try_cache(&metadata_1, || true);
-            assert_eq!(try_cache(&metadata_1, || { unreachable!() }), true);
+            assert!(try_cache(&metadata_1, || { unreachable!() }));
 
             *target.last_mut().unwrap() = b'2';
             let metadata_2 = log::MetadataBuilder::new()
@@ -530,7 +530,7 @@ mod tests {
                 .build();
 
             try_cache(&metadata_2, || false);
-            assert_eq!(try_cache(&metadata_2, || { unreachable!() }), false);
+            assert!(!try_cache(&metadata_2, || { unreachable!() }));
         })
         .join()
         .unwrap();

--- a/tracing-mock/src/layer.rs
+++ b/tracing-mock/src/layer.rs
@@ -76,7 +76,7 @@
 //!
 //! ```should_panic
 //! use tracing_mock::{expect, layer};
-//! use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};  
+//! use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 //!
 //! let span = expect::span()
 //!     .named("my_span");
@@ -1104,7 +1104,7 @@ impl fmt::Debug for MockLayer {
         }
 
         if let Ok(current) = self.current.try_lock() {
-            s.field("current", &format_args!("{:?}", &current));
+            s.field("current", &format_args!("{:?}", current));
         } else {
             s.field("current", &format_args!("<locked>"));
         }

--- a/tracing-subscriber/src/filter/layer_filters/mod.rs
+++ b/tracing-subscriber/src/filter/layer_filters/mod.rs
@@ -1074,7 +1074,7 @@ impl fmt::Debug for FilterMap {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let alt = f.alternate();
         let mut s = f.debug_struct("FilterMap");
-        s.field("disabled_by", &format_args!("{:?}", &FmtBitset(self.bits)));
+        s.field("disabled_by", &format_args!("{:?}", FmtBitset(self.bits)));
 
         if alt {
             s.field("bits", &format_args!("{:b}", self.bits));

--- a/tracing-subscriber/src/fmt/time/chrono_crate.rs
+++ b/tracing-subscriber/src/fmt/time/chrono_crate.rs
@@ -9,7 +9,6 @@ use alloc::{format, string::String, sync::Arc};
 /// [local time]: [`chrono::offset::Local`]
 /// [UTC time]: [`chrono::offset::Utc`]
 /// [`chrono` crate]: [`chrono`]
-
 /// Formats the current [local time] using a [formatter] from the [`chrono`] crate.
 ///
 /// [local time]: chrono::Local::now()


### PR DESCRIPTION
## Motivation

Fix CI with Rust 1.97.1 (current stable):
```
error: redundant reference in `format_args!` argument
    --> tracing-subscriber/src/filter/layer_filters/mod.rs:1077:54
     |
1077 |         s.field("disabled_by", &format_args!("{:?}", &FmtBitset(self.bits)));
     |                                                      ^^^^^^^^^^^^^^^^^^^^^ help: remove the redundant `&`: `FmtBitset(self.bits)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting
     = note: `-D clippy::useless-borrows-in-formatting` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::useless_borrows_in_formatting)]`
```

## Solution

Apply the suggestion.
