### PR TITLE
feat: Add a #[trace_return] attribute

### DIFF
--- a/tracing-attributes/src/attr.rs
+++ b/tracing-attributes/src/attr.rs
@@ -171,6 +171,46 @@ impl EventArgs {
     }
 }
 
+#[derive(Clone, Default, Debug)]
+pub(crate) struct TraceReturnArgs {
+    pub(crate) err_args: Option<EventArgs>,
+    pub(crate) ret_args: Option<EventArgs>,
+    parse_warnings: Vec<syn::Error>,
+}
+
+impl Parse for TraceReturnArgs {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let mut args = Self::default();
+        while !input.is_empty() {
+            let lookahead = input.lookahead1();
+            if lookahead.peek(kw::err) {
+                let _ = input.parse::<kw::err>()?;
+                args.err_args = Some(EventArgs::parse(input)?);
+            } else if lookahead.peek(kw::ret) {
+                let _ = input.parse::<kw::ret>()?;
+                args.ret_args = Some(EventArgs::parse(input)?);
+            } else if lookahead.peek(Token![,]) {
+                let _ = input.parse::<Token![,]>()?;
+            } else {
+                args.parse_warnings.push(lookahead.error());
+                let _ = input.parse::<proc_macro2::TokenTree>();
+            }
+        }
+        Ok(args)
+    }
+}
+
+impl From<TraceReturnArgs> for InstrumentArgs {
+    fn from(args: TraceReturnArgs) -> Self {
+        Self {
+            err_args: args.err_args,
+            ret_args: args.ret_args,
+            parse_warnings: args.parse_warnings,
+            ..Self::default()
+        }
+    }
+}
+
 impl Parse for EventArgs {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         if !input.peek(syn::token::Paren) {

--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -21,6 +21,7 @@ pub(crate) fn gen_function<'a, B: ToTokens + 'a>(
     args: InstrumentArgs,
     instrumented_function_name: &str,
     self_type: Option<&TypePath>,
+    with_span: bool,
 ) -> proc_macro2::TokenStream {
     // these are needed ahead of time, as ItemFn contains the function body _and_
     // isn't representable inside a quote!/quote_spanned! macro
@@ -98,6 +99,7 @@ pub(crate) fn gen_function<'a, B: ToTokens + 'a>(
         args,
         instrumented_function_name,
         self_type,
+        with_span,
     );
 
     let mut result = quote!(
@@ -131,6 +133,7 @@ fn gen_block<B: ToTokens>(
     mut args: InstrumentArgs,
     instrumented_function_name: &str,
     self_type: Option<&TypePath>,
+    with_span: bool,
 ) -> proc_macro2::TokenStream {
     // generate the span's name
     let span_name = args
@@ -262,6 +265,7 @@ fn gen_block<B: ToTokens>(
 
         ))
     })();
+    let span = with_span.then_some(span);
 
     let target = args.target();
 
@@ -344,24 +348,31 @@ fn gen_block<B: ToTokens>(
             ),
         };
 
-        return quote!(
-            let __tracing_attr_span = #span;
-            let __tracing_instrument_future = #mk_fut;
-            #[allow(clippy::implicit_return)]
-            if !__tracing_attr_span.is_disabled() {
-                #follows_from
-                ::tracing::Instrument::instrument(
-                    __tracing_instrument_future,
-                    __tracing_attr_span
-                )
-                .await
-            } else {
+        return match span {
+            Some(span) => quote!(
+                let __tracing_attr_span = #span;
+                let __tracing_instrument_future = #mk_fut;
+                #[allow(clippy::implicit_return)]
+                if !__tracing_attr_span.is_disabled() {
+                    #follows_from
+                    ::tracing::Instrument::instrument(
+                        __tracing_instrument_future,
+                        __tracing_attr_span
+                    )
+                    .await
+                } else {
+                    __tracing_instrument_future.await
+                }
+            ),
+            None => quote!(
+                let __tracing_instrument_future = #mk_fut;
+                #[allow(clippy::implicit_return)]
                 __tracing_instrument_future.await
-            }
-        );
+            ),
+        };
     }
 
