### PR TITLE
Bump tracing-attributes to syn 3.0

### DIFF
--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -37,7 +37,7 @@ async-await = []
 
 [dependencies]
 proc-macro2 = "1.0.60"
-syn = { version = "2.0", default-features = false, features = [
+syn = { version = "^3.0.3", default-features = false, features = [
     "full",
     "parsing",
     "printing",

--- a/tracing-attributes/src/expand.rs
+++ b/tracing-attributes/src/expand.rs
@@ -37,7 +37,7 @@ pub(crate) fn gen_function<'a, B: ToTokens + 'a>(
     let Signature {
         output,
         inputs: params,
-        unsafety,
+        safety,
         asyncness,
         constness,
         abi,
@@ -102,7 +102,7 @@ pub(crate) fn gen_function<'a, B: ToTokens + 'a>(
 
     let mut result = quote!(
         #(#outer_attrs) *
-        #vis #constness #asyncness #unsafety #abi #fn_token #ident
+        #vis #constness #asyncness #safety #abi #fn_token #ident
         #lt_token #gen_params #gt_token
     );
 
@@ -831,11 +831,11 @@ struct ImplTraitEraser;
 
 impl VisitMut for ImplTraitEraser {
     fn visit_type_mut(&mut self, t: &mut Type) {
-        if let Type::ImplTrait(..) = t {
-            *t = syn::TypeInfer {
+        if let Type::ImplTrait(tt) = t {
+            *t = Type::Infer(syn::TypeInfer {
+                attrs: tt.attrs.clone(),
                 underscore_token: Token![_](t.span()),
-            }
-            .into();
+            });
         } else {
             syn::visit_mut::visit_type_mut(self, t);
         }

--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -85,7 +85,7 @@ use quote::TokenStreamExt;
 use quote::{quote, ToTokens};
 use syn::parse::{Parse, ParseStream};
 use syn::token::Brace;
-use syn::{Attribute, ItemFn, Signature, Visibility};
+use syn::{Attribute, FnModifiers, ItemFn, Signature, Visibility};
 
 mod attr;
 mod expand;
@@ -642,6 +642,7 @@ struct MaybeItemFn {
     sig: Signature,
     brace_token: Brace,
     block: TokenStream,
+    modifiers: FnModifiers,
 }
 
 impl MaybeItemFn {
@@ -675,6 +676,7 @@ impl Parse for MaybeItemFn {
             sig,
             brace_token,
             block,
+            modifiers: FnModifiers::default(), // TODO: do we need to parse these instead?
         })
     }
 }
@@ -686,6 +688,7 @@ impl From<ItemFn> for MaybeItemFn {
             vis,
             sig,
             block,
+            modifiers,
         }: ItemFn,
     ) -> Self {
         let (outer_attrs, inner_attrs) = attrs
@@ -700,6 +703,7 @@ impl From<ItemFn> for MaybeItemFn {
             sig,
             brace_token: block.brace_token,
             block: block_tokens,
+            modifiers,
         }
     }
 }


### PR DESCRIPTION
## Motivation

I noticed a downstream app pulling both syn 2.x (via here) and syn 3.x (from other crates).

Changelog for syn 3 [here](https://github.com/dtolnay/syn/releases/tag/3.0.0).

## Solution

Dependency upgrade + required code changes. No tests were changed, which I think is a good thing.

Refs https://github.com/tokio-rs/tracing/issues/3582