### PR TITLE
[tracing-attributes]: Correct comment about async fns in trait

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -528,8 +528,8 @@ mod expand;
 ///
 /// It also works with [async-trait](https://crates.io/crates/async-trait)
 /// (a crate that allows defining async functions in traits,
-/// something not currently possible in Rust),
-/// and hopefully most libraries that exhibit similar behaviors:
+/// which was not possible before Rust 1.75 and is currently not possible in `dyn Trait`), and
+/// hopefully most libraries that exhibit similar behaviors:
 ///
 /// ```
 /// # use tracing::instrument;


### PR DESCRIPTION
## Motivation

`async fn` in `Trait` is available for quite some time by now, so when I stumbled over this I thought we could maybe make that comment a bit more explicit, to reduce the potential for confusion of newcomers.

Feel free of course to suggest some other wording! :heart: 