### PR TITLE
Use a function to convert from `Level` to `log::Level` to reduce the amount of generated code

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1014,6 +1014,18 @@ pub mod __macro_support {
         interest.is_always() || crate::dispatcher::get_default(|default| default.enabled(meta))
     }
 
+    #[cfg(feature = "log")]
+    #[inline(always)]
+    pub fn __level_to_log(level: crate::Level) -> crate::log::Level {
+        match level {
+            crate::Level::ERROR => crate::log::Level::Error,
+            crate::Level::WARN => crate::log::Level::Warn,
+            crate::Level::INFO => crate::log::Level::Info,
+            crate::Level::DEBUG => crate::log::Level::Debug,
+            _ => crate::log::Level::Trace,
+        }
+    }
+
     /// /!\ WARNING: This is *not* a stable API! /!\
     /// This function, and all code contained in the `__macro_support` module, is
     /// a *private* API of `tracing`. It is exposed publicly because it is used

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -3232,13 +3232,7 @@ macro_rules! fieldset {
 #[macro_export]
 macro_rules! level_to_log {
     ($level:expr) => {
-        match $level {
-            $crate::Level::ERROR => $crate::log::Level::Error,
-            $crate::Level::WARN => $crate::log::Level::Warn,
-            $crate::Level::INFO => $crate::log::Level::Info,
-            $crate::Level::DEBUG => $crate::log::Level::Debug,
-            _ => $crate::log::Level::Trace,
-        }
+        $crate::__macro_support::__level_to_log($level)
     };
 }
 


### PR DESCRIPTION
## Motivation

I was profiling the compilation time and generated source code size of https://github.com/rust-lang/bors, and I saw in the generated macro output that there is one often duplicated sentence when tracing logs are expanded. Specifically, it was this match statement:

```rust
if match ::tracing::Level::DEBUG {
      ::tracing::Level::ERROR => ::tracing::log::Level::Error,
      ::tracing::Level::WARN => ::tracing::log::Level::Warn,
      ::tracing::Level::INFO => ::tracing::log::Level::Info,
      ::tracing::Level::DEBUG => ::tracing::log::Level::Debug,
      _ => ::tracing::log::Level::Trace,
  } <= ::tracing::log::STATIC_MAX_LEVEL {
if !::tracing::dispatcher::has_been_set() {
  {
      use ::tracing::log;
      let level =
          match ::tracing::Level::DEBUG {
              ::tracing::Level::ERROR => ::tracing::log::Level::Error,
              ::tracing::Level::WARN => ::tracing::log::Level::Warn,
              ::tracing::Level::INFO => ::tracing::log::Level::Info,
              ::tracing::Level::DEBUG => ::tracing::log::Level::Debug,
              _ => ::tracing::log::Level::Trace,
          };
      if level <= log::max_level() {
          let meta = __CALLSITE.metadata();
          let log_meta = ...
```

This seems a bit wasteful in terms of the generated code size.

## Solution

I tried replacing the match statement with a call to a helper function that does the conversion instead, and it reduced the size of `cargo expand --lib --tests` on `bors` by ~5%, from `7894057 B` to `7479042 B`, in absolute terms by ~400 KiB of source code.

So the code now looks like this:

```rust
if ::tracing::__macro_support::__level_to_log(::tracing::Level::DEBUG)
    <= ::tracing::log::STATIC_MAX_LEVEL {
if !::tracing::dispatcher::has_been_set() {
    {
        use ::tracing::log;
        let level =
            ::tracing::__macro_support::__level_to_log(::tracing::Level::DEBUG);
        if level <= log::max_level() {
            let meta = __CALLSITE.metadata();
            let log_meta =

```

I haven't been able to find any measurable effect on compilation time in my case, but it still seems like a reasonable thing to do to reduce the code size, so I sent this PR. Let me know what you think!