### PR TITLE
tracing-subscriber: Fix chrono tests

### DIFF
--- a/tracing-subscriber/src/fmt/time/chrono_crate.rs
+++ b/tracing-subscriber/src/fmt/time/chrono_crate.rs
@@ -134,7 +134,7 @@ mod tests {
         let mut dst: Writer<'_> = Writer::new(&mut buf);
         assert!(FormatTime::format_time(&ChronoUtc::default(), &mut dst).is_ok());
         // e.g. `buf` contains "2023-08-18T19:05:08.662499+00:00"
-        assert!(chrono::DateTime::parse_from_str(&buf, "%FT%H:%M:%S%.6f%z").is_ok());
+        assert!(chrono::DateTime::parse_from_str(&buf, "%FT%H:%M:%S%.f%z").is_ok());
     }
 
     #[test]
@@ -155,7 +155,7 @@ mod tests {
         let mut dst: Writer<'_> = Writer::new(&mut buf);
         assert!(FormatTime::format_time(&ChronoLocal::default(), &mut dst).is_ok());
         // e.g. `buf` contains "2023-08-18T14:59:08.662499-04:00".
-        assert!(chrono::DateTime::parse_from_str(&buf, "%FT%H:%M:%S%.6f%z").is_ok());
+        assert!(chrono::DateTime::parse_from_str(&buf, "%FT%H:%M:%S%.f%z").is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Don't check number of fractional second digits as system supports nanosecond precision would have 9 digits.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
