### PR TITLE
core: add missing `on_register_dispatch` implementations for `Box<S>` and `Arc<S>`

### DIFF
--- a/tracing-core/src/subscriber.rs
+++ b/tracing-core/src/subscriber.rs
@@ -709,6 +709,11 @@ where
     S: Subscriber + ?Sized,
 {
     #[inline]
+    fn on_register_dispatch(&self, subscriber: &Dispatch) {
+        self.as_ref().on_register_dispatch(subscriber);
+    }
+
+    #[inline]
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         self.as_ref().register_callsite(metadata)
     }
@@ -793,6 +798,11 @@ impl<S> Subscriber for Arc<S>
 where
     S: Subscriber + ?Sized,
 {
+    #[inline]
+    fn on_register_dispatch(&self, subscriber: &Dispatch) {
+        self.as_ref().on_register_dispatch(subscriber);
+    }
+
     #[inline]
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         self.as_ref().register_callsite(metadata)


### PR DESCRIPTION
## Motivation

The two implementation were missing and the default implementation does nothing. This means that if we have a subscriber that has a layer that needs to save the dispatcher for later, boxing this subscriber breaks the wrapped layer.

## Solution

Add the two missing implementations.