### PR TITLE
journald: normalize events from the log bridge

### DIFF
--- a/tracing-journald/Cargo.toml
+++ b/tracing-journald/Cargo.toml
@@ -15,12 +15,18 @@ categories = [
 keywords = ["tracing", "journald"]
 rust-version = "1.65.0"
 
+[features]
+default = ["tracing-log"]
+tracing-log = ["dep:tracing-log"]
+
 [dependencies]
 libc = "0.2.126"
 tracing-core = { path = "../tracing-core", version = "0.1.28" }
+tracing-log = { path = "../tracing-log", version = "0.2.0", optional = true, default-features = false, features = ["log-tracer", "std"] }
 tracing-subscriber = { path = "../tracing-subscriber", version = "0.3.0", default-features = false, features = ["registry"] }
 
 [dev-dependencies]
+log = "0.4.17"
 serde_json = "1.0.82"
 serde = { version = "1.0.140", features = ["derive"] }
 tracing = { path = "../tracing", version = "0.1.35" }

--- a/tracing-journald/src/lib.rs
+++ b/tracing-journald/src/lib.rs
@@ -47,6 +47,8 @@ use tracing_core::{
     span::{Attributes, Id, Record},
     Field, Level, Metadata, Subscriber,
 };
+#[cfg(feature = "tracing-log")]
+use tracing_log::NormalizeEvent;
 use tracing_subscriber::{layer::Context, registry::LookupSpan};
 
 #[cfg(target_os = "linux")]
@@ -342,8 +344,14 @@ where
         }
 
         // Record event fields
-        self.put_priority(&mut buf, event.metadata());
-        put_metadata(&mut buf, event.metadata(), None);
+        #[cfg(feature = "tracing-log")]
+        let normalized_meta = event.normalized_metadata();
+        #[cfg(feature = "tracing-log")]
+        let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
+        #[cfg(not(feature = "tracing-log"))]
+        let meta = event.metadata();
+        self.put_priority(&mut buf, meta);
+        put_metadata(&mut buf, meta, None);
         put_field_length_encoded(&mut buf, "SYSLOG_IDENTIFIER", |buf| {
             write!(buf, "{}", self.syslog_identifier).unwrap()
         });
@@ -416,6 +424,11 @@ impl<'a> EventVisitor<'a> {
 
 impl Visit for EventVisitor<'_> {
     fn record_str(&mut self, field: &Field, value: &str) {
+        // Skip fields that are actually log metadata that have already been handled
+        #[cfg(feature = "tracing-log")]
+        if field.name().starts_with("log.") {
+            return;
+        }
         self.put_prefix(field);
         put_field_length_encoded(self.buf, field.name(), |buf| {
             buf.extend_from_slice(value.as_bytes())
@@ -423,6 +436,10 @@ impl Visit for EventVisitor<'_> {
     }
 
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        #[cfg(feature = "tracing-log")]
+        if field.name().starts_with("log.") {
+            return;
+        }
         self.put_prefix(field);
         put_field_length_encoded(self.buf, field.name(), |buf| {
             write!(buf, "{:?}", value).unwrap()

--- a/tracing-journald/tests/journal.rs
+++ b/tracing-journald/tests/journal.rs
@@ -177,6 +177,27 @@ fn simple_message() {
     });
 }
 
+#[cfg(feature = "tracing-log")]
+#[test]
+fn log_bridge_message() {
+    with_journald(|| {
+        let _ = tracing_log::LogTracer::init();
+
+        info_span!("log_bridge", test.name = "log_bridge_message").in_scope(|| {
+            log::info!(target: "log_bridge_target", "Hello Log");
+        });
+
+        let message = retry_read_one_line_from_journal("log_bridge_message");
+        assert_eq!(message["MESSAGE"], "Hello Log");
+        assert_eq!(message["PRIORITY"], "5");
+        assert_eq!(message["TARGET"], "log_bridge_target");
+        assert_eq!(message["CODE_FILE"], file!());
+        assert!(message.contains_key("CODE_LINE"));
+        assert!(!message.contains_key("LOG_TARGET"));
+        assert!(!message.contains_key("LOG_FILE"));
+    });
+}
+
 #[test]
 fn custom_priorities() {
     fn check_message(level: &str, priority: &str) {


### PR DESCRIPTION
## Motivation

Events that reach `tracing-journald` through `tracing_log::LogTracer` carry the static `log` callsite. The journal record then reads `TARGET=log` with no `CODE_FILE`/`CODE_LINE`, while the real values ride along as `LOG_TARGET`, `LOG_FILE`, `LOG_LINE`, `LOG_MODULE_PATH` fields (or `F_LOG_*` with the default field prefix). Anything that filters or groups on `TARGET` sees one bucket named `log` for every `log`-crate dependency.

`tracing-subscriber`'s fmt layer already solves this with `NormalizeEvent::normalized_metadata()` and by skipping the `log.*` fields; the journald layer did not.

## Solution

Behind a new `tracing-log` feature (on by default, mirroring `tracing-subscriber`), `on_event` takes the metadata from `normalized_metadata()` when present for `PRIORITY`, `TARGET`, `CODE_FILE`, `CODE_LINE`, and `EventVisitor` skips fields whose name starts with `log.`. Without the feature the behaviour is unchanged.

A record from a `log::info!` in `lsm_tree::version::recovery` now reads `TARGET=lsm_tree::version::recovery`, `CODE_FILE=.../recovery.rs`, `CODE_LINE=40`, and no `LOG_*` fields.

Adds `log_bridge_message` to `tests/journal.rs`, following the existing journald-backed tests.
