### PR TITLE
decrease amount of generated code from most macros

### DIFF
--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -1128,6 +1128,17 @@ pub mod __macro_support {
         }
     }
 
+    #[cfg(feature = "log")]
+    pub const fn level_to_log(level: crate::Level) -> crate::log::Level {
+        match level {
+            crate::Level::ERROR => crate::log::Level::Error,
+            crate::Level::WARN => crate::log::Level::Warn,
+            crate::Level::INFO => crate::log::Level::Info,
+            crate::Level::DEBUG => crate::log::Level::Debug,
+            _ => crate::log::Level::Trace
+        }
+    }
+
     static CALLSITE: crate::callsite::DefaultCallsite =
         crate::callsite::DefaultCallsite::new(&META);
     static META: crate::Metadata<'static> = crate::metadata! {

--- a/tracing/src/macros.rs
+++ b/tracing/src/macros.rs
@@ -32,23 +32,27 @@ macro_rules! span {
                 fields: $($fields)*
             };
             let mut interest = $crate::subscriber::Interest::never();
-            if $crate::level_enabled!($lvl)
-                && { interest = __CALLSITE.interest(); !interest.is_never() }
-                && $crate::__macro_support::__is_enabled(__CALLSITE.metadata(), interest)
-            {
-                let meta = __CALLSITE.metadata();
-                // span with explicit parent
-                $crate::Span::child_of(
-                    $parent,
-                    meta,
-                    &$crate::valueset_all!(meta.fields(), $($fields)*),
-                )
-            } else {
-                let span = $crate::__macro_support::__disabled_span(__CALLSITE.metadata());
-                $crate::if_log_enabled! { $lvl, {
-                    span.record_all(&$crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*));
-                }};
-                span
+            match $crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*) {
+                value_set => {
+                    if $crate::level_enabled!($lvl)
+                        && { interest = __CALLSITE.interest(); !interest.is_never() }
+                        && $crate::__macro_support::__is_enabled(__CALLSITE.metadata(), interest)
+                    {
+                        let meta = __CALLSITE.metadata();
+                        // span with explicit parent
+                        $crate::Span::child_of(
+                            $parent,
+                            meta,
+                            &value_set,
+                        )
+                    } else {
+                        let span = $crate::__macro_support::__disabled_span(__CALLSITE.metadata());
+                        $crate::if_log_enabled! { $lvl, {
+                            span.record_all(&value_set);
+                        }};
+                        span
+                    }
+                }
             }
         }
     };
@@ -63,22 +67,26 @@ macro_rules! span {
                 fields: $($fields)*
             };
             let mut interest = $crate::subscriber::Interest::never();
-            if $crate::level_enabled!($lvl)
-                && { interest = __CALLSITE.interest(); !interest.is_never() }
-                && $crate::__macro_support::__is_enabled(__CALLSITE.metadata(), interest)
-            {
-                let meta = __CALLSITE.metadata();
-                // span with contextual parent
-                $crate::Span::new(
-                    meta,
-                    &$crate::valueset_all!(meta.fields(), $($fields)*),
-                )
-            } else {
-                let span = $crate::__macro_support::__disabled_span(__CALLSITE.metadata());
-                $crate::if_log_enabled! { $lvl, {
-                    span.record_all(&$crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*));
-                }};
-                span
+            match $crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*) {
+                value_set => {
+                    if $crate::level_enabled!($lvl)
+                        && { interest = __CALLSITE.interest(); !interest.is_never() }
+                        && $crate::__macro_support::__is_enabled(__CALLSITE.metadata(), interest)
+                    {
+                        let meta = __CALLSITE.metadata();
+                        // span with contextual parent
+                        $crate::Span::new(
+                            meta,
+                            &value_set,
+                        )
+                    } else {
+                        let span = $crate::__macro_support::__disabled_span(__CALLSITE.metadata());
+                        $crate::if_log_enabled! { $lvl, {
+                            span.record_all(&value_set);
+                        }};
+                        span
+                    }
+                }
             }
         }
     };
@@ -628,27 +636,23 @@ macro_rules! event {
             let interest = __CALLSITE.interest();
             !interest.is_never() && $crate::__macro_support::__is_enabled(__CALLSITE.metadata(), interest)
         };