-    let span = quote!(
+    let span = span.map(|span| quote!(
         // These variables are left uninitialized and initialized only
         // if the tracing level is statically enabled at this point.
         // While the tracing level is also checked at span creation
@@ -379,7 +390,7 @@ fn gen_block<B: ToTokens>(
             #follows_from
             __tracing_attr_guard = __tracing_attr_span.enter();
         }
-    );
+    ));
 
     match (err_event, ret_event) {
         (Some(err_event), Some(ret_event)) => quote_spanned! {block.span()=>
@@ -708,6 +719,7 @@ impl<'block> AsyncInfo<'block> {
         self,
         args: InstrumentArgs,
         instrumented_function_name: &str,
+        with_span: bool,
     ) -> Result<proc_macro::TokenStream, syn::Error> {
         // let's rewrite some statements!
         let mut out_stmts: Vec<TokenStream> = self
@@ -736,6 +748,7 @@ impl<'block> AsyncInfo<'block> {
                         args,
                         instrumented_function_name,
                         self.self_type.as_ref(),
+                        with_span,
                     )
                 }
                 // `async move { ... }`, optionally pinned
@@ -750,6 +763,7 @@ impl<'block> AsyncInfo<'block> {
                         args,
                         instrumented_function_name,
                         None,
+                        with_span,
                     );
                     let async_attrs = &async_expr.attrs;
                     if pinned_box {

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -579,14 +579,49 @@ pub fn instrument(
 ) -> proc_macro::TokenStream {
     let args = syn::parse_macro_input!(args as attr::InstrumentArgs);
     // Cloning a `TokenStream` is cheap since it's reference counted internally.
-    instrument_precise(args.clone(), item.clone())
-        .unwrap_or_else(|_err| instrument_speculative(args, item))
+    instrument_precise(args.clone(), item.clone(), ExpansionKind::Instrument)
+        .unwrap_or_else(|_err| instrument_speculative(args, item, ExpansionKind::Instrument))
+}
+
+/// Emits an event when a function returns, without creating a new span.
+///
+/// This attribute accepts the same `ret` and `err` arguments as
+/// [`#[instrument]`][instrument]. It is useful when a function should emit a
+/// return-value event in the caller's current span rather than creating and
+/// entering a span of its own.
+///
+/// `const fn` cannot be annotated with `trace_return`.
+#[proc_macro_attribute]
+pub fn trace_return(
+    args: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let args = syn::parse_macro_input!(args as attr::TraceReturnArgs);
+    instrument_precise(
+        args.clone().into(),
+        item.clone(),
+        ExpansionKind::TraceReturn,
+    )
+    .unwrap_or_else(|_err| instrument_speculative(args.into(), item, ExpansionKind::TraceReturn))
+}
+
+#[derive(Clone, Copy)]
+enum ExpansionKind {
+    Instrument,
+    TraceReturn,
+}
+
+impl ExpansionKind {
+    fn creates_span(self) -> bool {
+        matches!(self, Self::Instrument)
+    }
 }
 
 /// Instrument the function, without parsing the function body (instead using the raw tokens).
 fn instrument_speculative(
     args: attr::InstrumentArgs,
     item: proc_macro::TokenStream,
+    kind: ExpansionKind,
 ) -> proc_macro::TokenStream {
     let input = syn::parse_macro_input!(item as MaybeItemFn);
     let instrumented_function_name = input.sig.ident.to_string();
@@ -595,6 +630,7 @@ fn instrument_speculative(
         args,
         instrumented_function_name.as_str(),
         None,
+        kind.creates_span(),
     )
     .into()
 }
@@ -604,21 +640,31 @@ fn instrument_speculative(
 fn instrument_precise(
     args: attr::InstrumentArgs,
     item: proc_macro::TokenStream,
+    kind: ExpansionKind,
 ) -> Result<proc_macro::TokenStream, syn::Error> {
     let input = syn::parse::<ItemFn>(item)?;
     let instrumented_function_name = input.sig.ident.to_string();
 
     if input.sig.constness.is_some() {
-        return Ok(quote! {
-            compile_error!("the `#[instrument]` attribute may not be used with `const fn`s")
-        }
-        .into());
+        let message = match kind {
+            ExpansionKind::Instrument => {
+                "the `#[instrument]` attribute may not be used with `const fn`s"
+            }
+            ExpansionKind::TraceReturn => {
+                "the `#[trace_return]` attribute may not be used with `const fn`s"
+            }
+        };
+        return Ok(quote! { compile_error!(#message) }.into());
     }
 
     // check for async_trait-like patterns in the block, and instrument
     // the future instead of the wrapper
     if let Some(async_like) = expand::AsyncInfo::from_fn(&input) {
-        return async_like.gen_async(args, instrumented_function_name.as_str());
+        return async_like.gen_async(
+            args,
+            instrumented_function_name.as_str(),
+            kind.creates_span(),
+        );
     }
 
     let input = MaybeItemFn::from(input);
@@ -628,6 +674,7 @@ fn instrument_precise(
         args,
         instrumented_function_name.as_str(),
         None,
+        kind.creates_span(),
     )
     .into())
 }

--- a/tracing-attributes/tests/trace_return.rs
+++ b/tracing-attributes/tests/trace_return.rs
@@ -1,0 +1,71 @@
+use std::convert::TryFrom;
+use std::num::TryFromIntError;
+
+use tracing::{subscriber::with_default, trace_return, Level};
+use tracing_mock::{expect, subscriber};
+
+#[trace_return(ret)]
+fn ret() -> i32 {
+    42
+}
+
+#[test]
+fn emits_return_event_without_creating_span() {
+    let (subscriber, handle) = subscriber::mock()
+        .event(
+            expect::event()
+                .with_fields(expect::field("return").with_value(&tracing::field::debug(42)))
+                .at_level(Level::INFO),
+        )
+        .only()
+        .run_with_handle();
+
+    with_default(subscriber, ret);
+    handle.assert_finished();
+}
+
+#[test]
+fn emits_event_in_current_span() {
+    let parent = expect::span().named("parent");
+    let event = expect::event()
+        .with_fields(expect::field("return").with_value(&tracing::field::debug(42)))
+        .with_ancestry(expect::has_contextual_parent("parent"));
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(parent.clone())
+        .enter(parent.clone())
+        .event(event)
+        .exit(parent.clone())
+        .drop_span(parent)
+        .only()
+        .run_with_handle();
+
+    with_default(subscriber, || {
+        tracing::info_span!("parent").in_scope(ret);
+    });
+    handle.assert_finished();
+}
+
+#[trace_return(err(Debug, level = "info"))]
+fn err_debug_info() -> Result<u8, TryFromIntError> {
+    u8::try_from(1234)
+}
+
+#[test]
+fn configures_error_format_and_level() {
+    let error = u8::try_from(1234).unwrap_err();
+    let (subscriber, handle) = subscriber::mock()
+        .event(
+            expect::event()
+                .with_fields(
+                    expect::field("error")
+                        .with_value(&tracing::field::debug(error))
+                        .only(),
+                )
+                .at_level(Level::INFO),
+        )
+        .only()
+        .run_with_handle();
+
+    with_default(subscriber, || err_debug_info().ok());
+    handle.assert_finished();
+}

--- a/tracing-attributes/tests/ui/fail/const_trace_return.rs
+++ b/tracing-attributes/tests/ui/fail/const_trace_return.rs
@@ -1,0 +1,8 @@
+use tracing::trace_return;
+
+#[trace_return(ret)]
+const fn answer() -> i32 {
+    42
+}
+
+fn main() {}

--- a/tracing-attributes/tests/ui/fail/const_trace_return.stderr
+++ b/tracing-attributes/tests/ui/fail/const_trace_return.stderr
@@ -1,0 +1,15 @@
+error: macros that expand to items must be delimited with braces or followed by a semicolon
+ --> tests/ui/fail/const_trace_return.rs:3:1
+  |
+3 | #[trace_return(ret)]
+  | ^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `trace_return` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: the `#[trace_return]` attribute may not be used with `const fn`s
+ --> tests/ui/fail/const_trace_return.rs:3:1
+  |
+3 | #[trace_return(ret)]
+  | ^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `trace_return` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -971,7 +971,7 @@ pub use self::span::Span;
 #[cfg(feature = "attributes")]
 #[cfg_attr(docsrs, doc(cfg(feature = "attributes")))]
 #[doc(inline)]
-pub use tracing_attributes::instrument;
+pub use tracing_attributes::{instrument, trace_return};
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
Implements #2464

## Motivation

This attribute allows for tracing the return value of a function without creating a new sub-span.

## Solution

```
use tracing_attributes::trace_return;

#[trace_return(ret)]
fn answer() -> i32 {
    42
}
 ```

Operates like `instrument` in other cases as well:
 ```rust                                                                                                                                                                        
 use tracing_attributes::trace_return;
 
#[trace_return(ret, err)]
 pub fn parse(input: &str) -> Result<i32, std::num::ParseIntError> {
     input.parse()
 }
 ```  
