### PR TITLE
feat(subscriber): allow event dependency when making a writer

### DIFF
--- a/examples/examples/env-filter-explorer.rs
+++ b/examples/examples/env-filter-explorer.rs
@@ -157,7 +157,7 @@ impl io::Write for LogWidget {
     }
 }
 
-impl<'a> MakeWriter<'a> for LogWidget {
+impl<'a, S> MakeWriter<'a, S> for LogWidget {
     type Writer = Self;
 
     fn make_writer(&'a self) -> Self::Writer {

--- a/tracing-appender/benches/bench.rs
+++ b/tracing-appender/benches/bench.rs
@@ -18,7 +18,7 @@ impl NoOpWriter {
     }
 }
 
-impl MakeWriter<'_> for NoOpWriter {
+impl<S> MakeWriter<'_, S> for NoOpWriter {
     type Writer = NoOpWriter;
 
     fn make_writer(&self) -> Self::Writer {

--- a/tracing-appender/src/non_blocking.rs
+++ b/tracing-appender/src/non_blocking.rs
@@ -261,7 +261,7 @@ impl std::io::Write for NonBlocking {
     }
 }
 
-impl<'a> MakeWriter<'a> for NonBlocking {
+impl<'a, S> MakeWriter<'a, S> for NonBlocking {
     type Writer = NonBlocking;
 
     fn make_writer(&'a self) -> Self::Writer {

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -240,7 +240,7 @@ impl io::Write for RollingFileAppender {
     }
 }
 
-impl<'a> tracing_subscriber::fmt::writer::MakeWriter<'a> for RollingFileAppender {
+impl<'a, S> tracing_subscriber::fmt::writer::MakeWriter<'a, S> for RollingFileAppender {
     type Writer = RollingWriter<'a>;
     fn make_writer(&'a self) -> Self::Writer {
         let now = self.now();

--- a/tracing-subscriber/src/fmt/fmt_layer.rs
+++ b/tracing-subscriber/src/fmt/fmt_layer.rs
@@ -760,7 +760,7 @@ where
     S: Subscriber + for<'a> LookupSpan<'a>,
     N: for<'writer> FormatFields<'writer> + 'static,
     E: FormatEvent<S, N> + 'static,
-    W: for<'writer> MakeWriter<'writer> + 'static,
+    W: for<'writer> MakeWriter<'writer, S> + 'static,
 {
     #[inline]
     fn make_ctx<'a>(&'a self, ctx: Context<'a, S>, event: &'a Event<'a>) -> FmtContext<'a, S, N> {
@@ -869,7 +869,7 @@ where
     S: Subscriber + for<'a> LookupSpan<'a>,
     N: for<'writer> FormatFields<'writer> + 'static,
     E: FormatEvent<S, N> + 'static,
-    W: for<'writer> MakeWriter<'writer> + 'static,
+    W: for<'writer> MakeWriter<'writer, S> + 'static,
 {
     fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         let span = ctx.span(id).expect("Span not found, this is a bug");
@@ -1034,11 +1034,12 @@ where
                 }
             };
 
-            let ctx = self.make_ctx(ctx, event);
+            let mut writer = self.make_writer.make_writer_for_event(event, &ctx);
+            let fmt_ctx = self.make_ctx(ctx, event);
             if self
                 .fmt_event
                 .format_event(
-                    &ctx,
+                    &fmt_ctx,
                     format::Writer::new(&mut buf)
                         .with_ansi(self.is_ansi)
                         .with_ansi_sanitization(self.ansi_sanitization),
@@ -1046,7 +1047,6 @@ where
                 )
                 .is_ok()
             {
-                let mut writer = self.make_writer.make_writer_for(event.metadata());
                 let res = io::Write::write_all(&mut writer, buf.as_bytes());
                 if self.log_internal_errors {
                     if let Err(e) = res {
@@ -1056,7 +1056,6 @@ where
             } else if self.log_internal_errors {
                 let err_msg = format!("Unable to format the following event. Name: {}; Fields: {:?}\n",
                     event.metadata().name(), event.fields());
-                let mut writer = self.make_writer.make_writer_for(event.metadata());
                 let res = io::Write::write_all(&mut writer, err_msg.as_bytes());
                 if let Err(e) = res {
                     eprintln!("[tracing-subscriber] Unable to write an \"event formatting error\" to the Writer for this Subscriber! Error: {}\n", e);
@@ -1295,18 +1294,21 @@ impl Timings {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::fmt::{
-        self,
-        format::{self, test::MockTime, Format},
-        layer::Layer as _,
-        test::{MockMakeWriter, MockWriter},
-        time,
-    };
     use crate::Registry;
+    use crate::{
+        fmt::{
+            self,
+            format::{self, test::MockTime, Format},
+            layer::Layer as _,
+            test::{MockMakeWriter, MockWriter},
+            time,
+        },
+        layer::SubscriberExt,
+    };
     use alloc::{string::ToString, vec, vec::Vec};
     use format::FmtSpan;
     use regex::Regex;
-    use tracing::subscriber::with_default;
+    use tracing::{field::Visit, subscriber::with_default};
     use tracing_core::dispatcher::Dispatch;
 
     #[test]
@@ -1542,7 +1544,7 @@ mod test {
             make_writer2: MockMakeWriter,
         }
 
-        impl<'a> MakeWriter<'a> for MakeByTarget {
+        impl<'a, S> MakeWriter<'a, S> for MakeByTarget {
             type Writer = MockWriter;
 
             fn make_writer(&'a self) -> Self::Writer {
@@ -1594,6 +1596,170 @@ mod test {
             "fake time writer1_span{x=42}: hello writer2!\n\
              fake time writer1_span{x=42}:writer2_span: close timing timing\n",
             actual.as_str()
+        );
+    }
+
+    #[test]
+    fn make_writer_based_on_span() {
+        struct MakeByDynamicId {
+            make_writer1: MockMakeWriter,
+            make_writer2: MockMakeWriter,
+        }
+
+        impl MakeByDynamicId {
+            fn make_by_id(&self, id: Option<i64>) -> MockWriter {
+                match id {
+                    Some(2) => self.make_writer2.make_writer(),
+                    _ => self.make_writer1.make_writer(),
+                }
+            }
+        }
+
+        #[derive(Default)]
+        struct IdExtractor {
+            id: Option<i64>,
+        }
+
+        impl Visit for IdExtractor {
+            fn record_debug(&mut self, _field: &field::Field, _value: &dyn core::fmt::Debug) {}
+
+            fn record_i64(&mut self, field: &field::Field, value: i64) {
+                if field.name() == "id" {
+                    self.id = Some(value);
+                }
+            }
+        }
+
+        /// Captures the span value that specifies, which writer to use
+        /// and inserts it into the spans extensions.
+        struct CaptureIdLayer<S>(PhantomData<S>);
+
+        #[derive(Clone, Copy)]
+        struct WriterIdExt {
+            id: i64,
+        }
+
+        impl<S> crate::layer::Layer<S> for CaptureIdLayer<S>
+        where
+            S: Subscriber + for<'b> LookupSpan<'b>,
+        {
+            fn on_new_span(
+                &self,
+                attrs: &tracing_core::span::Attributes<'_>,
+                id: &tracing_core::span::Id,
+                ctx: Context<'_, S>,
+            ) {
+                let span = ctx.span(id).unwrap();
+                let mut extractor = IdExtractor::default();
+                attrs.record(&mut extractor);
+                if let Some(id) = extractor.id {
+                    span.extensions_mut().insert(WriterIdExt { id });
+                }
+            }
+
+            fn on_follows_from(
+                &self,
+                span: &tracing_core::span::Id,
+                follows: &tracing_core::span::Id,
+                ctx: Context<'_, S>,
+            ) {
+                let lhs = ctx.span(span).unwrap();
+                let rhs = ctx.span(follows).unwrap();
+                if rhs.extensions().get::<WriterIdExt>().is_some() {
+                    return;
+                }
+                let exts = lhs.extensions();
+                if let Some(ext) = exts.get::<WriterIdExt>().cloned() {
+                    // Derive.
+                    rhs.extensions_mut().insert(ext);
+                }
+            }
+        }
+
+        impl<'a, S> MakeWriter<'a, S> for MakeByDynamicId
+        where
+            S: Subscriber + for<'b> LookupSpan<'b>,
+        {
+            type Writer = MockWriter;
+
+            fn make_writer(&'a self) -> Self::Writer {
+                self.make_writer1.make_writer()
+            }
+
+            fn make_writer_for_event(
+                &'a self,
+                event: &Event<'_>,
+                ctx: &Context<'_, S>,
+            ) -> Self::Writer {
+                let mut extractor = IdExtractor::default();
+                event.record(&mut extractor);
+                if extractor.id.is_some() {
+                    return self.make_by_id(extractor.id);
+                };
+                // Check for the id in the spans.
+                for span in ctx
+                    .event_scope(event)
+                    .into_iter()
+                    .flat_map(|s| s.into_iter())
+                {
+                    if let Some(write) = span.extensions().get::<WriterIdExt>() {
+                        return self.make_by_id(Some(write.id));
+                    }
+                }
+                self.make_by_id(None)
+            }
+        }
+
+        let make_writer1 = MockMakeWriter::default();
+        let make_writer2 = MockMakeWriter::default();
+
+        let make_writer = MakeByDynamicId {
+            make_writer1: make_writer1.clone(),
+            make_writer2: make_writer2.clone(),
+        };
+
+        let subscriber = crate::registry()
+            .with(
+                crate::fmt::layer()
+                    .with_writer(make_writer)
+                    .with_level(false)
+                    .with_target(false)
+                    .with_ansi(false)
+                    .with_timer(MockTime),
+            )
+            .with(CaptureIdLayer(PhantomData));
+
+        let id1 = || 1;
+        let id2 = || 2;
+        with_default(subscriber, || {
+            tracing::info!(id = id2(), "hello to 1!");
+            let span1 = tracing::info_span!("writer1_span", id = id1());
+            let _e = span1.enter();
+            tracing::info!("hello from 1");
+            let span2 = tracing::info_span!("writer2_span", id = id2());
+            let _e = span2.enter();
+            tracing::warn!("hello from 2");
+            tracing::info!(id = id1(), "another hello from 1");
+
+            let span3 = tracing::info_span!(parent: None, "follow_span");
+            // Followed span inherits writer.
+            span3.follows_from(&span1);
+            let _e = span3.enter();
+            tracing::warn!("followed");
+        });
+
+        let actual = sanitize_timings(make_writer1.get_string());
+        assert_eq!(
+            "fake time writer1_span{id=1}: hello from 1\n\
+            fake time writer1_span{id=1}:writer2_span{id=2}: another hello from 1 id=1\n\
+            fake time follow_span: followed\n",
+            actual.as_str(),
+        );
+        let actual = sanitize_timings(make_writer2.get_string());
+        assert_eq!(
+            "fake time hello to 1! id=2\n\
+            fake time writer1_span{id=1}:writer2_span{id=2}: hello from 2\n",
+            actual.as_str(),
         );
     }
 

--- a/tracing-subscriber/src/fmt/mod.rs
+++ b/tracing-subscriber/src/fmt/mod.rs
@@ -1340,7 +1340,7 @@ mod test {
         }
     }
 
-    impl<'a> MakeWriter<'a> for MockMakeWriter {
+    impl<'a, S> MakeWriter<'a, S> for MockMakeWriter {
         type Writer = MockWriter;
 
         fn make_writer(&'a self) -> Self::Writer {

--- a/tracing-subscriber/src/fmt/writer.rs
+++ b/tracing-subscriber/src/fmt/writer.rs
@@ -9,7 +9,9 @@ use std::{
     print,
     sync::{Mutex, MutexGuard},
 };
-use tracing_core::Metadata;
+use tracing_core::{Event, Metadata};
+
+use crate::{layer::Context, Registry};
 
 /// A type that can create [`io::Write`] instances.
 ///
@@ -95,7 +97,7 @@ use tracing_core::Metadata;
 /// [`Metadata`]: tracing_core::Metadata
 /// [levels]: tracing_core::Level
 /// [targets]: tracing_core::Metadata::target
-pub trait MakeWriter<'a> {
+pub trait MakeWriter<'a, S = Registry> {
     /// The concrete [`io::Write`] implementation returned by [`make_writer`].
     ///
     /// [`io::Write`]: std::io::Write
@@ -176,7 +178,7 @@ pub trait MakeWriter<'a> {
     ///     }
     /// }
     ///
-    /// impl<'a> MakeWriter<'a> for MyMakeWriter {
+    /// impl<'a, S> MakeWriter<'a, S> for MyMakeWriter {
     ///     type Writer = StdioLock<'a>;
     ///
     ///     fn make_writer(&'a self) -> Self::Writer {
@@ -208,6 +210,22 @@ pub trait MakeWriter<'a> {
     fn make_writer_for(&'a self, meta: &Metadata<'_>) -> Self::Writer {
         let _ = meta;
         self.make_writer()
+    }
+
+    /// Returns a [`Writer`] for writing data from the span or event represented
+    /// by the provided [`Event`] in the specified context.
+    ///
+    /// By default, this calls [`make_writer_for`] with the event's metadata.
+    /// Implementations may override this method to provide event-specific
+    /// behavior.
+    ///
+    /// For example, an implementation might route event data based on a dynamic
+    /// value attached to the event, such as a query ID in a serving system.
+    ///
+    /// [`Writer`]: MakeWriter::Writer
+    /// [`make_writer_for`]: Self::make_writer_for
+    fn make_writer_for_event(&'a self, event: &Event<'_>, _ctx: &Context<'_, S>) -> Self::Writer {
+        self.make_writer_for(event.metadata())
     }
 }
 
@@ -545,8 +563,8 @@ pub struct TestWriter {
 ///
 /// [`Subscriber`]: tracing::Subscriber
 /// [`io::Write`]: std::io::Write
-pub struct BoxMakeWriter {
-    inner: Box<dyn for<'a> MakeWriter<'a, Writer = Box<dyn Write + 'a>> + Send + Sync>,
+pub struct BoxMakeWriter<S = Registry> {
+    inner: Box<dyn for<'a> MakeWriter<'a, S, Writer = Box<dyn Write + 'a>> + Send + Sync>,
     name: &'static str,
 }
 
@@ -679,7 +697,7 @@ pub(in crate::fmt) struct WriteAdaptor<'a> {
     fmt_write: &'a mut dyn fmt::Write,
 }
 
-impl<'a, F, W> MakeWriter<'a> for F
+impl<'a, S, F, W> MakeWriter<'a, S> for F
 where
     F: Fn() -> W,
     W: io::Write,
@@ -691,7 +709,7 @@ where
     }
 }
 
-impl<'a, W> MakeWriter<'a> for Arc<W>
+impl<'a, S, W> MakeWriter<'a, S> for Arc<W>
 where
     &'a W: io::Write + 'a,
 {
@@ -701,7 +719,7 @@ where
     }
 }
 
-impl<'a> MakeWriter<'a> for std::fs::File {
+impl<'a, S> MakeWriter<'a, S> for std::fs::File {
     type Writer = &'a std::fs::File;
     fn make_writer(&'a self) -> Self::Writer {
         self
@@ -738,7 +756,7 @@ impl io::Write for TestWriter {
     }
 }
 
-impl<'a> MakeWriter<'a> for TestWriter {
+impl<'a, S> MakeWriter<'a, S> for TestWriter {
     type Writer = Self;
 
     fn make_writer(&'a self) -> Self::Writer {
@@ -748,12 +766,15 @@ impl<'a> MakeWriter<'a> for TestWriter {
 
 // === impl BoxMakeWriter ===
 
-impl BoxMakeWriter {
+impl<S> BoxMakeWriter<S>
+where
+    S: 'static,
+{
     /// Constructs a `BoxMakeWriter` wrapping a type implementing [`MakeWriter`].
     ///
     pub fn new<M>(make_writer: M) -> Self
     where
-        M: for<'a> MakeWriter<'a> + Send + Sync + 'static,
+        M: for<'a> MakeWriter<'a, S> + Send + Sync + 'static,
     {
         Self {
             inner: Box::new(Boxed(make_writer)),
@@ -762,7 +783,7 @@ impl BoxMakeWriter {
     }
 }
 
-impl fmt::Debug for BoxMakeWriter {
+impl<S> fmt::Debug for BoxMakeWriter<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("BoxMakeWriter")
             .field(&format_args!("<{}>", self.name))
@@ -770,7 +791,7 @@ impl fmt::Debug for BoxMakeWriter {
     }
 }
 
-impl<'a> MakeWriter<'a> for BoxMakeWriter {
+impl<'a, S> MakeWriter<'a, S> for BoxMakeWriter<S> {
     type Writer = Box<dyn Write + 'a>;
 
     #[inline]
@@ -782,13 +803,19 @@ impl<'a> MakeWriter<'a> for BoxMakeWriter {
     fn make_writer_for(&'a self, meta: &Metadata<'_>) -> Self::Writer {
         self.inner.make_writer_for(meta)
     }
+
+    #[inline]
+    fn make_writer_for_event(&'a self, event: &Event<'_>, ctx: &Context<'_, S>) -> Self::Writer {
+        self.inner.make_writer_for_event(event, ctx)
+    }
 }
 
 struct Boxed<M>(M);
 
-impl<'a, M> MakeWriter<'a> for Boxed<M>
+impl<'a, M, S> MakeWriter<'a, S> for Boxed<M>
 where
-    M: MakeWriter<'a>,
+    M: MakeWriter<'a, S>,
+    S: 'static,
 {
     type Writer = Box<dyn Write + 'a>;
 
@@ -801,11 +828,16 @@ where
         let w = self.0.make_writer_for(meta);
         Box::new(w)
     }
+
+    fn make_writer_for_event(&'a self, event: &Event<'_>, ctx: &Context<'_, S>) -> Self::Writer {
+        let w = self.0.make_writer_for_event(event, ctx);
+        Box::new(w)
+    }
 }
 
 // === impl Mutex/MutexGuardWriter ===
 
-impl<'a, W> MakeWriter<'a> for Mutex<W>
+impl<'a, S, W> MakeWriter<'a, S> for Mutex<W>
 where
     W: io::Write + 'a,
 {
@@ -941,7 +973,7 @@ impl<M> WithMaxLevel<M> {
     }
 }
 
-impl<'a, M: MakeWriter<'a>> MakeWriter<'a> for WithMaxLevel<M> {
+impl<'a, S, M: MakeWriter<'a, S>> MakeWriter<'a, S> for WithMaxLevel<M> {
     type Writer = OptionalWriter<M::Writer>;
 
     #[inline]
@@ -954,6 +986,14 @@ impl<'a, M: MakeWriter<'a>> MakeWriter<'a> for WithMaxLevel<M> {
     fn make_writer_for(&'a self, meta: &Metadata<'_>) -> Self::Writer {
         if meta.level() <= &self.level {
             return OptionalWriter::some(self.make.make_writer_for(meta));
+        }
+        OptionalWriter::none()
+    }
+
+    #[inline]
+    fn make_writer_for_event(&'a self, event: &Event<'_>, ctx: &Context<'_, S>) -> Self::Writer {
+        if event.metadata().level() <= &self.level {
+            return OptionalWriter::some(self.make.make_writer_for_event(event, ctx));
         }
         OptionalWriter::none()
     }
@@ -974,7 +1014,7 @@ impl<M> WithMinLevel<M> {
     }
 }
 
-impl<'a, M: MakeWriter<'a>> MakeWriter<'a> for WithMinLevel<M> {
+impl<'a, S, M: MakeWriter<'a, S>> MakeWriter<'a, S> for WithMinLevel<M> {
     type Writer = OptionalWriter<M::Writer>;
 
     #[inline]
@@ -990,14 +1030,23 @@ impl<'a, M: MakeWriter<'a>> MakeWriter<'a> for WithMinLevel<M> {
         }
         OptionalWriter::none()
     }
+
+    #[inline]
+    fn make_writer_for_event(&'a self, event: &Event<'_>, ctx: &Context<'_, S>) -> Self::Writer {
+        if event.metadata().level() >= &self.level {
+            return OptionalWriter::some(self.make.make_writer_for_event(event, ctx));
+        }
+        OptionalWriter::none()
+    }
 }
 
 // ==== impl WithFilter ===
 
 impl<M, F> WithFilter<M, F> {
     /// Wraps `make` with the provided `filter`, returning a [`MakeWriter`] that
-    /// will call `make.make_writer_for()` when `filter` returns `true` for a
-    /// span or event's [`Metadata`], and returns a [`sink`] otherwise.
+    /// will call `make.make_writer_for()` (or `make.make_writer_for_event`) when
+    /// `filter` returns `true` for a span or event's [`Metadata`], and returns a
+    /// [`sink`] otherwise.
     ///
     /// See [`MakeWriterExt::with_filter`] for details.
     ///
@@ -1011,9 +1060,9 @@ impl<M, F> WithFilter<M, F> {
     }
 }
 
-impl<'a, M, F> MakeWriter<'a> for WithFilter<M, F>
+impl<'a, S, M, F> MakeWriter<'a, S> for WithFilter<M, F>
 where
-    M: MakeWriter<'a>,
+    M: MakeWriter<'a, S>,
     F: Fn(&Metadata<'_>) -> bool,
 {
     type Writer = OptionalWriter<M::Writer>;
@@ -1027,6 +1076,15 @@ where
     fn make_writer_for(&'a self, meta: &Metadata<'_>) -> Self::Writer {
         if (self.filter)(meta) {
             OptionalWriter::some(self.make.make_writer_for(meta))
+        } else {
+            OptionalWriter::none()
+        }
+    }
+
+    #[inline]
+    fn make_writer_for_event(&'a self, event: &Event<'_>, ctx: &Context<'_, S>) -> Self::Writer {
+        if (self.filter)(event.metadata()) {
+            OptionalWriter::some(self.make.make_writer_for_event(event, ctx))
         } else {
             OptionalWriter::none()
         }
@@ -1048,10 +1106,10 @@ impl<A, B> Tee<A, B> {
     }
 }
 
-impl<'a, A, B> MakeWriter<'a> for Tee<A, B>
+impl<'a, S, A, B> MakeWriter<'a, S> for Tee<A, B>
 where
-    A: MakeWriter<'a>,
-    B: MakeWriter<'a>,
+    A: MakeWriter<'a, S>,
+    B: MakeWriter<'a, S>,
 {
     type Writer = Tee<A::Writer, B::Writer>;
 
@@ -1063,6 +1121,14 @@ where
     #[inline]
     fn make_writer_for(&'a self, meta: &Metadata<'_>) -> Self::Writer {
         Tee::new(self.a.make_writer_for(meta), self.b.make_writer_for(meta))
+    }
+
+    #[inline]
+    fn make_writer_for_event(&'a self, event: &Event<'_>, ctx: &Context<'_, S>) -> Self::Writer {
+        Tee::new(
+            self.a.make_writer_for_event(event, ctx),
+            self.b.make_writer_for_event(event, ctx),
+        )
     }
 }
 
@@ -1126,10 +1192,10 @@ impl<A, B> OrElse<A, B> {
     }
 }
 
-impl<'a, A, B, W> MakeWriter<'a> for OrElse<A, B>
+impl<'a, S, A, B, W> MakeWriter<'a, S> for OrElse<A, B>
 where
-    A: MakeWriter<'a, Writer = OptionalWriter<W>>,
-    B: MakeWriter<'a>,
+    A: MakeWriter<'a, S, Writer = OptionalWriter<W>>,
+    B: MakeWriter<'a, S>,
     W: io::Write,
 {
     type Writer = EitherWriter<W, B::Writer>;
@@ -1147,6 +1213,14 @@ where
         match self.inner.make_writer_for(meta) {
             EitherWriter::A(writer) => EitherWriter::A(writer),
             EitherWriter::B(_) => EitherWriter::B(self.or_else.make_writer_for(meta)),
+        }
+    }
+
+    #[inline]
+    fn make_writer_for_event(&'a self, event: &Event<'_>, ctx: &Context<'_, S>) -> Self::Writer {
+        match self.inner.make_writer_for_event(event, ctx) {
+            EitherWriter::A(writer) => EitherWriter::A(writer),
+            EitherWriter::B(_) => EitherWriter::B(self.or_else.make_writer_for_event(event, ctx)),
         }
     }
 }

--- a/tracing-subscriber/tests/ansi_escaping.rs
+++ b/tracing-subscriber/tests/ansi_escaping.rs
@@ -31,7 +31,7 @@ impl std::io::Write for TestWriter {
     }
 }
 
-impl<'a> MakeWriter<'a> for TestWriter {
+impl<'a, S> MakeWriter<'a, S> for TestWriter {
     type Writer = TestWriter;
 
     fn make_writer(&'a self) -> Self::Writer {
@@ -155,7 +155,7 @@ fn test_json_ansi_escaping() {
     );
 }
 
-/// Test that pretty formatter properly escapes ANSI sequences  
+/// Test that pretty formatter properly escapes ANSI sequences
 #[cfg(feature = "ansi")]
 #[test]
 fn test_pretty_ansi_escaping() {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

The patch 805eb51 explains the motivation for the MakeWriter::make_writer_for method. However, this method only receives static metadata, which may not be sufficient in some cases.

For example, consider a server that accepts client connections and needs to write trace events for each connection to a separate file. The client IP address would likely be recorded as an event field rather than as the target, since dynamic targets are not supported.

Therefore, it would be useful to configure the writer based on dynamic field values.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This patch adds a MakeWriter::make_writer_for_event method that allows to depend on the event dynamic values and its context when making a writer.

Closes #3587
Refs #3194