-        if enabled {
-            (|value_set: $crate::field::ValueSet| {
+        match $crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*) {
+            value_set => {
                 $crate::__tracing_log!(
                     $lvl,
                     __CALLSITE,
                     &value_set
                 );
-                let meta = __CALLSITE.metadata();
-                // event with explicit parent
-                $crate::Event::child_of(
-                    $parent,
-                    meta,
-                    &value_set
-                );
-            })($crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*));
-        } else {
-            $crate::__tracing_log!(
-                $lvl,
-                __CALLSITE,
-                &$crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*)
-            );
+                if enabled {
+                    let meta = __CALLSITE.metadata();
+                    // event with explicit parent
+                    $crate::Event::child_of(
+                        $parent,
+                        meta,
+                        &value_set
+                    );
+                }
+            }
         }
     });
     (name: $name:expr, target: $target:expr, parent: $parent:expr, $lvl:expr, { $($fields:tt)* }, $($arg:tt)+ ) => (
@@ -681,26 +685,23 @@ macro_rules! event {
             let interest = __CALLSITE.interest();
             !interest.is_never() && $crate::__macro_support::__is_enabled(__CALLSITE.metadata(), interest)
         };
-        if enabled {
-            (|value_set: $crate::field::ValueSet| {
-                let meta = __CALLSITE.metadata();
-                // event with contextual parent
-                $crate::Event::dispatch(
-                    meta,
-                    &value_set
-                );
+        match $crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*) {
+            value_set => {
+                if enabled {
+                    let meta = __CALLSITE.metadata();
+                    // event with contextual parent
+                    $crate::Event::dispatch(
+                        meta,
+                        &value_set
+                    );
+                }
+
                 $crate::__tracing_log!(
                     $lvl,
                     __CALLSITE,
                     &value_set
                 );
-            })($crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*));
-        } else {
-            $crate::__tracing_log!(
-                $lvl,
-                __CALLSITE,
-                &$crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*)
-            );
+            }
         }
     });
     (name: $name:expr, target: $target:expr, $lvl:expr, { $($fields:tt)* }, $($arg:tt)+ ) => (
@@ -738,27 +739,24 @@ macro_rules! event {
             let interest = __CALLSITE.interest();
             !interest.is_never() && $crate::__macro_support::__is_enabled(__CALLSITE.metadata(), interest)
         };
-        if enabled {
-            (|value_set: $crate::field::ValueSet| {
+        match $crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*) {
+            value_set => {
                 $crate::__tracing_log!(
                     $lvl,
                     __CALLSITE,
                     &value_set
                 );
-                let meta = __CALLSITE.metadata();
-                // event with explicit parent
-                $crate::Event::child_of(
-                    $parent,
-                    meta,
-                    &value_set
-                );
-            })($crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*));
-        } else {
-            $crate::__tracing_log!(
-                $lvl,
-                __CALLSITE,
-                &$crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*)
-            );
+
+                if enabled {
+                    let meta = __CALLSITE.metadata();
+                    // event with explicit parent
+                    $crate::Event::child_of(
+                        $parent,
+                        meta,
+                        &value_set
+                    );
+                }
+            }
         }
     });
     (target: $target:expr, parent: $parent:expr, $lvl:expr, { $($fields:tt)* }, $($arg:tt)+ ) => (
@@ -791,27 +789,24 @@ macro_rules! event {
             let interest = __CALLSITE.interest();
             !interest.is_never() && $crate::__macro_support::__is_enabled(__CALLSITE.metadata(), interest)
         };
-        if enabled {
-            (|value_set: $crate::field::ValueSet| {
+        match $crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*) {
+            value_set => {
                 $crate::__tracing_log!(
                     $lvl,
                     __CALLSITE,
                     &value_set
                 );
-                let meta = __CALLSITE.metadata();
-                // event with explicit parent
-                $crate::Event::child_of(
-                    $parent,
-                    meta,
-                    &value_set
-                );
-            })($crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*));
-        } else {
-            $crate::__tracing_log!(
-                $lvl,
-                __CALLSITE,
-                &$crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*)
-            );
+
+                if enabled {
+                    let meta = __CALLSITE.metadata();
+                    // event with explicit parent
+                    $crate::Event::child_of(
+                        $parent,
+                        meta,
+                        &value_set
+                    );
+                }
+            }
         }
     });
     (name: $name:expr, parent: $parent:expr, $lvl:expr, { $($fields:tt)* }, $($arg:tt)+ ) => (
@@ -843,26 +838,22 @@ macro_rules! event {
             let interest = __CALLSITE.interest();
             !interest.is_never() && $crate::__macro_support::__is_enabled(__CALLSITE.metadata(), interest)
         };
-        if enabled {
-            (|value_set: $crate::field::ValueSet| {
-                let meta = __CALLSITE.metadata();
-                // event with contextual parent
-                $crate::Event::dispatch(
-                    meta,
-                    &value_set
-                );
+        match $crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*) {
+            value_set => {
+                if enabled {
+                    let meta = __CALLSITE.metadata();
+                    // event with contextual parent
+                    $crate::Event::dispatch(
+                        meta,
+                        &value_set
+                    );
+                }
                 $crate::__tracing_log!(
                     $lvl,
                     __CALLSITE,
                     &value_set
                 );
-            })($crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*));
-        } else {
-            $crate::__tracing_log!(
-                $lvl,
-                __CALLSITE,
-                &$crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*)
-            );
+            }
         }
     });
     (name: $name:expr, $lvl:expr, { $($fields:tt)* }, $($arg:tt)+ ) => (
@@ -898,26 +889,23 @@ macro_rules! event {
             let interest = __CALLSITE.interest();
             !interest.is_never() && $crate::__macro_support::__is_enabled(__CALLSITE.metadata(), interest)
         };
-        if enabled {
-            (|value_set: $crate::field::ValueSet| {
-                let meta = __CALLSITE.metadata();
-                // event with contextual parent
-                $crate::Event::dispatch(
-                    meta,
-                    &value_set
-                );
+        match $crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*) {
+            value_set => {
+                if enabled {
+                    let meta = __CALLSITE.metadata();
+                    // event with contextual parent
+                    $crate::Event::dispatch(
+                        meta,
+                        &value_set
+                    );
+                }
+
                 $crate::__tracing_log!(
                     $lvl,
                     __CALLSITE,
                     &value_set
                 );
-            })($crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*));
-        } else {
-            $crate::__tracing_log!(
-                $lvl,
-                __CALLSITE,
-                &$crate::valueset_all!(__CALLSITE.metadata().fields(), $($fields)*)
-            );
+            }
         }
     });
     (target: $target:expr, $lvl:expr, { $($fields:tt)* }, $($arg:tt)+ ) => (
@@ -3227,21 +3215,6 @@ macro_rules! fieldset {
 
 }
 
-#[cfg(feature = "log")]
-#[doc(hidden)]
-#[macro_export]
-macro_rules! level_to_log {
-    ($level:expr) => {
-        match $level {
-            $crate::Level::ERROR => $crate::log::Level::Error,
-            $crate::Level::WARN => $crate::log::Level::Warn,
-            $crate::Level::INFO => $crate::log::Level::Info,
-            $crate::Level::DEBUG => $crate::log::Level::Debug,
-            _ => $crate::log::Level::Trace,
-        }
-    };
-}
-
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __tracing_stringify {
@@ -3267,7 +3240,7 @@ macro_rules! __tracing_log {
     ($level:expr, $callsite:expr, $value_set:expr) => {
         $crate::if_log_enabled! { $level, {
             use $crate::log;
-            let level = $crate::level_to_log!($level);
+            let level = $crate::__macro_support::level_to_log($level);
             if level <= log::max_level() {
                 let meta = $callsite.metadata();
                 let log_meta = log::Metadata::builder()
@@ -3309,7 +3282,7 @@ macro_rules! if_log_enabled {
         $crate::if_log_enabled! { $lvl, $if_log else {} }
     };
     ($lvl:expr, $if_log:block else $else_block:block) => {
-        if $crate::level_to_log!($lvl) <= $crate::log::STATIC_MAX_LEVEL {
+        if $crate::__macro_support::level_to_log($lvl) <= $crate::log::STATIC_MAX_LEVEL {
             if !$crate::dispatcher::has_been_set() {
                 $if_log
             } else {
@@ -3332,7 +3305,7 @@ macro_rules! if_log_enabled {
         $crate::if_log_enabled! { $lvl, $if_log else {} }
     };
     ($lvl:expr, $if_log:block else $else_block:block) => {
-        if $crate::level_to_log!($lvl) <= $crate::log::STATIC_MAX_LEVEL {
+        if $crate::__macro_support::level_to_log($lvl) <= $crate::log::STATIC_MAX_LEVEL {
             #[allow(unused_braces)]
             $if_log
         } else {

--- a/tracing/src/span.rs
+++ b/tracing/src/span.rs
@@ -584,7 +584,7 @@ impl Span {
             let values = attrs.values();
             span.log(
                 target,
-                level_to_log!(*meta.level()),
+                crate::__macro_support::level_to_log(*meta.level()),
                 format_args!("++ {};{}", meta.name(), crate::log::LogValueSet { values, is_first: false }),
             );
         }}
@@ -1239,7 +1239,7 @@ impl Span {
                 };
                 self.log(
                     target,
-                    level_to_log!(*_meta.level()),
+                    crate::__macro_support::level_to_log(*_meta.level()),
                     format_args!("{};{}", _meta.name(), crate::log::LogValueSet { values, is_first: false }),
                 );
             }}
@@ -1344,7 +1344,7 @@ impl Span {
     #[inline]
     fn log(&self, target: &str, level: log::Level, message: fmt::Arguments<'_>) {
         if let Some(meta) = self.meta {
-            if level_to_log!(*meta.level()) <= log::max_level() {
+            if crate::__macro_support::level_to_log(*meta.level()) <= log::max_level() {
                 let logger = log::logger();
                 let log_meta = log::Metadata::builder().level(level).target(target).build();
                 if logger.enabled(&log_meta) {


### PR DESCRIPTION
This decreases the amount of code generated from most event-generating macros in the crate. Mainly, it does this by deduplicating some calls to `$crate::valueset_all!` and turning the `level_to_log` macro into a function.

## Motivation

When profiling build times for a set of large enterprise crates, I noticed (with `-Zmacro-stats`) that tracing macros took up a large percentage of the generated code. So I went to fix it.

These changes improve compile times by 2-5% across a few different debug configurations in these aforementioned crates.

I would recommend reviewing this with [whitespace disabled](https://github.com/tokio-rs/tracing/pull/3608/changes?w=1) - it becomes a lot easier to understand.